### PR TITLE
cancel bubble on blob download

### DIFF
--- a/packages/ag-grid-community/src/ts/exporter/downloader.ts
+++ b/packages/ag-grid-community/src/ts/exporter/downloader.ts
@@ -13,7 +13,11 @@ export class Downloader {
             element.setAttribute("download", fileName);
             element.style.display = "none";
             document.body.appendChild(element);
-            element.click();
+            const event = new MouseEvent('click', {
+                view: window,
+                bubbles: false
+            });
+            element.dispatchEvent(event);
             window.URL.revokeObjectURL(url);
             document.body.removeChild(element);
         }


### PR DESCRIPTION
Not canceling the bubble causes conflict with Google Tag Manager on some implementations.