### PR TITLE
docs: fix typo in `reactNext` prop

### DIFF
--- a/packages/ag-grid-docs/src/react-more-details/index.php
+++ b/packages/ag-grid-docs/src/react-more-details/index.php
@@ -244,7 +244,7 @@ class GridComponent extends Component {
                 href="#react-15">here.</a></note>
     <p>With React 16 <a href="https://reactjs.org/docs/portals.html">Portals</a> were introduced and these are the official way to create React components dynamically within React so
         this is what we use internally for component creation within the grid.</p>
-    <p>If you use React 16+ you'll need to enable <code>reatNext </code> as follows:</p>
+    <p>If you use React 16+ you'll need to enable <code>reactNext</code> as follows:</p>
 <snippet>
 // Grid Definition
 &lt;AgGridReact


### PR DESCRIPTION
Fix typo `reatNext` to `reactNext` prop in docs site.

[link](https://www.ag-grid.com/react-more-details/#react-16)

![image](https://user-images.githubusercontent.com/16452789/61650902-7435f380-acbd-11e9-9458-5d79f980501a.png)
