### PR TITLE
Fix for the default options bug

### DIFF
--- a/src/ts/filter/dateFilter.ts
+++ b/src/ts/filter/dateFilter.ts
@@ -38,6 +38,11 @@ export class DateFilter extends ScalarBaseFilter<Date, IDateFilterParams, Serial
 
     private dateTo:Date;
 
+    public init(params:IDateFilterParams){
+        this.defaultFilter = BaseFilter.EQUALS;
+        super.init(params);
+    }
+
     public modelFromFloatingFilter(from: string): SerializedDateFilter {
         return {
             dateFrom: from,
@@ -155,7 +160,7 @@ export class DateFilter extends ScalarBaseFilter<Date, IDateFilterParams, Serial
     public resetState():void{
         this.setDateFrom(null);
         this.setDateTo(null);
-        this.setFilterType(this.defaultFilter || "equals");
+        this.setFilterType(this.defaultFilter);
     }
 
     public parse(model: SerializedDateFilter): void {

--- a/src/ts/filter/dateFilter.ts
+++ b/src/ts/filter/dateFilter.ts
@@ -155,7 +155,7 @@ export class DateFilter extends ScalarBaseFilter<Date, IDateFilterParams, Serial
     public resetState():void{
         this.setDateFrom(null);
         this.setDateTo(null);
-        this.setFilterType("equals");
+        this.setFilterType(this.defaultFilter || "equals");
     }
 
     public parse(model: SerializedDateFilter): void {

--- a/src/ts/filter/numberFilter.ts
+++ b/src/ts/filter/numberFilter.ts
@@ -154,7 +154,7 @@ export class NumberFilter extends ScalarBaseFilter<number, INumberFilterParams, 
     public resetState():void{
         this.setFilterType(BaseFilter.EQUALS);
         this.setFilter(null);
-        this.setFilterTo(null);
+        this.setFilterTo(this.defaultFilter || null);
     }
 
     public setType (filterType:string):void{

--- a/src/ts/filter/numberFilter.ts
+++ b/src/ts/filter/numberFilter.ts
@@ -32,6 +32,11 @@ export class NumberFilter extends ScalarBaseFilter<number, INumberFilterParams, 
         };
     }
 
+    public init(params:INumberFilterParams) {
+        this.defaultFilter = BaseFilter.EQUALS;
+        super.init(params);
+    }
+
     public getApplicableFilterTypes ():string[]{
         return [BaseFilter.EQUALS, BaseFilter.NOT_EQUAL, BaseFilter.LESS_THAN, BaseFilter.LESS_THAN_OR_EQUAL,
             BaseFilter.GREATER_THAN, BaseFilter.GREATER_THAN_OR_EQUAL, BaseFilter.IN_RANGE];
@@ -152,9 +157,9 @@ export class NumberFilter extends ScalarBaseFilter<number, INumberFilterParams, 
     }
 
     public resetState():void{
-        this.setFilterType(BaseFilter.EQUALS);
+        this.setFilterType(this.defaultFilter);
         this.setFilter(null);
-        this.setFilterTo(this.defaultFilter || null);
+        this.setFilterTo(null);
     }
 
     public setType (filterType:string):void{

--- a/src/ts/filter/textFilter.ts
+++ b/src/ts/filter/textFilter.ts
@@ -66,6 +66,10 @@ export class TextFilter extends ComparableBaseFilter <string, ITextFilterParams,
         return BaseFilter.CONTAINS;
     }
 
+    public init(params:ITextFilterParams) {
+        this.defaultFilter = BaseFilter.CONTAINS;
+        super.init(params);
+    }
 
     public customInit(): void {
         this.comparator = this.filterParams.textCustomComparator ? this.filterParams.textCustomComparator : TextFilter.DEFAULT_COMPARATOR;
@@ -172,7 +176,7 @@ export class TextFilter extends ComparableBaseFilter <string, ITextFilterParams,
 
     public resetState(): void{
         this.setFilter(null);
-        this.setFilterType(this.defaultFilter || BaseFilter.CONTAINS);
+        this.setFilterType(this.defaultFilter);
     }
 
     public serialize(): SerializedTextFilter{

--- a/src/ts/filter/textFilter.ts
+++ b/src/ts/filter/textFilter.ts
@@ -172,7 +172,7 @@ export class TextFilter extends ComparableBaseFilter <string, ITextFilterParams,
 
     public resetState(): void{
         this.setFilter(null);
-        this.setFilterType(BaseFilter.CONTAINS);
+        this.setFilterType(this.defaultFilter || BaseFilter.CONTAINS);
     }
 
     public serialize(): SerializedTextFilter{


### PR DESCRIPTION
This corrects the bug where when a grid's data changes (or the clear button is called as that is probably related to this issue as well considering the problem is related to the reset function hard coding the defaultFilter that it resets to). Test out the clear as well (my app doesn't do that). Also, fixed the date filter's default to use the BaseFilter.EQUALS instead of the text.