### PR TITLE
Set default auto group column position

### DIFF
--- a/src/ts/columnController/columnController.ts
+++ b/src/ts/columnController/columnController.ts
@@ -1920,11 +1920,12 @@ export class ColumnController {
 
         if (_.missing(this.groupAutoColumns)) { return; }
 
-        this.gridColumns = this.groupAutoColumns.concat(this.gridColumns);
+        let autoGroupColumnIndex = this.gridOptionsWrapper.getAutoGroupColumnIndex() || 0;
+        _.insertArrayIntoArray(this.gridColumns, this.groupAutoColumns, autoGroupColumnIndex);
 
         let autoColBalancedTree = this.balancedColumnTreeBuilder.createForAutoGroups(this.groupAutoColumns, this.gridBalancedTree);
 
-        this.gridBalancedTree = autoColBalancedTree.concat(this.gridBalancedTree);
+        _.insertArrayIntoArray(this.gridBalancedTree, autoColBalancedTree, autoGroupColumnIndex);
     }
 
     // gets called after we copy down grid columns, to make sure any part of the gui

--- a/src/ts/columnController/columnController.ts
+++ b/src/ts/columnController/columnController.ts
@@ -1171,6 +1171,10 @@ export class ColumnController {
         let columnStateList = this.primaryColumns.map(this.createStateItemFromColumn.bind(this));
 
         if (!this.pivotMode) {
+            if (this.groupAutoColumns) {
+                // to keep the order of auto group column in setColumnState()
+                columnStateList.push({ colId: AutoGroupColService.GROUP_AUTO_COLUMN_ID });
+            }
             this.orderColumnStateList(columnStateList);
         }
 
@@ -1228,6 +1232,9 @@ export class ColumnController {
 
         if (columnState) {
             columnState.forEach((stateItem: any) => {
+                if (stateItem.colId == AutoGroupColService.GROUP_AUTO_COLUMN_ID) {
+                    return;
+                }
                 let column = this.getPrimaryColumn(stateItem.colId);
                 if (!column) {
                     console.warn('ag-grid: column ' + stateItem.colId + ' not found');

--- a/src/ts/entities/gridOptions.ts
+++ b/src/ts/entities/gridOptions.ts
@@ -193,6 +193,7 @@ export interface GridOptions {
     //Deprecated in v11.0 substituted by autoGroupColumnDef
     groupColumnDef?: ColDef;
     autoGroupColumnDef?: ColDef;
+    autoGroupColumnIndex?: number;
     // deprecated - should use domLayout
     forPrint?: boolean;
 

--- a/src/ts/gridOptionsWrapper.ts
+++ b/src/ts/gridOptionsWrapper.ts
@@ -283,6 +283,7 @@ export class GridOptionsWrapper {
     public isGroupUseEntireRow() { return isTrue(this.gridOptions.groupUseEntireRow); }
     public isEnableRtl() { return isTrue(this.gridOptions.enableRtl); }
     public getAutoGroupColumnDef(): ColDef { return this.gridOptions.autoGroupColumnDef; }
+    public getAutoGroupColumnIndex(): number { return this.gridOptions.autoGroupColumnIndex; }
     public isGroupSuppressRow() { return isTrue(this.gridOptions.groupSuppressRow); }
     public getRowGroupPanelShow() { return this.gridOptions.rowGroupPanelShow; }
     public getPivotPanelShow() { return this.gridOptions.pivotPanelShow; }

--- a/src/ts/propertyKeys.ts
+++ b/src/ts/propertyKeys.ts
@@ -9,7 +9,7 @@ export class PropertyKeys {
         'icons', 'datasource', 'enterpriseDatasource', 'viewportDatasource', 'groupRowRendererParams', 'aggFuncs',
         'fullWidthCellRendererParams', 'defaultColGroupDef', 'defaultColDef', 'defaultExportParams', 'columnTypes',
         'rowClassRules', 'detailGridOptions', 'detailCellRendererParams', 'loadingOverlayComponentParams',
-        'noRowsOverlayComponentParams', 'popupParent'
+        'noRowsOverlayComponentParams', 'popupParent', 'autoGroupColumnIndex'
         //,'cellRenderers','cellEditors'
     ];
 


### PR DESCRIPTION
* Set the default position of the auto group column using option `autoGroupColumnIndex`
* Keep the auto group column position using getColumnState() and setColumnState()