### PR TITLE
Adding suppressAutoSizeAll property to ColDef

### DIFF
--- a/dist/ag-grid-community.js
+++ b/dist/ag-grid-community.js
@@ -7243,7 +7243,11 @@ var ColumnController = /** @class */ (function () {
     ColumnController.prototype.autoSizeAllColumns = function (source) {
         if (source === void 0) { source = "api"; }
         var allDisplayedColumns = this.getAllDisplayedColumns();
-        this.autoSizeColumns(allDisplayedColumns, source);
+        var columnsToAutoSize = _.filter(allDisplayedColumns, function(column) {
+            return column.getColDef().suppressAutoSizeAll === false;
+        });
+
+        this.autoSizeColumns(columnsToAutoSize, source);
     };
     ColumnController.prototype.getColumnsFromTree = function (rootColumns) {
         var result = [];

--- a/dist/ag-grid-community.js
+++ b/dist/ag-grid-community.js
@@ -7243,11 +7243,7 @@ var ColumnController = /** @class */ (function () {
     ColumnController.prototype.autoSizeAllColumns = function (source) {
         if (source === void 0) { source = "api"; }
         var allDisplayedColumns = this.getAllDisplayedColumns();
-        var columnsToAutoSize = _.filter(allDisplayedColumns, function(column) {
-            return column.getColDef().suppressAutoSizeAll === false;
-        });
-
-        this.autoSizeColumns(columnsToAutoSize, source);
+        this.autoSizeColumns(allDisplayedColumns, source);
     };
     ColumnController.prototype.getColumnsFromTree = function (rootColumns) {
         var result = [];

--- a/packages/ag-grid-angular/src/agGridColumn.ts
+++ b/packages/ag-grid-angular/src/agGridColumn.ts
@@ -153,6 +153,7 @@ export class AgGridColumn {
     @Input() public sortable: any;
     @Input() public resizable: any;
     @Input() public singleClickEdit: any;
+    @Input() public suppressAutoSizeAll: any;
     // @END@
 
 }

--- a/packages/ag-grid-aurelia/src/agGridColumn.ts
+++ b/packages/ag-grid-aurelia/src/agGridColumn.ts
@@ -26,7 +26,7 @@ import {generateBindables} from "./agUtils";
     "pinnedRowValueFormatter", "valueParser", "allowedAggFuncs", "rowGroup", "showRowGroup", "pivot", "equals", "pivotComparator",
     "menuTabs", "colSpan", "suppressPaste", "template", "templateUrl", "pivotValueColumn", "pivotTotalColumnIds", "headerComponent",
     "headerComponentFramework", "headerComponentParams", "floatingFilterComponent", "floatingFilterComponentParams",
-    "lockPinned"])
+    "lockPinned", "suppressAutoSizeAll"])
 // <slot> is required for @children to work.  https://github.com/aurelia/templating/issues/451#issuecomment-254206622
 @inlineView(`<template><slot></slot></template>`)
 @autoinject()

--- a/packages/ag-grid-community/src/ts/columnController/columnController.ts
+++ b/packages/ag-grid-community/src/ts/columnController/columnController.ts
@@ -437,7 +437,11 @@ export class ColumnController {
 
     public autoSizeAllColumns(source: ColumnEventType = "api"): void {
         const allDisplayedColumns = this.getAllDisplayedColumns();
-        this.autoSizeColumns(allDisplayedColumns, source);
+        const columnsToAutoSize = _.filter(allDisplayedColumns, (column: Column): boolean => {
+            return column.getColDef().suppressAutoSizeAll === false;
+        });
+        
+        this.autoSizeColumns(columnsToAutoSize, source);
     }
 
     private getColumnsFromTree(rootColumns: OriginalColumnGroupChild[]): Column[] {

--- a/packages/ag-grid-community/src/ts/entities/colDef.ts
+++ b/packages/ag-grid-community/src/ts/entities/colDef.ts
@@ -244,6 +244,9 @@ export interface ColDef extends AbstractColDef {
     /** Set to true if you do not want this column to be auto-resizable by double clicking it's edge. */
     suppressAutoSize?: boolean;
 
+    /** Set to true if you do not want this column to be auto-resized during 'auto size all columns' operation. */
+    suppressAutoSizeAll?: boolean;
+
     /** Allows user to suppress certain keyboard events */
     suppressKeyboardEvent?: (params: SuppressKeyboardEventParams) => boolean;
 

--- a/packages/ag-grid-community/src/ts/propertyKeys.ts
+++ b/packages/ag-grid-community/src/ts/propertyKeys.ts
@@ -61,7 +61,7 @@ export class PropertyKeys {
         'suppressRowHoverHighlight', 'gridAutoHeight', 'suppressRowTransform', 'suppressClipboardPaste',
         'serverSideSortingAlwaysResets', 'reactNext', 'suppressSetColumnStateEvents', 'enableCharts',
         'deltaColumnMode', 'suppressMaintainUnsortedOrder', 'enableCellTextSelection', 'suppressBrowserResizeObserver',
-        'suppressMaxRenderedRowRestriction', 'excludeChildrenWhenTreeDataFiltering'
+        'suppressMaxRenderedRowRestriction', 'excludeChildrenWhenTreeDataFiltering', 'suppressAutoSizeAll'
     ];
 
     public static FUNCTION_PROPERTIES = ['localeTextFunc', 'groupRowInnerRenderer', 'groupRowInnerRendererFramework',


### PR DESCRIPTION
Adding in property to allow columns to be configured to not be auto-sized during `gridApi.columnApi.autoSizeAllColumns()`