### PR TITLE
build: added .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: node_js
+sudo: false
+node_js:
+  - 4
+  - 5
+
+cache:
+  directories:
+    - node_modules
+
+before_install:
+  - npm install
+
+script:
+  - gulp stylus
+  - gulp tsc


### PR DESCRIPTION
.travis.yml addition based on #506, now node.d.ts files are no longer needed.
tested on my branch here - https://travis-ci.org/S-YOU/ag-grid/builds

You just need to do following to setup travis-ci
1. register account, link github and enable ag-grid repo in https://travis-ci.org
2. add Travis CI service in github webhooks - https://github.com/ceolter/ag-grid/settings/hooks
It will automatically build from your next commit.
