### PR TITLE
Fix check IComponent impl for no func definition

### DIFF
--- a/packages/ag-grid-community/src/ts/components/framework/agComponentUtils.ts
+++ b/packages/ag-grid-community/src/ts/components/framework/agComponentUtils.ts
@@ -65,6 +65,6 @@ export class AgComponentUtils {
 
     public doesImplementIComponent(candidate: AgGridRegisteredComponentInput<IComponent<any>>): boolean {
         if (!candidate) { return false; }
-        return (candidate as any).prototype && 'getGui' in (candidate as any).prototype;
+        return 'getGui' in (candidate as any) || (candidate as any).prototype && 'getGui' in (candidate as any).prototype;
     }
 }


### PR DESCRIPTION
if create es6 class or object-literal component, prototype has no getGui.
```
class DetailCellRenderer  {
	...
	public getGui(): HTMLElement {}
}
agComponentUtils.doesImplementIComponent(DetailCellRenderer) // false is wrong
```
but
```
class IComponent {
	public getGui(): HTMLElement {}
}
class DetailCellRenderer extends IComponent  {
	...
}
agComponentUtils.doesImplementIComponent(DetailCellRenderer) // true
```