### PR TITLE
Fix problem when running embedded in gwt

### DIFF
--- a/dist/lib/widgets/popupService.js
+++ b/dist/lib/widgets/popupService.js
@@ -186,7 +186,7 @@ var PopupService = (function () {
     //so that when the background is clicked, the child is removed again, giving
     //a model look to popups.
     PopupService.prototype.addAsModalPopup = function (eChild, closeOnEsc, closedCallback) {
-        var eBody = document.body;
+        var eBody = this.gridOptionsWrapper.getDocument().body;
         if (!eBody) {
             console.warn('ag-grid: could not find the body of the document, document.body is empty');
             return;


### PR DESCRIPTION
This fixes our integration problems with our GWT. If I use the getDocument() that we set when constructing the document, both popup menus open and close correctly, _and_ D&N works. If document is used, the popups do not close correctly when clicking outside them somewhere else on the grid.

Maybe that's not everything that's needed to build all your versions, but changing this statement in the dist files made it work for us in all integrations.