### PR TITLE
Pass groupSelectsFiltered param when selecting child nodes

### DIFF
--- a/src/ts/entities/rowNode.ts
+++ b/src/ts/entities/rowNode.ts
@@ -750,7 +750,8 @@ export class RowNode implements IEventEmitter {
                 updatedCount += children[i].setSelectedParams({
                     newValue: newValue,
                     clearSelection: false,
-                    tailingNodeInSequence: true
+                    tailingNodeInSequence: true,
+                    groupSelectsFiltered: groupSelectsFiltered
                 });
         }
         return updatedCount;


### PR DESCRIPTION
Fixed a bug with groupSelectsFiltered where selecting a row with child nodes does not properly select only filtered nodes.
https://github.com/ag-grid/ag-grid/issues/2373