### PR TITLE
Use rowDataChangeDetectionStrategy / deltaRowDataMode for pinned rows

### DIFF
--- a/packages/ag-grid-react/src/agGridReact.ts
+++ b/packages/ag-grid-react/src/agGridReact.ts
@@ -142,7 +142,7 @@ export class AgGridReact extends Component<AgGridReactProps, {}> {
     }
 
     private getStrategyTypeForProp(propKey: string) {
-        if (propKey === 'rowData') {
+        if (propKey === 'rowData' || propKey === 'pinnedTopRowData' || propKey === 'pinnedBottomRowData') {
             // for row data we either return the supplied strategy, or:
             // if deltaRowDataMode we default to IdentityChecks,
             // if not we default to DeepValueChecks (with the rest of the properties)


### PR DESCRIPTION
Currently if you set the `rowDataChangeDetectionStrategy` or `deltaRowDataMode` props they are only used for `rowData`

I believe this should also be applied to `pinnedTopRowData` and `pinnedBottomRowData`.

The issue I am facing is that I have a pinned top row, where the data in each cell is a complex object. As I cannot set the change detection strategy for this row, the default change detection strategy `DeepValueCheck` is applied, which is extremely slow (4-5 seconds to render). I would like to be able to override this to use an `IdentityCheck` instead.