### PR TITLE
Provide access to GridApi and ColumnApi in getQuickFilterText params

### DIFF
--- a/community-modules/core/src/ts/entities/colDef.ts
+++ b/community-modules/core/src/ts/entities/colDef.ts
@@ -378,15 +378,6 @@ export interface IsColumnFuncParams {
     columnApi: ColumnApi | null | undefined;
 }
 
-export interface GetQuickFilterTextParams {
-    value: any;
-    node: RowNode;
-    data: any;
-    column: Column;
-    colDef: ColDef;
-    context: any;
-}
-
 export interface BaseColDefParams {
     node: RowNode;
     data: any;
@@ -399,6 +390,9 @@ export interface BaseColDefParams {
 
 export interface BaseWithValueColDefParams extends BaseColDefParams {
     value: any;
+}
+
+export interface GetQuickFilterTextParams extends BaseWithValueColDefParams {
 }
 
 export interface ValueGetterParams extends BaseColDefParams {

--- a/community-modules/core/src/ts/filter/filterManager.ts
+++ b/community-modules/core/src/ts/filter/filterManager.ts
@@ -379,6 +379,8 @@ export class FilterManager {
                 data: rowNode.data,
                 column: column,
                 colDef: colDef,
+                api: this.gridOptionsWrapper.getApi(),
+                columnApi: this.gridOptionsWrapper.getColumnApi(),
                 context: this.gridOptionsWrapper.getContext()
             };
             valueAfterCallback = column.getColDef().getQuickFilterText(params);

--- a/grid-packages/ag-grid-docs/src/javascript-grid-filter-quick/index.php
+++ b/grid-packages/ag-grid-docs/src/javascript-grid-filter-quick/index.php
@@ -42,7 +42,24 @@ colDef = {
     }
 }</snippet>
 
-<p>Params contains {value, node, data, column, colDef, context}.</p>
+<p>The interface for <code>getQuickFilterText</code> is as follows:</p>
+
+<snippet>
+// function for valueFormatter
+function getQuickFilterText(params: GetQuickFilterTextParams) =&gt; any;
+
+// interface for params
+interface GetQuickFilterTextParams {
+    value: any, // the unformatted value for this cell
+    data: any, // the data you provided for this row
+    node: RowNode, // the row node for this row
+    colDef: ColDef, // the column def for this column
+    column: Column, // the column for this column
+    api: GridApi, // the grid API
+    columnApi: ColumnApi, // the grid Column API
+    context: any  // the context
+}
+</snippet>
 
 <note>
     You only need to override the quick filter value if you have a problem. If you don't have a quick filter


### PR DESCRIPTION
Most column definition function params provide a reference to
GridApi and ColumnApi objects. Those references are easily accessible
when building the GetQuickFilterTextParams object, but were not included.
This adds them to the GetQuickFilterTextParams definition.

This also:

* Updates documentation for `getQuickFilterText` to reflect
  the new parameter properties.

* Formats documentation for the `getQuickFilterText` parameters to
  be more consistent with other column definition function
  documentation.