### PR TITLE
Added columnBuffer with same functionality as rowBuffer

### DIFF
--- a/packages/ag-grid/src/ts/columnController/columnController.ts
+++ b/packages/ag-grid/src/ts/columnController/columnController.ts
@@ -531,13 +531,13 @@ export class ColumnController {
         let emptySpaceBeforeColumn = (col: Column) => col.getLeft() > this.viewportLeft;
 
         // if doing column virtualisation, then we filter based on the viewport.
-        let filterCallback = this.suppressColumnVirtualisation ? null : this.isColumnInViewportorBuffer.bind(this);
+        let filterCallback = this.suppressColumnVirtualisation ? null : this.isColumnInViewportOrBuffer.bind(this);
 
         return this.getDisplayedColumnsForRow(rowNode, this.displayedCenterColumns,
             filterCallback, emptySpaceBeforeColumn);
     }
 
-    private isColumnInViewportorBuffer(col: Column): boolean {
+    private isColumnInViewportOrBuffer(col: Column): boolean {
         let columnBuffer = this.gridOptionsWrapper.getColumnBuffer();
 
         let columnLeft = col.getLeft();
@@ -2422,7 +2422,7 @@ export class ColumnController {
     }
 
     private filterOutColumnsWithinViewport(): Column[] {
-        return _.filter(this.displayedCenterColumns, this.isColumnInViewportorBuffer.bind(this));
+        return _.filter(this.displayedCenterColumns, this.isColumnInViewportOrBuffer.bind(this));
     }
 
     // called from api

--- a/packages/ag-grid/src/ts/columnController/columnController.ts
+++ b/packages/ag-grid/src/ts/columnController/columnController.ts
@@ -538,10 +538,12 @@ export class ColumnController {
     }
 
     private isColumnInViewport(col: Column): boolean {
+        let columnBuffer = this.gridOptionsWrapper.getColumnBuffer();
+
         let columnLeft = col.getLeft();
         let columnRight = col.getLeft() + col.getActualWidth();
-        let columnToMuchLeft = columnLeft < this.viewportLeft && columnRight < this.viewportLeft;
-        let columnToMuchRight = columnLeft > this.viewportRight && columnRight > this.viewportRight;
+        let columnToMuchLeft = columnLeft < ( this.viewportLeft - columnBuffer ) && columnRight < ( this.viewportLeft - columnBuffer );
+        let columnToMuchRight = columnLeft > ( this.viewportRight + columnBuffer ) && columnRight > ( this.viewportRight + columnBuffer );
 
         return !columnToMuchLeft && !columnToMuchRight;
     }

--- a/packages/ag-grid/src/ts/columnController/columnController.ts
+++ b/packages/ag-grid/src/ts/columnController/columnController.ts
@@ -531,13 +531,13 @@ export class ColumnController {
         let emptySpaceBeforeColumn = (col: Column) => col.getLeft() > this.viewportLeft;
 
         // if doing column virtualisation, then we filter based on the viewport.
-        let filterCallback = this.suppressColumnVirtualisation ? null : this.isColumnInViewport.bind(this);
+        let filterCallback = this.suppressColumnVirtualisation ? null : this.isColumnInViewportorBuffer.bind(this);
 
         return this.getDisplayedColumnsForRow(rowNode, this.displayedCenterColumns,
             filterCallback, emptySpaceBeforeColumn);
     }
 
-    private isColumnInViewport(col: Column): boolean {
+    private isColumnInViewportorBuffer(col: Column): boolean {
         let columnBuffer = this.gridOptionsWrapper.getColumnBuffer();
 
         let columnLeft = col.getLeft();
@@ -2422,7 +2422,7 @@ export class ColumnController {
     }
 
     private filterOutColumnsWithinViewport(): Column[] {
-        return _.filter(this.displayedCenterColumns, this.isColumnInViewport.bind(this));
+        return _.filter(this.displayedCenterColumns, this.isColumnInViewportorBuffer.bind(this));
     }
 
     // called from api

--- a/packages/ag-grid/src/ts/constants.ts
+++ b/packages/ag-grid/src/ts/constants.ts
@@ -8,6 +8,7 @@ export class Constants {
     static STEP_PIVOT = 5;
 
     static ROW_BUFFER_SIZE = 10;
+    static COL_BUFFER_SIZE = 0;
     static LAYOUT_INTERVAL = 500;
     static BATCH_WAIT_MILLIS = 50;
 
@@ -54,4 +55,3 @@ export class Constants {
     static PINNED_BOTTOM = 'bottom';
 
 }
-

--- a/packages/ag-grid/src/ts/entities/gridOptions.ts
+++ b/packages/ag-grid/src/ts/entities/gridOptions.ts
@@ -106,6 +106,7 @@ export interface GridOptions {
     suppressTabbing?: boolean;
     unSortIcon?: boolean;
     rowBuffer?: number;
+    columnBuffer? :number;
     enableRtl?: boolean;
     enableColResize?: boolean;
     colResizeDefault?: string;

--- a/packages/ag-grid/src/ts/gridOptionsWrapper.ts
+++ b/packages/ag-grid/src/ts/gridOptionsWrapper.ts
@@ -632,6 +632,17 @@ export class GridOptionsWrapper {
         }
     }
 
+    public getColumnBuffer() {
+      if (typeof this.gridOptions.columnBuffer === 'number') {
+        if (this.gridOptions.columnBuffer < 0) {
+          console.warn('ag-Grid: columnBuffer should not be negative')
+        }
+        return this.gridOptions.columnBuffer;
+      } else {
+        return Constants.COL_BUFFER_SIZE;
+      }
+    }
+
     public getRowBuffer() {
         if (typeof this.gridOptions.rowBuffer === 'number') {
             if (this.gridOptions.rowBuffer < 0) {


### PR DESCRIPTION
Hello,
As we need to use ag-grid in internet explorer we have poor performance when vertical scrolling is done. As a solution I added a configurable columnBuffer just like rowBuffer (https://www.ag-grid.com/javascript-grid-properties/#miscellaneous). 

It can be set in the grid's options and is passed as a number in pixels how far to the left and right columns are drawn outside the viewport.