### PR TITLE
replace duplicated setting of datasource to serverSideDatasource

### DIFF
--- a/packages/ag-grid-community/src/ts/components/componentUtil.ts
+++ b/packages/ag-grid-community/src/ts/components/componentUtil.ts
@@ -164,8 +164,8 @@ export class ComponentUtil {
             api.setColumnDefs(changes.columnDefs.currentValue, "gridOptionsChanged");
         }
 
-        if (changes.datasource) {
-            api.setDatasource(changes.datasource.currentValue);
+        if (changes.serverSideDatasource) {
+            api.setServerSideDatasource(changes.serverSideDatasource.currentValue);
         }
 
         if (changes.headerHeight) {


### PR DESCRIPTION
I need to set the serverSideDatasource after the initialization of the grid.
I could see that it does not get updated in onChanges. But datasource gets updated twice.
Please, check if this is a bug.

Thanks!
Nik