### PR TITLE
Fix typo in row spanning documentation

### DIFF
--- a/packages/ag-grid-docs/src/javascript-grid-row-spanning/index.php
+++ b/packages/ag-grid-docs/src/javascript-grid-row-spanning/index.php
@@ -80,7 +80,7 @@ interface RowSpanParams {
 
     <ul class="content">
         <li>
-            The athlete column is configured to span 2 rows for 'Aleksey Nemov' and 3 rows
+            The athlete column is configured to span 2 rows for 'Aleksey Nemov' and 4 rows
             for 'Ryan Lochte'.
         </li>
         <li>


### PR DESCRIPTION
Row spanning documentation refers to 3 rows in one instance where example code applies to 4 rows.