### PR TITLE
Fix invalid use of $cell-horizontal-padding in theme-base

### DIFF
--- a/packages/ag-grid-community/src/styles/ag-theme-base/sass/_ag-theme-base.scss
+++ b/packages/ag-grid-community/src/styles/ag-theme-base/sass/_ag-theme-base.scss
@@ -934,7 +934,7 @@
     ////////////////////////////////////////
     .ag-cell {
         &.ag-cell-inline-editing {
-            padding: $cell-horizontal-padding;
+            padding: 0 $cell-horizontal-padding;
             height: $row-height + $grid-size * 3;
         }
         &.ag-cell-inline-editing, &.ag-popup-editor {


### PR DESCRIPTION
It was being used for vertical padding also.