### PR TITLE
fix(cell-stop-editing): add try-catch to prevent node.removeChild error from breaking the grid in Chrome

### DIFF
--- a/packages/ag-grid-community/src/ts/utils.ts
+++ b/packages/ag-grid-community/src/ts/utils.ts
@@ -611,7 +611,11 @@ export class Utils {
     static removeAllChildren(node: HTMLElement) {
         if (node) {
             while (node.hasChildNodes() && node.lastChild) {
-                node.removeChild(node.lastChild);
+                try {
+                    node.removeChild(node.lastChild);
+                } catch (e) {
+                    return;
+                }
             }
         }
     }


### PR DESCRIPTION
Context: `stopEditingWhenGridLosesFocus: true`, more than 1 column with custom cellRenderer and keyboard navigation cause `Failed to execute 'removeChild' on 'Node'` error.

Environment: Angular 7.1.4 | Aggrid 20.0.0 | Chrome (IE is fine)


![image](https://user-images.githubusercontent.com/46801674/51363416-ef122c00-1b2b-11e9-8868-8533ded87b7f.png)
