### PR TITLE
Fix peer dependency warning messages

### DIFF
--- a/packages/ag-grid-angular/package.json
+++ b/packages/ag-grid-angular/package.json
@@ -58,10 +58,9 @@
   },
   "peerDependencies": {
     "@angular/compiler": ">=2.1.x",
-    "@angular/compiler-cli": ">=2.1.x",
     "@angular/core": ">=2.1.x",
     "ag-grid-community": "^21.0.0",
-    "core-js": "^2.4.1",
+    "core-js": ">2.4.x",
     "rxjs": ">=5.0.0-beta.12",
     "zone.js": ">=0.6.x"
   }


### PR DESCRIPTION
@seanlandsman I'm starting to go nuts from peer dependency warnings. I don't want compiler-cli installed (I have zero use for it, and I use ag-grid just fine without it), and core-js is just a polyfill library, you don't have to be so tight on its requirements.

PLEASE READ THIS, THIS ONLY WILL TAKE YOU 10 SECONDS. I'm starting to feel like talking to you guys is a waste of my time.