### PR TITLE
Fix AutoHeight for React Components (cellRendererFramework)

### DIFF
--- a/community-modules/react/src/reactComponent.ts
+++ b/community-modules/react/src/reactComponent.ts
@@ -44,7 +44,7 @@ export class ReactComponent extends BaseReactComponent {
     public init(params: any): Promise<void> {
         this.eParentElement = this.createParentElement(params);
 
-        // we populate the innerHTML first, so that autoRowHeight can be calulated first
+        // we populate the innerHTML first, so that autoRowHeight can be calculated first
         if (params.colDef.autoHeight) {
             const reactComponent = React.createElement(this.reactComponent, params);
             this.eParentElement.innerHTML = renderToStaticMarkup(reactComponent);
@@ -85,7 +85,7 @@ export class ReactComponent extends BaseReactComponent {
         this.portal = portal;
         if (!params.colDef.autoHeight) {
             this.parentComponent.mountReactPortal(portal!, this, resolve);
-        } else { // remove the hack that allowed autoHeight to work (note, does not affect display, so it's an visually invisible change to the user)
+        } else { // remove the hack that allowed autoHeight to work (note: does not affect display, so it's a visually invisible change to the user)
             this.parentComponent.mountReactPortal(portal!, this, (value: any) => {
                 resolve(value);
                 setTimeout(() => {

--- a/community-modules/react/src/reactComponent.ts
+++ b/community-modules/react/src/reactComponent.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import {ReactPortal} from 'react';
+import {renderToStaticMarkup} from 'react-dom/server';
 import * as ReactDOM from 'react-dom';
 import {Promise, Utils} from '@ag-grid-community/core';
 import {AgGridReact} from "./agGridReact";
@@ -11,6 +12,7 @@ export class ReactComponent extends BaseReactComponent {
     static REACT_MEMO_TYPE = ReactComponent.hasSymbol() ? Symbol.for('react.memo') : 0xead3;
 
     private eParentElement!: HTMLElement;
+    private autoHeightMarkForDeath: HTMLElement | null = null;
     private componentInstance: any;
 
     private reactComponent: any;
@@ -40,8 +42,18 @@ export class ReactComponent extends BaseReactComponent {
     }
 
     public init(params: any): Promise<void> {
+        this.eParentElement = this.createParentElement(params);
+
+        // we populate the innerHTML first, so that autoRowHeight can be calulated first
+        if (params.colDef.autoHeight) {
+            const reactComponent = React.createElement(this.reactComponent, params);
+            this.eParentElement.innerHTML = renderToStaticMarkup(reactComponent);
+            if (this.eParentElement.children.length > 0) { // in theory, we should get a new HTML element
+                this.autoHeightMarkForDeath = this.eParentElement.children[0] as HTMLElement;
+            }
+        }
+        
         return new Promise<void>((resolve: any) => {
-            this.eParentElement = this.createParentElement(params);
             this.createReactComponent(params, resolve);
         });
     }
@@ -71,7 +83,19 @@ export class ReactComponent extends BaseReactComponent {
             generateNewKey() // fixed deltaRowModeRefreshCompRenderer
         );
         this.portal = portal;
-        this.parentComponent.mountReactPortal(portal!, this, resolve);
+        if (!params.colDef.autoHeight) {
+            this.parentComponent.mountReactPortal(portal!, this, resolve);
+        } else { // remove the hack that allowed autoHeight to work (note, does not affect display, so it's an visually invisible change to the user)
+            this.parentComponent.mountReactPortal(portal!, this, (value: any) => {
+                resolve(value);
+                setTimeout(() => {
+                    const markForDeath = this.autoHeightMarkForDeath;
+                    if (markForDeath != null) {
+                        markForDeath.remove();
+                    }
+                }, 100);
+            });
+        }
     }
 
     private addParentContainerStyleAndClasses() {

--- a/packages/ag-grid-react/src/reactComponent.ts
+++ b/packages/ag-grid-react/src/reactComponent.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import {ReactPortal} from 'react';
+import {renderToStaticMarkup} from 'react-dom/server';
 import * as ReactDOM from 'react-dom';
 import {Promise, Utils} from 'ag-grid-community';
 import {AgGridReact} from "./agGridReact";
@@ -11,6 +12,7 @@ export class ReactComponent extends BaseReactComponent {
     static REACT_MEMO_TYPE = ReactComponent.hasSymbol() ? Symbol.for('react.memo') : 0xead3;
 
     private eParentElement!: HTMLElement;
+    private autoHeightMarkForDeath: HTMLElement | null = null;
     private componentInstance: any;
 
     private reactComponent: any;
@@ -38,10 +40,19 @@ export class ReactComponent extends BaseReactComponent {
     public getReactComponentName(): string {
         return this.reactComponent.name;
     }
-
     public init(params: any): Promise<void> {
+        this.eParentElement = this.createParentElement(params);
+
+        // we populate the innerHTML first, so that autoRowHeight can be calulated first
+        if (params.colDef.autoHeight) {
+            const reactComponent = React.createElement(this.reactComponent, params);
+            this.eParentElement.innerHTML = renderToStaticMarkup(reactComponent);
+            if (this.eParentElement.children.length > 0) { // in theory, we should get a new HTML element
+                this.autoHeightMarkForDeath = this.eParentElement.children[0] as HTMLElement;
+            }
+        }
+        
         return new Promise<void>((resolve: any) => {
-            this.eParentElement = this.createParentElement(params);
             this.createReactComponent(params, resolve);
         });
     }
@@ -71,7 +82,19 @@ export class ReactComponent extends BaseReactComponent {
             generateNewKey() // fixed deltaRowModeRefreshCompRenderer
         );
         this.portal = portal;
-        this.parentComponent.mountReactPortal(portal!, this, resolve);
+        if (!params.colDef.autoHeight) {
+            this.parentComponent.mountReactPortal(portal!, this, resolve);
+        } else { // remove the hack that allowed autoHeight to work (note, does not affect display, so it's an visually invisible change to the user)
+            this.parentComponent.mountReactPortal(portal!, this, (value: any) => {
+                resolve(value);
+                setTimeout(() => {
+                    const markForDeath = this.autoHeightMarkForDeath;
+                    if (markForDeath != null) {
+                        markForDeath.remove();
+                    }
+                }, 100);
+            });
+        }
     }
 
     private addParentContainerStyleAndClasses() {

--- a/packages/ag-grid-react/src/reactComponent.ts
+++ b/packages/ag-grid-react/src/reactComponent.ts
@@ -43,7 +43,7 @@ export class ReactComponent extends BaseReactComponent {
     public init(params: any): Promise<void> {
         this.eParentElement = this.createParentElement(params);
 
-        // we populate the innerHTML first, so that autoRowHeight can be calulated first
+        // we populate the innerHTML first, so that autoRowHeight can be calculated first
         if (params.colDef.autoHeight) {
             const reactComponent = React.createElement(this.reactComponent, params);
             this.eParentElement.innerHTML = renderToStaticMarkup(reactComponent);
@@ -84,7 +84,7 @@ export class ReactComponent extends BaseReactComponent {
         this.portal = portal;
         if (!params.colDef.autoHeight) {
             this.parentComponent.mountReactPortal(portal!, this, resolve);
-        } else { // remove the hack that allowed autoHeight to work (note, does not affect display, so it's an visually invisible change to the user)
+        } else { // remove the hack that allowed autoHeight to work (note: does not affect display, so it's a visually invisible change to the user)
             this.parentComponent.mountReactPortal(portal!, this, (value: any) => {
                 resolve(value);
                 setTimeout(() => {


### PR DESCRIPTION
This PR seems to be related to then new comments in the issue: #3160 

Minimum code to replicate bug (can't get `plunkr` to work) is in [this repo](https://github.com/csit-intern-james/ag-grid-react-autoheight-bug).

Bug seen on Firefox/73.0.1 on Ubuntu. The code changes in this PR attempts to fix the bug, although it is admittedly quite hacky; perhaps someone here has a better way to solve this :smile: 

From my understanding, the main cause of this issue is the race condition between React portals rendering the components onto the grid and `core/ts/rendering/autoHeightCalculator.ts` inferring the height from a dummy component.

I have tried a few ways of solving this:
1. Adding an interface to allow `IComponent`s to specify the height directly;
2. Invoke component rendering when laying out the components in the dummy container in `core/ts/rendering/autoHeightCalculator.ts`;
3. Rendering the component during `init` in `reactComponent` and removing the duplicated HTML after a while :sweat_smile:

Hopefully this will be enough information for somebody more experienced to find a better solution :smile: 