### PR TITLE
fix type for ColDef.headerComponentFramework

### DIFF
--- a/src/ts/entities/colDef.ts
+++ b/src/ts/entities/colDef.ts
@@ -289,7 +289,7 @@ export interface ColDef extends AbstractColDef {
     /** The custom header component to be used for rendering the component header. If none specified the default ag-Grid is used**/
     headerComponent?:{new(): any}
     /** The custom header component to be used for rendering the component header in the hosting framework (ie: React/Angular). If none specified the default ag-Grid is used**/
-    headerComponentFramework?: {new (): any};
+    headerComponentFramework?: any;
     /** The custom header component parameters**/
     headerComponentParams?:any
 


### PR DESCRIPTION
When setting the `headerComponentFramework` of a colDef to an Angular component, there is a type error because it expects the component class to have a `new` function. 

When comparing the types of `headerComponentFramework` and `cellRendererFramework` (which I'm currently using without getting this type error), I noticed that `cellRendererFramework` has type of simply `any`.