### PR TITLE
Add the possibility to override odd-row-background-color with Material Theme

### DIFF
--- a/packages/ag-grid-community/src/styles/ag-theme-material/vars/_ag-theme-material-vars.scss
+++ b/packages/ag-grid-community/src/styles/ag-theme-material/vars/_ag-theme-material-vars.scss
@@ -59,6 +59,7 @@ $header-background-color: $background-color !default;
 $header-cell-hover-background-color: darken($header-background-color, 5%) !default;
 $header-cell-moving-background-color: $header-cell-hover-background-color !default;
 $header-foreground-color: $secondary-foreground-color !default;
+$odd-row-background-color : $background-color !default;
 
 $border-color: $mat-grey-300 !default;
 $primary-color: $mat-indigo-500 !default;
@@ -120,6 +121,7 @@ $params: (
     header-cell-hover-background-color: $header-cell-hover-background-color,
     header-cell-moving-background-color: $header-cell-moving-background-color,
     header-foreground-color: $header-foreground-color,
+    odd-row-background-color: $odd-row-background-color,
 
     focused-textbox-border: 2px solid $primary-color,
     input-bottom-border: 2px solid $border-color,


### PR DESCRIPTION
When we follow the sample on this page : https://www.ag-grid.com/react-getting-started/?utm_source=ag-grid-readme&utm_medium=repository&utm_campaign=github#customize-the-theme-look

We can't override **odd-row-background-color** with Material Theme.

odd-row-background-color isn't set in $params map variable used to init ag-grid-theme 
`@include ag-grid-theme($params)`