### PR TITLE
Update cellComp.ts for tooltip issue #2505

### DIFF
--- a/packages/ag-grid/src/ts/rendering/cellComp.ts
+++ b/packages/ag-grid/src/ts/rendering/cellComp.ts
@@ -148,7 +148,7 @@ export class CellComp extends Component {
         templateParts.push(` comp-id="${this.getCompId()}" `);
         templateParts.push(` col-id="${colIdSanitised}"`);
         templateParts.push(` class="${cssClasses.join(' ')}"`);
-        templateParts.push(tooltipSanitised ? ` title="${tooltipSanitised}"` : ``);
+        templateParts.push( (tooltipSanitised || tooltipSanitised === this.tooltip) ? ` title="${tooltipSanitised}"` : ``);
         templateParts.push(` style="width: ${width}px; left: ${left}px; ${stylesFromColDef} ${stylesForRowSpanning}" >`);
         templateParts.push(wrapperStartTemplate);
         templateParts.push(valueSanitised);


### PR DESCRIPTION
Fixes #2505 

When the data for the cell is `0` or `false`, the `tooltipSanitised = _.escape(tooltip)` sets `0` or `false` as tooltip.  
Hence, 

    templateParts.push(  tooltipSanitised ? ` title="${tooltipSanitised}"` : ``);

statement doesn't push any tooltip for `templateParts`. If we add   

    tooltipSanitised || (tooltipSanitised === tooltip)

condition, then it will push the data as well.

- it is not causing any performance harm - it will only check the second condition if the tooltip is not sanitised and if both values are same (which will be there in case of `0` or `false`)