### PR TITLE
Fix "params.filterParams is undefined" error

### DIFF
--- a/packages/ag-grid-community/src/ts/filter/provided/date/defaultDateComponent.ts
+++ b/packages/ag-grid-community/src/ts/filter/provided/date/defaultDateComponent.ts
@@ -14,7 +14,7 @@ export class DefaultDateComponent extends Component implements IDateComp {
     public init(params: IDateParams): void {
         this.eDateInput = this.getGui().querySelector('input') as HTMLInputElement;
 
-        if (_.isBrowserChrome() || params.filterParams.browserDatePicker) {
+        if (_.isBrowserChrome() || ( params.filterParams && params.filterParams.browserDatePicker)) {
             if (_.isBrowserIE()) {
                 console.warn('ag-grid: browserDatePicker is specified to true, but it is not supported in IE 11, reverting to plain text date picker');
             } else {


### PR DESCRIPTION
If the `filterParams` isn't specified and the browser isn't chrome, an error is thrown trying to access `browerDatePicker` from `undefined`.
Check if `filterParams` exists before accessing properties.