### PR TITLE
Fix not using innerRenderer for non group row

### DIFF
--- a/src/ts/rendering/cellRenderers/groupCellRenderer.ts
+++ b/src/ts/rendering/cellRenderers/groupCellRenderer.ts
@@ -19,6 +19,7 @@ export interface GroupCellRendererParams extends ICellRendererParams{
     pinned:string,
     padding:number,
     suppressPadding:boolean,
+    innerRenderer:any,
     footerValueGetter:any,
     suppressCount:boolean,
     fullWidth:boolean,
@@ -180,6 +181,8 @@ export class GroupCellRenderer extends Component implements ICellRenderer {
         } else if (rowNode.group) {
             this.createGroupCell();
             this.addChildCount();
+        } else if (this.params.innerRenderer) {
+            this.createGroupCell();
         } else {
             this.createLeafCell();
         }


### PR DESCRIPTION
If group renderer with innerRenderer option is used, innerRenderer
is not used for non group row with version 13.

innerRenderer works for non grouping row with version 12.