### PR TITLE
Introduce generics for cartesian chart axes

### DIFF
--- a/packages/ag-grid-enterprise/src/chartAdaptor/builder/chartBuilder.ts
+++ b/packages/ag-grid-enterprise/src/chartAdaptor/builder/chartBuilder.ts
@@ -26,7 +26,7 @@ import {
     FontWeight,
 } from "ag-grid-community";
 
-import { CartesianChart, CartesianChartLayout } from "../../charts/chart/cartesianChart";
+import { CartesianAxis, CartesianChart, CartesianChartLayout } from "../../charts/chart/cartesianChart";
 import { PolarChart } from "../../charts/chart/polarChart";
 import { LineSeries } from "../../charts/chart/series/lineSeries";
 import { ScatterSeries } from "../../charts/chart/series/scatterSeries";
@@ -44,7 +44,7 @@ import { Caption } from "../../charts/caption";
 import { GroupedCategoryAxis } from "../../charts/chart/axis/groupedCategoryAxis";
 
 export class ChartBuilder {
-    static createCartesianChart(options: CartesianChartOptions): CartesianChart {
+    static createCartesianChart(options: CartesianChartOptions): CartesianChart<CartesianAxis, CartesianAxis> {
         const chart = new CartesianChart({
             document: options.document,
             xAxis: ChartBuilder.createAxis(options.xAxis),
@@ -54,10 +54,10 @@ export class ChartBuilder {
         return ChartBuilder.initCartesianChart(chart, options);
     }
 
-    static createBarChart(options: BarChartOptions): CartesianChart {
+    static createBarChart(options: BarChartOptions): CartesianChart<CartesianAxis, CartesianAxis> {
         const chart = new CartesianChart({
             document: options.document,
-            xAxis: ChartBuilder.createNumberAxis(options.xAxis), 
+            xAxis: ChartBuilder.createNumberAxis(options.xAxis),
             yAxis: ChartBuilder[options.isGroupingEnabled ? "createGroupedAxis" : "createCategoryAxis"](options.yAxis),
         });
 
@@ -66,7 +66,7 @@ export class ChartBuilder {
         return ChartBuilder.initCartesianChart(chart, options, "bar");
     }
 
-    static createColumnChart(options: BarChartOptions): CartesianChart {
+    static createColumnChart(options: BarChartOptions): CartesianChart<CartesianAxis, CartesianAxis> {
         const chart = new CartesianChart({
             document: options.document,
             xAxis: ChartBuilder[options.isGroupingEnabled ? "createGroupedAxis" : "createCategoryAxis"](options.xAxis),
@@ -76,7 +76,7 @@ export class ChartBuilder {
         return ChartBuilder.initCartesianChart(chart, options, "bar");
     }
 
-    static createLineChart(options: LineChartOptions): CartesianChart {
+    static createLineChart(options: LineChartOptions): CartesianChart<CartesianAxis, CartesianAxis> {
         const chart = new CartesianChart({
             document: options.document,
             xAxis: ChartBuilder[options.isGroupingEnabled ? "createGroupedAxis" : "createCategoryAxis"](options.xAxis),
@@ -86,7 +86,7 @@ export class ChartBuilder {
         return ChartBuilder.initCartesianChart(chart, options, "line");
     }
 
-    static createScatterChart(options: ScatterChartOptions): CartesianChart {
+    static createScatterChart(options: ScatterChartOptions): CartesianChart<CartesianAxis, CartesianAxis> {
         const chart = new CartesianChart({
             document: options.document,
             xAxis: ChartBuilder.createNumberAxis(options.xAxis),
@@ -96,7 +96,7 @@ export class ChartBuilder {
         return ChartBuilder.initCartesianChart(chart, options, "scatter");
     }
 
-    static createAreaChart(options: AreaChartOptions): CartesianChart {
+    static createAreaChart(options: AreaChartOptions): CartesianChart<CartesianAxis, CartesianAxis> {
         const chart = new CartesianChart({
             document: options.document,
             xAxis: ChartBuilder[options.isGroupingEnabled ? "createGroupedAxis" : "createCategoryAxis"](options.xAxis),
@@ -112,9 +112,9 @@ export class ChartBuilder {
 
     static createPieChart = (options: PieChartOptions): PolarChart => ChartBuilder.initPolarChart(new PolarChart(), options, "pie");
 
-    static createLineSeries = (options: LineSeriesOptions): LineSeries => new LineSeries();
+    static createLineSeries = (options: LineSeriesOptions): LineSeries<CartesianAxis, CartesianAxis> => new LineSeries();
 
-    static createScatterSeries = (options: ScatterSeriesOptions): ScatterSeries => new ScatterSeries();
+    static createScatterSeries = (options: ScatterSeriesOptions): ScatterSeries<CartesianAxis, CartesianAxis> => new ScatterSeries();
 
     static createSeries(options: { type?: SeriesType }, type?: SeriesType) {
         switch (type || options && options.type) {
@@ -151,7 +151,7 @@ export class ChartBuilder {
         return chart;
     }
 
-    static initCartesianChart(chart: CartesianChart, options: CartesianChartOptions, seriesType?: CartesianSeriesType) {
+    static initCartesianChart(chart: CartesianChart<CartesianAxis, CartesianAxis>, options: CartesianChartOptions, seriesType?: CartesianSeriesType) {
         ChartBuilder.initChart(chart, options, seriesType);
 
         return chart;
@@ -159,7 +159,7 @@ export class ChartBuilder {
 
     static initPolarChart(chart: PolarChart, options: PolarChartOptions, seriesType?: PolarSeriesType) {
         ChartBuilder.initChart(chart, options, seriesType);
-        
+
         return chart;
     }
 
@@ -169,18 +169,18 @@ export class ChartBuilder {
         return series;
     }
 
-    static initLineSeries(series: LineSeries, options: LineSeriesOptions) {
+    static initLineSeries(series: LineSeries<CartesianAxis, CartesianAxis>, options: LineSeriesOptions) {
         ChartBuilder.initSeries(series, options);
 
         _.copyPropertiesIfPresent(
-            options, 
-            series, 
-            "title", 
-            "xField", 
-            "yField", 
-            "fill", 
-            "stroke", 
-            "strokeWidth", 
+            options,
+            series,
+            "title",
+            "xField",
+            "yField",
+            "fill",
+            "stroke",
+            "strokeWidth",
             "highlightStyle",
             "marker",
             "markerSize",
@@ -190,18 +190,18 @@ export class ChartBuilder {
         return series;
     }
 
-    static initScatterSeries(series: ScatterSeries, options: ScatterSeriesOptions) {
+    static initScatterSeries(series: ScatterSeries<CartesianAxis, CartesianAxis>, options: ScatterSeriesOptions) {
         ChartBuilder.initSeries(series, options);
 
         _.copyPropertiesIfPresent(
             options,
-            series, 
-            "title", 
-            "xField", 
-            "yField", 
-            "radiusField", 
+            series,
+            "title",
+            "xField",
+            "yField",
+            "radiusField",
             "labelField",
-            "xFieldName", 
+            "xFieldName",
             "yFieldName",
             "radiusFieldName",
             "labelFieldName",
@@ -222,19 +222,19 @@ export class ChartBuilder {
         _.copyPropertiesIfPresent(options, series, "labelFontStyle", "labelFontWeight", "labelFontSize", "labelFontFamily", "labelColor");
     }
 
-    static initBarSeries(series: BarSeries, options: BarSeriesOptions) {
+    static initBarSeries(series: BarSeries<CartesianAxis, CartesianAxis>, options: BarSeriesOptions) {
         ChartBuilder.initSeries(series, options);
         ChartBuilder.initLabelFormatting(series, options);
 
         _.copyPropertiesIfPresent(
-            options, 
-            series, 
-            "xField", 
-            "yFields", 
-            "yFieldNames", 
-            "grouped", 
+            options,
+            series,
+            "xField",
+            "yFields",
+            "yFieldNames",
+            "grouped",
             "normalizedTo",
-            "fills", 
+            "fills",
             "strokes",
             "fillOpacity",
             "strokeOpacity",
@@ -249,12 +249,12 @@ export class ChartBuilder {
         return series;
     }
 
-    static initAreaSeries(series: AreaSeries, options: AreaSeriesOptions) {
+    static initAreaSeries(series: AreaSeries<CartesianAxis, CartesianAxis>, options: AreaSeriesOptions) {
         ChartBuilder.initSeries(series, options);
 
         _.copyPropertiesIfPresent(
-            options, 
-            series, 
+            options,
+            series,
             "xField",
             "yFields",
             "yFieldNames",
@@ -282,9 +282,9 @@ export class ChartBuilder {
         _.copyPropertyIfPresent(options, series, "title", t => ChartBuilder.createPieTitle(t!));
 
         _.copyPropertiesIfPresent(
-            options, 
-            series, 
-            "calloutColors", 
+            options,
+            series,
+            "calloutColors",
             "calloutStrokeWidth",
             "calloutLength",
             "labelMinAngle",
@@ -304,19 +304,19 @@ export class ChartBuilder {
             "tooltipRenderer");
 
         _.copyPropertyIfPresent(options, series, "shadow", s => ChartBuilder.createDropShadow(s));
-        
+
         return series;
     }
 
     static initLegend(legend: Legend, options: LegendOptions) {
         ChartBuilder.initLabelFormatting(legend, options);
-        
+
         _.copyPropertiesIfPresent(
-            options, 
-            legend, 
-            "enabled", 
-            "markerStrokeWidth", 
-            "markerSize", 
+            options,
+            legend,
+            "enabled",
+            "markerStrokeWidth",
+            "markerSize",
             "markerPadding",
             "itemPaddingX",
             "itemPaddingY");
@@ -385,7 +385,7 @@ export class ChartBuilder {
             if (name === 'type') {
                 continue;
             }
-            
+
             if (name === 'title' && options.title) {
                 axis.title = ChartBuilder.createTitle(options.title);
                 continue;

--- a/packages/ag-grid-enterprise/src/chartAdaptor/chartComp/chartProxies/cartesian/areaChartProxy.ts
+++ b/packages/ag-grid-enterprise/src/chartAdaptor/chartComp/chartProxies/cartesian/areaChartProxy.ts
@@ -2,7 +2,7 @@ import { AreaChartOptions, ChartType, _, FontWeight } from "ag-grid-community";
 import { ChartBuilder } from "../../../builder/chartBuilder";
 import { AreaSeries } from "../../../../charts/chart/series/areaSeries";
 import { ChartProxyParams, UpdateChartParams } from "../chartProxy";
-import { CartesianChart } from "../../../../charts/chart/cartesianChart";
+import { CartesianAxis, CartesianChart } from "../../../../charts/chart/cartesianChart";
 import { CategoryAxis } from "../../../../charts/chart/axis/categoryAxis";
 import { CartesianChartProxy, LineMarkerProperty } from "./cartesianChartProxy";
 
@@ -17,11 +17,11 @@ export class AreaChartProxy extends CartesianChartProxy<AreaChartOptions> {
         this.setAxisPadding(this.chart);
 
         const areaSeries = ChartBuilder.createSeries(this.chartOptions.seriesDefaults!);
-        
+
         if (areaSeries) { this.chart.addSeries(areaSeries); }
     }
 
-    private setAxisPadding(chart: CartesianChart) {
+    private setAxisPadding(chart: CartesianChart<CartesianAxis, CartesianAxis>) {
         const xAxis = chart.xAxis;
 
         if (xAxis instanceof CategoryAxis) {
@@ -38,7 +38,7 @@ export class AreaChartProxy extends CartesianChartProxy<AreaChartOptions> {
             this.updateAreaChart(params);
         } else {
             // stacked and normalized has a single series
-            const areaSeries = this.chart.series[0] as AreaSeries;
+            const areaSeries = this.chart.series[0] as AreaSeries<CartesianAxis, CartesianAxis>;
             const { fills, strokes } = this.overriddenPalette || this.chartProxyParams.getSelectedPalette();
 
             areaSeries.data = params.data;
@@ -60,22 +60,22 @@ export class AreaChartProxy extends CartesianChartProxy<AreaChartOptions> {
 
         const lineChart = this.chart;
         const fieldIds = params.fields.map(f => f.colId);
-        const existingSeriesMap: { [id: string]: AreaSeries } = {};
+        const existingSeriesMap: { [id: string]: AreaSeries<CartesianAxis, CartesianAxis> } = {};
         const { fills, strokes } = this.overriddenPalette || this.chartProxyParams.getSelectedPalette();
         const seriesOptions = this.chartOptions.seriesDefaults!;
 
         lineChart.series
-            .map(series => series as AreaSeries)
-            .forEach(areaSeries=> {
+            .map(series => series as AreaSeries<CartesianAxis, CartesianAxis>)
+            .forEach(areaSeries => {
                 const id = areaSeries.yFields[0];
-    
+
                 _.includes(fieldIds, id) ? existingSeriesMap[id] = areaSeries : lineChart.removeSeries(areaSeries);
             });
 
 
         params.fields.forEach((f, index) => {
             const existingSeries = existingSeriesMap[f.colId];
-            const areaSeries = existingSeries || ChartBuilder.createSeries(seriesOptions) as AreaSeries;
+            const areaSeries = existingSeries || ChartBuilder.createSeries(seriesOptions) as AreaSeries<CartesianAxis, CartesianAxis>;
 
             if (areaSeries) {
                 areaSeries.yFieldNames = [ f.displayName ];
@@ -93,7 +93,7 @@ export class AreaChartProxy extends CartesianChartProxy<AreaChartOptions> {
     }
 
     public setSeriesProperty(property: AreaSeriesProperty | LineMarkerProperty, value: any): void {
-        const series = this.getChart().series as AreaSeries[];
+        const series = this.getChart().series as AreaSeries<CartesianAxis, CartesianAxis>[];
         series.forEach(s => (s[property] as any) = value);
 
         if (!this.chartOptions.seriesDefaults) {

--- a/packages/ag-grid-enterprise/src/chartAdaptor/chartComp/chartProxies/cartesian/barChartProxy.ts
+++ b/packages/ag-grid-enterprise/src/chartAdaptor/chartComp/chartProxies/cartesian/barChartProxy.ts
@@ -3,6 +3,7 @@ import { ChartBuilder } from "../../../builder/chartBuilder";
 import { BarSeries } from "../../../../charts/chart/series/barSeries";
 import { ChartProxyParams, UpdateChartParams } from "../chartProxy";
 import { CartesianChartProxy } from "./cartesianChartProxy";
+import { CartesianAxis } from "../../../../charts/chart/cartesianChart";
 
 export type BarSeriesProperty = 'strokeWidth' | 'strokeOpacity' | 'fillOpacity' | 'tooltipEnabled';
 export type BarSeriesFontProperty = 'labelEnabled' | 'labelFontFamily' | 'labelFontStyle' | 'labelFontWeight' | 'labelFontSize' | 'labelColor';
@@ -22,7 +23,7 @@ export class BarChartProxy extends CartesianChartProxy<BarChartOptions> {
 
     public update(params: UpdateChartParams): void {
         const chart = this.chart;
-        const barSeries = chart.series[0] as BarSeries;
+        const barSeries = chart.series[0] as BarSeries<CartesianAxis, CartesianAxis>;
         const { fills, strokes } = this.overriddenPalette || this.chartProxyParams.getSelectedPalette();
 
         barSeries.data = params.data;
@@ -42,7 +43,7 @@ export class BarChartProxy extends CartesianChartProxy<BarChartOptions> {
     }
 
     public setSeriesProperty(property: BarSeriesProperty | BarSeriesFontProperty, value: any): void {
-        const series = this.getChart().series as BarSeries[];
+        const series = this.getChart().series as BarSeries<CartesianAxis, CartesianAxis>[];
         series.forEach(s => (s[property] as any) = value);
 
         if (!this.chartOptions.seriesDefaults) {

--- a/packages/ag-grid-enterprise/src/chartAdaptor/chartComp/chartProxies/cartesian/cartesianChartProxy.ts
+++ b/packages/ag-grid-enterprise/src/chartAdaptor/chartComp/chartProxies/cartesian/cartesianChartProxy.ts
@@ -1,6 +1,6 @@
 import { ChartProxy, ChartProxyParams } from "../chartProxy";
 import { CartesianChartOptions, _ } from "ag-grid-community";
-import { CartesianChart } from "../../../../charts/chart/cartesianChart";
+import { CartesianAxis, CartesianChart } from "../../../../charts/chart/cartesianChart";
 import { ChartModel } from "../../chartModel";
 import { IAxisFormatting, ILabelFormatting } from "../../../../charts/axis";
 
@@ -8,7 +8,7 @@ export type LineMarkerProperty = 'marker' | 'markerSize' | 'markerStrokeWidth';
 export type LineSeriesProperty = 'strokeWidth' | 'tooltipEnabled' | 'markerSize' | 'markerStrokeWidth';
 export type ScatterSeriesProperty = 'tooltipEnabled' | 'markerSize' | 'markerStrokeWidth';
 
-export abstract class CartesianChartProxy<T extends CartesianChartOptions> extends ChartProxy<CartesianChart, T> {
+export abstract class CartesianChartProxy<T extends CartesianChartOptions> extends ChartProxy<CartesianChart<CartesianAxis, CartesianAxis>, T> {
     protected constructor(params: ChartProxyParams) {
         super(params);
     }
@@ -25,10 +25,10 @@ export abstract class CartesianChartProxy<T extends CartesianChartOptions> exten
 
     public setCommonAxisProperty(property: keyof IAxisFormatting | keyof ILabelFormatting, value: any) {
         const cartesianChart = this.chart;
-        
+
         _.setProperty(cartesianChart.xAxis, property, value);
         _.setProperty(cartesianChart.yAxis, property, value);
-        
+
         cartesianChart.performLayout();
 
         _.setProperty(this.chartOptions.xAxis, property, value);
@@ -63,5 +63,5 @@ export abstract class CartesianChartProxy<T extends CartesianChartOptions> exten
         this.raiseChartOptionsChangedEvent();
     }
 
-    private getCartesianChart = (): CartesianChart => this.chart;
+    private getCartesianChart = (): CartesianChart<CartesianAxis, CartesianAxis> => this.chart;
 }

--- a/packages/ag-grid-enterprise/src/chartAdaptor/chartComp/chartProxies/cartesian/lineChartProxy.ts
+++ b/packages/ag-grid-enterprise/src/chartAdaptor/chartComp/chartProxies/cartesian/lineChartProxy.ts
@@ -3,6 +3,7 @@ import { ChartBuilder } from "../../../builder/chartBuilder";
 import { ChartProxyParams, UpdateChartParams } from "../chartProxy";
 import { LineSeries } from "../../../../charts/chart/series/lineSeries";
 import { CartesianChartProxy, LineMarkerProperty, LineSeriesProperty } from "./cartesianChartProxy";
+import { CartesianAxis } from "../../../../charts/chart/cartesianChart";
 
 export class LineChartProxy extends CartesianChartProxy<LineChartOptions> {
     public constructor(params: ChartProxyParams) {
@@ -22,21 +23,21 @@ export class LineChartProxy extends CartesianChartProxy<LineChartOptions> {
 
         const lineChart = this.chart;
         const fieldIds = params.fields.map(f => f.colId);
-        const existingSeriesMap: { [id: string]: LineSeries } = {};
+        const existingSeriesMap: { [id: string]: LineSeries<CartesianAxis, CartesianAxis> } = {};
         const { fills, strokes } = this.overriddenPalette || this.chartProxyParams.getSelectedPalette();
         const seriesOptions = this.chartOptions.seriesDefaults!;
 
         lineChart.series
-            .map(series => series as LineSeries)
+            .map(series => series as LineSeries<CartesianAxis, CartesianAxis>)
             .forEach(lineSeries => {
                 const id = lineSeries.yField;
-                
+
                 _.includes(fieldIds, id) ? existingSeriesMap[id] = lineSeries : lineChart.removeSeries(lineSeries);
             });
 
         params.fields.forEach((f, index) => {
             const existingSeries = existingSeriesMap[f.colId];
-            const lineSeries = existingSeries || ChartBuilder.createSeries(seriesOptions) as LineSeries;
+            const lineSeries = existingSeries || ChartBuilder.createSeries(seriesOptions) as LineSeries<CartesianAxis, CartesianAxis>;
 
             if (lineSeries) {
                 lineSeries.title = f.displayName;
@@ -56,7 +57,7 @@ export class LineChartProxy extends CartesianChartProxy<LineChartOptions> {
     }
 
     public setSeriesProperty(property: LineSeriesProperty | LineMarkerProperty, value: any): void {
-        const series = this.getChart().series as LineSeries[];
+        const series = this.getChart().series as LineSeries<CartesianAxis, CartesianAxis>[];
         series.forEach(s => (s[property] as any) = value);
 
         if (!this.chartOptions.seriesDefaults) {

--- a/packages/ag-grid-enterprise/src/chartAdaptor/chartComp/chartProxies/cartesian/scatterChartProxy.ts
+++ b/packages/ag-grid-enterprise/src/chartAdaptor/chartComp/chartProxies/cartesian/scatterChartProxy.ts
@@ -4,6 +4,7 @@ import { ChartProxyParams, UpdateChartParams } from "../chartProxy";
 import { ScatterSeries } from "../../../../charts/chart/series/scatterSeries";
 import { ChartModel } from "../../chartModel";
 import { CartesianChartProxy, LineMarkerProperty, ScatterSeriesProperty } from "./cartesianChartProxy";
+import { CartesianAxis } from "../../../../charts/chart/cartesianChart";
 
 export class ScatterChartProxy extends CartesianChartProxy<ScatterChartOptions> {
     public constructor(params: ChartProxyParams) {
@@ -23,14 +24,14 @@ export class ScatterChartProxy extends CartesianChartProxy<ScatterChartOptions> 
         const isBubbleChart = this.chartType === ChartType.Bubble;
         const yFields = params.fields.slice(1, params.fields.length).filter((_, i) => !isBubbleChart || i % 2 === 0);
         const fieldIds = yFields.map(f => f.colId);
-        const existingSeriesMap: { [id: string]: ScatterSeries } = {};
+        const existingSeriesMap: { [id: string]: ScatterSeries<CartesianAxis, CartesianAxis> } = {};
         const defaultCategorySelected = params.category.id === ChartModel.DEFAULT_CATEGORY;
         const { fills, strokes } = this.overriddenPalette || this.chartProxyParams.getSelectedPalette();
         const seriesOptions = this.chartOptions.seriesDefaults!;
         const xFieldDefinition = params.fields[0];
 
         chart.series
-            .map(series => series as ScatterSeries)
+            .map(series => series as ScatterSeries<CartesianAxis, CartesianAxis>)
             .forEach(scatterSeries => {
                 const yField = scatterSeries.yField;
 
@@ -45,7 +46,7 @@ export class ScatterChartProxy extends CartesianChartProxy<ScatterChartOptions> 
 
         yFields.forEach((yFieldDefinition, index) => {
             const existingSeries = existingSeriesMap[yFieldDefinition.colId];
-            const series = existingSeries || ChartBuilder.createSeries(seriesOptions) as ScatterSeries;
+            const series = existingSeries || ChartBuilder.createSeries(seriesOptions) as ScatterSeries<CartesianAxis, CartesianAxis>;
 
             if (!series) { return; }
 
@@ -90,7 +91,7 @@ export class ScatterChartProxy extends CartesianChartProxy<ScatterChartOptions> 
     }
 
     public setSeriesProperty(property: ScatterSeriesProperty | LineMarkerProperty, value: any): void {
-        const series = this.getChart().series as ScatterSeries[];
+        const series = this.getChart().series as ScatterSeries<CartesianAxis, CartesianAxis>[];
         series.forEach(s => (s[property] as any) = value);
 
         if (!this.chartOptions.seriesDefaults) {

--- a/packages/ag-grid-enterprise/src/chartAdaptor/chartComp/chartProxies/chartProxy.ts
+++ b/packages/ag-grid-enterprise/src/chartAdaptor/chartComp/chartProxies/chartProxy.ts
@@ -17,6 +17,7 @@ import { BarSeries } from "../../../charts/chart/series/barSeries";
 import { DropShadow } from "../../../charts/scene/dropShadow";
 import { AreaSeries } from "../../../charts/chart/series/areaSeries";
 import { PieSeries } from "../../../charts/chart/series/pieSeries";
+import { CartesianAxis } from "../../../charts/chart/cartesianChart";
 
 export interface ChartProxyParams {
     chartType: ChartType;
@@ -32,7 +33,7 @@ export interface ChartProxyParams {
     isDarkTheme: () => boolean;
 }
 
-export interface FieldDefinition { 
+export interface FieldDefinition {
     colId: string;
     displayName: string;
 }
@@ -94,7 +95,7 @@ export abstract class ChartProxy<TChart extends Chart, TOptions extends ChartOpt
         // so this allows the chart defaults to be overridden
         this.chartOptions.width = this.chartProxyParams.width || this.chartOptions.width;
         this.chartOptions.height = this.chartProxyParams.height || this.chartOptions.height;
-        
+
         // this cannot be overridden via the processChartOptions callback
         this.chartOptions.parent = this.chartProxyParams.parentElement;
     }
@@ -188,9 +189,9 @@ export abstract class ChartProxy<TChart extends Chart, TOptions extends ChartOpt
     }
 
     public setShadowProperty(property: ShadowProperty, value: any): void {
-        const series = this.getChart().series as BarSeries[] | AreaSeries[] | PieSeries[];
+        const series = this.getChart().series as BarSeries<CartesianAxis, CartesianAxis>[] | AreaSeries<CartesianAxis, CartesianAxis>[] | PieSeries[];
 
-        series.forEach((s: BarSeries | AreaSeries | PieSeries) => {
+        series.forEach((s: BarSeries<CartesianAxis, CartesianAxis> | AreaSeries<CartesianAxis, CartesianAxis> | PieSeries) => {
             if (!s.shadow) {
                 s.shadow = new DropShadow({ enabled: false, blur: 0, xOffset: 0, yOffset: 0, color: "rgba(0,0,0,0.5)" });
             }
@@ -219,7 +220,7 @@ export abstract class ChartProxy<TChart extends Chart, TOptions extends ChartOpt
             chartType: this.chartType,
             chartOptions: this.chartOptions
         };
-        
+
         this.chartProxyParams.eventService.dispatchEvent(event);
     }
 

--- a/packages/ag-grid-enterprise/src/charts/chart/cartesianChart.ts
+++ b/packages/ag-grid-enterprise/src/charts/chart/cartesianChart.ts
@@ -13,17 +13,17 @@ export enum CartesianChartLayout {
     Horizontal
 }
 
-type CartesianAxis = Axis<Scale<any, number>> | GroupedCategoryAxis;
+export type CartesianAxis = Axis<Scale<any, number>> | GroupedCategoryAxis;
 
-export interface CartesianChartOptions extends ChartOptions {
-    xAxis: CartesianAxis;
-    yAxis: CartesianAxis;
+export interface CartesianChartOptions<XAxis extends CartesianAxis, YAxis extends CartesianAxis> extends ChartOptions {
+    xAxis: XAxis;
+    yAxis: YAxis;
 }
 
-export class CartesianChart extends Chart {
+export class CartesianChart<XAxis extends CartesianAxis, YAxis extends CartesianAxis> extends Chart {
     private axisAutoPadding = new Padding();
 
-    constructor(options: CartesianChartOptions) {
+    constructor(options: CartesianChartOptions<XAxis, YAxis>) {
         super(options);
 
         const { xAxis, yAxis } = options;
@@ -40,22 +40,22 @@ export class CartesianChart extends Chart {
         return this.seriesClipRect;
     }
 
-    private readonly _xAxis: CartesianAxis;
-    get xAxis(): CartesianAxis {
+    private readonly _xAxis: XAxis;
+    get xAxis(): XAxis {
         return this._xAxis;
     }
 
-    private readonly _yAxis: CartesianAxis;
-    get yAxis(): CartesianAxis {
+    private readonly _yAxis: YAxis;
+    get yAxis(): YAxis {
         return this._yAxis;
     }
 
-    set series(values: Series<CartesianChart>[]) {
+    set series(values: Series<CartesianChart<XAxis, YAxis>>[]) {
         this.removeAllSeries();
         values.forEach(series => this.addSeries(series));
     }
-    get series(): Series<CartesianChart>[] {
-        return this._series as Series<CartesianChart>[];
+    get series(): Series<CartesianChart<XAxis, YAxis>>[] {
+        return this._series as Series<CartesianChart<XAxis, YAxis>>[];
     }
 
     performLayout(): void {

--- a/packages/ag-grid-enterprise/src/charts/chart/chart.ts
+++ b/packages/ag-grid-enterprise/src/charts/chart/chart.ts
@@ -582,9 +582,9 @@ export abstract class Chart {
         const top = event.pageY + offset[1];
         let left = event.pageX + offset[0];
 
-        if (tooltipRect && 
-            parent && 
-            parent.parentElement && 
+        if (tooltipRect &&
+            parent &&
+            parent.parentElement &&
             (left - pageXOffset + tooltipRect.width > parent.parentElement.offsetWidth)) {
             left -= tooltipRect.width + offset[0];
         }

--- a/packages/ag-grid-enterprise/src/charts/chart/series/areaSeries.ts
+++ b/packages/ag-grid-enterprise/src/charts/chart/series/areaSeries.ts
@@ -1,6 +1,6 @@
 import { Group } from "../../scene/group";
 import { Selection } from "../../scene/selection";
-import { CartesianChart } from "../cartesianChart";
+import { CartesianAxis, CartesianChart } from "../cartesianChart";
 import { DropShadow } from "../../scene/dropShadow";
 import { Series, SeriesNodeDatum } from "./series";
 import ContinuousScale from "../../scale/continuousScale";
@@ -38,7 +38,7 @@ export interface AreaTooltipRendererParams {
     color?: string;
 }
 
-export class AreaSeries extends Series<CartesianChart> {
+export class AreaSeries<XAxis extends CartesianAxis, YAxis extends CartesianAxis> extends Series<CartesianChart<XAxis, YAxis>> {
     static className = 'AreaSeries';
 
     tooltipRenderer?: (params: AreaTooltipRendererParams) => string;
@@ -101,13 +101,13 @@ export class AreaSeries extends Series<CartesianChart> {
     private yData: number[][] = [];
     private domainY: any[] = [];
 
-    set chart(chart: CartesianChart | undefined) {
+    set chart(chart: CartesianChart<XAxis, YAxis> | undefined) {
         if (this._chart !== chart) {
             this._chart = chart;
             this.scheduleData();
         }
     }
-    get chart(): CartesianChart | undefined {
+    get chart(): CartesianChart<XAxis, YAxis> | undefined {
         return this._chart;
     }
 
@@ -287,13 +287,13 @@ export class AreaSeries extends Series<CartesianChart> {
 
         if (isContinuousX) {
             const [ min, max ] = domainX as number[];
-            
+
             if (min === max) {
                 domainX[0] = min - 1;
                 domainX[1] = max + 1;
             }
         }
-        
+
         let yMin: number = Infinity;
         let yMax: number = -Infinity;
 
@@ -347,7 +347,7 @@ export class AreaSeries extends Series<CartesianChart> {
     }
 
     private generateSelectionData(): { areaSelectionData: AreaSelectionDatum[], markerSelectionData: MarkerSelectionDatum[] } {
-        const { 
+        const {
             yFields,
             fills,
             strokes,
@@ -408,7 +408,7 @@ export class AreaSeries extends Series<CartesianChart> {
     private updateAreaSelection(areaSelectionData: AreaSelectionDatum[]): void {
         const { fills, fillOpacity, yFieldEnabled, shadow } = this;
         const updateAreas = this.areaSelection.setData(areaSelectionData);
-        
+
         updateAreas.exit.remove();
 
         const enterAreas = updateAreas.enter.append(Path)
@@ -438,7 +438,7 @@ export class AreaSeries extends Series<CartesianChart> {
                     path.moveTo(x, y);
                 }
             });
-            
+
             path.closePath();
         });
 

--- a/packages/ag-grid-enterprise/src/charts/chart/series/barSeries.ts
+++ b/packages/ag-grid-enterprise/src/charts/chart/series/barSeries.ts
@@ -1,6 +1,6 @@
 import { Group } from "../../scene/group";
 import { Selection } from "../../scene/selection";
-import { CartesianChart } from "../cartesianChart";
+import { CartesianAxis, CartesianChart } from "../cartesianChart";
 import { Rect } from "../../scene/shape/rect";
 import { Text, FontStyle, FontWeight } from "../../scene/shape/text";
 import { BandScale } from "../../scale/bandScale";
@@ -56,7 +56,7 @@ export interface BarTooltipRendererParams {
     color?: string;
 }
 
-export class BarSeries extends Series<CartesianChart> {
+export class BarSeries<XAxis extends CartesianAxis, YAxis extends CartesianAxis> extends Series<CartesianChart<XAxis, YAxis>> {
 
     static className = 'BarSeries';
 
@@ -128,13 +128,13 @@ export class BarSeries extends Series<CartesianChart> {
      */
     private groupScale = new BandScale<string>();
 
-    set chart(chart: CartesianChart | undefined) {
+    set chart(chart: CartesianChart<XAxis, YAxis> | undefined) {
         if (this._chart !== chart) {
             this._chart = chart;
             this.scheduleData();
         }
     }
-    get chart(): CartesianChart | undefined {
+    get chart(): CartesianChart<XAxis, YAxis> | undefined {
         return this._chart;
     }
 
@@ -529,7 +529,7 @@ export class BarSeries extends Series<CartesianChart> {
     private updateRectSelection(selectionData: SelectionDatum[]): void {
         const { fillOpacity, strokeOpacity, shadow, highlightedNode, highlightStyle: { fill, stroke } } = this;
         const updateRects = this.rectSelection.setData(selectionData);
-        
+
         updateRects.exit.remove();
 
         const enterRects = updateRects.enter.append(Rect).each(rect => {
@@ -573,7 +573,7 @@ export class BarSeries extends Series<CartesianChart> {
 
         textSelection.each((text, datum) => {
             const label = datum.label;
-            
+
             if (label && labelEnabled) {
                 text.fontStyle = label.fontStyle;
                 text.fontWeight = label.fontWeight;

--- a/packages/ag-grid-enterprise/src/charts/chart/series/lineSeries.ts
+++ b/packages/ag-grid-enterprise/src/charts/chart/series/lineSeries.ts
@@ -1,4 +1,4 @@
-import { CartesianChart } from "../cartesianChart";
+import { CartesianAxis, CartesianChart } from "../cartesianChart";
 import { Path } from "../../scene/shape/path";
 import ContinuousScale from "../../scale/continuousScale";
 import { Selection } from "../../scene/selection";
@@ -30,7 +30,7 @@ export interface LineTooltipRendererParams {
     color?: string;
 }
 
-export class LineSeries extends Series<CartesianChart> {
+export class LineSeries<XAxis extends CartesianAxis, YAxis extends CartesianAxis> extends Series<CartesianChart<XAxis, YAxis>> {
 
     static className = 'LineSeries';
 
@@ -53,13 +53,13 @@ export class LineSeries extends Series<CartesianChart> {
         this.group.append(lineNode);
     }
 
-    set chart(chart: CartesianChart | undefined) {
+    set chart(chart: CartesianChart<XAxis, YAxis> | undefined) {
         if (this._chart !== chart) {
             this._chart = chart;
             this.scheduleData();
         }
     }
-    get chart(): CartesianChart | undefined {
+    get chart(): CartesianChart<XAxis, YAxis> | undefined {
         return this._chart;
     }
 

--- a/packages/ag-grid-enterprise/src/charts/chart/series/scatterSeries.ts
+++ b/packages/ag-grid-enterprise/src/charts/chart/series/scatterSeries.ts
@@ -1,4 +1,4 @@
-import { CartesianChart } from "../cartesianChart";
+import { CartesianAxis, CartesianChart } from "../cartesianChart";
 import { Selection } from "../../scene/selection";
 import { Group } from "../../scene/group";
 import { Arc, ArcType } from "../../scene/shape/arc";
@@ -34,7 +34,7 @@ export interface ScatterTooltipRendererParams {
     color?: string;
 }
 
-export class ScatterSeries extends Series<CartesianChart> {
+export class ScatterSeries<XAxis extends CartesianAxis, YAxis extends CartesianAxis> extends Series<CartesianChart<XAxis, YAxis>> {
 
     static className = 'ScatterSeries';
 
@@ -47,13 +47,14 @@ export class ScatterSeries extends Series<CartesianChart> {
 
     private groupSelection: Selection<Group, Group, GroupSelectionDatum, any> = Selection.select(this.group).selectAll<Group>();
 
-    set chart(chart: CartesianChart | undefined) {
+    set chart(chart: CartesianChart<XAxis, YAxis> | undefined) {
         if (this._chart !== chart) {
             this._chart = chart;
             this.scheduleData();
         }
     }
-    get chart(): CartesianChart | undefined {
+
+    get chart(): CartesianChart<XAxis, YAxis> | undefined {
         return this._chart;
     }
 
@@ -64,6 +65,7 @@ export class ScatterSeries extends Series<CartesianChart> {
             this.scheduleLayout();
         }
     }
+
     get title(): string | undefined {
         return this._title;
     }
@@ -76,6 +78,7 @@ export class ScatterSeries extends Series<CartesianChart> {
             this.scheduleData();
         }
     }
+
     get xField(): string {
         return this._xField;
     }
@@ -88,6 +91,7 @@ export class ScatterSeries extends Series<CartesianChart> {
             this.scheduleData();
         }
     }
+
     get yField(): string {
         return this._yField;
     }
@@ -100,6 +104,7 @@ export class ScatterSeries extends Series<CartesianChart> {
             this.scheduleData();
         }
     }
+
     get radiusField(): string | undefined {
         return this._radiusField;
     }
@@ -111,6 +116,7 @@ export class ScatterSeries extends Series<CartesianChart> {
             this.scheduleData();
         }
     }
+
     get labelField(): string | undefined {
         return this._labelField;
     }
@@ -127,6 +133,7 @@ export class ScatterSeries extends Series<CartesianChart> {
             this.update();
         }
     }
+
     get marker(): boolean {
         return this._marker;
     }
@@ -138,6 +145,7 @@ export class ScatterSeries extends Series<CartesianChart> {
             this.update();
         }
     }
+
     get markerSize(): number {
         return this._markerSize;
     }
@@ -149,6 +157,7 @@ export class ScatterSeries extends Series<CartesianChart> {
             this.update();
         }
     }
+
     get minMarkerSize(): number {
         return this._minMarkerSize;
     }
@@ -160,19 +169,20 @@ export class ScatterSeries extends Series<CartesianChart> {
             this.update();
         }
     }
+
     get markerStrokeWidth(): number {
         return this._markerStrokeWidth;
     }
 
     processData(): boolean {
-        const { 
+        const {
             chart,
             xField,
             yField,
             radiusField,
             markerSize,
             minMarkerSize,
-         } = this;
+        } = this;
 
         if (!(chart && chart.xAxis && chart.yAxis)) {
             return false;
@@ -181,19 +191,18 @@ export class ScatterSeries extends Series<CartesianChart> {
         if (!(xField && yField)) {
             this._data = [];
         }
-        
+
         this.xData = this.data.map(d => d[xField]);
         this.yData = this.data.map(d => d[yField]);
 
         if (radiusField) {
             this.radiusData = this.data.map(d => d[radiusField]);
-        }
-        else {
+        } else {
             this.radiusData = [];
         }
 
-        this.radiusScale.domain = numericExtent(this.radiusData) || [ 1, 1 ];
-        this.radiusScale.range = [ minMarkerSize / 2, markerSize / 2 ];
+        this.radiusScale.domain = numericExtent(this.radiusData) || [1, 1];
+        this.radiusScale.range = [minMarkerSize / 2, markerSize / 2];
         this.domainX = this.calculateDomain(this.xData);
         this.domainY = this.calculateDomain(this.yData);
 
@@ -202,8 +211,8 @@ export class ScatterSeries extends Series<CartesianChart> {
 
     private calculateDomain(data: any[]): [number, number] {
         const domain = numericExtent(data) || [0, 1];
-        const [ min, max ] = domain;
-        
+        const [min, max] = domain;
+
         if (min === max) {
             domain[0] = min - 1;
             domain[1] = max + 1;
@@ -220,6 +229,7 @@ export class ScatterSeries extends Series<CartesianChart> {
             this.scheduleData();
         }
     }
+
     get fill(): string {
         return this._fill;
     }
@@ -231,6 +241,7 @@ export class ScatterSeries extends Series<CartesianChart> {
             this.scheduleData();
         }
     }
+
     get stroke(): string {
         return this._stroke;
     }
@@ -242,6 +253,7 @@ export class ScatterSeries extends Series<CartesianChart> {
             this.scheduleLayout();
         }
     }
+
     get fillOpacity(): number {
         return this._fillOpacity;
     }
@@ -253,6 +265,7 @@ export class ScatterSeries extends Series<CartesianChart> {
             this.scheduleLayout();
         }
     }
+
     get strokeOpacity(): number {
         return this._strokeOpacity;
     }
@@ -288,7 +301,7 @@ export class ScatterSeries extends Series<CartesianChart> {
             return;
         }
 
-        const { xAxis, yAxis } = chart;
+        const {xAxis, yAxis} = chart;
         const xScale = xAxis.scale;
         const yScale = yAxis.scale;
         const xOffset = (xScale.bandwidth || 0) / 2;
@@ -326,7 +339,7 @@ export class ScatterSeries extends Series<CartesianChart> {
         enterGroups.append(Arc).each(arc => arc.type = ArcType.Chord);
 
         const groupSelection = updateGroups.merge(enterGroups);
-        const { fill: highlightFill, stroke: highlightStroke } = this.highlightStyle;
+        const {fill: highlightFill, stroke: highlightStroke} = this.highlightStyle;
 
         groupSelection.selectByClass(Arc)
             .each((arc, datum) => {
@@ -363,7 +376,7 @@ export class ScatterSeries extends Series<CartesianChart> {
             radiusFieldName,
             labelFieldName,
             fill: color
-         } = this;
+        } = this;
 
         let html: string = '';
 
@@ -372,7 +385,7 @@ export class ScatterSeries extends Series<CartesianChart> {
         }
 
         const title = this.title;
-        
+
         if (this.tooltipRenderer && this.xField) {
             html = this.tooltipRenderer({
                 datum: nodeDatum.seriesDatum,


### PR DESCRIPTION
so that we know what type of axis it is (e.g. in chart.xAxis.labelFormatter).