### PR TITLE
Fix compilation with latest typescript

### DIFF
--- a/packages/ag-grid-enterprise/src/setFilter/setFilterListItem.ts
+++ b/packages/ag-grid-enterprise/src/setFilter/setFilterListItem.ts
@@ -79,8 +79,8 @@ export class SetFilterListItem extends Component {
 
     private updateCheckboxIcon() {
         if (this.eCheckbox.children) {
-            for (let i=0; i<this.eCheckbox.children.length; i++) {
-                this.eCheckbox.removeChild(this.eCheckbox.children.item(i));
+            while (this.eCheckbox.lastChild) {
+                this.eCheckbox.removeChild(this.eCheckbox.lastChild);
             }
         }
 


### PR DESCRIPTION
With typescript 3.1.6, the previous code failed to compile with:

_ERROR in [at-loader] ./src/client/widgets/grid/set_filter/setFilterListItem.ts:83:44
    TS2345: Argument of type 'Element | null' is not assignable to parameter of type 'Node'.
  Type 'null' is not assignable to type 'Node'._