### PR TITLE
Fix incorrect signature of `afterGuiAttached`

### DIFF
--- a/dist/lib/widgets/component.d.ts
+++ b/dist/lib/widgets/component.d.ts
@@ -19,7 +19,7 @@ export declare class Component extends BeanStub implements IComponent<any, IAfte
     private compId;
     constructor(template?: string);
     setTemplateNoHydrate(template: string): void;
-    afterGuiAttached(params: IAfterGuiAttachedParams): void;
+    afterGuiAttached(params?: IAfterGuiAttachedParams): void;
     getCompId(): number;
     instantiate(context: Context): void;
     private instantiateRecurse(parentNode, context);


### PR DESCRIPTION
Change signature to have an optional parameter `params` to match the specification in interfaces/iComponent.d.ts. Otherwise it causes TypeScript with strictNullChecks to throw an error. See issue #1889