### PR TITLE
Fix row drag drop cross groupping undefined issue

### DIFF
--- a/community-modules/core/src/ts/gridPanel/rowDragFeature.ts
+++ b/community-modules/core/src/ts/gridPanel/rowDragFeature.ts
@@ -491,8 +491,10 @@ export class RowDragFeature extends BeanStub implements DropTarget {
     private stopDragging(draggingEvent: DraggingEvent): void {
         this.ensureIntervalCleared();
 
-        this.getRowNodes(draggingEvent).forEach(rowNode => {
-            rowNode.setDragging(false);
-        });
+        if (this.getRowNodes(draggingEvent)) { 
+            this.getRowNodes(draggingEvent).forEach(rowNode => {
+                rowNode.setDragging(false);
+            });
+        }
     }
 }


### PR DESCRIPTION
Ag-grid row drag drop - Cannot read property 'forEach' of undefined
(1) https://stackoverflow.com/questions/62583624/ag-grid-row-drag-drop-cannot-read-property-foreach-of-undefined
(2) https://stackoverflow.com/questions/62613338/react-ag-grid-identifying-overnode-when-dragging-grid-to-grid

this.getRowNodes(draggingEvent) return null or array. It can't directly call forEach.