### PR TITLE
Fix IE11 height issue

### DIFF
--- a/packages/ag-grid-community/src/styles/ag-grid.scss
+++ b/packages/ag-grid-community/src/styles/ag-grid.scss
@@ -138,7 +138,7 @@ $icons: aggregation arrows asc checkbox-checked-readonly checkbox-checked checkb
     flex-direction: row;
 
     &.ag-layout-normal {
-        flex: 1;
+        flex: 1 1 auto;
         overflow: hidden;
     }
 }


### PR DESCRIPTION
We noticed that in some cases, IE11 will not heed the flexbox rule that flexbox items do not shrink below
their minimum content size, and will use flex-basis instead. With `flex: 1;` flex-basis is set to 0%, which then leads to grids with a height of zero. Setting explicitly `flex: 1 1 auto;` as done previously for another element in https://github.com/ag-grid/ag-grid/commit/6bd222946c0d26a7a42a40f38bf4dff94bb3b30d works around this.

In our current project, we are successfully working around this issue with the following entry in our css:

```
.ag-root-wrapper-body.ag-layout-normal {
  flex: 1 1 auto;
}
```

We noticed that `flex: 1;` is used in 8 more files of ag-grid. We are not sure whether `1 1 auto;` is a good choice for them all, but maybe a short review would be a good idea.