### PR TITLE
Fix CSV headers with grouping columns

### DIFF
--- a/src/ts/gridSerializer.ts
+++ b/src/ts/gridSerializer.ts
@@ -332,18 +332,18 @@ export class GridSerializer {
     }
 
     recursivelyAddHeaderGroups<T> (displayedGroups:ColumnGroupChild[], gridSerializingSession:GridSerializingSession<T>):void{
-        let directChildrenHeaderGroups:ColumnGroupChild[];
+        let directChildrenHeaderGroups:ColumnGroupChild[] = [];
         displayedGroups.forEach((columnGroupChild: ColumnGroupChild) => {
             let columnGroup: ColumnGroup = columnGroupChild as ColumnGroup;
             if (!columnGroup.getChildren) return;
-            directChildrenHeaderGroups = columnGroup.getChildren();
+            directChildrenHeaderGroups = directChildrenHeaderGroups.concat(columnGroup.getChildren());
         });
 
         if (displayedGroups.length > 0 && displayedGroups[0] instanceof ColumnGroup) {
             this.doAddHeaderHeader(gridSerializingSession, displayedGroups);
         }
 
-        if (directChildrenHeaderGroups){
+        if (directChildrenHeaderGroups.length > 0){
             this.recursivelyAddHeaderGroups(directChildrenHeaderGroups, gridSerializingSession);
         }
     }
@@ -355,7 +355,8 @@ export class GridSerializer {
             let columnGroup: ColumnGroup = columnGroupChild as ColumnGroup;
             let colDef = columnGroup.getDefinition();
 
-            gridRowIterator.onColumn(colDef != null ? colDef.headerName : '', columnIndex++, columnGroup.getLeafColumns().length - 1);
+            gridRowIterator.onColumn(colDef != null && colDef.headerName != null ? colDef.headerName : '',
+                columnIndex++, columnGroup.getLeafColumns().length - 1);
         });
     }
 }


### PR DESCRIPTION
CSV headers are not correctly displayed with grouping columns.
When 3 level nested headers, header position of second level is
wrong.
Header `undefined` is shown above no grouping columns.

For example grouping header of CSV export looks wrong with the following header.

![header_example](https://user-images.githubusercontent.com/170831/29107224-12b27622-7d14-11e7-83bf-6bb0e52184d5.png)

CSV export shown in Excel
![csv_export_example](https://user-images.githubusercontent.com/170831/29107471-5bc0fd9c-7d15-11e7-8660-82c06228fce8.png)
