### PR TITLE
Fix group header name `undefined` in CSV/Excel export

### DIFF
--- a/src/ts/columnController/balancedColumnTreeBuilder.ts
+++ b/src/ts/columnController/balancedColumnTreeBuilder.ts
@@ -65,7 +65,7 @@ export class BalancedColumnTreeBuilder {
                 let newChild = child;
                 for (let i = columnDept-1; i>=currentDept; i--) {
                     let newColId = columnKeyCreator.getUniqueKey(null, null);
-                    let colGroupDefMerged = this.createMergedColGroupDef(null);
+                    let colGroupDefMerged = this.createMergedColGroupDef(<ColGroupDef> { headerName : '' });
                     let paddedGroup = new OriginalColumnGroup(colGroupDefMerged, newColId, true);
                     this.context.wireBean(paddedGroup);
                     paddedGroup.setChildren([newChild]);


### PR DESCRIPTION
If an empty column group is built, `undefined` is shown in
CSV/Excel export.