### PR TITLE
Fix types of sortingOrder

### DIFF
--- a/community-modules/grid-core/src/ts/entities/colDef.ts
+++ b/community-modules/grid-core/src/ts/entities/colDef.ts
@@ -85,7 +85,7 @@ export interface ColDef extends AbstractColDef {
     sortedAt?: number;
 
     /** The sort order, provide an array with any of the following in any order ['asc','desc',null] */
-    sortingOrder?: string[] | null;
+    sortingOrder?: (string | null)[];
 
     /** The field of the row to get the cells data from */
     field?: string;

--- a/community-modules/grid-core/src/ts/entities/gridOptions.ts
+++ b/community-modules/grid-core/src/ts/entities/gridOptions.ts
@@ -120,7 +120,7 @@ export interface GridOptions {
     suppressCellSelection?: boolean;
     suppressClearOnFillReduction?: boolean;
     suppressMaintainUnsortedOrder?: boolean;
-    sortingOrder?: string[];
+    sortingOrder?: (string | null)[];
     suppressMultiSort?: boolean;
     multiSortKey?: string;
     accentedSort?: boolean;


### PR DESCRIPTION
This fixes the sortingOrder types. I was having difficulties with this when trying to change sort order in TypeScript. The type before did not correspond to the docs or even the comment right above the type definition.

This PR is missing build (updated dist files) as I had difficulties building this in my environment and did not have time to debug why. Feel free to update the commit or redo it separately, I don't need any credits 👍 

