### PR TITLE
Fixed SetFloatingFilter to skip keyboard input on readonly input

### DIFF
--- a/src/ts/filter/floatingFilter.ts
+++ b/src/ts/filter/floatingFilter.ts
@@ -292,10 +292,7 @@ export class SetFloatingFilterComp extends InputTextFloatingFilterComp<Serialize
 
     asParentModel(): SerializedSetFilter {
         if (this.eColumnFloatingFilter.value == null || this.eColumnFloatingFilter.value === '') {
-            return {
-                values: [],
-                filterType: 'set'
-            };
+            return null;
         }
         return {
             values: this.eColumnFloatingFilter.value.split(","),


### PR DESCRIPTION
Issue is reproduced on official demo https://www.ag-grid.com/javascript-grid-filter-set/
To reproduce it click on some readonly input in grid column header (Athlete, Country) and enter some letters. Grid will be cleared and if you open minifilter then all check there will be unchecked.  