### PR TITLE
fix cell grouping for columns that are null, undefined or empty string

### DIFF
--- a/src/ts/rendering/cellRenderers/groupCellRenderer.ts
+++ b/src/ts/rendering/cellRenderers/groupCellRenderer.ts
@@ -77,7 +77,7 @@ export class GroupCellRenderer extends Component implements ICellRenderer {
 
         //This allows for empty strings to appear as groups since
         //it will only return for null or undefined.
-        if (params.value==null) {
+        if (params.value==null && params.colDef.field !== params.node.field) {
             return;
         }
 


### PR DESCRIPTION
fix cell grouping for columns that are null, undefined or empty string