### PR TITLE
AG-3327 - move ChartBuilder into charts module

### DIFF
--- a/packages/ag-grid-enterprise/src/chartAdaptor/chartComp/chartProxies/cartesian/areaChartProxy.ts
+++ b/packages/ag-grid-enterprise/src/chartAdaptor/chartComp/chartProxies/cartesian/areaChartProxy.ts
@@ -1,5 +1,5 @@
 import { AreaChartOptions, ChartType, _, FontWeight } from "ag-grid-community";
-import { ChartBuilder } from "../../../builder/chartBuilder";
+import { ChartBuilder } from "../../../../charts/chartBuilder";
 import { AreaSeries } from "../../../../charts/chart/series/areaSeries";
 import { ChartProxyParams, UpdateChartParams } from "../chartProxy";
 import { CartesianChart } from "../../../../charts/chart/cartesianChart";

--- a/packages/ag-grid-enterprise/src/chartAdaptor/chartComp/chartProxies/cartesian/barChartProxy.ts
+++ b/packages/ag-grid-enterprise/src/chartAdaptor/chartComp/chartProxies/cartesian/barChartProxy.ts
@@ -1,5 +1,5 @@
 import { BarChartOptions, ChartType, _, FontWeight } from "ag-grid-community";
-import { ChartBuilder } from "../../../builder/chartBuilder";
+import { ChartBuilder } from "../../../../charts/chartBuilder";
 import { BarSeries } from "../../../../charts/chart/series/barSeries";
 import { ChartProxyParams, UpdateChartParams } from "../chartProxy";
 import { CartesianChartProxy } from "./cartesianChartProxy";
@@ -19,6 +19,7 @@ export class BarChartProxy extends CartesianChartProxy<BarChartOptions> {
         } else {
             builderFunction = params.grouping ? "createGroupedBarChart" : "createBarChart";
         }
+
         this.chart = ChartBuilder[builderFunction](params.parentElement, this.chartOptions);
 
         const barSeries = ChartBuilder.createSeries(this.chartOptions.seriesDefaults!);

--- a/packages/ag-grid-enterprise/src/chartAdaptor/chartComp/chartProxies/cartesian/lineChartProxy.ts
+++ b/packages/ag-grid-enterprise/src/chartAdaptor/chartComp/chartProxies/cartesian/lineChartProxy.ts
@@ -1,5 +1,5 @@
 import { LineChartOptions, _, FontWeight } from "ag-grid-community";
-import { ChartBuilder } from "../../../builder/chartBuilder";
+import { ChartBuilder } from "../../../../charts/chartBuilder";
 import { ChartProxyParams, UpdateChartParams } from "../chartProxy";
 import { LineSeries } from "../../../../charts/chart/series/lineSeries";
 import { CartesianChartProxy, LineMarkerProperty, LineSeriesProperty } from "./cartesianChartProxy";

--- a/packages/ag-grid-enterprise/src/chartAdaptor/chartComp/chartProxies/cartesian/scatterChartProxy.ts
+++ b/packages/ag-grid-enterprise/src/chartAdaptor/chartComp/chartProxies/cartesian/scatterChartProxy.ts
@@ -1,5 +1,5 @@
 import { ChartType, ScatterChartOptions, _, FontWeight } from "ag-grid-community";
-import { ChartBuilder } from "../../../builder/chartBuilder";
+import { ChartBuilder } from "../../../../charts/chartBuilder";
 import { ChartProxyParams, UpdateChartParams } from "../chartProxy";
 import { ScatterSeries } from "../../../../charts/chart/series/scatterSeries";
 import { ChartModel } from "../../chartModel";

--- a/packages/ag-grid-enterprise/src/chartAdaptor/chartComp/chartProxies/polar/doughnutChartProxy.ts
+++ b/packages/ag-grid-enterprise/src/chartAdaptor/chartComp/chartProxies/polar/doughnutChartProxy.ts
@@ -1,4 +1,4 @@
-import { ChartBuilder } from "../../../builder/chartBuilder";
+import { ChartBuilder } from "../../../../charts/chartBuilder";
 import { DoughnutChartOptions, CaptionOptions, _ } from "ag-grid-community";
 import { ChartProxyParams, UpdateChartParams } from "../chartProxy";
 import { PieSeries } from "../../../../charts/chart/series/pieSeries";

--- a/packages/ag-grid-enterprise/src/chartAdaptor/chartComp/chartProxies/polar/pieChartProxy.ts
+++ b/packages/ag-grid-enterprise/src/chartAdaptor/chartComp/chartProxies/polar/pieChartProxy.ts
@@ -1,4 +1,4 @@
-import { ChartBuilder } from "../../../builder/chartBuilder";
+import { ChartBuilder } from "../../../../charts/chartBuilder";
 import { PieChartOptions, CaptionOptions } from "ag-grid-community";
 import { ChartProxyParams, UpdateChartParams } from "../chartProxy";
 import { PieSeries } from "../../../../charts/chart/series/pieSeries";

--- a/packages/ag-grid-enterprise/src/charts/axis.ts
+++ b/packages/ag-grid-enterprise/src/charts/axis.ts
@@ -39,6 +39,19 @@ export interface IGridStyle {
     lineDash?: number[];
 }
 
+export interface ILinearAxis<S extends Scale<D, number> = Scale<any, number>, D = any> {
+    group: Group;
+    scale: S;
+    domain: D[];
+    rotation: number;
+    translationX: number;
+    translationY: number;
+    parallelLabels: boolean;
+    gridLength: number;
+    getBBox(includeTitle?: boolean): BBox;
+    update(): void;
+}
+
 /**
  * A general purpose linear axis with no notion of orientation.
  * The axis is always rendered vertically, with horizontal labels positioned to the left
@@ -48,7 +61,7 @@ export interface IGridStyle {
  * The generic `D` parameter is the type of the domain of the axis' scale.
  * The output range of the axis' scale is always numeric (screen coordinates).
  */
-export class Axis<S extends Scale<D, number>, D = any> implements IAxisFormatting, ILabelFormatting {
+export class Axis<S extends Scale<D, number>, D = any> implements ILinearAxis<S>, IAxisFormatting, ILabelFormatting {
 
     // debug (bbox)
     // private bboxRect = (() => {
@@ -161,7 +174,7 @@ export class Axis<S extends Scale<D, number>, D = any> implements IAxisFormattin
      * digits used by the tick step. For example, if the tick step is `0.0005`,
      * the `fractionDigits` is 4.
      */
-    labelFormatter?: (params: {value: any, index: number, fractionDigits?: number, formatter?: (x: any) => string}) => string;
+    labelFormatter?: (params: { value: any, index: number, fractionDigits?: number, formatter?: (x: any) => string }) => string;
 
     labelFontStyle: FontStyle | undefined = undefined;
     labelFontWeight: FontWeight | undefined = undefined;
@@ -336,7 +349,7 @@ export class Axis<S extends Scale<D, number>, D = any> implements IAxisFormattin
         const enter = update.enter.append(Group);
         // Line auto-snaps to pixel grid if vertical or horizontal.
         enter.append(Line).each(node => node.tag = Tags.Tick);
-        
+
         if (this.gridLength) {
             if (this.radialGrid) {
                 enter.append(Arc).each(node => node.tag = Tags.GridLine);

--- a/packages/ag-grid-enterprise/src/charts/chart/axis/groupedCategoryAxis.ts
+++ b/packages/ag-grid-enterprise/src/charts/chart/axis/groupedCategoryAxis.ts
@@ -9,7 +9,7 @@ import { Caption } from "../../caption";
 // import { Rect } from "../../scene/shape/rect"; debug (bbox)
 import { BandScale } from "../../scale/bandScale";
 import { ticksToTree, TreeLayout, treeLayout } from "../../layout/tree";
-import { IAxisFormatting, ILabelFormatting, IGridStyle } from "../../axis";
+import { IGridStyle, ILinearAxis, IAxisFormatting, ILabelFormatting } from "../../axis";
 
 /**
  * A general purpose linear axis with no notion of orientation.
@@ -20,7 +20,7 @@ import { IAxisFormatting, ILabelFormatting, IGridStyle } from "../../axis";
  * The generic `D` parameter is the type of the domain of the axis' scale.
  * The output range of the axis' scale is always numeric (screen coordinates).
  */
-export class GroupedCategoryAxis implements IAxisFormatting, ILabelFormatting {
+export class GroupedCategoryAxis implements ILinearAxis<BandScale<string | number>, string | number>, IAxisFormatting, ILabelFormatting {
 
     // debug (bbox)
     // private bboxRect = (() => {
@@ -157,7 +157,7 @@ export class GroupedCategoryAxis implements IAxisFormatting, ILabelFormatting {
      */
     tickColor?: string = 'rgba(195, 195, 195, 1)';
 
-    labelFormatter?: (params: {value: any, index: number}) => string;
+    labelFormatter?: (params: { value: any, index: number }) => string;
 
     labelFontStyle: FontStyle | undefined = undefined;
     labelFontWeight: FontWeight | undefined = undefined;
@@ -353,7 +353,7 @@ export class GroupedCategoryAxis implements IAxisFormatting, ILabelFormatting {
             : (regularFlipFlag === -1 ? Math.PI : 0);
 
         const labelGrid = this.labelGrid;
-        const separatorData = [] as {y: number, x1: number, x2: number, toString: () => string}[];
+        const separatorData = [] as { y: number, x1: number, x2: number, toString: () => string }[];
         labelSelection.each((label, datum, index) => {
             label.x = labelX;
             label.rotationCenterX = labelX;

--- a/packages/ag-grid-enterprise/src/charts/chart/cartesianChart.ts
+++ b/packages/ag-grid-enterprise/src/charts/chart/cartesianChart.ts
@@ -1,5 +1,5 @@
 import { Chart, ChartOptions } from "./chart";
-import { Axis } from "../axis";
+import { Axis, ILinearAxis } from "../axis";
 import Scale from "../scale/scale";
 import { Series } from "./series/series";
 import { numericExtent } from "../util/array";
@@ -12,15 +12,15 @@ export enum CartesianChartLayout {
     Horizontal
 }
 
-export interface CartesianChartOptions extends ChartOptions {
-    xAxis: Axis<Scale<any, number>>;
-    yAxis: Axis<Scale<any, number>>;
+export interface CartesianChartOptions<TX extends ILinearAxis = Axis<Scale<any, number>>, TY extends ILinearAxis = Axis<Scale<any, number>>> extends ChartOptions {
+    xAxis: TX;
+    yAxis: TY;
 }
 
-export class CartesianChart extends Chart {
-    private axisAutoPadding = new Padding();
+export class CartesianChart<TX extends ILinearAxis = Axis<Scale<any, number>>, TY extends ILinearAxis = Axis<Scale<any, number>>> extends Chart {
+    protected axisAutoPadding = new Padding();
 
-    constructor(options: CartesianChartOptions) {
+    constructor(options: CartesianChartOptions<TX, TY>) {
         super(options);
 
         const { xAxis, yAxis } = options;
@@ -28,31 +28,31 @@ export class CartesianChart extends Chart {
         this._xAxis = xAxis;
         this._yAxis = yAxis;
 
-        this.scene.root!.append([xAxis.group, yAxis.group, this.seriesClipRect]);
+        this.scene.root!.append([xAxis.group, yAxis.group, this._seriesRoot]);
         this.scene.root!.append(this.legend.group);
     }
 
-    private seriesClipRect = new Group();
+    private _seriesRoot = new Group();
     get seriesRoot(): Group {
-        return this.seriesClipRect;
+        return this._seriesRoot;
     }
 
-    private readonly _xAxis: Axis<Scale<any, number>>;
-    get xAxis(): Axis<Scale<any, number>> {
+    private readonly _xAxis: TX;
+    get xAxis(): TX {
         return this._xAxis;
     }
 
-    private readonly _yAxis: Axis<Scale<any, number>>;
-    get yAxis(): Axis<Scale<any, number>> {
+    private readonly _yAxis: TY;
+    get yAxis(): TY {
         return this._yAxis;
     }
 
-    set series(values: Series<CartesianChart>[]) {
+    set series(values: Series<CartesianChart<TX, TY>>[]) {
         this.removeAllSeries();
         values.forEach(series => this.addSeries(series));
     }
-    get series(): Series<CartesianChart>[] {
-        return this._series as Series<CartesianChart>[];
+    get series(): Series<CartesianChart<TX, TY>>[] {
+        return this._series as Series<CartesianChart<TX, TY>>[];
     }
 
     performLayout(): void {

--- a/packages/ag-grid-enterprise/src/charts/chart/groupedCategoryChart.ts
+++ b/packages/ag-grid-enterprise/src/charts/chart/groupedCategoryChart.ts
@@ -1,150 +1,16 @@
-import { Chart, ChartOptions } from "./chart";
-import { CartesianChartLayout } from "./cartesianChart";
+import { CartesianChartLayout, CartesianChart, CartesianChartOptions } from "./cartesianChart";
 import { Axis } from "../axis";
 import Scale from "../scale/scale";
-import { Series } from "./series/series";
 import { numericExtent } from "../util/array";
-import { Padding } from "../util/padding";
-import { Group } from "../scene/group";
 import { GroupedCategoryAxis } from "./axis/groupedCategoryAxis";
 
 export type GroupedCategoryChartAxis = GroupedCategoryAxis | Axis<Scale<any, number>>;
-export interface GroupedCategoryChartOptions extends ChartOptions {
-    xAxis: GroupedCategoryChartAxis;
-    yAxis: GroupedCategoryChartAxis;
+export interface GroupedCategoryChartOptions extends CartesianChartOptions<GroupedCategoryChartAxis, GroupedCategoryChartAxis> {
 }
 
-export class GroupedCategoryChart extends Chart {
-    private axisAutoPadding = new Padding();
-
+export class GroupedCategoryChart extends CartesianChart<GroupedCategoryChartAxis, GroupedCategoryChartAxis> {
     constructor(options: GroupedCategoryChartOptions) {
         super(options);
-
-        const xAxis = options.xAxis;
-        const yAxis = options.yAxis;
-
-        this._xAxis = xAxis;
-        this._yAxis = yAxis;
-
-        this.scene.root!.append([xAxis.group, yAxis.group, this.seriesRoot]);
-        this.scene.root!.append(this.legend.group);
-    }
-
-    private _seriesRoot = new Group();
-    get seriesRoot(): Group {
-        return this._seriesRoot;
-    }
-
-    private readonly _xAxis: GroupedCategoryChartAxis;
-    get xAxis(): GroupedCategoryChartAxis {
-        return this._xAxis;
-    }
-
-    private readonly _yAxis: GroupedCategoryChartAxis;
-    get yAxis(): GroupedCategoryChartAxis {
-        return this._yAxis;
-    }
-
-    set series(values: Series<GroupedCategoryChart>[]) {
-        this.removeAllSeries();
-        values.forEach(series => {
-            this.addSeries(series);
-        });
-    }
-    get series(): Series<GroupedCategoryChart>[] {
-        return this._series as Series<GroupedCategoryChart>[];
-    }
-
-    performLayout(): void {
-        if (this.dataPending || !(this.xAxis && this.yAxis)) {
-            return;
-        }
-
-        const shrinkRect = {
-            x: 0,
-            y: 0,
-            width: this.width,
-            height: this.height
-        };
-
-        const captionAutoPadding = this.captionAutoPadding;
-        shrinkRect.y += captionAutoPadding;
-        shrinkRect.height -= captionAutoPadding;
-
-        if (this.legend.enabled && this.legend.data.length) {
-            const legendAutoPadding = this.legendAutoPadding;
-            shrinkRect.x += legendAutoPadding.left;
-            shrinkRect.y += legendAutoPadding.top;
-            shrinkRect.width -= legendAutoPadding.left + legendAutoPadding.right;
-            shrinkRect.height -= legendAutoPadding.top + legendAutoPadding.bottom;
-
-            const legendPadding = this.legendPadding;
-            switch (this.legendPosition) {
-                case 'right':
-                    shrinkRect.width -= legendPadding;
-                    break;
-                case 'bottom':
-                    shrinkRect.height -= legendPadding;
-                    break;
-                case 'left':
-                    shrinkRect.x += legendPadding;
-                    shrinkRect.width -= legendPadding;
-                    break;
-                case 'top':
-                    shrinkRect.y += legendPadding;
-                    shrinkRect.height -= legendPadding;
-                    break;
-            }
-        }
-
-        const padding = this.padding;
-        shrinkRect.x += padding.left;
-        shrinkRect.y += padding.top;
-        shrinkRect.width -= padding.left + padding.right;
-        shrinkRect.height -= padding.top + padding.bottom;
-
-        const axisAutoPadding = this.axisAutoPadding;
-        shrinkRect.x += axisAutoPadding.left;
-        shrinkRect.y += axisAutoPadding.top;
-        shrinkRect.width -= axisAutoPadding.left + axisAutoPadding.right;
-        shrinkRect.height -= axisAutoPadding.top + axisAutoPadding.bottom;
-
-        const xAxis = this.xAxis;
-        const yAxis = this.yAxis;
-
-        xAxis.range = [0, shrinkRect.width];
-        xAxis.rotation = -90;
-        xAxis.translationX = Math.floor(shrinkRect.x);
-        xAxis.translationY = Math.floor(shrinkRect.y + shrinkRect.height + 1);
-        xAxis.parallelLabels = true;
-        xAxis.gridLength = shrinkRect.height;
-
-        yAxis.range = [shrinkRect.height, 0];
-        yAxis.translationX = Math.floor(shrinkRect.x);
-        yAxis.translationY = Math.floor(shrinkRect.y);
-        yAxis.gridLength = shrinkRect.width;
-
-        this.updateAxes();
-
-        this.series.forEach(series => {
-            series.group.translationX = Math.floor(shrinkRect.x);
-            series.group.translationY = Math.floor(shrinkRect.y);
-            series.update(); // this has to happen after the `updateAxis` call
-        });
-
-        this.positionCaptions();
-        this.positionLegend();
-    }
-
-    private _layout: CartesianChartLayout = CartesianChartLayout.Vertical;
-    set layout(value: CartesianChartLayout) {
-        if (this._layout !== value) {
-            this._layout = value;
-            this.layoutPending = true;
-        }
-    }
-    get layout(): CartesianChartLayout {
-        return this._layout;
     }
 
     updateAxes() {
@@ -159,21 +25,21 @@ export class GroupedCategoryChart extends Chart {
         const xDomains: any[][] = [];
         const yDomains: any[][] = [];
 
-        let isNumericX: boolean | undefined = undefined;
-        this.series.forEach((series, index) => {
-            if (series.visible) {
-                const xDomain = series.getDomainX();
-                const yDomain = series.getDomainY();
+        let isNumericXAxis: boolean | undefined = undefined;
 
-                const isFirstVisibleSeries = isNumericX === undefined;
-                if (isFirstVisibleSeries) {
-                    isNumericX = typeof xDomain[0] === 'number';
-                }
-                if (isNumericX || isFirstVisibleSeries) {
-                    xDomains.push(xDomain);
-                }
-                yDomains.push(yDomain);
+        this.series.filter(s => s.visible).forEach(series => {
+            const xDomain = series.getDomainX();
+
+            if (isNumericXAxis === undefined) {
+                // always add first X domain
+                xDomains.push(xDomain);
+                isNumericXAxis = typeof xDomain[0] === 'number';
+            } else if (isNumericXAxis) {
+                // only add further X domains if the axis is numeric
+                xDomains.push(xDomain);
             }
+
+            yDomains.push(series.getDomainY());
         });
 
         const xDomain = new Array<any>().concat(...xDomains);
@@ -185,7 +51,8 @@ export class GroupedCategoryChart extends Chart {
         xAxis.update();
         yAxis.update();
 
-        // The `xAxis` and `yAxis` have `.this` prefix on purpose here.
+        // The `xAxis` and `yAxis` have `.this` prefix on purpose here,
+        // because the local `xAxis` and `yAxis` variables may be swapped.
         const xAxisBBox = this.xAxis.getBBox();
         const yAxisBBox = this.yAxis.getBBox();
 

--- a/packages/ag-grid-enterprise/src/charts/chart/series/barSeries.ts
+++ b/packages/ag-grid-enterprise/src/charts/chart/series/barSeries.ts
@@ -425,7 +425,7 @@ export class BarSeries extends Series<CartesianChart> {
             // console.warn('Zero or infinite y-range.');
         }
 
-        this.domainY = [ yMin, yMax ];
+        this.domainY = [yMin, yMax];
 
         const chart = this.chart;
 
@@ -638,8 +638,8 @@ export class BarSeries extends Series<CartesianChart> {
                 title = title ? `<div class="title" ${titleStyle}>${title}</div>` : '';
                 const xValue = datum[xField];
                 const yValue = datum[yField];
-                const xString = typeof(xValue) === 'number' ? toFixed(xValue) : String(xValue);
-                const yString = typeof(yValue) === 'number' ? toFixed(yValue) : String(yValue);
+                const xString = typeof xValue === 'number' ? toFixed(xValue) : String(xValue);
+                const yString = typeof yValue === 'number' ? toFixed(yValue) : String(yValue);
 
                 html = `${title}<div class="content">${xString}: ${yString}</div>`;
             }

--- a/packages/ag-grid-enterprise/src/charts/chartBuilder.ts
+++ b/packages/ag-grid-enterprise/src/charts/chartBuilder.ts
@@ -1,53 +1,46 @@
 import {
-    _,
-    ILabelFormattingOptions,
-    AxisOptions,
-    BarSeriesOptions,
-    AreaSeriesOptions,
+    ChartOptions,
     CartesianChartOptions,
-    DropShadowOptions,
+    PolarChartOptions,
+    SeriesOptions,
+    BarSeriesOptions,
     LineSeriesOptions,
     ScatterSeriesOptions,
+    AreaSeriesOptions,
     PieSeriesOptions,
-    DoughnutChartOptions,
-    ChartOptions,
-    BarChartOptions,
-    AreaChartOptions,
+    LabelFormattingOptions,
     LegendOptions,
-    PolarChartOptions,
-    LineChartOptions,
-    ScatterChartOptions,
-    PieChartOptions,
-    SeriesOptions,
     CaptionOptions,
-    CartesianSeriesType,
-    PolarSeriesType,
-    SeriesType,
     FontWeight,
-} from "ag-grid-community";
-
-import { CartesianChart, CartesianChartLayout } from "../../charts/chart/cartesianChart";
-import { PolarChart } from "../../charts/chart/polarChart";
-import { LineSeries } from "../../charts/chart/series/lineSeries";
-import { ScatterSeries } from "../../charts/chart/series/scatterSeries";
-import { BarSeries } from "../../charts/chart/series/barSeries";
-import { AreaSeries } from "../../charts/chart/series/areaSeries";
-import { PieSeries } from "../../charts/chart/series/pieSeries";
-import { Chart } from "../../charts/chart/chart";
-import { Series } from "../../charts/chart/series/series";
-import { DropShadow } from "../../charts/scene/dropShadow";
-import { CategoryAxis } from "../../charts/chart/axis/categoryAxis";
-import { NumberAxis } from "../../charts/chart/axis/numberAxis";
-import { Padding } from "../../charts/util/padding";
-import { Legend } from "../../charts/chart/legend";
-import { Caption } from "../../charts/caption";
-import { GroupedCategoryAxis } from "../../charts/chart/axis/groupedCategoryAxis";
-import { GroupedCategoryChart, GroupedCategoryChartAxis } from "../../charts/chart/groupedCategoryChart";
-import { Axis } from "../../charts/axis";
-import Scale from "../../charts/scale/scale";
+    DropShadowOptions,
+    AxisOptions,
+} from "./chartOptions";
+import { CartesianChart, CartesianChartLayout } from "./chart/cartesianChart";
+import { PolarChart } from "./chart/polarChart";
+import { LineSeries } from "./chart/series/lineSeries";
+import { ScatterSeries } from "./chart/series/scatterSeries";
+import { BarSeries } from "./chart/series/barSeries";
+import { AreaSeries } from "./chart/series/areaSeries";
+import { PieSeries } from "./chart/series/pieSeries";
+import { Chart } from "./chart/chart";
+import { Series } from "./chart/series/series";
+import { DropShadow } from "./scene/dropShadow";
+import { CategoryAxis } from "./chart/axis/categoryAxis";
+import { NumberAxis } from "./chart/axis/numberAxis";
+import { Padding } from "./util/padding";
+import { Legend } from "./chart/legend";
+import { Caption } from "./caption";
+import { GroupedCategoryAxis } from "./chart/axis/groupedCategoryAxis";
+import { GroupedCategoryChart, GroupedCategoryChartAxis } from "./chart/groupedCategoryChart";
+import { Axis } from "./axis";
+import Scale from "./scale/scale";
 
 export class ChartBuilder {
-    private static createCartesianChart(parent: HTMLElement, xAxis: Axis<Scale<any, number>>, yAxis: Axis<Scale<any, number>>, document?: Document): CartesianChart {
+    private static createCartesianChart(
+        parent: HTMLElement,
+        xAxis: Axis<Scale<any, number>>,
+        yAxis: Axis<Scale<any, number>>,
+        document?: Document): CartesianChart {
         return new CartesianChart({
             parent,
             xAxis,
@@ -56,7 +49,11 @@ export class ChartBuilder {
         });
     }
 
-    private static createGroupedCategoryChart(parent: HTMLElement, xAxis: GroupedCategoryChartAxis, yAxis: GroupedCategoryChartAxis, document?: Document): GroupedCategoryChart {
+    private static createGroupedCategoryChart(
+        parent: HTMLElement,
+        xAxis: GroupedCategoryChartAxis,
+        yAxis: GroupedCategoryChartAxis,
+        document?: Document): GroupedCategoryChart {
         return new GroupedCategoryChart({
             parent,
             xAxis,
@@ -65,7 +62,7 @@ export class ChartBuilder {
         });
     }
 
-    static createBarChart(parent: HTMLElement, options: BarChartOptions): CartesianChart {
+    static createBarChart(parent: HTMLElement, options: CartesianChartOptions<BarSeriesOptions>): CartesianChart {
         const chart = this.createCartesianChart(
             parent,
             ChartBuilder.createNumberAxis(options.xAxis),
@@ -74,62 +71,100 @@ export class ChartBuilder {
 
         chart.layout = CartesianChartLayout.Horizontal;
 
-        return ChartBuilder.initCartesianChart(chart, options, "bar");
+        ChartBuilder.initChart(chart, options);
+
+        if (options.series) {
+            chart.series = options.series.map(s => ChartBuilder.initBarSeries(new BarSeries(), s));
+        }
+
+        return chart;
     }
 
-    static createColumnChart(parent: HTMLElement, options: BarChartOptions): CartesianChart {
+    static createColumnChart(parent: HTMLElement, options: CartesianChartOptions<BarSeriesOptions>): CartesianChart {
         const chart = this.createCartesianChart(
             parent,
             ChartBuilder.createCategoryAxis(options.xAxis),
             ChartBuilder.createNumberAxis(options.yAxis),
             options.document);
 
-        return ChartBuilder.initCartesianChart(chart, options, "bar");
+        ChartBuilder.initChart(chart, options);
+
+        if (options.series) {
+            chart.series = options.series.map(s => ChartBuilder.initBarSeries(new BarSeries(), s));
+        }
+
+        return chart;
     }
 
-    static createLineChart(parent: HTMLElement, options: LineChartOptions): CartesianChart {
+    static createLineChart(parent: HTMLElement, options: CartesianChartOptions<LineSeriesOptions>): CartesianChart {
         const chart = this.createCartesianChart(
             parent,
             ChartBuilder.createCategoryAxis(options.xAxis),
             ChartBuilder.createNumberAxis(options.yAxis),
             options.document);
 
-        return ChartBuilder.initCartesianChart(chart, options, "line");
+        ChartBuilder.initChart(chart, options);
+
+        if (options.series) {
+            chart.series = options.series.map(s => ChartBuilder.initLineSeries(new LineSeries(), s));
+        }
+
+        return chart;
     }
 
-    static createScatterChart(parent: HTMLElement, options: ScatterChartOptions): CartesianChart {
+    static createScatterChart(parent: HTMLElement, options: CartesianChartOptions<ScatterSeriesOptions>): CartesianChart {
         const chart = this.createCartesianChart(
             parent,
             ChartBuilder.createNumberAxis(options.xAxis),
             ChartBuilder.createNumberAxis(options.yAxis),
             options.document);
 
-        return ChartBuilder.initCartesianChart(chart, options, "scatter");
+        ChartBuilder.initChart(chart, options);
+
+        if (options.series) {
+            chart.series = options.series.map(s => ChartBuilder.initScatterSeries(new ScatterSeries(), s));
+        }
+
+        return chart;
     }
 
-    static createAreaChart(parent: HTMLElement, options: AreaChartOptions): CartesianChart {
+    static createAreaChart(parent: HTMLElement, options: CartesianChartOptions<AreaSeriesOptions>): CartesianChart {
         const chart = this.createCartesianChart(
             parent,
             ChartBuilder.createCategoryAxis(options.xAxis),
             ChartBuilder.createNumberAxis(options.yAxis),
             options.document);
 
-        return ChartBuilder.initCartesianChart(chart, options, "area");
+        ChartBuilder.initChart(chart, options);
+
+        if (options.series) {
+            chart.series = options.series.map(s => ChartBuilder.initAreaSeries(new AreaSeries(), s));
+        }
+
+        return chart;
     }
 
-    private static createPolarChart(parent: HTMLElement, options: PolarChartOptions): PolarChart {
-        return ChartBuilder.initPolarChart(new PolarChart({ parent }), options);
+    private static createPolarChart<T>(parent: HTMLElement): PolarChart {
+        return new PolarChart({ parent });
     }
 
-    static createDoughnutChart(parent: HTMLElement, options: DoughnutChartOptions): PolarChart {
-        return this.createPolarChart(parent, options);
+    static createDoughnutChart(parent: HTMLElement, options: PolarChartOptions<PieSeriesOptions>): PolarChart {
+        return this.createPieChart(parent, options);
     }
 
-    static createPieChart(parent: HTMLElement, options: PieChartOptions): PolarChart {
-        return this.createPolarChart(parent, options);
+    static createPieChart(parent: HTMLElement, options: PolarChartOptions<PieSeriesOptions>): PolarChart {
+        const chart = this.createPolarChart(parent);
+
+        ChartBuilder.initChart(chart, options);
+
+        if (options.series) {
+            chart.series = options.series.map(s => ChartBuilder.initPieSeries(new PieSeries(), s));
+        }
+
+        return chart;
     }
 
-    static createGroupedColumnChart(parent: HTMLElement, options: BarChartOptions): GroupedCategoryChart {
+    static createGroupedColumnChart(parent: HTMLElement, options: CartesianChartOptions<BarSeriesOptions>): GroupedCategoryChart {
         const chart = this.createGroupedCategoryChart(
             parent,
             ChartBuilder.createGroupedAxis(options.xAxis),
@@ -137,10 +172,16 @@ export class ChartBuilder {
             options.document
         );
 
-        return ChartBuilder.initGroupedCategoryChart(chart, options, "bar");
+        ChartBuilder.initChart(chart, options);
+
+        if (options.series) {
+            chart.series = options.series.map(s => ChartBuilder.initBarSeries(new BarSeries(), s));
+        }
+
+        return chart;
     }
 
-    static createGroupedBarChart(parent: HTMLElement, options: BarChartOptions): GroupedCategoryChart {
+    static createGroupedBarChart(parent: HTMLElement, options: CartesianChartOptions<BarSeriesOptions>): GroupedCategoryChart {
         const chart = this.createGroupedCategoryChart(
             parent,
             ChartBuilder.createNumberAxis(options.xAxis),
@@ -150,10 +191,16 @@ export class ChartBuilder {
 
         chart.layout = CartesianChartLayout.Horizontal;
 
-        return ChartBuilder.initGroupedCategoryChart(chart, options, "bar");
+        ChartBuilder.initChart(chart, options);
+
+        if (options.series) {
+            chart.series = options.series.map(s => ChartBuilder.initBarSeries(new BarSeries(), s));
+        }
+
+        return chart;
     }
 
-    static createGroupedLineChart(parent: HTMLElement, options: BarChartOptions): GroupedCategoryChart {
+    static createGroupedLineChart(parent: HTMLElement, options: CartesianChartOptions<LineSeriesOptions>): GroupedCategoryChart {
         const chart = this.createGroupedCategoryChart(
             parent,
             ChartBuilder.createGroupedAxis(options.xAxis),
@@ -161,10 +208,16 @@ export class ChartBuilder {
             options.document,
         );
 
-        return ChartBuilder.initGroupedCategoryChart(chart, options, "line");
+        ChartBuilder.initChart(chart, options);
+
+        if (options.series) {
+            chart.series = options.series.map(s => ChartBuilder.initLineSeries(new LineSeries(), s));
+        }
+
+        return chart;
     }
 
-    static createGroupedAreaChart(parent: HTMLElement, options: AreaChartOptions): GroupedCategoryChart {
+    static createGroupedAreaChart(parent: HTMLElement, options: CartesianChartOptions<AreaSeriesOptions>): GroupedCategoryChart {
         const chart = this.createGroupedCategoryChart(
             parent,
             ChartBuilder.createGroupedAxis(options.xAxis),
@@ -172,15 +225,17 @@ export class ChartBuilder {
             options.document
         );
 
-        return ChartBuilder.initGroupedCategoryChart(chart, options, "area");
+        ChartBuilder.initChart(chart, options);
+
+        if (options.series) {
+            chart.series = options.series.map(s => ChartBuilder.initAreaSeries(new AreaSeries(), s));
+        }
+
+        return chart;
     }
 
-    static createLineSeries = (options: LineSeriesOptions): LineSeries => new LineSeries();
-
-    static createScatterSeries = (options: ScatterSeriesOptions): ScatterSeries => new ScatterSeries();
-
-    static createSeries(options: { type?: SeriesType }, type?: SeriesType) {
-        switch (type || options && options.type) {
+    static createSeries(options: SeriesOptions) {
+        switch (options && options.type) {
             case "line":
                 return ChartBuilder.initLineSeries(new LineSeries(), options);
             case "scatter":
@@ -196,15 +251,14 @@ export class ChartBuilder {
         }
     }
 
-    static initChart<C extends Chart>(chart: C, options: ChartOptions, seriesType?: SeriesType) {
-        _.copyPropertiesIfPresent(options, chart, "width", "height", "legendPosition", "legendPadding", "data", "tooltipClass");
-        _.copyPropertyIfPresent(options, chart, "title", t => ChartBuilder.createTitle(t!));
-        _.copyPropertyIfPresent(options, chart, "subtitle", t => ChartBuilder.createSubtitle(t!));
-        _.copyPropertyIfPresent(options, chart, "series", s => s!.map(series => ChartBuilder.createSeries(series, seriesType)).filter(x => x));
-        _.copyPropertyIfPresent(options, chart, "padding", p => new Padding(p!.top, p!.right, p!.bottom, p!.left));
+    static initChart<C extends Chart, T extends SeriesOptions>(chart: C, options: ChartOptions<T>) {
+        this.copyPropertiesIfPresent(options, chart, "width", "height", "legendPosition", "legendPadding", "data", "tooltipClass");
+        this.copyPropertyIfPresent(options, chart, "title", t => ChartBuilder.createTitle(t));
+        this.copyPropertyIfPresent(options, chart, "subtitle", t => ChartBuilder.createSubtitle(t));
+        this.copyPropertyIfPresent(options, chart, "padding", p => new Padding(p.top, p.right, p.bottom, p.left));
 
         if (options.background !== undefined) {
-            _.copyPropertiesIfPresent(options.background, chart.background, "fill", "visible");
+            this.copyPropertiesIfPresent(options.background, chart.background, "fill", "visible");
         }
 
         if (options.legend !== undefined) {
@@ -214,27 +268,8 @@ export class ChartBuilder {
         return chart;
     }
 
-    static initCartesianChart(chart: CartesianChart, options: CartesianChartOptions, seriesType?: CartesianSeriesType) {
-        ChartBuilder.initChart(chart, options, seriesType);
-
-        return chart;
-    }
-
-    static initPolarChart(chart: PolarChart, options: PolarChartOptions, seriesType?: PolarSeriesType) {
-        ChartBuilder.initChart(chart, options, seriesType);
-
-
-        return chart;
-    }
-
-    static initGroupedCategoryChart(chart: GroupedCategoryChart, options: CartesianChartOptions, seriesType?: CartesianSeriesType) {
-        ChartBuilder.initChart(chart, options, seriesType);
-
-        return chart;
-    }
-
     static initSeries<S extends Series<any>>(series: S, options: SeriesOptions) {
-        _.copyPropertiesIfPresent(options, series, "visible", "showInLegend", "tooltipEnabled", "data");
+        this.copyPropertiesIfPresent(options, series, "visible", "showInLegend", "tooltipEnabled", "data");
 
         return series;
     }
@@ -242,7 +277,7 @@ export class ChartBuilder {
     static initLineSeries(series: LineSeries, options: LineSeriesOptions) {
         ChartBuilder.initSeries(series, options);
 
-        _.copyPropertiesIfPresent(
+        this.copyPropertiesIfPresent(
             options,
             series,
             "title",
@@ -263,7 +298,7 @@ export class ChartBuilder {
     static initScatterSeries(series: ScatterSeries, options: ScatterSeriesOptions) {
         ChartBuilder.initSeries(series, options);
 
-        _.copyPropertiesIfPresent(
+        this.copyPropertiesIfPresent(
             options,
             series,
             "title",
@@ -288,15 +323,15 @@ export class ChartBuilder {
         return series;
     }
 
-    static initLabelFormatting<T extends ILabelFormattingOptions>(series: T, options: ILabelFormattingOptions) {
-        _.copyPropertiesIfPresent(options, series, "labelFontStyle", "labelFontWeight", "labelFontSize", "labelFontFamily", "labelColor");
+    static initLabelFormatting<T extends LabelFormattingOptions>(series: T, options: LabelFormattingOptions) {
+        this.copyPropertiesIfPresent(options, series, "labelFontStyle", "labelFontWeight", "labelFontSize", "labelFontFamily", "labelColor");
     }
 
     static initBarSeries(series: BarSeries, options: BarSeriesOptions) {
         ChartBuilder.initSeries(series, options);
         ChartBuilder.initLabelFormatting(series, options);
 
-        _.copyPropertiesIfPresent(
+        this.copyPropertiesIfPresent(
             options,
             series,
             "xField",
@@ -314,7 +349,7 @@ export class ChartBuilder {
             "labelFormatter",
             "tooltipRenderer");
 
-        _.copyPropertyIfPresent(options, series, "shadow", s => ChartBuilder.createDropShadow(s));
+        this.copyPropertyIfPresent(options, series, "shadow", s => ChartBuilder.createDropShadow(s));
 
         return series;
     }
@@ -322,7 +357,7 @@ export class ChartBuilder {
     static initAreaSeries(series: AreaSeries, options: AreaSeriesOptions) {
         ChartBuilder.initSeries(series, options);
 
-        _.copyPropertiesIfPresent(
+        this.copyPropertiesIfPresent(
             options,
             series,
             "xField",
@@ -340,7 +375,7 @@ export class ChartBuilder {
             "markerStrokeWidth",
             "tooltipRenderer");
 
-        _.copyPropertyIfPresent(options, series, "shadow", s => ChartBuilder.createDropShadow(s));
+        this.copyPropertyIfPresent(options, series, "shadow", s => ChartBuilder.createDropShadow(s));
 
         return series;
     }
@@ -349,9 +384,9 @@ export class ChartBuilder {
         ChartBuilder.initSeries(series, options);
         ChartBuilder.initLabelFormatting(series, options);
 
-        _.copyPropertyIfPresent(options, series, "title", t => ChartBuilder.createPieTitle(t!));
+        this.copyPropertyIfPresent(options, series, "title", t => ChartBuilder.createPieTitle(t!));
 
-        _.copyPropertiesIfPresent(
+        this.copyPropertiesIfPresent(
             options,
             series,
             "calloutColors",
@@ -373,7 +408,7 @@ export class ChartBuilder {
             "strokeWidth",
             "tooltipRenderer");
 
-        _.copyPropertyIfPresent(options, series, "shadow", s => ChartBuilder.createDropShadow(s));
+        this.copyPropertyIfPresent(options, series, "shadow", s => ChartBuilder.createDropShadow(s));
 
         return series;
     }
@@ -381,7 +416,7 @@ export class ChartBuilder {
     static initLegend(legend: Legend, options: LegendOptions) {
         ChartBuilder.initLabelFormatting(legend, options);
 
-        _.copyPropertiesIfPresent(
+        this.copyPropertiesIfPresent(
             options,
             legend,
             "enabled",
@@ -442,7 +477,7 @@ export class ChartBuilder {
     static createCaption(options: CaptionOptions) {
         const caption = new Caption();
 
-        _.copyPropertiesIfPresent(
+        this.copyPropertiesIfPresent(
             options, caption, "text", "fontStyle", "fontWeight", "fontSize", "fontFamily", "color", "enabled");
 
         return caption;
@@ -452,38 +487,13 @@ export class ChartBuilder {
 
     static populateAxisProperties<T extends { title?: Caption }>(axis: T, options: AxisOptions) {
         for (const name in options) {
-            if (name === 'type') {
-                continue;
-            }
-
             if (name === 'title' && options.title) {
                 axis.title = ChartBuilder.createTitle(options.title);
                 continue;
             }
 
-            _.copyPropertyIfPresent(options, axis, name as keyof AxisOptions);
+            this.copyPropertyIfPresent(options, axis, name);
         }
-    }
-
-    static createAxis(options: AxisOptions): CategoryAxis | NumberAxis {
-        let axis: CategoryAxis | NumberAxis | undefined = undefined;
-
-        switch (options.type) {
-            case "category":
-                axis = new CategoryAxis();
-                break;
-            case "number":
-                axis = new NumberAxis();
-                break;
-        }
-
-        if (!axis) {
-            throw new Error("Unknown axis type.");
-        }
-
-        this.populateAxisProperties(axis, options);
-
-        return axis;
     }
 
     static createNumberAxis(options: AxisOptions): NumberAxis {
@@ -508,5 +518,17 @@ export class ChartBuilder {
         this.populateAxisProperties(axis, options);
 
         return axis;
+    }
+
+    private static copyPropertiesIfPresent(source: any, target: any, ...properties: any[]) {
+        properties.forEach(p => this.copyPropertyIfPresent(source, target, p));
+    }
+
+    private static copyPropertyIfPresent(source: any, target: any, property: any, transform?: (value: any) => any) {
+        const value = source[property];
+
+        if (value !== undefined) {
+            target[property] = transform ? transform(value) : value;
+        }
     }
 }

--- a/packages/ag-grid-enterprise/src/charts/chartOptions.ts
+++ b/packages/ag-grid-enterprise/src/charts/chartOptions.ts
@@ -1,0 +1,289 @@
+export interface ChartOptions<T> {
+    document?: Document;
+    series?: T[];
+    data?: any;
+    width?: number;
+    height?: number;
+    padding?: IPadding;
+    background?: BackgroundOptions;
+    title?: CaptionOptions;
+    subtitle?: CaptionOptions;
+    legend?: LegendOptions;
+    legendPosition?: LegendPosition;
+    legendPadding?: number;
+    tooltipClass?: string;
+}
+
+export interface IPadding {
+    top: number;
+    right: number;
+    bottom: number;
+    left: number;
+}
+
+export interface BackgroundOptions {
+    fill?: string;
+    visible?: boolean;
+}
+
+export interface CaptionOptions {
+    text?: string;
+    fontStyle?: FontStyle;
+    fontWeight?: FontWeight;
+    fontSize?: number;
+    fontFamily?: string;
+    color?: string;
+    enabled?: boolean;
+}
+
+export declare type FontStyle = "normal" | "italic" | "oblique";
+export declare type FontWeight = "normal" | "bold" | "bolder" | "lighter" | "100" | "200" | "300" | "400" | "500" | "600" | "700" | "800" | "900";
+
+export interface LegendOptions extends LabelFormattingOptions {
+    enabled?: boolean;
+    markerSize?: number;
+    markerPadding?: number;
+    markerStrokeWidth?: number;
+    itemPaddingX?: number;
+    itemPaddingY?: number;
+}
+
+export interface LabelFormattingOptions {
+    labelFontStyle?: FontStyle;
+    labelFontWeight?: FontWeight;
+    labelFontSize?: number;
+    labelFontFamily?: string;
+    labelColor?: string;
+}
+
+export declare type LegendPosition = "top" | "right" | "bottom" | "left";
+
+export interface CartesianChartOptions<T> extends ChartOptions<T> {
+    xAxis: AxisOptions;
+    yAxis: AxisOptions;
+    isGroupingEnabled?: boolean;
+}
+
+export interface PolarChartOptions<T> extends ChartOptions<T> {
+}
+
+export interface AxisOptions extends LabelFormattingOptions {
+    title?: CaptionOptions;
+
+    lineWidth?: number;
+    lineColor?: string;
+
+    tickWidth?: number;
+    tickSize?: number;
+    tickColor?: string;
+
+    labelPadding?: number;
+    labelRotation?: number;
+    mirrorLabels?: boolean;
+    parallelLabels?: boolean;
+    labelFormatter?: (value: any, fractionDigits?: number) => string;
+    gridStyle?: GridStyle[];
+}
+
+export interface GridStyle {
+    stroke?: string;
+    lineDash?: number[];
+}
+
+export type CartesianSeriesType = "line" | "scatter" | "bar" | "area";
+export type PolarSeriesType = "pie";
+export type SeriesType = CartesianSeriesType | PolarSeriesType;
+
+export interface SeriesOptions {
+    type?: SeriesType;
+    data?: any[];
+    visible?: boolean;
+    showInLegend?: boolean;
+    tooltipEnabled?: boolean;
+}
+
+export interface HighlightStyle {
+    fill?: string;
+    stroke?: string;
+}
+
+export interface DropShadowOptions {
+    enabled?: boolean;
+    color?: string;
+    xOffset?: number;
+    yOffset?: number;
+    blur?: number;
+}
+
+export interface BarSeriesOptions extends SeriesOptions, LabelFormattingOptions {
+    xField?: string;
+    yFields?: string[];
+    yFieldNames?: string[];
+
+    grouped?: boolean;
+    normalizedTo?: number;
+
+    fills?: string[];
+    strokes?: string[];
+    fillOpacity?: number;
+    strokeOpacity?: number;
+    strokeWidth?: number;
+    highlightStyle?: HighlightStyle;
+
+    shadow?: DropShadowOptions;
+
+    labelEnabled?: boolean;
+    labelFormatter?: (params: BarLabelFormatterParams) => string;
+
+    tooltipRenderer?: (params: BarTooltipRendererParams) => string;
+}
+
+export interface BarLabelFormatterParams {
+    value: number;
+}
+
+export interface BarTooltipRendererParams {
+    datum: any;
+    xField: string;
+    yField: string;
+    title?: string;
+    color?: string;
+}
+
+export interface LineSeriesOptions extends SeriesOptions {
+    title?: string;
+
+    xField?: string;
+    yField?: string;
+
+    fill?: string;
+    stroke?: string;
+    strokeWidth?: number;
+    highlightStyle?: HighlightStyle;
+
+    marker?: boolean;
+    markerSize?: number;
+    markerStrokeWidth?: number;
+
+    tooltipRenderer?: (params: LineTooltipRendererParams) => string;
+}
+
+export interface LineTooltipRendererParams {
+    datum: any;
+    xField: string;
+    yField: string;
+    title?: string;
+    color?: string;
+}
+
+export interface ScatterSeriesOptions extends SeriesOptions {
+    title?: string;
+
+    xField?: string;
+    yField?: string;
+    radiusField?: string;
+    labelField?: string;
+
+    xFieldName?: string;
+    yFieldName?: string;
+    radiusFieldName?: string;
+    labelFieldName?: string;
+
+    fill?: string;
+    fillOpacity?: number;
+    stroke?: string;
+    strokeOpacity?: number;
+    highlightStyle?: HighlightStyle;
+
+    marker?: boolean;
+    markerSize?: number;
+    minMarkerSize?: number;
+    markerStrokeWidth?: number;
+
+    tooltipRenderer?: (params: ScatterTooltipRendererParams) => string;
+}
+
+export interface ScatterTooltipRendererParams {
+    datum: any;
+    xField: string;
+    yField: string;
+    radiusField?: string;
+    labelField?: string;
+    xFieldName: string;
+    yFieldName: string;
+    radiusFieldName?: string;
+    labelFieldName?: string;
+    title?: string;
+    color?: string;
+}
+
+export interface AreaSeriesOptions extends SeriesOptions {
+    xField?: string;
+    yFields?: string[];
+    yFieldNames?: string[];
+
+    grouped?: boolean;
+    normalizedTo?: number;
+
+    fills?: string[];
+    strokes?: string[];
+    fillOpacity?: number;
+    strokeOpacity?: number;
+    strokeWidth?: number;
+    highlightStyle?: HighlightStyle;
+
+    marker?: boolean;
+    markerSize?: number;
+    markerStrokeWidth?: number;
+
+    shadow?: DropShadowOptions;
+
+    tooltipRenderer?: (params: AreaTooltipRendererParams) => string;
+}
+
+export interface AreaTooltipRendererParams {
+    datum: any;
+    xField: string;
+    yField: string;
+    title?: string;
+    color?: string;
+}
+
+export interface PieSeriesOptions extends SeriesOptions, LabelFormattingOptions {
+    title?: CaptionOptions;
+
+    fills?: string[];
+    strokes?: string[];
+    fillOpacity?: number;
+    strokeOpacity?: number;
+    strokeWidth?: number;
+    highlightStyle?: HighlightStyle;
+
+    angleField?: string;
+    radiusField?: string;
+
+    labelEnabled?: boolean;
+    labelField?: string;
+    labelMinAngle?: number;
+    labelOffset?: number;
+
+    calloutLength?: number;
+    calloutStrokeWidth?: number;
+    calloutColors?: string[];
+
+    rotation?: number;
+
+    outerRadiusOffset?: number;
+    innerRadiusOffset?: number;
+
+    shadow?: DropShadowOptions;
+
+    tooltipRenderer?: (params: PieTooltipRendererParams) => string;
+}
+
+export interface PieTooltipRendererParams {
+    datum: any;
+    angleField: string;
+    radiusField?: string;
+    labelField?: string;
+}


### PR DESCRIPTION
First step of moving the ChartBuilder into the charts module along with copies of relevant interfaces. Once this is done we can start to evolve the charts API and the grid options API separately, with the proxies translating into the options interfaces required when calling the ChartBuilder.