### PR TITLE
Delay the layout math until the styles are present

### DIFF
--- a/src/styles/ag-grid.scss
+++ b/src/styles/ag-grid.scss
@@ -297,6 +297,7 @@ ag-grid-aurelia {
     width: 100%;
     box-sizing: border-box;
 }
+
 .ag-layout-normal .ag-body {
     height: 100%;
     position: absolute;
@@ -773,6 +774,12 @@ ag-grid-aurelia {
         padding-right: 6px;
     }
 }
+
+/* this is a dummy property to detect styles being loaded in borderLayout.ts */
+.ag-layout-normal {
+    caption-side: bottom; 
+}
+
 
 $ag-icons-path: './icons/' !default;
 $ag-icons-filter: 'initial' !default;

--- a/src/ts/layout/borderLayout.ts
+++ b/src/ts/layout/borderLayout.ts
@@ -163,6 +163,9 @@ export class BorderLayout {
         return this.eGui;
     }
 
+    stylesLoaded = false;
+    styleChecks = 0;
+
     // returns true if any item changed size, otherwise returns false
     public doLayout() {
 
@@ -171,6 +174,17 @@ export class BorderLayout {
             this.visibleLastTime = false;
             return false;
         }
+
+        if (!this.stylesLoaded && window.getComputedStyle(this.eGui).captionSide !== "bottom") {
+            if (this.styleChecks > 100) {
+                throw new Error("The styles for ag-Grid were not detected");
+            } else {
+                this.styleChecks ++;
+                return false;
+            }
+        }
+
+        this.stylesLoaded = true;
 
         let atLeastOneChanged = false;
 


### PR DESCRIPTION
Guys, please review this. It improves the way layout happens when using the scripts which bundle css. 

It basically waits to do the layout until the loaded styles actually kick in. There is also a "I give up" clause. 

The CSS property I use should have no effect on the element. 