### PR TITLE
Add the api param to NavigateToNextCellParams

### DIFF
--- a/dist/lib/entities/gridOptions.d.ts
+++ b/dist/lib/entities/gridOptions.d.ts
@@ -450,6 +450,7 @@ export interface NavigateToNextCellParams {
     previousCellDef: GridCellDef;
     nextCellDef: GridCellDef;
     event: KeyboardEvent;
+    api: GridApi;
 }
 export interface TabToNextCellParams {
     backwards: boolean;

--- a/packages/ag-grid-community/dist/lib/entities/gridOptions.d.ts
+++ b/packages/ag-grid-community/dist/lib/entities/gridOptions.d.ts
@@ -450,6 +450,7 @@ export interface NavigateToNextCellParams {
     previousCellDef: GridCellDef;
     nextCellDef: GridCellDef;
     event: KeyboardEvent;
+    api: GridApi;
 }
 export interface TabToNextCellParams {
     backwards: boolean;

--- a/packages/ag-grid-community/src/ts/entities/gridOptions.ts
+++ b/packages/ag-grid-community/src/ts/entities/gridOptions.ts
@@ -614,6 +614,7 @@ export interface NavigateToNextCellParams {
     previousCellDef: GridCellDef;
     nextCellDef: GridCellDef;
     event: KeyboardEvent;
+    api: GridApi;
 }
 
 export interface TabToNextCellParams {

--- a/packages/ag-grid-community/src/ts/rendering/rowRenderer.ts
+++ b/packages/ag-grid-community/src/ts/rendering/rowRenderer.ts
@@ -967,7 +967,8 @@ export class RowRenderer extends BeanStub {
                     key: key,
                     previousCellDef: previousCell,
                     nextCellDef: nextCell ? nextCell.getGridCellDef() : null,
-                    event: event
+                    event: event,
+                    api: this.gridApi
                 } as NavigateToNextCellParams;
                 const nextCellDef = userFunc(params);
                 if (_.exists(nextCellDef)) {

--- a/packages/ag-grid-docs/src/javascript-grid-keyboard-navigation/index.php
+++ b/packages/ag-grid-docs/src/javascript-grid-keyboard-navigation/index.php
@@ -105,6 +105,12 @@ interface NavigateToNextCellParams {
 
     // the cell the grid would normally pick as the next cell for this navigation
     nextCellDef: GridCellDef;
+ 
+    // the keyboard event the grid received
+    event: KeyboardEvent;
+
+    // the grid API of the detail grid
+    api: GridApi;
 }</snippet>
 
     <h2><code>tabToNextCell</code></h2>


### PR DESCRIPTION
Hi ag-grid team, I use your table in my project and params of the method `navigateToNextCell` are not convenient for me. I need to access the grid api somehow, so I need to cash it somewhere.

In the pull request I've added the grid api to `NavigateToNextCellParams` and after it using the method `navigateToNextCell` became easier. Also, your grid has a similar approach in other places, like `GetMainMenuItemsParams`, `ProcessRowParams`.