### PR TITLE
FIX for issue #1865 - class 'ag-row-focus' getting applied to all rows on load

### DIFF
--- a/src/ts/rendering/rowComp.ts
+++ b/src/ts/rendering/rowComp.ts
@@ -839,8 +839,7 @@ export class RowComp extends Component {
         }
 
         classes.push('ag-row');
-        classes.push('ag-row-no-focus');
-        classes.push(this.rowFocused ? 'ag-row-no-focus' : 'ag-row-focus');
+        classes.push(this.rowFocused ? 'ag-row-focus' : 'ag-row-no-focus');
 
         if (this.fadeRowIn) {
             classes.push('ag-opacity-zero');


### PR DESCRIPTION
Removed un-necessary ‘ag-row-no-focus’ class push() on row 842

swapped logic on ternary on row 843 so that if a row doesn't have focus class 'ag-row-no-focus’ is added to
the row otherwise if it does have focus class 'ag-row-focus' is added to the row.