### PR TITLE
Added ascii_only flag to terserOptions to support UTF-8 restrictions

### DIFF
--- a/community-modules/all-modules/gulpfile.js
+++ b/community-modules/all-modules/gulpfile.js
@@ -45,7 +45,8 @@ const webpackTask = (minify, styles, libraryTarget) => {
                     new TerserPlugin({
                         terserOptions: {
                             output: {
-                                comments: false
+                                comments: false,
+                                ascii_only: true
                             }
                         },
                         extractComments: false


### PR DESCRIPTION
Currently AG-Grid uglifys and includes a few special characters which are incompatible with UTF-8.  There are three characters I am aware of - arrow up (↑), arrow down(↓) and £.  This flag will keep these characters in their UTF-8 Encoding (as they are in the un-minified version)