### PR TITLE
doc: change array to function

### DIFF
--- a/packages/ag-grid-docs/src/javascript-grid-sorting/index.php
+++ b/packages/ag-grid-docs/src/javascript-grid-sorting/index.php
@@ -175,7 +175,7 @@ colDef.comparator = function (valueA, valueB, nodeA, nodeB, isInverted) {
     <snippet>
 var groupColumn = {
     headerName: "Group",
-    comparator: [yourOwnComparator], // this is the important bit
+    comparator: yourOwnComparator, // this is the important bit
     cellRenderer: {
         renderer: "agGroupCellRenderer",
     }


### PR DESCRIPTION
In the document.
A property comparator expected a function, not an array.

https://github.com/ag-grid/ag-grid/blob/c2851ab6522e13182065e4a5bdf0c361dbd44c5a/community-modules/grid-core/src/ts/entities/colDef.ts#L190