### PR TITLE
Fix onTouchUp bug in DragService

### DIFF
--- a/dist/lib/dragAndDrop/dragService.js
+++ b/dist/lib/dragAndDrop/dragService.js
@@ -204,7 +204,7 @@ var DragService = (function () {
         this.onCommonMove(mouseEvent, this.mouseStartEvent);
     };
     DragService.prototype.onTouchUp = function (touchEvent) {
-        var touch = this.getFirstActiveTouch(touchEvent.changedTouches);
+        var touch = this.getFirstActiveTouch(touchEvent.targetTouches);
         // i haven't worked this out yet, but there is no matching touch
         // when we get the touch up event. to get around this, we swap in
         // the last touch. this is a hack to 'get it working' while we

--- a/dist/lib/dragAndDrop/dragService.js
+++ b/dist/lib/dragAndDrop/dragService.js
@@ -204,7 +204,7 @@ var DragService = (function () {
         this.onCommonMove(mouseEvent, this.mouseStartEvent);
     };
     DragService.prototype.onTouchUp = function (touchEvent) {
-        var touch = this.getFirstActiveTouch(touchEvent.targetTouches);
+        var touch = this.getFirstActiveTouch(touchEvent.changedTouches);
         // i haven't worked this out yet, but there is no matching touch
         // when we get the touch up event. to get around this, we swap in
         // the last touch. this is a hack to 'get it working' while we

--- a/src/ts/dragAndDrop/dragService.ts
+++ b/src/ts/dragAndDrop/dragService.ts
@@ -241,7 +241,7 @@ export class DragService {
     }
 
     public onTouchUp(touchEvent: TouchEvent): void {
-        let touch = this.getFirstActiveTouch(touchEvent.targetTouches);
+        let touch = this.getFirstActiveTouch(touchEvent.changedTouches);
 
         // i haven't worked this out yet, but there is no matching touch
         // when we get the touch up event. to get around this, we swap in


### PR DESCRIPTION
`onTouchUp` will call the `getFirstActiveTouch` with `touchEvent.targetTouches`, which is an empty `TouchList`, and will default to assigning `touch = this.touchLastTime`. This is problematic because using the `onRowDragEnd` prop in React, if trying to save the row position using the `TouchEvent` data, the data corresponds to the `touchLastTime` data instead of where the last touch event occurred.

This makes use of `changedTouches`, which does include the last touch event.