### PR TITLE
Delete orphaned nodes from allNodesMap in NodeManager

### DIFF
--- a/packages/ag-grid-community/src/ts/rowModels/clientSide/clientSideNodeManager.ts
+++ b/packages/ag-grid-community/src/ts/rowModels/clientSide/clientSideNodeManager.ts
@@ -233,7 +233,7 @@ export class ClientSideNodeManager {
             rowNode.clearRowTop();
 
             _.removeFromArray(this.rootNode.allLeafChildren, rowNode);
-            this.allNodesMap[rowNode.id] = undefined;
+            delete this.allNodesMap[rowNode.id];
         }
     }
 

--- a/packages/ag-grid-community/src/ts/rowModels/clientSide/immutableService.ts
+++ b/packages/ag-grid-community/src/ts/rowModels/clientSide/immutableService.ts
@@ -42,7 +42,7 @@ export class ImmutableService {
             add: []
         };
 
-        const existingNodesMap: { [id: string]: RowNode | undefined } = this.clientSideRowModel.getCopyOfNodesMap();
+        const existingNodesMap: { [id: string]: RowNode } = this.clientSideRowModel.getCopyOfNodesMap();
 
         const orderMap: { [id: string]: number } = {};
 


### PR DESCRIPTION
When using `deltaRowDataMode=true`, and streaming row updates of 1000+ rows with unique IDs every ~250ms, performance gets gradually worse (and the grid eventually becomes unusable) as `ClientSideNodeManager.getCopyOfNodesMap()` performs a clone of the nodes map on every update, taking several 100ms to do so whenever the map has 100k+ orphaned entries all set to `undefined`:
```typescript
    public getCopyOfNodesMap(): {[id:string]: RowNode} {
        const result: {[id:string]: RowNode} = _.cloneObject(this.allNodesMap);
        return result;
    }
```

I don't see anywhere in the codebase that relies on the keys being set on the object (i.e. `for`/`in`/`hasOwnProperty`/`Object.keys`), so an immediate delete should do the same as setting the item to `undefined`, while fixing the performance issue with the cloning.

Example benchmark: https://repl.it/@stefanruijsenaars/MediumTurbulentFirm