### PR TITLE
Utils.isBrowserSafari p undefined issue #2649

### DIFF
--- a/dist/lib/utils.js
+++ b/dist/lib/utils.js
@@ -1000,7 +1000,7 @@ var Utils = /** @class */ (function () {
             // taken from https://github.com/ag-grid/ag-grid/issues/550
             this.isSafari = Object.prototype.toString.call(anyWindow.HTMLElement).indexOf('Constructor') > 0
                 || (function (p) {
-                    return p.toString() === "[object SafariRemoteNotification]";
+                    return p?p.toString() === "[object SafariRemoteNotification]":false;  
                 })(!anyWindow.safari || anyWindow.safari.pushNotification);
         }
         return this.isSafari;


### PR DESCRIPTION
Since p sometimes return undefined and tries to convert it into string 

https://github.com/ag-grid/ag-grid/blob/master/dist/lib/utils.js#L1003

added condition before tries to do p.toString()
