### PR TITLE
Stylingservice split classes

### DIFF
--- a/packages/ag-grid-community/src/ts/styling/stylingService.ts
+++ b/packages/ag-grid-community/src/ts/styling/stylingService.ts
@@ -35,18 +35,18 @@ export class StylingService {
     public processStaticCellClasses(colDef: ColDef, params: CellClassParams, onApplicableClass: (className: string) => void) {
         const cellClass = colDef.cellClass;
         if (cellClass) {
-            let classOrClasses: any;
+            let classOrClasses: string | string[];
 
-            if (typeof colDef.cellClass === 'function') {
-                const cellClassFunc = colDef.cellClass as (cellClassParams: any) => string | string[];
-                classOrClasses = cellClassFunc(params);
+            if (typeof cellClass === 'function') {
+                classOrClasses = cellClass(params);
             } else {
-                classOrClasses = colDef.cellClass;
+                classOrClasses = cellClass;
             }
 
             if (typeof classOrClasses === 'string') {
-                onApplicableClass(classOrClasses);
-            } else if (Array.isArray(classOrClasses)) {
+                classOrClasses = classOrClasses.split(/ +/g);
+            }
+            if (Array.isArray(classOrClasses)) {
                 classOrClasses.forEach((cssClassItem: string) => {
                     onApplicableClass(cssClassItem);
                 });


### PR DESCRIPTION
Ran into this issue trying to debug Excel Styles when the `cellClass` had been set to `'ExcelCurrency text-right'`. This was difficult to track down, it seemed like splitting it here would cause less confusion.

The only potential breaking change here is if there's any matching on a combination of classes.