### PR TITLE
Rename method calls for propagating changes to pinned row data

### DIFF
--- a/src/ts/components/componentUtil.ts
+++ b/src/ts/components/componentUtil.ts
@@ -185,12 +185,12 @@ export class ComponentUtil {
             api.setRowData(changes.rowData.currentValue);
         }
 
-        if (changes.floatingTopRowData) {
-            api.setFloatingTopRowData(changes.floatingTopRowData.currentValue);
+        if (changes.pinnedTopRowData) {
+            api.setPinnedTopRowData(changes.pinnedTopRowData.currentValue);
         }
 
-        if (changes.floatingBottomRowData) {
-            api.setFloatingBottomRowData(changes.floatingBottomRowData.currentValue);
+        if (changes.pinnedBottomRowData) {
+            api.setPinnedBottomRowData(changes.pinnedBottomRowData.currentValue);
         }
 
         if (changes.columnDefs) {


### PR DESCRIPTION
Without this change, the pinned rows would now appear, at least in conjunction with ag-grid-react.