### PR TITLE
Remove @angular/compiler-cli peer dependency

### DIFF
--- a/packages/ag-grid-angular/package.json
+++ b/packages/ag-grid-angular/package.json
@@ -57,7 +57,6 @@
   },
   "peerDependencies": {
     "@angular/compiler": ">=2.1.x",
-    "@angular/compiler-cli": ">=2.1.x",
     "@angular/core": ">=2.1.x",
     "ag-grid-community": "^20.2.0",
     "core-js": "^2.4.1",


### PR DESCRIPTION
I don't use the cli, so it shouldn't be necessary to install ag-grid-angular.