### PR TITLE
fix isAutoRowHeightActive to respect only visible columns

### DIFF
--- a/packages/ag-grid-community/src/ts/columnController/columnController.ts
+++ b/packages/ag-grid-community/src/ts/columnController/columnController.ts
@@ -233,11 +233,11 @@ export class ColumnController {
     }
 
     public isAutoRowHeightActive(): boolean {
-        return this.autoRowHeightColumns && this.autoRowHeightColumns.length > 0;
+        return this.getAllVisibleAutoRowHeightCols().length > 0;
     }
 
-    public getAllAutoRowHeightCols(): Column[] {
-        return this.autoRowHeightColumns;
+    public getAllVisibleAutoRowHeightCols(): Column[] {
+        return this.autoRowHeightColumns ? this.autoRowHeightColumns.filter(col => col.isVisible()) : [];
     }
 
     private setVirtualViewportLeftAndRight(): void {

--- a/packages/ag-grid-community/src/ts/rendering/autoHeightCalculator.ts
+++ b/packages/ag-grid-community/src/ts/rendering/autoHeightCalculator.ts
@@ -37,10 +37,8 @@ export class AutoHeightCalculator {
         eBodyContainer.appendChild(this.eDummyContainer);
 
         const cellComps: CellComp[] = [];
-        const autoRowHeightCols = this.columnController.getAllAutoRowHeightCols();
-        const visibleAutoRowHeightCols = autoRowHeightCols.filter(col => col.isVisible());
-
-        visibleAutoRowHeightCols.forEach(col => {
+        const cols = this.columnController.getAllVisibleAutoRowHeightCols();
+        cols.forEach(col => {
             const cellComp = new CellComp(
                 this.$scope,
                 this.beans,


### PR DESCRIPTION
since 2c7400a7c819c27fc90991258c04ebd874d7573e the autoheight is calculated only with visible columns. with this PR isAutoHeightActive() respects this behaviour also.

Without this change, the height is set to `minRowHeight` instead of `rowHeight` in https://github.com/ag-grid/ag-grid/blob/334f9e1c9038c5486587dd8f9d25052d9875070e/packages/ag-grid-community/src/ts/gridOptionsWrapper.ts#L1536-L1546

I don't know if this has an effect on https://github.com/ag-grid/ag-grid/blob/334f9e1c9038c5486587dd8f9d25052d9875070e/packages/ag-grid-enterprise/src/rowModels/serverSide/serverSideRowModel.ts#L345-L349