### PR TITLE
Mark lastRow in IServerSideGetRowsParams as optional

### DIFF
--- a/community-modules/core/src/ts/interfaces/iServerSideDatasource.ts
+++ b/community-modules/core/src/ts/interfaces/iServerSideDatasource.ts
@@ -36,7 +36,7 @@ export interface IServerSideGetRowsParams {
     parentNode: RowNode;
 
     // success callback, pass the rows back the grid asked for
-    successCallback(rowsThisPage: any[], lastRow: number): void;
+    successCallback(rowsThisPage: any[], lastRow?: number): void;
 
     // fail callback, tell the grid the call failed so it can adjust it's state
     failCallback(): void;


### PR DESCRIPTION
This change matches what the docs describe here https://www.ag-grid.com/javascript-grid-server-side-model-datasource/#implementing-the-server-side-datasource and as well as my observations if I leave that parameter empty with ts-ignore

It's my first contribution so please let me know if there is anything else that I should update