### PR TITLE
Replace React lifecycle hook "componentWillReceiveProps" with "componentDidUpdate"

### DIFF
--- a/packages/ag-grid-react/src/agGridReact.ts
+++ b/packages/ag-grid-react/src/agGridReact.ts
@@ -156,64 +156,64 @@ export class AgGridReact extends React.Component<AgGridReactProps, {}> {
         return ChangeDetectionStrategyType.DeepValueCheck;
     }
 
-    componentWillReceiveProps(nextProps: any) {
+    componentDidUpdate(prevProps: any) {
         const changes = <any>{};
 
-        this.extractGridPropertyChanges(nextProps, changes);
-        this.extractDeclarativeColDefChanges(nextProps, changes);
+        this.extractGridPropertyChanges(prevProps, changes);
+        this.extractDeclarativeColDefChanges(prevProps, changes);
 
         AgGrid.ComponentUtil.processOnChange(changes, this.gridOptions, this.api!, this.columnApi);
     }
 
-    private extractDeclarativeColDefChanges(nextProps: any, changes: any) {
-        let debugLogging = !!nextProps.debug;
+    private extractDeclarativeColDefChanges(prevProps: any, changes: any) {
+        let debugLogging = !!this.props.debug;
 
-        if (AgGridColumn.hasChildColumns(nextProps)) {
+        if (AgGridColumn.hasChildColumns(this.props)) {
             const detectionStrategy = this.changeDetectionService.getStrategy(ChangeDetectionStrategyType.DeepValueCheck);
 
-            const currentColDefs = this.gridOptions.columnDefs;
-            const newColDefs = AgGridColumn.mapChildColumnDefs(nextProps);
-            if (!detectionStrategy.areEqual(currentColDefs, newColDefs)) {
+            const previousColDefs = AgGridColumn.mapChildColumnDefs(prevProps);
+            const newColDefs = this.gridOptions.columnDefs;
+            if (!detectionStrategy.areEqual(previousColDefs, newColDefs)) {
                 if (debugLogging) {
                     console.log(`agGridReact: colDefs definitions changed`);
                 }
 
                 changes['columnDefs'] =
                     {
-                        previousValue: this.gridOptions.columnDefs,
-                        currentValue: AgGridColumn.mapChildColumnDefs(nextProps)
+                        previousValue: AgGridColumn.mapChildColumnDefs(prevProps),
+                        currentValue: this.gridOptions.columnDefs
                     }
             }
         }
     }
 
-    private extractGridPropertyChanges(nextProps: any, changes: any) {
-        let debugLogging = !!nextProps.debug;
+    private extractGridPropertyChanges(prevProps: any, changes: any) {
+        let debugLogging = !!this.props.debug;
 
-        const changedKeys = Object.keys(nextProps);
+        const changedKeys = Object.keys(this.props);
         changedKeys.forEach((propKey) => {
             if (AgGrid.ComponentUtil.ALL_PROPERTIES.indexOf(propKey) !== -1) {
                 const changeDetectionStrategy = this.changeDetectionService.getStrategy(this.getStrategyTypeForProp(propKey));
-                if (!changeDetectionStrategy.areEqual(this.props[propKey], nextProps[propKey])) {
+                if (!changeDetectionStrategy.areEqual(prevProps[propKey], this.props[propKey])) {
                     if (debugLogging) {
                         console.log(`agGridReact: [${propKey}] property changed`);
                     }
 
                     changes[propKey] = {
-                        previousValue: this.props[propKey],
-                        currentValue: nextProps[propKey]
+                        previousValue: prevProps[propKey],
+                        currentValue: this.props[propKey]
                     };
                 }
             }
         });
         AgGrid.ComponentUtil.getEventCallbacks().forEach((funcName: string) => {
-            if (this.props[funcName] !== nextProps[funcName]) {
+            if (prevProps[funcName] !== this.props[funcName]) {
                 if (debugLogging) {
                     console.log(`agGridReact: [${funcName}] event callback changed`);
                 }
                 changes[funcName] = {
-                    previousValue: this.props[funcName],
-                    currentValue: nextProps[funcName]
+                    previousValue: prevProps[funcName],
+                    currentValue: this.props[funcName]
                 };
             }
         });


### PR DESCRIPTION
Per the React documentation regarding [componentWillReceiveProps](https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops): 
 > Using this lifecycle method often leads to bugs and inconsistencies
 >
 > If you need to perform a side effect (for example, data fetching or an animation) in response to a change in props, use `componentDidUpdate` lifecycle instead.

Previously, the `componentWillReceiveProps` method could be called multiple times; triggering multiple costly change detection strategy calls. This would cause the app to block the main thread especially with large data sets or column definitions and often result in 0 changes. 

This proposed update will trigger the change detection strategy once and only when React has detected a change to props. The side effect though is that this is post-render. So determining the changes are now from `prevProps` as opposed to `nextProps`.