### PR TITLE
fix ag-grid-react main.d.ts

### DIFF
--- a/packages/ag-grid-react/main.d.ts
+++ b/packages/ag-grid-react/main.d.ts
@@ -4,24 +4,19 @@ export * from './lib/agGridColumn';
 import {AgGridReactProps} from "./lib/agGridReact";
 import {AgGridColumnProps, AgGridColumnGroupProps} from "./lib/agGridColumn";
 import {Component} from "react";
-declare module "ag-grid-react" {
-    export class AgGridReact extends Component<AgGridReactProps, {}> {
-    }
-    export class AgGridColumn extends Component<AgGridColumnProps | AgGridColumnGroupProps, {}> {
-    }
 
-    export {ICellEditorReactComp} from './lib/interfaces';
-    export {AgReactFrameworkComponent}  from './lib/interfaces';
-    export {IHeaderGroupReactComp }  from './lib/interfaces';
-    export {IHeaderReactComp }  from './lib/interfaces';
-    export {IDateReactComp }  from './lib/interfaces';
-    export {IFilterReactComp }  from './lib/interfaces';
-    export {ICellRendererReactComp }  from './lib/interfaces';
-    export {ILoadingCellRendererReactComp }  from './lib/interfaces';
-    export {ILoadingOverlayReactComp }  from './lib/interfaces';
-    export {INoRowsOverlayReactComp }  from './lib/interfaces';
-    export {IStatusPanelReactComp }  from './lib/interfaces';
-    export {IToolPanelReactComp }  from './lib/interfaces';
-}
+export declare class AgGridReact extends Component<AgGridReactProps, {}> {}
+export declare class AgGridColumn extends Component<AgGridColumnProps | AgGridColumnGroupProps, {}> {}
 
-
+export {ICellEditorReactComp} from './lib/interfaces';
+export {AgReactFrameworkComponent} from './lib/interfaces';
+export {IHeaderGroupReactComp} from './lib/interfaces';
+export {IHeaderReactComp} from './lib/interfaces';
+export {IDateReactComp} from './lib/interfaces';
+export {IFilterReactComp} from './lib/interfaces';
+export {ICellRendererReactComp} from './lib/interfaces';
+export {ILoadingCellRendererReactComp} from './lib/interfaces';
+export {ILoadingOverlayReactComp} from './lib/interfaces';
+export {INoRowsOverlayReactComp} from './lib/interfaces';
+export {IStatusPanelReactComp} from './lib/interfaces';
+export {IToolPanelReactComp} from './lib/interfaces';


### PR DESCRIPTION
After upgrading to the latest ag-grid I get the following type errors (using ts 3.3.1): 
```
node_modules/ag-grid-react/main.d.ts:13:5 - error TS2666: Exports and export assignments are not permitted in module augmentations.
13     export {ICellEditorReactComp} from './lib/interfaces';
       ~~~~~~
node_modules/ag-grid-react/main.d.ts:13:40 - error TS2307: Cannot find module './lib/interfaces'.
13     export {ICellEditorReactComp} from './lib/interfaces';
```
(error is repeated for each of the exports from lib/interfaces)

Removing the `declare module` fixes the issue. I don't think the declare is needed, there is nothing similar in any of the other packages.