### PR TITLE
auto height perf

### DIFF
--- a/src/ts/rendering/rowContainerComponent.ts
+++ b/src/ts/rendering/rowContainerComponent.ts
@@ -38,7 +38,7 @@ export class RowContainerComponent {
 
     @PostConstruct
     private postConstruct(): void {
-        this.domOrder = this.gridOptionsWrapper.isEnsureDomOrder() && !this.gridOptionsWrapper.isForPrint();
+        this.domOrder = this.gridOptionsWrapper.isAutoHeight() || (this.gridOptionsWrapper.isEnsureDomOrder() && !this.gridOptionsWrapper.isForPrint());
         this.checkVisibility();
     }
 

--- a/src/ts/rendering/rowRenderer.ts
+++ b/src/ts/rendering/rowRenderer.ts
@@ -254,10 +254,10 @@ export class RowRenderer extends BeanStub {
 
         this.scrollToTopIfNewData(params);
 
-        // never keep rendered rows if doing forPrint or autoHeight, as we do not use 'top' to
+        // never keep rendered rows if doing forPrint, as we do not use 'top' to
         // position the rows (it uses normal flow), so we have to remove
         // all rows and insert them again from scratch
-        let rowsUsingFlow = this.forPrint || this.autoHeight;
+        let rowsUsingFlow = this.forPrint;
         let recycleRows = rowsUsingFlow ? false : params.recycleRows;
         let animate = rowsUsingFlow ? false : params.animate;
 


### PR DESCRIPTION
We saw a major slowdown in the time it takes to do a row expansion when auto-height was turned on.

We have a table with 20 rows, and one of the columns has a custom angular component rendered in the cells. Every time a row was expanded this would cause a redraw of every cell, including these custom angular components. 

The cost of this was quite high, and on Edge we noticed it was taking around 3 seconds to expand. I was able to get that time down to 150ms by NOT redrawing the rows and just ensuring the dom order. I think there could be other fixes here instead, perhaps just putting the new expanded rows in the correct location instead of ensuring order afterwards.