### PR TITLE
correctly type getValueCallback field to accept Columns

### DIFF
--- a/packages/ag-grid-community/src/ts/valueService/valueService.ts
+++ b/packages/ag-grid-community/src/ts/valueService/valueService.ts
@@ -221,7 +221,7 @@ export class ValueService {
         return result;
     }
 
-    private getValueCallback(node: RowNode, field: string): any {
+    private getValueCallback(node: RowNode, field: string | Column): any {
         let otherColumn = this.columnController.getPrimaryColumn(field);
         if (otherColumn) {
             return this.getValue(otherColumn, node);


### PR DESCRIPTION
`ColumnController.getPrimaryColumn` takes `string | Column` as its key, so `ValueService.getValueCallback` can take the same as field.