### PR TITLE
Reverted changes that caused deprecation warning

### DIFF
--- a/packages/ag-grid/dist/lib/resizeObserver.js
+++ b/packages/ag-grid/dist/lib/resizeObserver.js
@@ -51,6 +51,7 @@ var throttle = function (callback, delay) {
     return proxy;
 };
 var REFRESH_DELAY = 20;
+var mutationObserverSupported = typeof MutationObserver !== "undefined";
 var getWindowOf = function (target) {
     var ownerGlobal = target && target.ownerDocument && target.ownerDocument.defaultView;
     return ownerGlobal || window;
@@ -184,8 +185,19 @@ var ResizeObserverController = (function () {
             return;
         }
         window.addEventListener("resize", this.refresh);
-        document.addEventListener("DOMSubtreeModified", this.refresh);
-        this.mutationEventsAdded_ = true;
+        if (mutationObserverSupported) {
+            this.mutationsObserver_ = new MutationObserver(this.refresh);
+            this.mutationsObserver_.observe(document, {
+                attributes: true,
+                childList: true,
+                characterData: true,
+                subtree: true
+            });
+        }
+        else {
+            document.addEventListener("DOMSubtreeModified", this.refresh);
+            this.mutationEventsAdded_ = true;
+        }
         this.connected_ = true;
     };
     ResizeObserverController.prototype.disconnect_ = function () {

--- a/packages/ag-grid/src/ts/resizeObserver.ts
+++ b/packages/ag-grid/src/ts/resizeObserver.ts
@@ -56,6 +56,8 @@ let throttle = function(callback: ()=>void, delay: number) {
 
 let REFRESH_DELAY = 20;
 
+let mutationObserverSupported = typeof MutationObserver !== "undefined";
+
 let getWindowOf = function(target: HTMLElement) {
     let ownerGlobal = target && target.ownerDocument && target.ownerDocument.defaultView;
 
@@ -236,8 +238,20 @@ class ResizeObserverController {
 
         window.addEventListener("resize", this.refresh);
 
-        document.addEventListener("DOMSubtreeModified", this.refresh);
-        this.mutationEventsAdded_ = true;
+        if (mutationObserverSupported) {
+            this.mutationsObserver_ = new MutationObserver(this.refresh);
+
+            this.mutationsObserver_.observe(document, {
+                attributes: true,
+                childList: true,
+                characterData: true,
+                subtree: true
+            });
+        } else {
+            document.addEventListener("DOMSubtreeModified", this.refresh);
+
+            this.mutationEventsAdded_ = true;
+        }
 
         this.connected_ = true;
     }


### PR DESCRIPTION
MutationObserver use in resizeObserver has been removed in release 18.1.2. which caused "Use of Mutation Events is deprecated. Use MutationObserver instead." for DOMSubtreeModified event listener. 
This PR reverts those changes.