### PR TITLE
Specify exact expected type for onCellValueChanged ColDef property

### DIFF
--- a/community-modules/core/src/ts/entities/colDef.ts
+++ b/community-modules/core/src/ts/entities/colDef.ts
@@ -323,7 +323,7 @@ export interface ColDef extends AbstractColDef {
     cellClassRules?: { [cssClassName: string]: (Function | string); };
 
     /** Callbacks for editing.See editing section for further details. */
-    onCellValueChanged?: Function;
+    onCellValueChanged?: (params: NewValueParams) => void;
 
     /** Function callback, gets called when a cell is clicked. */
     onCellClicked?: (event: CellClickedEvent) => void;


### PR DESCRIPTION
The `onCellValueChanged` function optionally expected on the ColDef interface takes a single argument of the type `NewValueParams`, when called. This change more accurately defines the type for that function to avoid ambiguity with the previous type of `Function`.