### PR TITLE
Fix full width cell renderer not removed

### DIFF
--- a/src/ts/gridCore.ts
+++ b/src/ts/gridCore.ts
@@ -248,6 +248,9 @@ export class GridCore {
             // if interval is negative, this stops the layout from happening
             if (intervalMillis>0){
                 this.frameworkFactory.setTimeout( () => {
+                    if (this.finished) {
+                        return;
+                    }
                     this.doLayout();
                     this.gridPanel.periodicallyCheck();
                     this.periodicallyDoLayout();
@@ -256,6 +259,9 @@ export class GridCore {
                 // if user provided negative number, we still do the check every 5 seconds,
                 // in case the user turns the number positive again
                 this.frameworkFactory.setTimeout( () => {
+                    if (this.finished) {
+                        return;
+                    }
                     this.periodicallyDoLayout();
                 }, 5000);
             }

--- a/src/ts/rendering/rowRenderer.ts
+++ b/src/ts/rendering/rowRenderer.ts
@@ -427,6 +427,12 @@ export class RowRenderer extends BeanStub {
 
         let rowIndexesToRemove = Object.keys(this.rowCompsByIndex);
         this.removeRowComps(rowIndexesToRemove);
+        this.floatingTopRowComps.forEach( rowComp => {
+            rowComp.destroy();
+        });
+        this.floatingBottomRowComps.forEach( rowComp => {
+            rowComp.destroy();
+        });
     }
 
     private binRowComps(recycleRows: boolean): {[key: string]: RowComp} {


### PR DESCRIPTION
Full width cell renderer of pinned rows is not removed after grid is destroyed.