### PR TITLE
Make RowNode parametric i.e. RowNode<T> with data: T

### DIFF
--- a/packages/ag-grid-community/src/ts/entities/cellPosition.ts
+++ b/packages/ag-grid-community/src/ts/entities/cellPosition.ts
@@ -3,19 +3,19 @@ import { Column } from "./column";
 import { RowPosition } from "./rowPosition";
 
 // this is what gets pass into and out of the api, as JavaScript users
-export interface CellPosition extends RowPosition {
-    column: Column;
+export interface CellPosition<T> extends RowPosition {
+    column: Column<T>;
 }
 
 @Bean('cellPositionUtils')
 export class CellPositionUtils {
 
-    public createId(cellPosition: CellPosition): string {
+    public createId(cellPosition: CellPosition<unknown>): string {
         const { rowIndex, rowPinned, column } = cellPosition;
         return `${rowIndex}.${rowPinned == null ? 'null' : rowPinned}.${column.getId()}`;
     }
 
-    public equals(cellA: CellPosition, cellB: CellPosition): boolean {
+    public equals(cellA: CellPosition<unknown>, cellB: CellPosition<unknown>): boolean {
         const colsMatch = cellA.column === cellB.column;
         const floatingMatch = cellA.rowPinned === cellB.rowPinned;
         const indexMatch = cellA.rowIndex === cellB.rowIndex;

--- a/packages/ag-grid-community/src/ts/entities/colDef.ts
+++ b/packages/ag-grid-community/src/ts/entities/colDef.ts
@@ -39,9 +39,9 @@ export interface AbstractColDef {
     tooltipComponentParams?: any;
 }
 
-export interface ColGroupDef extends AbstractColDef {
+export interface ColGroupDef<T> extends AbstractColDef {
     /** Columns in this group */
-    children: (ColDef | ColGroupDef)[];
+    children: (ColDef<T> | ColGroupDef<T>)[];
     /** Group ID */
     groupId?: string;
     /** Open by Default */
@@ -63,7 +63,7 @@ export interface IAggFunc {
 /****************************************************************
  * Don't forget to update ComponentUtil if changing this class. PLEASE!*
  ****************************************************************/
-export interface ColDef extends AbstractColDef {
+export interface ColDef<T> extends AbstractColDef {
 
     /** The unique ID to give the column. This is optional. If missing, the ID will default to the field.
      *  If both field and colId are missing, a unique ID will be generated.
@@ -105,13 +105,13 @@ export interface ColDef extends AbstractColDef {
     tooltipValueGetter?: (params: ITooltipParams) => string;
 
     /** Expression or function to get the cells value. */
-    valueGetter?: ((params: ValueGetterParams) => any) | string;
+    valueGetter?: ((params: ValueGetterParams<T>) => any) | string;
 
     /** Expression or function to get the cells value for filtering. */
-    filterValueGetter?: ((params: ValueGetterParams) => any) | string;
+    filterValueGetter?: ((params: ValueGetterParams<T>) => any) | string;
 
     /** If not using a field, then this puts the value into the cell */
-    valueSetter?: ((params: ValueSetterParams) => boolean) | string;
+    valueSetter?: ((params: ValueSetterParams<T>) => boolean) | string;
 
     /** Function to return the key for a value - use this if the value is an object (not a primitive type) and you
      * want to a) group by this field or b) use set filter on this field. */
@@ -130,7 +130,7 @@ export interface ColDef extends AbstractColDef {
     autoHeight?: boolean;
 
     /** Class to use for the cell. Can be string, array of strings, or function. */
-    cellClass?: string | string[] | ((cellClassParams: CellClassParams) => string | string[]);
+    cellClass?: string | string[] | ((cellClassParams: CellClassParams<T>) => string | string[]);
 
     /** An object of css values. Or a function returning an object of css values. */
     cellStyle?: {} | ((params: any) => {});
@@ -153,12 +153,12 @@ export interface ColDef extends AbstractColDef {
     pinnedRowCellRendererParams?: any;
 
     /** A function to format a value, should return a string. Not used for CSV export or copy to clipboard, only for UI cell rendering. */
-    valueFormatter?: (params: ValueFormatterParams) => string | string;
+    valueFormatter?: (params: ValueFormatterParams<T>) => string | string;
     /** A function to format a pinned row value, should return a string. Not used for CSV export or copy to clipboard, only for UI cell rendering. */
-    pinnedRowValueFormatter?: (params: ValueFormatterParams) => string | string;
+    pinnedRowValueFormatter?: (params: ValueFormatterParams<T>) => string | string;
 
     /** Gets called after editing, converts the value in the cell. */
-    valueParser?: (params: ValueParserParams) => any | string;
+    valueParser?: (params: ValueParserParams<T>) => any | string;
 
     /** Name of function to use for aggregation. One of [sum,min,max,first,last] or a function. */
     aggFunc?: string | IAggFunc;
@@ -179,7 +179,7 @@ export interface ColDef extends AbstractColDef {
     pivot?: boolean;
 
     /** Comparator function for custom sorting. */
-    comparator?: (valueA: any, valueB: any, nodeA: RowNode, nodeB: RowNode, isInverted: boolean) => number;
+    comparator?: (valueA: any, valueB: any, nodeA: RowNode<T>, nodeB: RowNode<T>, isInverted: boolean) => number;
 
     /** Comparator for values, used by renderer to know if values have changed. Cells who's values have not changed don't get refreshed. */
     equals?: (valueA: any, valueB: any) => boolean;
@@ -203,7 +203,7 @@ export interface ColDef extends AbstractColDef {
     dndSource?: boolean | ((params: any) => boolean);
 
     /** For native drag and drop, set to true to allow custom onRowDrag processing */
-    dndSourceOnRowDrag?: ((params: {rowNode: RowNode, dragEvent: DragEvent}) => void);
+    dndSourceOnRowDrag?: ((params: {rowNode: RowNode<unknown>, dragEvent: DragEvent}) => void);
 
     /** Set to true if no menu should be shown for this column header. */
     suppressMenu?: boolean;
@@ -252,7 +252,7 @@ export interface ColDef extends AbstractColDef {
     suppressAutoSize?: boolean;
 
     /** Allows user to suppress certain keyboard events */
-    suppressKeyboardEvent?: (params: SuppressKeyboardEventParams) => boolean;
+    suppressKeyboardEvent?: (params: SuppressKeyboardEventParams<T>) => boolean;
 
     /** If true, GUI will allow adding this columns as a row group */
     enableRowGroup?: boolean;
@@ -264,20 +264,20 @@ export interface ColDef extends AbstractColDef {
     enableValue?: boolean;
 
     /** Set to true if this col is editable, otherwise false. Can also be a function to have different rows editable. */
-    editable?: boolean | IsColumnFunc;
+    editable?: boolean | IsColumnFunc<T>;
 
-    colSpan?: (params: ColSpanParams) => number;
+    colSpan?: (params: ColSpanParams<T>) => number;
 
-    rowSpan?: (params: RowSpanParams) => number;
+    rowSpan?: (params: RowSpanParams<T>) => number;
 
     /** Set to true if this col should not be allowed take new values from teh clipboard . */
-    suppressPaste?: boolean | IsColumnFunc;
+    suppressPaste?: boolean | IsColumnFunc<T>;
 
     /** Set to tru if this col should not be navigable with the tab key. Can also be a function to have different rows editable. */
-    suppressNavigable?: boolean | IsColumnFunc;
+    suppressNavigable?: boolean | IsColumnFunc<T>;
 
     /** To create the quick filter text for this column, if toString is not good enough on the value. */
-    getQuickFilterText?: (params: GetQuickFilterTextParams) => string;
+    getQuickFilterText?: (params: GetQuickFilterTextParams<T>) => string;
 
     /** Callbacks for editing. See editing section for further details.
      * Return true if the update was successful, or false if not.
@@ -324,7 +324,7 @@ export interface ColDef extends AbstractColDef {
     enableCellChangeFlash?: boolean;
 
     /** Never set this, it is used internally by grid when doing in-grid pivoting */
-    pivotValueColumn?: Column | null;
+    pivotValueColumn?: Column<T> | null;
 
     /** Never set this, it is used internally by grid when doing in-grid pivoting */
     pivotTotalColumnIds?: string[];
@@ -349,79 +349,79 @@ export interface ColDef extends AbstractColDef {
     fillOperation?: string;
 }
 
-export interface IsColumnFunc {
-    (params: IsColumnFuncParams): boolean;
+export interface IsColumnFunc<T> {
+    (params: IsColumnFuncParams<T>): boolean;
 }
 
-export interface IsColumnFuncParams {
-    node: RowNode;
+export interface IsColumnFuncParams<T> {
+    node: RowNode<T>;
     data: any;
-    column: Column;
-    colDef: ColDef;
+    column: Column<T>;
+    colDef: ColDef<T>;
     context: any;
     api: GridApi | null | undefined;
     columnApi: ColumnApi | null | undefined;
 }
 
-export interface GetQuickFilterTextParams {
+export interface GetQuickFilterTextParams<T> {
     value: any;
-    node: RowNode;
+    node: RowNode<T>;
     data: any;
-    column: Column;
-    colDef: ColDef;
+    column: Column<T>;
+    colDef: ColDef<T>;
     context: any;
 }
 
-export interface BaseColDefParams {
-    node: RowNode;
+export interface BaseColDefParams<T> {
+    node: RowNode<T>;
     data: any;
-    colDef: ColDef;
-    column: Column;
+    colDef: ColDef<T>;
+    column: Column<T>;
     api: GridApi | null | undefined;
     columnApi: ColumnApi | null | undefined;
     context: any;
 }
 
-export interface BaseWithValueColDefParams extends BaseColDefParams {
+export interface BaseWithValueColDefParams<T> extends BaseColDefParams<T> {
     value: any;
 }
 
-export interface ValueGetterParams extends BaseColDefParams {
+export interface ValueGetterParams<T> extends BaseColDefParams<T> {
     getValue: (field: string) => any;
 }
 
-export interface NewValueParams extends BaseColDefParams {
+export interface NewValueParams<T> extends BaseColDefParams<T> {
     oldValue: any;
     newValue: any;
 }
 
-export interface ValueSetterParams extends NewValueParams {
+export interface ValueSetterParams<T> extends NewValueParams<T> {
 }
 
-export interface ValueParserParams extends NewValueParams {
+export interface ValueParserParams<T> extends NewValueParams<T> {
 }
 
-export interface ValueFormatterParams extends BaseWithValueColDefParams {
+export interface ValueFormatterParams<T> extends BaseWithValueColDefParams<T> {
 }
 
-export interface ColSpanParams extends BaseColDefParams {
+export interface ColSpanParams<T> extends BaseColDefParams<T> {
 }
 
-export interface RowSpanParams extends BaseColDefParams {
+export interface RowSpanParams<T> extends BaseColDefParams<T> {
 }
 
-export interface SuppressKeyboardEventParams extends IsColumnFuncParams {
+export interface SuppressKeyboardEventParams<T> extends IsColumnFuncParams<T> {
     // the keyboard event the grid received
     event: KeyboardEvent;
     // whether the cell is editing or not
     editing: boolean;
 }
 
-export interface CellClassParams {
+export interface CellClassParams<T> {
     value: any;
     data: any;
-    node: RowNode;
-    colDef: ColDef;
+    node: RowNode<T>;
+    colDef: ColDef<T>;
     rowIndex: number;
     $scope: any;
     api: GridApi;

--- a/packages/ag-grid-community/src/ts/entities/column.ts
+++ b/packages/ag-grid-community/src/ts/entities/column.ts
@@ -398,7 +398,7 @@ export class Column<T> implements ColumnGroupChild<T>, OriginalColumnGroupChild,
         this.eventService.dispatchEvent(this.createColumnEvent(Column.EVENT_MOVING_CHANGED, source));
     }
 
-    private createColumnEvent(type: string, source: ColumnEventType): ColumnEvent {
+    private createColumnEvent(type: string, source: ColumnEventType): ColumnEvent<T> {
         return {
             api: this.gridApi,
             columnApi: this.columnApi,

--- a/packages/ag-grid-community/src/ts/entities/columnGroup.ts
+++ b/packages/ag-grid-community/src/ts/entities/columnGroup.ts
@@ -9,7 +9,7 @@ import { GridOptionsWrapper } from "../gridOptionsWrapper";
 import { AgEvent } from "../events";
 import { _ } from "../utils";
 
-export class ColumnGroup implements ColumnGroupChild {
+export class ColumnGroup<T> implements ColumnGroupChild<T> {
 
     public static HEADER_GROUP_SHOW_OPEN = 'open';
     public static HEADER_GROUP_SHOW_CLOSED = 'closed';
@@ -26,9 +26,9 @@ export class ColumnGroup implements ColumnGroupChild {
     @Autowired('gridOptionsWrapper') gridOptionsWrapper: GridOptionsWrapper;
 
     // all the children of this group, regardless of whether they are opened or closed
-    private children: ColumnGroupChild[];
+    private children: ColumnGroupChild<T>[];
     // depends on the open/closed state of the group, only displaying columns are stored here
-    private displayedChildren: ColumnGroupChild[] = [];
+    private displayedChildren: ColumnGroupChild<T>[] = [];
 
     private readonly groupId: string;
     private readonly instanceId: number;
@@ -40,7 +40,7 @@ export class ColumnGroup implements ColumnGroupChild {
     private oldLeft: number;
     private localEventService: EventService = new EventService();
 
-    private parent: ColumnGroup;
+    private parent: ColumnGroup<T>;
 
     constructor(originalColumnGroup: OriginalColumnGroup, groupId: string, instanceId: number, pinned: string) {
         this.groupId = groupId;
@@ -57,11 +57,11 @@ export class ColumnGroup implements ColumnGroupChild {
         this.displayedChildren = null;
     }
 
-    public getParent(): ColumnGroup {
+    public getParent(): ColumnGroup<T> {
         return this.parent;
     }
 
-    public setParent(parent: ColumnGroup): void {
+    public setParent(parent: ColumnGroup<T>): void {
         this.parent = parent;
     }
 
@@ -88,9 +88,9 @@ export class ColumnGroup implements ColumnGroupChild {
 
     public checkLeft(): void {
         // first get all children to setLeft, as it impacts our decision below
-        this.displayedChildren.forEach((child: ColumnGroupChild) => {
+        this.displayedChildren.forEach((child: ColumnGroupChild<T>) => {
             if (child instanceof ColumnGroup) {
-                (child as ColumnGroup).checkLeft();
+                (child as ColumnGroup<T>).checkLeft();
             }
         });
 
@@ -153,15 +153,15 @@ export class ColumnGroup implements ColumnGroupChild {
         return this.instanceId;
     }
 
-    public isChildInThisGroupDeepSearch(wantedChild: ColumnGroupChild): boolean {
+    public isChildInThisGroupDeepSearch(wantedChild: ColumnGroupChild<T>): boolean {
         let result = false;
 
-        this.children.forEach((foundChild: ColumnGroupChild) => {
+        this.children.forEach((foundChild: ColumnGroupChild<T>) => {
             if (wantedChild === foundChild) {
                 result = true;
             }
             if (foundChild instanceof ColumnGroup) {
-                if ((foundChild as ColumnGroup).isChildInThisGroupDeepSearch(wantedChild)) {
+                if ((foundChild as ColumnGroup<T>).isChildInThisGroupDeepSearch(wantedChild)) {
                     result = true;
                 }
             }
@@ -173,7 +173,7 @@ export class ColumnGroup implements ColumnGroupChild {
     public getActualWidth(): number {
         let groupActualWidth = 0;
         if (this.displayedChildren) {
-            this.displayedChildren.forEach((child: ColumnGroupChild) => {
+            this.displayedChildren.forEach((child: ColumnGroupChild<T>) => {
                 groupActualWidth += child.getActualWidth();
             });
         }
@@ -185,7 +185,7 @@ export class ColumnGroup implements ColumnGroupChild {
 
         // if at least one child is resizable, then the group is resizable
         let result = false;
-        this.displayedChildren.forEach((child: ColumnGroupChild) => {
+        this.displayedChildren.forEach((child: ColumnGroupChild<T>) => {
             if (child.isResizable()) {
                 result = true;
             }
@@ -196,31 +196,31 @@ export class ColumnGroup implements ColumnGroupChild {
 
     public getMinWidth(): number {
         let result = 0;
-        this.displayedChildren.forEach((groupChild: ColumnGroupChild) => {
+        this.displayedChildren.forEach((groupChild: ColumnGroupChild<T>) => {
             result += groupChild.getMinWidth();
         });
         return result;
     }
 
-    public addChild(child: ColumnGroupChild): void {
+    public addChild(child: ColumnGroupChild<T>): void {
         if (!this.children) {
             this.children = [];
         }
         this.children.push(child);
     }
 
-    public getDisplayedChildren(): ColumnGroupChild[] {
+    public getDisplayedChildren(): ColumnGroupChild<T>[] {
         return this.displayedChildren;
     }
 
-    public getLeafColumns(): Column[] {
-        const result: Column[] = [];
+    public getLeafColumns(): Column<T>[] {
+        const result: Column<T>[] = [];
         this.addLeafColumns(result);
         return result;
     }
 
-    public getDisplayedLeafColumns(): Column[] {
-        const result: Column[] = [];
+    public getDisplayedLeafColumns(): Column<T>[] {
+        const result: Column<T>[] = [];
         this.addDisplayedLeafColumns(result);
         return result;
     }
@@ -230,7 +230,7 @@ export class ColumnGroup implements ColumnGroupChild {
         return this.originalColumnGroup.getColGroupDef();
     }
 
-    public getColGroupDef(): ColGroupDef {
+    public getColGroupDef(): ColGroupDef<T> {
         return this.originalColumnGroup.getColGroupDef();
     }
 
@@ -250,27 +250,27 @@ export class ColumnGroup implements ColumnGroupChild {
         this.originalColumnGroup.setExpanded(expanded);
     }
 
-    private addDisplayedLeafColumns(leafColumns: Column[]): void {
-        this.displayedChildren.forEach((child: ColumnGroupChild) => {
+    private addDisplayedLeafColumns(leafColumns: Column<T>[]): void {
+        this.displayedChildren.forEach((child: ColumnGroupChild<T>) => {
             if (child instanceof Column) {
-                leafColumns.push(child as Column);
+                leafColumns.push(child as Column<T>);
             } else if (child instanceof ColumnGroup) {
-                (child as ColumnGroup).addDisplayedLeafColumns(leafColumns);
+                (child as ColumnGroup<T>).addDisplayedLeafColumns(leafColumns);
             }
         });
     }
 
-    private addLeafColumns(leafColumns: Column[]): void {
-        this.children.forEach((child: ColumnGroupChild) => {
+    private addLeafColumns(leafColumns: Column<T>[]): void {
+        this.children.forEach((child: ColumnGroupChild<T>) => {
             if (child instanceof Column) {
-                leafColumns.push(child as Column);
+                leafColumns.push(child as Column<T>);
             } else if (child instanceof ColumnGroup) {
-                (child as ColumnGroup).addLeafColumns(leafColumns);
+                (child as ColumnGroup<T>).addLeafColumns(leafColumns);
             }
         });
     }
 
-    public getChildren(): ColumnGroupChild[] {
+    public getChildren(): ColumnGroupChild<T>[] {
         return this.children;
     }
 
@@ -285,7 +285,7 @@ export class ColumnGroup implements ColumnGroupChild {
     public calculateDisplayedColumns() {
         // clear out last time we calculated
         this.displayedChildren = [];
-        let topLevelGroup: ColumnGroup = this;
+        let topLevelGroup: ColumnGroup<T> = this;
 
         // find the column group that is controlling expandable. this is relevant when we have padding (empty)
         // groups, where the expandable is actually the first parent that is not a padding group.

--- a/packages/ag-grid-community/src/ts/entities/columnGroupChild.ts
+++ b/packages/ag-grid-community/src/ts/entities/columnGroupChild.ts
@@ -4,7 +4,7 @@ import { ColumnGroup } from "./columnGroup";
 
 // Implemented by Column and ColumnGroup. Allows the groups to contain a list of this type for it's children.
 // See the note at the top of Column class.
-export interface ColumnGroupChild extends IEventEmitter {
+export interface ColumnGroupChild<T> extends IEventEmitter {
     getUniqueId(): string;
     getActualWidth(): number;
     getMinWidth(): number;
@@ -12,9 +12,9 @@ export interface ColumnGroupChild extends IEventEmitter {
     getOldLeft(): number;
     getDefinition(): AbstractColDef;
     getColumnGroupShow(): string | undefined;
-    getParent(): ColumnGroupChild;
+    getParent(): ColumnGroupChild<T>;
     isResizable(): boolean;
-    setParent(parent: ColumnGroup): void;
+    setParent(parent: ColumnGroup<T>): void;
     isEmptyGroup(): boolean;
     isMoving(): boolean;
     getPinned(): string;

--- a/packages/ag-grid-community/src/ts/entities/defaultColumnTypes.ts
+++ b/packages/ag-grid-community/src/ts/entities/defaultColumnTypes.ts
@@ -1,6 +1,6 @@
 import { ColDef } from "./colDef";
 
-export const DefaultColumnTypes: { [key: string]: ColDef } = {
+export const DefaultColumnTypes: { [key: string]: ColDef<unknown> } = {
     numericColumn: {
         headerClass: "ag-numeric-header",
         cellClass: "ag-numeric-cell"

--- a/packages/ag-grid-community/src/ts/entities/gridOptions.ts
+++ b/packages/ag-grid-community/src/ts/entities/gridOptions.ts
@@ -83,7 +83,7 @@ import { ChartOptions, ChartType } from "../interfaces/iChartOptions";
 /****************************************************************
  * Don't forget to update ComponentUtil if changing this class. *
  ****************************************************************/
-export interface GridOptions {
+export interface GridOptions<T> {
 
     /****************************************************************
      * Don't forget to update ComponentUtil if changing this class. PLEASE!*
@@ -156,7 +156,7 @@ export interface GridOptions {
     suppressClickEdit?: boolean;
 
     /** Allows user to suppress certain keyboard events */
-    suppressKeyboardEvent?: (params: SuppressKeyboardEventParams) => boolean;
+    suppressKeyboardEvent?: (params: SuppressKeyboardEventParams<T>) => boolean;
 
     stopEditingWhenGridLosesFocus?: boolean;
     debug?: boolean;
@@ -277,8 +277,8 @@ export interface GridOptions {
     // cellRenderers?: {[key: string]: {new(): ICellRenderer} | ICellRendererFunc};
     /* a map of strings (cellEditor keys) to cellEditors */
     // cellEditors?: {[key: string]: {new(): ICellEditor}};
-    defaultColGroupDef?: ColGroupDef;
-    defaultColDef?: ColDef;
+    defaultColGroupDef?: ColGroupDef<T>;
+    defaultColDef?: ColDef<T>;
     defaultExportParams?: CsvExportParams;
 
     /****************************************************************
@@ -298,8 +298,8 @@ export interface GridOptions {
     groupMultiAutoColumn?: boolean;
     groupSuppressBlankHeader?: boolean;
     /** @deprecated in v11.0 substituted by autoGroupColumnDef */
-    groupColumnDef?: ColDef;
-    autoGroupColumnDef?: ColDef;
+    groupColumnDef?: ColDef<T>;
+    autoGroupColumnDef?: ColDef<T>;
     forPrint?: boolean;
     enableOldSetFilterModel?: boolean;
     enableCharts?: boolean;
@@ -314,8 +314,8 @@ export interface GridOptions {
     rowClass?: string | string[];
     groupDefaultExpanded?: number;
     /** @deprecated slaveGrids, replace with alignedGrids */
-    slaveGrids?: GridOptions[];
-    alignedGrids?: GridOptions[];
+    slaveGrids?: GridOptions<T>[];
+    alignedGrids?: GridOptions<T>[];
     rowSelection?: string;
     rowDeselection?: boolean;
     rowMultiSelectWithClick?: boolean;
@@ -345,8 +345,8 @@ export interface GridOptions {
     /** @deprecated */
     showToolPanel?: boolean;
     sideBar?: SideBarDef | string | boolean;
-    columnDefs?: (ColDef | ColGroupDef)[];
-    columnTypes?: { [key: string]: ColDef };
+    columnDefs?: (ColDef<T> | ColGroupDef<T>)[];
+    columnTypes?: { [key: string]: ColDef<T> };
     datasource?: IDatasource;
     viewportDatasource?: IViewportDatasource;
     serverSideDatasource?: IServerSideDatasource;
@@ -379,7 +379,7 @@ export interface GridOptions {
 
     isExternalFilterPresent?(): boolean;
 
-    doesExternalFilterPass?(node: RowNode): boolean;
+    doesExternalFilterPass?(node: RowNode<T>): boolean;
 
     getRowStyle?: Function;
     getRowClass?: (params: any) => (string | string[]);
@@ -387,10 +387,10 @@ export interface GridOptions {
     getRowHeight?: Function;
     sendToClipboard?: (params: any) => void;
     processDataFromClipboard?: (params: ProcessDataFromClipboardParams) => string[][] | null;
-    navigateToNextCell?: (params: NavigateToNextCellParams) => CellPosition;
-    tabToNextCell?: (params: TabToNextCellParams) => CellPosition;
+    navigateToNextCell?: (params: NavigateToNextCellParams) => CellPosition<T>;
+    tabToNextCell?: (params: TabToNextCellParams) => CellPosition<T>;
     getDocument?: () => Document;
-    defaultGroupSortComparator?: (nodeA: RowNode, nodeB: RowNode) => number;
+    defaultGroupSortComparator?: (nodeA: RowNode<T>, nodeB: RowNode<T>) => number;
 
     loadingCellRenderer?: { new(): ICellRenderer } | string;
     loadingCellRendererFramework?: any;
@@ -406,11 +406,11 @@ export interface GridOptions {
     fullWidthCellRendererFramework?: any;
     fullWidthCellRendererParams?: any;
 
-    isFullWidthCell?(rowNode: RowNode): boolean;
+    isFullWidthCell?(rowNode: RowNode<T>): boolean;
 
-    groupRowAggNodes?(nodes: RowNode[]): any;
+    groupRowAggNodes?(nodes: RowNode<T>[]): any;
 
-    getBusinessKeyForNode?(node: RowNode): string;
+    getBusinessKeyForNode?(node: RowNode<T>): string;
 
     /** @deprecated */
     getNodeChildDetails?: GetNodeChildDetails;
@@ -436,11 +436,11 @@ export interface GridOptions {
 
     processCellFromClipboard?(params: ProcessCellForExportParams): any;
 
-    processSecondaryColDef?(colDef: ColDef): void;
+    processSecondaryColDef?(colDef: ColDef<T>): void;
 
-    processSecondaryColGroupDef?(colGroupDef: ColGroupDef): void;
+    processSecondaryColGroupDef?(colGroupDef: ColGroupDef<T>): void;
 
-    postSort?(nodes: RowNode[]): void;
+    postSort?(nodes: RowNode<T>[]): void;
 
     processChartOptions?(params: ProcessChartOptionsParams): ChartOptions;
 
@@ -598,8 +598,8 @@ export interface FillOperationParams {
     columnApi: ColumnApi;
     context: any;
     direction: string; // up, down, left or right
-    column?: Column; // only present if up / down
-    rowNode?: RowNode; // only present if left / right
+    column?: Column<T>; // only present if up / down
+    rowNode?: RowNode<T>; // only present if left / right
 }
 
 export interface GetDataPath {

--- a/packages/ag-grid-community/src/ts/entities/rowNode.ts
+++ b/packages/ag-grid-community/src/ts/entities/rowNode.ts
@@ -29,22 +29,22 @@ export interface SetSelectedParams {
     groupSelectsFiltered?: boolean;
 }
 
-export interface RowNodeEvent extends AgEvent {
-    node: RowNode;
+export interface RowNodeEvent<T> extends AgEvent {
+    node: RowNode<T>;
 }
 
-export interface DataChangedEvent extends RowNodeEvent {
-    oldData: any;
-    newData: any;
+export interface DataChangedEvent<T> extends RowNodeEvent<T> {
+    oldData: T;
+    newData: T;
     update: boolean;
 }
 
-export interface CellChangedEvent extends RowNodeEvent {
+export interface CellChangedEvent<T> extends RowNodeEvent<T> {
     column: Column;
     newValue: any;
 }
 
-export class RowNode implements IEventEmitter {
+export class RowNode<T> implements IEventEmitter {
 
     private static OBJECT_ID_SEQUENCE = 0;
 
@@ -84,9 +84,9 @@ export class RowNode implements IEventEmitter {
     /** The aggregated data */
     public aggData: any;
     /** The user provided data */
-    public data: any;
+    public data: T;
     /** The parent node to this node, or empty if top level */
-    public parent: RowNode | null;
+    public parent: RowNode<T> | null;
     /** How many levels this node is from the top */
     public level: number;
     /** How many levels this node is from the top in the UI (different to the level when removing parents)*/
@@ -104,7 +104,7 @@ export class RowNode implements IEventEmitter {
     /** True if this row is a detail row, part of master / detail (ie child row of an expanded master row)*/
     public detail: boolean;
     /** If this row is a master row that was expanded, this points to the associated detail row. */
-    public detailNode: RowNode;
+    public detailNode: RowNode<T>;
     /** If master detail, this contains details about the detail grid */
     public detailGridInfo: DetailGridInfo | null;
 
@@ -113,7 +113,7 @@ export class RowNode implements IEventEmitter {
     /** Same as detail, kept for legacy reasons */
     public flower: boolean;
     /** Same as detailNode, kept for legacy reasons */
-    public childFlower: RowNode;
+    public childFlower: RowNode<T>;
 
     /** True if this node is a group and the group is the bottom level in the tree */
     public leafGroup: boolean;
@@ -141,14 +141,14 @@ export class RowNode implements IEventEmitter {
     public stub: boolean;
 
     /** All user provided nodes */
-    public allLeafChildren: RowNode[];
+    public allLeafChildren: RowNode<T>[];
 
     /** Groups only - Children of this group */
-    public childrenAfterGroup: RowNode[];
+    public childrenAfterGroup: RowNode<T>[];
     /** Groups only - Filtered children of this group */
-    public childrenAfterFilter: RowNode[];
+    public childrenAfterFilter: RowNode<T>[];
     /** Groups only - Sorted children of this group */
-    public childrenAfterSort: RowNode[];
+    public childrenAfterSort: RowNode<T>[];
     /** Groups only - Number of children and grand children */
     public allChildrenCount: number | null;
 
@@ -161,7 +161,7 @@ export class RowNode implements IEventEmitter {
     /** Groups only - True if group is expanded, otherwise false */
     public expanded: boolean;
     /** Groups only - If doing footers, reference to the footer node for this group */
-    public sibling: RowNode;
+    public sibling: RowNode<T>;
 
     /** The height, in pixels, of this row */
     public rowHeight: number;
@@ -181,7 +181,7 @@ export class RowNode implements IEventEmitter {
      * a copy where daemon=true. */
     public daemon: boolean;
 
-    /** True by default - can be overridden via gridOptions.isRowSelectable(rowNode) */
+    /** True by default - can be overridden via gridOptions.isRowSelectable(RowNode<T>) */
     public selectable = true;
 
     /** Used by the value service, stores values for a particular change detection turn. */
@@ -198,7 +198,7 @@ export class RowNode implements IEventEmitter {
     private selected = false;
     private eventService: EventService;
 
-    public setData(data: any): void {
+    public setData(data: T): void {
         const oldData = this.data;
         this.data = data;
 
@@ -208,12 +208,12 @@ export class RowNode implements IEventEmitter {
 
         this.checkRowSelectable();
 
-        const event: DataChangedEvent = this.createDataChangedEvent(data, oldData, false);
+        const event: DataChangedEvent<T> = this.createDataChangedEvent(data, oldData, false);
         this.dispatchLocalEvent(event);
     }
 
     // when we are doing master / detail, the detail node is lazy created, but then kept around.
-    // so if we show / hide the detail, the same detail rowNode is used. so we need to keep the data
+    // so if we show / hide the detail, the same detail RowNode<T> is used. so we need to keep the data
     // in sync, otherwise expand/collapse of the detail would still show the old values.
     private updateDataOnDetailNode(): void {
         if (this.detailNode) {
@@ -221,7 +221,7 @@ export class RowNode implements IEventEmitter {
         }
     }
 
-    private createDataChangedEvent(newData: any, oldData: any, update: boolean): DataChangedEvent {
+    private createDataChangedEvent(newData: any, oldData: any, update: boolean): DataChangedEvent<T> {
         return {
             type: RowNode.EVENT_DATA_CHANGED,
             node: this,
@@ -231,7 +231,7 @@ export class RowNode implements IEventEmitter {
         };
     }
 
-    private createLocalRowEvent(type: string): RowNodeEvent {
+    private createLocalRowEvent(type: string): RowNodeEvent<T> {
         return {
             type: type,
             node: this
@@ -253,7 +253,7 @@ export class RowNode implements IEventEmitter {
 
         this.updateDataOnDetailNode();
 
-        const event: DataChangedEvent = this.createDataChangedEvent(data, oldData, true);
+        const event: DataChangedEvent<T> = this.createDataChangedEvent(data, oldData, true);
         this.dispatchLocalEvent(event);
     }
 
@@ -267,8 +267,8 @@ export class RowNode implements IEventEmitter {
         }
     }
 
-    private createDaemonNode(): RowNode {
-        const oldNode = new RowNode();
+    private createDaemonNode(): RowNode<T> {
+        const oldNode = new RowNode<T>();
         this.context.wireBean(oldNode);
         // just copy the id and data, this is enough for the node to be used
         // in the selection controller (the selection controller is the only
@@ -294,7 +294,7 @@ export class RowNode implements IEventEmitter {
 
         this.checkRowSelectable();
 
-        const event: DataChangedEvent = this.createDataChangedEvent(data, oldData, false);
+        const event: DataChangedEvent<T> = this.createDataChangedEvent(data, oldData, false);
         this.dispatchLocalEvent(event);
     }
 
@@ -322,7 +322,7 @@ export class RowNode implements IEventEmitter {
             if (this.data) {
                 this.id = getRowNodeId(this.data);
             } else {
-                // this can happen if user has set blank into the rowNode after the row previously
+                // this can happen if user has set blank into the RowNode<T> after the row previously
                 // having data. this happens in virtual page row model, when data is delete and
                 // the page is refreshed.
                 this.id = undefined;
@@ -441,7 +441,7 @@ export class RowNode implements IEventEmitter {
         this.mainEventService.dispatchEvent(event);
 
         if (this.gridOptionsWrapper.isGroupIncludeFooter()) {
-            this.gridApi.redrawRows({rowNodes: [this]});
+            this.gridApi.redrawRows({ rowNodes: [this] });
         }
     }
 
@@ -517,7 +517,7 @@ export class RowNode implements IEventEmitter {
     }
 
     private dispatchCellChangedEvent(column: Column, newValue: any): void {
-        const cellChangedEvent: CellChangedEvent = {
+        const cellChangedEvent: CellChangedEvent<T> = {
             type: RowNode.EVENT_CELL_CHANGED,
             node: this,
             column: column,
@@ -543,7 +543,7 @@ export class RowNode implements IEventEmitter {
         return this.selected;
     }
 
-    public depthFirstSearch(callback: (rowNode: RowNode) => void): void {
+    public depthFirstSearch(callback: (rowNode: RowNode<T>) => void): void {
         if (this.childrenAfterGroup) {
             this.childrenAfterGroup.forEach(child => child.depthFirstSearch(callback));
         }
@@ -730,7 +730,7 @@ export class RowNode implements IEventEmitter {
         return updatedCount;
     }
 
-    public isParentOfNode(potentialParent: RowNode): boolean {
+    public isParentOfNode(potentialParent: RowNode<T>): boolean {
         let parentNode = this.parent;
         while (parentNode) {
             if (parentNode === potentialParent) {
@@ -793,15 +793,15 @@ export class RowNode implements IEventEmitter {
         this.dispatchLocalEvent(this.createLocalRowEvent(RowNode.EVENT_MOUSE_LEAVE));
     }
 
-    public getFirstChildOfFirstChild(rowGroupColumn: Column | null): RowNode {
-        let currentRowNode: RowNode = this;
+    public getFirstChildOfFirstChild(rowGroupColumn: Column | null): RowNode<T> {
+        let currentRowNode: RowNode<T> = this;
 
         // if we are hiding groups, then if we are the first child, of the first child,
         // all the way up to the column we are interested in, then we show the group cell.
 
         let isCandidate = true;
         let foundFirstChildPath = false;
-        let nodeToSwapIn: RowNode;
+        let nodeToSwapIn: RowNode<T>;
 
         while (isCandidate && !foundFirstChildPath) {
 

--- a/packages/ag-grid-community/src/ts/events.ts
+++ b/packages/ag-grid-community/src/ts/events.ts
@@ -74,13 +74,13 @@ export interface SelectionChangedEvent extends AgGridEvent {
 export interface FilterChangedEvent extends AgGridEvent {
 }
 
-export interface FilterModifiedEvent extends AgGridEvent {
+export interface FilterModifiedEvent<T> extends AgGridEvent {
     filterInstance: IFilterComp;
-    column: Column;
+    column: Column<T>;
 }
 
-export interface FilterOpenedEvent extends AgGridEvent {
-    column: Column;
+export interface FilterOpenedEvent<T> extends AgGridEvent {
+    column: Column<T>;
     source: FilterRequestSource;
     eGui: HTMLElement;
 }
@@ -120,25 +120,25 @@ export interface GridSizeChangedEvent extends AgGridEvent {
     clientHeight: number;
 }
 
-export interface RowDragEvent extends AgGridEvent {
-    node: RowNode;
+export interface RowDragEvent<T> extends AgGridEvent {
+    node: RowNode<T>;
     y: number;
     vDirection: string;
     event: MouseEvent;
     overIndex: number;
-    overNode: RowNode;
+    overNode: RowNode<T>;
 }
 
-export interface RowDragEnterEvent extends RowDragEvent {
+export interface RowDragEnterEvent<T> extends RowDragEvent<T>  {
 }
 
-export interface RowDragEndEvent extends RowDragEvent {
+export interface RowDragEndEvent<T> extends RowDragEvent<T>  {
 }
 
-export interface RowDragMoveEvent extends RowDragEvent {
+export interface RowDragMoveEvent<T> extends RowDragEvent<T>  {
 }
 
-export interface RowDragLeaveEvent extends RowDragEvent {
+export interface RowDragLeaveEvent<T> extends RowDragEvent<T>  {
 }
 
 export interface PasteStartEvent extends AgGridEvent {
@@ -176,8 +176,8 @@ export interface ColumnGroupOpenedEvent extends AgGridEvent {
     columnGroup: OriginalColumnGroup;
 }
 
-export interface ItemsAddedEvent extends AgGridEvent {
-    items: RowNode[];
+export interface ItemsAddedEvent<T> extends AgGridEvent {
+    items: RowNode<T>[];
 }
 
 export interface BodyScrollEvent extends AgGridEvent {
@@ -200,9 +200,9 @@ export interface PaginationChangedEvent extends AgGridEvent {
 
 // this does not extent CellEvent as the focus service doesn't keep a reference to
 // the rowNode.
-export interface CellFocusedEvent extends AgGridEvent {
+export interface CellFocusedEvent<T> extends AgGridEvent {
     rowIndex: number;
-    column: Column;
+    column: Column<T>;
     rowPinned: string;
     forceBrowserFocus: boolean;
     // floating is for backwards compatibility, this is the same as rowPinned.
@@ -241,34 +241,34 @@ export type ColumnEventType =
     "api" |
     "pivotChart";
 
-export interface ColumnEvent extends AgGridEvent {
-    column: Column | null;
-    columns: Column[] | null;
+export interface ColumnEvent<T> extends AgGridEvent {
+    column: Column<T> | null;
+    columns: Column<T>[] | null;
     source: ColumnEventType;
 }
 
-export interface ColumnResizedEvent extends ColumnEvent {
+export interface ColumnResizedEvent<T> extends ColumnEvent<T> {
     finished: boolean;
 }
 
-export interface ColumnPivotChangedEvent extends ColumnEvent {
+export interface ColumnPivotChangedEvent<T> extends ColumnEvent<T> {
 }
 
-export interface ColumnRowGroupChangedEvent extends ColumnEvent {
+export interface ColumnRowGroupChangedEvent<T> extends ColumnEvent<T> {
 }
 
-export interface ColumnValueChangedEvent extends ColumnEvent {
+export interface ColumnValueChangedEvent<T> extends ColumnEvent<T> {
 }
 
-export interface ColumnMovedEvent extends ColumnEvent {
+export interface ColumnMovedEvent<T> extends ColumnEvent<T> {
     toIndex: number | undefined;
 }
 
-export interface ColumnVisibleEvent extends ColumnEvent {
+export interface ColumnVisibleEvent<T> extends ColumnEvent<T> {
     visible: boolean | undefined;
 }
 
-export interface ColumnPinnedEvent extends ColumnEvent {
+export interface ColumnPinnedEvent<T> extends ColumnEvent<T> {
     pinned: string | null;
 }
 
@@ -276,8 +276,8 @@ export interface ColumnPinnedEvent extends ColumnEvent {
 
 /** ROW EVENTS */
 /**------------*/
-export interface RowEvent extends AgGridEvent {
-    node: RowNode;
+export interface RowEvent<T> extends AgGridEvent {
+    node: RowNode<T>;
     data: any;
     rowIndex: number;
     rowPinned: string;
@@ -285,91 +285,91 @@ export interface RowEvent extends AgGridEvent {
     event?: Event | null;
 }
 
-export interface RowGroupOpenedEvent extends RowEvent {
+export interface RowGroupOpenedEvent<T> extends RowEvent<T> {
 }
 
-export interface RowValueChangedEvent extends RowEvent {
+export interface RowValueChangedEvent<T> extends RowEvent<T> {
 }
 
-export interface RowSelectedEvent extends RowEvent {
+export interface RowSelectedEvent<T> extends RowEvent<T> {
 }
 
-export interface VirtualRowRemovedEvent extends RowEvent {
+export interface VirtualRowRemovedEvent<T> extends RowEvent<T> {
 }
 
-export interface RowClickedEvent extends RowEvent {
+export interface RowClickedEvent<T> extends RowEvent<T> {
 }
 
-export interface RowDoubleClickedEvent extends RowEvent {
+export interface RowDoubleClickedEvent<T> extends RowEvent<T> {
 }
 
-export interface RowEditingStartedEvent extends RowEvent {
+export interface RowEditingStartedEvent<T> extends RowEvent<T> {
 }
 
-export interface RowEditingStoppedEvent extends RowEvent {
+export interface RowEditingStoppedEvent<T> extends RowEvent<T> {
 }
 
 /**------------*/
 
 /** CELL EVENTS */
 /**------------*/
-export interface CellEvent extends RowEvent {
-    column: Column;
-    colDef: ColDef;
+export interface CellEvent<T> extends RowEvent<T> {
+    column: Column<T>;
+    colDef: ColDef<T>;
     value: any;
 }
 
-export interface CellKeyDownEvent extends CellEvent {
+export interface CellKeyDownEvent<T> extends CellEvent<T> {
 }
 
-export interface CellKeyPressEvent extends CellEvent {
+export interface CellKeyPressEvent<T> extends CellEvent<T> {
 }
 
-export interface CellClickedEvent extends CellEvent {
+export interface CellClickedEvent<T> extends CellEvent<T> {
 }
 
-export interface CellMouseDownEvent extends CellEvent {
+export interface CellMouseDownEvent<T> extends CellEvent<T> {
 }
 
-export interface CellDoubleClickedEvent extends CellEvent {
+export interface CellDoubleClickedEvent<T> extends CellEvent<T> {
 }
 
-export interface CellMouseOverEvent extends CellEvent {
+export interface CellMouseOverEvent<T> extends CellEvent<T> {
 }
 
-export interface CellMouseOutEvent extends CellEvent {
+export interface CellMouseOutEvent<T> extends CellEvent<T> {
 }
 
-export interface CellContextMenuEvent extends CellEvent {
+export interface CellContextMenuEvent<T> extends CellEvent<T> {
 }
 
-export interface CellEditingStartedEvent extends CellEvent {
+export interface CellEditingStartedEvent<T> extends CellEvent<T> {
 }
 
-export interface CellEditingStoppedEvent extends CellEvent {
+export interface CellEditingStoppedEvent<T> extends CellEvent<T> {
 }
 
-export interface CellValueChangedEvent extends CellEvent {
+export interface CellValueChangedEvent<T> extends CellEvent<T> {
     oldValue: any;
     newValue: any;
 }
 
 // not documented, was put in for CS - more thought needed of how server side grouping / pivoting
 // is done and how these should be used before we fully document and share with the world.
-export interface ColumnRequestEvent extends AgGridEvent {
-    columns: Column[];
+export interface ColumnRequestEvent<T> extends AgGridEvent {
+    columns: Column<T>[];
 }
 
-export interface ColumnRowGroupChangeRequestEvent extends ColumnRequestEvent {
+export interface ColumnRowGroupChangeRequestEvent<T> extends ColumnRequestEvent<T>  {
 }
 
-export interface ColumnPivotChangeRequestEvent extends ColumnRequestEvent {
+export interface ColumnPivotChangeRequestEvent<T> extends ColumnRequestEvent<T>  {
 }
 
-export interface ColumnValueChangeRequestEvent extends ColumnRequestEvent {
+export interface ColumnValueChangeRequestEvent<T> extends ColumnRequestEvent<T>  {
 }
 
-export interface ColumnAggFuncChangeRequestEvent extends ColumnRequestEvent {
+export interface ColumnAggFuncChangeRequestEvent<T> extends ColumnRequestEvent<T>  {
     aggFunc: any;
 }
 

--- a/packages/ag-grid-community/src/ts/gridPanel/rowDragFeature.ts
+++ b/packages/ag-grid-community/src/ts/gridPanel/rowDragFeature.ts
@@ -14,11 +14,11 @@ import { Events } from "../eventKeys";
 import { IRowModel } from "../interfaces/iRowModel";
 import { Constants } from "../constants";
 
-export class RowDragFeature implements DropTarget {
+export class RowDragFeature<T> implements DropTarget<T> {
 
-    @Autowired('dragAndDropService') private dragAndDropService: DragAndDropService;
+    @Autowired('dragAndDropService') private dragAndDropService: DragAndDropService<T>;
     // this feature is only created when row model is ClientSide, so we can type it as ClientSide
-    @Autowired('rowModel') private rowModel: IRowModel;
+    @Autowired('rowModel') private rowModel: IRowModel<T>;
     @Autowired('focusedCellController') private focusedCellController: FocusedCellController;
     @Autowired('gridOptionsWrapper') private gridOptionsWrapper: GridOptionsWrapper;
     @Optional('rangeController') private rangeController: IRangeController;
@@ -36,7 +36,7 @@ export class RowDragFeature implements DropTarget {
     private movingIntervalId: number;
     private intervalCount: number;
 
-    private lastDraggingEvent: DraggingEvent;
+    private lastDraggingEvent: DraggingEvent<T>;
 
     constructor(eContainer: HTMLElement, gridPanel: GridPanel) {
         this.eContainer = eContainer;
@@ -62,7 +62,7 @@ export class RowDragFeature implements DropTarget {
         return DragAndDropService.ICON_MOVE;
     }
 
-    public onDragEnter(draggingEvent: DraggingEvent): void {
+    public onDragEnter(draggingEvent: DraggingEvent<T>): void {
         // when entering, we fire the enter event, then in onEnterOrDragging,
         // we also fire the move event. so we get both events when entering.
         this.dispatchEvent(Events.EVENT_ROW_DRAG_ENTER, draggingEvent);
@@ -71,11 +71,11 @@ export class RowDragFeature implements DropTarget {
         this.onEnterOrDragging(draggingEvent);
     }
 
-    public onDragging(draggingEvent: DraggingEvent): void {
+    public onDragging(draggingEvent: DraggingEvent<T>): void {
         this.onEnterOrDragging(draggingEvent);
     }
 
-    private onEnterOrDragging(draggingEvent: DraggingEvent): void {
+    private onEnterOrDragging(draggingEvent: DraggingEvent<T>): void {
         // this event is fired for enter and move
         this.dispatchEvent(Events.EVENT_ROW_DRAG_MOVE, draggingEvent);
 
@@ -90,7 +90,7 @@ export class RowDragFeature implements DropTarget {
         this.checkCenterForScrolling(pixel);
     }
 
-    private doManagedDrag(draggingEvent: DraggingEvent, pixel: number): void {
+    private doManagedDrag(draggingEvent: DraggingEvent<T>, pixel: number): void {
         const rowNode = draggingEvent.dragItem.rowNode;
         const rowWasMoved = this.clientSideRowModel.ensureRowAtPixel(rowNode, pixel);
 
@@ -171,7 +171,7 @@ export class RowDragFeature implements DropTarget {
     // i tried using generics here with this:
     //     public createEvent<T extends RowDragEvent>(type: string, clazz: {new(): T; }, draggingEvent: DraggingEvent) {
     // but it didn't work - i think it's because it only works with classes, and not interfaces, (the events are interfaces)
-    public dispatchEvent(type: string, draggingEvent: DraggingEvent): void {
+    public dispatchEvent(type: string, draggingEvent: DraggingEvent<T>): void {
 
         const yNormalised = this.normaliseForScroll(draggingEvent.y);
 
@@ -197,7 +197,7 @@ export class RowDragFeature implements DropTarget {
                 break;
         }
 
-        const event: RowDragEvent = {
+        const event: RowDragEvent<T> = {
             type: type,
             api: this.gridOptionsWrapper.getApi(),
             columnApi: this.gridOptionsWrapper.getColumnApi(),
@@ -212,17 +212,17 @@ export class RowDragFeature implements DropTarget {
         this.eventService.dispatchEvent(event);
     }
 
-    public onDragLeave(draggingEvent: DraggingEvent): void {
+    public onDragLeave(draggingEvent: DraggingEvent<T>): void {
         this.dispatchEvent(Events.EVENT_ROW_DRAG_LEAVE, draggingEvent);
         this.stopDragging(draggingEvent);
     }
 
-    public onDragStop(draggingEvent: DraggingEvent): void {
+    public onDragStop(draggingEvent: DraggingEvent<T>): void {
         this.dispatchEvent(Events.EVENT_ROW_DRAG_END, draggingEvent);
         this.stopDragging(draggingEvent);
     }
 
-    private stopDragging(draggingEvent: DraggingEvent): void {
+    private stopDragging(draggingEvent: DraggingEvent<T>): void {
         this.ensureIntervalCleared();
         draggingEvent.dragItem.rowNode.setDragging(false);
     }

--- a/packages/ag-grid-community/src/ts/interfaces/iRowModel.ts
+++ b/packages/ag-grid-community/src/ts/interfaces/iRowModel.ts
@@ -6,13 +6,13 @@ export interface RowBounds {
     rowIndex?: number;
 }
 
-export interface IRowModel {
+export interface IRowModel<T> {
 
     /** Returns the rowNode at the given index. */
-    getRow(index: number): RowNode | null;
+    getRow(index: number): RowNode<T> | null;
 
     /** Returns the rowNode for given id. */
-    getRowNode(id: string): RowNode | null;
+    getRowNode(id: string): RowNode<T> | null;
 
     /** This is legacy, not used by ag-Grid, but keeping for backward compatibility */
     getRowCount(): number;
@@ -25,7 +25,7 @@ export interface IRowModel {
     /** Returns total height of all the rows - used to size the height of the grid div that contains the rows */
     getCurrentPageHeight(): number;
     /** Returns true if the provided rowNode is in the list of rows to render */
-    isRowPresent(rowNode: RowNode): boolean;
+    isRowPresent(rowNode: RowNode<T>): boolean;
     /** Returns row top and bottom for a given row */
     getRowBounds(index: number): RowBounds;
 
@@ -39,11 +39,11 @@ export interface IRowModel {
 
     /** Returns all rows in range that should be selected. If there is a gap in range (non ClientSideRowModel) then
      *  then no rows should be returned  */
-    getNodesInRangeForSelection(first: RowNode, last: RowNode): RowNode[];
+    getNodesInRangeForSelection(first: RowNode<T>, last: RowNode<T>): RowNode<T>[];
 
     /** Iterate through each node. What this does depends on the model type. For clientSide, goes through
      * all nodes. For pagination, goes through current page. For virtualPage, goes through what's loaded in memory. */
-    forEachNode(callback: (rowNode: RowNode, index: number) => void): void;
+    forEachNode(callback: (rowNode: RowNode<T>, index: number) => void): void;
 
     /** The base class returns the type. We use this instead of 'instanceof' as the client might provide
      * their own implementation of the models in the future. */


### PR DESCRIPTION
Basically I changed RowNode to be generic, then started adding type parameters where needed.

It's still ongoing, with over 1,000 errors due to missing type parameters.

A main concern I have is that in contexts which access two or more generic types, the type parameters might need to be different. e.g. both RowNode<T> and ColDef<T> in the same class, might need to become RowNode<R> and ColDef<CD>.