### PR TITLE
Fix: Remove import breaking TS 3.7+ in dateFilter in v21

### DIFF
--- a/packages/ag-grid-community/dist/lib/filter/provided/date/dateFilter.d.ts
+++ b/packages/ag-grid-community/dist/lib/filter/provided/date/dateFilter.d.ts
@@ -2,7 +2,6 @@
 // Project: http://www.ag-grid.com/
 // Definitions by: Niall Crosby <https://github.com/ag-grid/>
 import { ConditionPosition, ISimpleFilterModel } from "../simpleFilter";
-import { IDateComparatorFunc } from "./dateFilter";
 import { Comparator, IScalarFilterParams, ScalerFilter } from "../scalerFilter";
 export interface DateFilterModel extends ISimpleFilterModel {
     dateFrom: string;


### PR DESCRIPTION
Reported in: https://github.com/ag-grid/ag-grid/issues/3467
This was fixed on master in https://github.com/ag-grid/ag-grid/pull/3468

We are planning to upgrade to the latest ag-grid after a few unrelated issues are worked in the next release, but in order not to hold up our TypeScript 3.7 upgrade, we are asking to please patch the v21.0.1 version on the b21.0.1 branch with this commit and publish it as v21.0.2.

Thanks,
Joel