### PR TITLE
fix(agGridReact): implement portals in the same tree to fix context support

### DIFF
--- a/packages/ag-grid-react/src/agReactComponent.ts
+++ b/packages/ag-grid-react/src/agReactComponent.ts
@@ -83,13 +83,6 @@ export class AgReactComponent {
     }
 
     private createReactComponent(params: any, resolve: (value: any) => void) {
-        // when using portals & redux with HOCs you need to manually add the store to the props
-        // wrapping the component with connect isn't sufficient
-        const {reduxStore} = params.agGridReact.props;
-        if (reduxStore) {
-            params.store = reduxStore;
-        }
-
         // grab hold of the actual instance created - we use a react ref for this as there is no other mechanism to
         // retrieve the created instance from either createPortal or render
         params.ref = element => {

--- a/packages/ag-grid-react/src/agReactComponent.ts
+++ b/packages/ag-grid-react/src/agReactComponent.ts
@@ -12,6 +12,7 @@ export class AgReactComponent {
 
     private reactComponent: any;
     private parentComponent: AgGridReact;
+    private portal: ReactPortal;
 
     constructor(reactComponent: any, parentComponent?: AgGridReact) {
         this.reactComponent = reactComponent;
@@ -55,6 +56,9 @@ export class AgReactComponent {
     }
 
     public destroy(): void {
+        if (!this.useLegacyReact()) {
+            return this.parentComponent.destroyPortal(this.portal);
+        }
         ReactDOM.unmountComponentAtNode(this.eParentElement);
     }
 
@@ -97,10 +101,7 @@ export class AgReactComponent {
             ReactComponent,
             this.eParentElement
         );
-
-        // MUST be a function, not an arrow function
-        ReactDOM.render(<any>portal, this.eParentElement, function() {
-            resolve(null);
-        });
+        this.portal = portal;
+        this.parentComponent.mountReactPortal(portal, resolve);
     }
 }


### PR DESCRIPTION
Closes #2838 

This PR fixes the usage of `reactNext` by implementing all the portals as children of `<AgGridReact />`, and by doing so, this will make Ag-Grid work with React 16.3 Context. 

Any component under `*framework` in react will still render in its the spot the user desires due to portals.

---
**Some tests of this PR that I am going through* 
- [x] destroy needs to tell parent to unmount and update - Fixed - added a batch updater mechanism
- [x] unmountComponentAtNode - since the parent component is now rendering the element, there is no need to do unmountComponentAtNode - the table will handle it


