### PR TITLE
React - Fix bug where ag grid treats rowData like it's changed when it hasn't with deltaRowDataMode

### DIFF
--- a/packages/ag-grid-react/src/agGridReact.ts
+++ b/packages/ag-grid-react/src/agGridReact.ts
@@ -119,7 +119,7 @@ export class AgGridReact extends React.Component<AgGridReactProps, {}> {
         const changedKeys = Object.keys(nextProps);
         changedKeys.forEach((propKey) => {
             if (AgGrid.ComponentUtil.ALL_PROPERTIES.indexOf(propKey) !== -1) {
-                if (this.skipPropertyCheck(propKey) ||
+                if (this.skipPropertyCheck(propKey, nextProps) ||
                     !this.areEquivalent(this.props[propKey], nextProps[propKey])) {
 
                     if (debugLogging) {
@@ -149,8 +149,8 @@ export class AgGridReact extends React.Component<AgGridReactProps, {}> {
         AgGrid.ComponentUtil.processOnChange(changes, this.gridOptions, this.api, this.columnApi);
     }
 
-    private skipPropertyCheck(propKey) {
-        return this.props['deltaRowDataMode'] && propKey === 'rowData';
+    private skipPropertyCheck(propKey, nextProps) {
+        return this.props['deltaRowDataMode'] && propKey === 'rowData' && this.props.rowData === nextProps.rowData;
     }
 
     componentWillUnmount() {


### PR DESCRIPTION
Don't always treat rowData like it's changed just because deltaRowDataMode is on.

I'm just submitting this for review...why wouldn't this work? Seems pretty quick and easy and would prevent undesirable side effects like firing 'onRowDataUpdated' even when the rowData prop has not changed. It skips the expensive 'areEquivalent' check, which my guess was the cause of the performance issues. I think the risk of this introducing issues should be low since rowData has to be immutable when using deltaRowDataMode anyway.

Please note, I have not tested this, as I'm not currently familiar with AgGrid's build process etc. I'd be willing to build and test it though if you have some tests for the performance issues so I can make sure this doesn't introduce regressions, since the reason for the original skipPropertyCheck method being added was to address performance issues with deltaRowDataMode and React.