### PR TITLE
Fix number-floating-filter allow non-numeric input.#3839

### DIFF
--- a/community-modules/core/src/ts/filter/floating/provided/textInputFloatingFilter.ts
+++ b/community-modules/core/src/ts/filter/floating/provided/textInputFloatingFilter.ts
@@ -1,5 +1,4 @@
 import { IFloatingFilterParams } from '../floatingFilter';
-import { RefSelector } from '../../../widgets/componentAnnotations';
 import { ProvidedFilterModel } from '../../../interfaces/iFilter';
 import { debounce } from '../../../utils/function';
 import { Constants } from '../../../constants';
@@ -14,19 +13,13 @@ import { ColumnController } from '../../../columnController/columnController';
 
 export abstract class TextInputFloatingFilter extends SimpleFloatingFilter {
     @Autowired('columnController') private columnController: ColumnController;
-    @RefSelector('eFloatingFilterInput') private eFloatingFilterInput: AgInputTextField;
+    protected eFloatingFilterInput: AgInputTextField;
 
     protected params: IFloatingFilterParams;
 
     private applyActive: boolean;
 
-    @PostConstruct
-    private postConstruct(): void {
-        this.setTemplate(/* html */`
-            <div class="ag-floating-filter-input" role="presentation">
-                <ag-input-text-field ref="eFloatingFilterInput"></ag-input-text-field>
-            </div>`);
-    }
+   
 
     protected getDefaultDebounceMs(): number {
         return 500;

--- a/community-modules/core/src/ts/filter/provided/number/numberFloatingFilter.ts
+++ b/community-modules/core/src/ts/filter/provided/number/numberFloatingFilter.ts
@@ -1,8 +1,20 @@
 import { NumberFilter, NumberFilterModel } from './numberFilter';
 import { SimpleFilter } from '../simpleFilter';
 import { TextInputFloatingFilter } from '../../floating/provided/textInputFloatingFilter';
+import { PostConstruct, Autowired } from '../../../context/context';
+import { RefSelector } from '../../../widgets/componentAnnotations';
+import { AgInputNumberField } from '../../../widgets/agInputNumberField';
 
 export class NumberFloatingFilter extends TextInputFloatingFilter {
+
+    @RefSelector('eFloatingFilterInput') protected eFloatingFilterInput: AgInputNumberField;
+    @PostConstruct
+    private postConstruct(): void {
+        this.setTemplate(/* html */`
+            <div class="ag-floating-filter-input" role="presentation">
+                <ag-input-number-field ref="eFloatingFilterInput"></ag-input-number-field>
+            </div>`);
+    } 
 
     protected getDefaultFilterOptions(): string[] {
         return NumberFilter.DEFAULT_FILTER_OPTIONS;

--- a/community-modules/core/src/ts/filter/provided/text/textFloatingFilter.ts
+++ b/community-modules/core/src/ts/filter/provided/text/textFloatingFilter.ts
@@ -1,7 +1,19 @@
 import { TextFilter, TextFilterModel } from './textFilter';
 import { TextInputFloatingFilter } from '../../floating/provided/textInputFloatingFilter';
-
+import { PostConstruct, Autowired } from '../../../context/context';
+import { RefSelector } from '../../../widgets/componentAnnotations';
+import { AgInputTextField } from '../../../widgets/agInputTextField';
 export class TextFloatingFilter extends TextInputFloatingFilter {
+
+    @RefSelector('eFloatingFilterInput') protected eFloatingFilterInput: AgInputTextField;
+    @PostConstruct
+    private postConstruct(): void {
+        this.setTemplate(/* html */`
+            <div class="ag-floating-filter-input" role="presentation">
+                <ag-input-text-field ref="eFloatingFilterInput"></ag-input-text-field>
+            </div>`);
+    }
+
 
     protected conditionToString(condition: TextFilterModel): string {
         // it's not possible to have 'in range' for string, so no need to check for it.


### PR DESCRIPTION
The number-floating-filter display NaN when filtered because allow non-numeric input.And it's hard to handle data type in server. Now this pr can fix number-floating-filter the same as the standard filter (popup) and only allow numbers.