### PR TITLE
Custom Theme Support for Vanilla Libraries

### DIFF
--- a/how-to-theme.md
+++ b/how-to-theme.md
@@ -1,0 +1,14 @@
+1. Open packages/ag-grid-community/src/styles
+1. Create a new folder called "your-custom-theme"
+1. Created the required subfolders, icons, resources, sass, vars (It may be useful to copy one of the existing themes to use as a base)
+1. Create any needed files:
+    - sass/your-custom-theme.scss - contains the main class for your theme as well as any custom styles you want to use
+    - vars/\_your-custom-theme-vars.scss - contains variables that will be used throughout your theme, primarily sizing and colors
+    - icons/ - svgs for all icons need, this is optional as you can simply point to one of the existing icons sets using the icons-path variable in your vars file.
+    - resources/ - extra sass files that are need for some themes (such as material)
+1. Add a require to packages/ag-grid-community/main-with-styles.js for your custom theme. The path for this should be './dist/styles/your-custom-theme-main-class.css'
+1. Replace 'your-custom-theme-main-class' to the customThemes array at the top of packages/ag-grid-community/src/ts/environment.ts (You can replace the sring 'your-custom-theme' that is already in the array with anything else)
+1. If compiling for the enterprise version add a require to packages/ag-grid-enterprise/webpack-with-styles.js for your custom theme. The path for this should be 'ag-grid-community/dist/styles/your-custom-theme-main-class.css'
+1. Build everything by running one of the following:
+    - npm run-script buildEnterprise - this will build the community and enterprise while making sure to include the theme you added by copying the compiled community version to ag-grid-enterprise's node_modules
+    - npm run-script buildVanilla - this will build the community and enterprise versions without copying the community changes over

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "build": "lerna run build",
     "buildCore": "lerna run build --scope ag-grid-community --scope ag-grid-enterprise --scope ag-grid-angular --scope ag-grid-react --scope ag-grid-vue --scope ag-grid-aurelia",
     "buildVanilla": "lerna run build --scope ag-grid-community --scope ag-grid-enterprise",
+    "buildEnterprise": "sh ./scripts/buildEnterprise.sh",
     "buildAngular": "lerna run build --scope ag-grid-community --scope ag-grid-angular",
     "buildVue": "lerna run build --scope ag-grid-community --scope ag-grid-vue",
     "buildReact": "lerna run build --scope ag-grid-community --scope ag-grid-react",

--- a/packages/ag-grid-community/src/ts/environment.ts
+++ b/packages/ag-grid-community/src/ts/environment.ts
@@ -1,9 +1,10 @@
 import { Bean, Autowired } from './context/context';
 import { _ } from "./utils";
 
+let customThemes = ["your-custom-theme"];
 const themeNames = ['fresh', 'dark', 'blue', 'bootstrap', 'material', 'balham-dark', 'balham'];
 const themes = themeNames.concat(themeNames.map(name => `theme-${name}`));
-const themeClass = new RegExp(`ag-(${themes.join('|')})`);
+const themeClass = new RegExp(`ag-(${themes.join("|")})|${customThemes.join("|")}`);
 
 const matGridSize = 8;
 interface HardCodedSize {

--- a/packages/ag-grid-community/src/ts/filter/baseFilter.ts
+++ b/packages/ag-grid-community/src/ts/filter/baseFilter.ts
@@ -404,7 +404,7 @@ export abstract class ComparableBaseFilter<T, P extends IComparableFilterParams,
 
         return optionsHtml.length <= 0 ?
             '' :
-            `<div>
+            `<div class="ag-filter-select-wrapper">
                 <select class="ag-filter-select" id="${id}" ${readOnly}>
                     ${optionsHtml.join('')}
                 </select>

--- a/scripts/buildEnterprise.sh
+++ b/scripts/buildEnterprise.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+lerna run build --scope ag-grid-community 
+rsync -av --exclude='packages/ag-grid-enterprise/node_modules/ag-grid-community/node_modules/.cache' packages/ag-grid-community packages/ag-grid-enterprise/node_modules
+lerna run build --scope ag-grid-enterprise


### PR DESCRIPTION
I've spent some time recently figuring out how to add my own custom theme to ag-grid so that I can use it with angularJS instead of overriding one of the existing themes. This only works for community and enterprise editions at the moment as I haven't spent time on the others. 

This pull request contains the minor changes necessary in order to do this along with a document (how-to-theme.md) with a basic description of the process for doing so. The document should probably be fleshed out a bit and added to the officially documentation if support for this is approved.

Additionally I added a script which properly pushes changes made in the community edition over to the enterprise edition as the buildVanilla script doesn't seem to do this. It just copies the packages/ag-grid-community folder to the node_modules folder of ag-grid-enterprise. This seems to be necessary for changes to actually go through to the compiled dist but I could be wrong.