### PR TITLE
Fix for issue #2435

### DIFF
--- a/packages/ag-grid/src/ts/filter/textFilter.ts
+++ b/packages/ag-grid/src/ts/filter/textFilter.ts
@@ -147,7 +147,7 @@ export class TextFilter extends ComparableBaseFilter <string, ITextFilterParams,
 
     private checkIndividualFilter (params: IDoesFilterPassParams, filterType:string, filterText: string) {
         let value = this.filterParams.valueGetter(params.node);
-        if (!value) {
+        if (value === undefined || value === null) {
             return filterType === BaseFilter.NOT_EQUAL || filterType === BaseFilter.NOT_CONTAINS;
         }
         let valueFormatted: string = this.formatter(value);


### PR DESCRIPTION
Restrict automatic pass/faill of TextFilter to `null` and `undefined`, instead of all falsy values. Typically useful for number `0` to match string `"0"`.