### PR TITLE
Fix issue with rowClass not being considered when autoSizing a column.

### DIFF
--- a/src/ts/rendering/autoWidthCalculator.ts
+++ b/src/ts/rendering/autoWidthCalculator.ts
@@ -41,6 +41,13 @@ export class AutoWidthCalculator {
             // on the same line, standard flow layout, by putting them into divs, they are laid
             // out one per line
             var eCloneParent = document.createElement('div');
+
+            // Apply row classes to the containing div. This will ensure that cells will get any special 
+            // styling that might be happening at the row level (eg. font changes, emphasis, etc).
+            eCloneParent.className = eCell.parentNode.className;
+            // "ag-row" class applies position:absolute that needs to be removed.
+            eCloneParent.style.position = 'static';
+
             // table-row, so that each cell is on a row. i also tried display='block', but this
             // didn't work in IE
             eCloneParent.style.display = 'table-row';


### PR DESCRIPTION
Currently `rowClass` is not being considered when auto-sizing on a column happens. This means that changes to font or emphasis done at the row-level do not end up being considered when sizing the column. This fixes that issue.

_Note_: this does not copy `rowStyle` properties over to the cloned cell's parent, so there is still a gap there for those that use that feature.
