### PR TITLE
[bugfix] custom floating filters

### DIFF
--- a/dist/lib/componentProvider.js
+++ b/dist/lib/componentProvider.js
@@ -50,42 +50,42 @@ var ComponentProvider = (function () {
                 defaultComponent: headerGroupComp_1.HeaderGroupComp
             },
             setFloatingFilterComponent: {
-                mandatoryMethodList: [],
+                mandatoryMethodList: ['onParentModelChanged'],
                 optionalMethodList: [],
                 defaultComponent: floatingFilter_1.SetFloatingFilterComp
             },
             textFloatingFilterComponent: {
-                mandatoryMethodList: [],
+                mandatoryMethodList: ['onParentModelChanged'],
                 optionalMethodList: [],
                 defaultComponent: floatingFilter_1.TextFloatingFilterComp
             },
             numberFloatingFilterComponent: {
-                mandatoryMethodList: [],
+                mandatoryMethodList: ['onParentModelChanged'],
                 optionalMethodList: [],
                 defaultComponent: floatingFilter_1.NumberFloatingFilterComp
             },
             dateFloatingFilterComponent: {
-                mandatoryMethodList: [],
+                mandatoryMethodList: ['onParentModelChanged'],
                 optionalMethodList: [],
                 defaultComponent: floatingFilter_1.DateFloatingFilterComp
             },
             readModelAsStringFloatingFilterComponent: {
-                mandatoryMethodList: [],
+                mandatoryMethodList: ['onParentModelChanged'],
                 optionalMethodList: [],
                 defaultComponent: floatingFilter_1.ReadModelAsStringFloatingFilterComp
             },
             floatingFilterWrapperComponent: {
-                mandatoryMethodList: [],
+                mandatoryMethodList: ['onParentModelChanged'],
                 optionalMethodList: [],
                 defaultComponent: floatingFilterWrapper_1.FloatingFilterWrapperComp
             },
             emptyFloatingFilterWrapperComponent: {
-                mandatoryMethodList: [],
+                mandatoryMethodList: ['onParentModelChanged'],
                 optionalMethodList: [],
                 defaultComponent: floatingFilterWrapper_1.EmptyFloatingFilterWrapperComp
             },
             floatingFilterComponent: {
-                mandatoryMethodList: [],
+                mandatoryMethodList: ['onParentModelChanged'],
                 optionalMethodList: [],
                 defaultComponent: null
             },

--- a/src/ts/componentProvider.ts
+++ b/src/ts/componentProvider.ts
@@ -90,42 +90,42 @@ export class ComponentProvider {
                 defaultComponent: HeaderGroupComp
             },
             setFloatingFilterComponent: {
-                mandatoryMethodList: [],
+                mandatoryMethodList: ['onParentModelChanged'],
                 optionalMethodList: [],
                 defaultComponent: SetFloatingFilterComp
             },
             textFloatingFilterComponent: {
-                mandatoryMethodList: [],
+                mandatoryMethodList: ['onParentModelChanged'],
                 optionalMethodList: [],
                 defaultComponent: TextFloatingFilterComp
             },
             numberFloatingFilterComponent: {
-                mandatoryMethodList: [],
+                mandatoryMethodList: ['onParentModelChanged'],
                 optionalMethodList: [],
                 defaultComponent: NumberFloatingFilterComp
             },
             dateFloatingFilterComponent: {
-                mandatoryMethodList: [],
+                mandatoryMethodList: ['onParentModelChanged'],
                 optionalMethodList: [],
                 defaultComponent: DateFloatingFilterComp
             },
             readModelAsStringFloatingFilterComponent: {
-                mandatoryMethodList: [],
+                mandatoryMethodList: ['onParentModelChanged'],
                 optionalMethodList: [],
                 defaultComponent: ReadModelAsStringFloatingFilterComp
             },
             floatingFilterWrapperComponent: {
-                mandatoryMethodList: [],
+                mandatoryMethodList: ['onParentModelChanged'],
                 optionalMethodList: [],
                 defaultComponent: FloatingFilterWrapperComp
             },
             emptyFloatingFilterWrapperComponent: {
-                mandatoryMethodList: [],
+                mandatoryMethodList: ['onParentModelChanged'],
                 optionalMethodList: [],
                 defaultComponent: EmptyFloatingFilterWrapperComp
             },
             floatingFilterComponent: {
-                mandatoryMethodList: [],
+                mandatoryMethodList: ['onParentModelChanged'],
                 optionalMethodList: [],
                 defaultComponent: null
             },


### PR DESCRIPTION
**Summary**

Partial fix the issue mentioned in this issue: https://github.com/ceolter/ag-grid/issues/1528 despite it being closed, it still appears to be happening as of version 10.0.1 

Heres a [plunkr](https://plnkr.co/6FFPWITofzjz7kffJ2qf?p=info) using version 10.0.1 that demonstrates the issue still happens.

**Details**

`onParentModelChanged` appears to be be missing from the `mandatoryMethodList` array in the component provider. Any time one tries to update a filter using a custom floating floating filter type, it breaks and throws a `this.floatingFilterComp.onParentModelChanged is not a function` error. This PR adds them to the array and appears to prevent the error from happening. That said, the filter model does not appear to be getting updated (to be fair, I could be missing something there). I'm still submitting this as the custom floating filters are simply not functional as is and this allows one to work around since we have access to the grid api directly in versions 10+ (thank you soooo much for adding that btw. So useful!!).  