### PR TITLE
Typing Fix

### DIFF
--- a/dist/lib/exporter/xmlFactory.d.ts
+++ b/dist/lib/exporter/xmlFactory.d.ts
@@ -13,7 +13,7 @@ export interface XmlElement {
     textNode?: string;
 }
 export interface HeaderElement {
-    [key: string]: string;
+    [key: string]: string | undefined;
     version?: string;
     standalone?: string;
     encoding?: string;


### PR DESCRIPTION
Optional interface elements are blocking TypeScript compilation, string or undefined is not assignable to string index type string.