### PR TITLE
Added full column editing as a beta-feature

### DIFF
--- a/src/ts/focusedCellController.ts
+++ b/src/ts/focusedCellController.ts
@@ -118,6 +118,11 @@ export class FocusedCellController {
         return this.focusedCell.rowIndex === rowIndex && this.focusedCell.floating === floatingOrNull;
     }
 
+    public isColumnFocused(colId: any): boolean {
+        if (_.missing(this.focusedCell)) { return false; }
+        return this.focusedCell.column.getId() === colId;
+    }
+
     private onCellFocused(forceBrowserFocus: boolean): void {
         let event: CellFocusedEvent = {
             type: Events.EVENT_CELL_FOCUSED,

--- a/src/ts/gridOptionsWrapper.ts
+++ b/src/ts/gridOptionsWrapper.ts
@@ -165,6 +165,7 @@ export class GridOptionsWrapper {
     }
 
     public isFullRowEdit() { return this.gridOptions.editType === 'fullRow'; }
+    public isFullColumnEdit() { return this.gridOptions.editType === 'fullColumn'; }
     public isSuppressFocusAfterRefresh() { return isTrue(this.gridOptions.suppressFocusAfterRefresh); }
     public isShowToolPanel() { return isTrue(this.gridOptions.showToolPanel); }
     public isToolPanelSuppressRowGroups() { return isTrue(this.gridOptions.toolPanelSuppressRowGroups); }

--- a/src/ts/rendering/cellEditors/selectCellEditor.ts
+++ b/src/ts/rendering/cellEditors/selectCellEditor.ts
@@ -46,6 +46,9 @@ export class SelectCellEditor extends Component implements ICellEditorComp {
         if (!this.gridOptionsWrapper.isFullRowEdit()) {
             this.addDestroyableEventListener(this.eSelect, 'change', ()=> params.stopEditing() );
         }
+        if (!this.gridOptionsWrapper.isFullColumnEdit()) {
+            this.addDestroyableEventListener(this.eSelect, 'change', ()=> params.stopEditing() );
+        }
 
         this.addDestroyableEventListener(this.eSelect, 'keydown', (event: KeyboardEvent)=> {
             let isNavigationKey = event.keyCode===Constants.KEY_UP || event.keyCode===Constants.KEY_DOWN;

--- a/src/ts/rendering/rowRenderer.ts
+++ b/src/ts/rendering/rowRenderer.ts
@@ -832,7 +832,7 @@ export class RowRenderer extends BeanStub {
     public startEditingCell(gridCell: GridCell, keyPress: number, charPress: string): void {
         let cell = this.getComponentForCell(gridCell);
         if (cell) {
-            cell.startRowOrCellEdit(keyPress, charPress);
+            cell.startComponentEdit(keyPress, charPress);
         }
     }
 
@@ -896,6 +896,8 @@ export class RowRenderer extends BeanStub {
             if (editing) {
                 if (this.gridOptionsWrapper.isFullRowEdit()) {
                     this.moveEditToNextRow(previousRenderedCell, nextRenderedCell);
+                } else if (this.gridOptionsWrapper.isFullColumnEdit()) {
+                    this.moveEditToNextColumn(previousRenderedCell, nextRenderedCell);
                 } else {
                     this.moveEditToNextCell(previousRenderedCell, nextRenderedCell);
                 }
@@ -939,6 +941,32 @@ export class RowRenderer extends BeanStub {
 
         nextRenderedCell.focusCell();
     }
+    // To be moved to a new "ColumnRenderer" class if we want to keep coherence
+    private moveEditToNextColumn(previousRenderedCell: CellComp, nextRenderedCell: CellComp): void {
+        let pGridCell = previousRenderedCell.getGridCell();
+        let nGridCell = nextRenderedCell.getGridCell();
+
+        let colsMatch = (pGridCell.column.getId() === nGridCell.column.getId())
+            && (pGridCell.floating === nGridCell.floating);
+
+        if (colsMatch) {
+            // same row, so we don't start / stop editing, we just move the focus along
+            previousRenderedCell.setFocusOutOnEditor();
+            nextRenderedCell.setFocusInOnEditor();
+        } else {
+            let pRow = previousRenderedCell.getRenderedRow();
+            let nRow = nextRenderedCell.getRenderedRow();
+
+            previousRenderedCell.setFocusOutOnEditor();
+            pRow.stopEditing();
+
+            nRow.startRowEditing();
+            nextRenderedCell.setFocusInOnEditor();
+        }
+
+        nextRenderedCell.focusCell();
+    }
+
 
     // called by the cell, when tab is pressed while editing.
     // @return: RenderedCell when navigation successful, otherwise null


### PR DESCRIPTION
Hello,

I know you rarely accept feature PRs, but I thought that one might be useful : full-column editing.

## How does it work ?
To enable it, you just have to set `gridOptions.editType = 'fullColumn'`.

## Description of the changes

- Added the new option in `gridOptionsWrapper.ts`

- Added `CellComp[]` as an attribute of `Column` (a list, not a JSON for the moment)

- Renamed `StartRowOrCellEdit` of class `CellComp` to `StartComponentEdit`, as we distinguish now between rows and columns. Did the same for `StopRowOrCellEdit`

- Added methods in the `Column` class for starting and stopping editing. For the moment, they do not have any listener (we use the Cell's listener instead). To keep some coherence, maybe we should create `ColComp` and `ColRenderer` classes, like for the rows

## Improvements to be done if we want to continue this way

- As said before, treat a Column like a Row, and add the corresponding Component and Renderer classes.

- Identify the colum's CellComps by the RowIndex
