### PR TITLE
Loosen type for refData

### DIFF
--- a/packages/ag-grid-community/dist/lib/entities/colDef.d.ts
+++ b/packages/ag-grid-community/dist/lib/entities/colDef.d.ts
@@ -270,7 +270,7 @@ export interface ColDef extends AbstractColDef {
     floatingFilterComponentParams?: any;
     floatingFilterComponentFramework?: any;
     refData?: {
-        [key: string]: string;
+        [key: string]: any;
     };
 }
 export interface IsColumnFunc {


### PR DESCRIPTION
As mentioned in https://github.com/ag-grid/ag-grid/issues/3053, properties of refData should not be restricted to strings. ag-grid's documentation shows examples of using arrays and other objects instead of strings (https://www.ag-grid.com/javascript-grid-reference-data/#example-reference-data-with-ref-data-prop).

Loosen the typing to match actual behavior.