### PR TITLE
Update selectCellEditor to parse value

### DIFF
--- a/packages/ag-grid-community/src/ts/rendering/cellEditors/selectCellEditor.ts
+++ b/packages/ag-grid-community/src/ts/rendering/cellEditors/selectCellEditor.ts
@@ -14,6 +14,7 @@ export class SelectCellEditor extends Component implements ICellEditorComp {
 
     private focusAfterAttached: boolean;
     private eSelect: HTMLSelectElement;
+    private params: ICellEditorParams;
 
     @Autowired('gridOptionsWrapper') private gridOptionsWrapper: GridOptionsWrapper;
     @Autowired('valueFormatterService') private valueFormatterService: ValueFormatterService;
@@ -24,6 +25,8 @@ export class SelectCellEditor extends Component implements ICellEditorComp {
     }
 
     public init(params: ISelectCellEditorParams) {
+
+        this.params = params;
         this.focusAfterAttached = params.cellStartedEdit;
 
         if (_.missing(params.values)) {
@@ -74,6 +77,6 @@ export class SelectCellEditor extends Component implements ICellEditorComp {
     }
 
     public getValue(): any {
-        return this.eSelect.value;
+        return this.params.parseValue(this.eSelect.value);
     }
 }


### PR DESCRIPTION
selectCellEditor is not using the valueparser at the moment, which means it's not possible to use it for non-string types (e.g. numbers). This updates the getValue function to parse the value using the column's valueparser, consistent with the other editors.