### PR TITLE
To get chevron icon padding in tree data

### DIFF
--- a/packages/ag-grid-community/dist/lib/rendering/cellRenderers/groupCellRenderer.js
+++ b/packages/ag-grid-community/dist/lib/rendering/cellRenderers/groupCellRenderer.js
@@ -108,7 +108,7 @@ var GroupCellRenderer = /** @class */ (function (_super) {
         }
         var params = this.params;
         var rowNode = params.node;
-        var paddingCount = rowNode.uiLevel;
+        var paddingCount = rowNode.level;
         var userProvidedPaddingPixelsTheDeprecatedWay = params.padding >= 0;
         if (userProvidedPaddingPixelsTheDeprecatedWay) {
             this.setPaddingDeprecatedWay(paddingCount, params.padding);


### PR DESCRIPTION
In ag-Grid-community v20.2.0 the chevron icon padding is not applied for tree data. The icon is at initial position only. After doing some Research in ag-grid-community,  I observed that GroupCellRender class’s setIndent() is updating the indentClass property based on rowNode.uiLevel. However, the uiLevel property value is always received as ‘0’. For now, we modified the source code of the community edition internally to check for a fix. By Modifying  rowNode.uiLevel with rowNode.level then it's working because for every parent and child rowNode.level is updating.