### PR TITLE
Fix case in mergeDeep where oldValue is null and newValue is an object

### DIFF
--- a/community-modules/core/src/ts/utils/object.ts
+++ b/community-modules/core/src/ts/utils/object.ts
@@ -74,7 +74,7 @@ export function mergeDeep(dest: any, source: any, copyUndefined = true): void {
 
         if (oldValue === newValue) { return; }
 
-        if (typeof oldValue === 'object' && typeof newValue === 'object' && !Array.isArray(oldValue)) {
+        if (typeof oldValue === 'object' && oldValue !== null && typeof newValue === 'object' && !Array.isArray(oldValue)) {
             mergeDeep(oldValue, newValue);
         } else if (copyUndefined || newValue !== undefined) {
             dest[key] = newValue;


### PR DESCRIPTION
See this issue for a detailed description: https://github.com/ag-grid/ag-grid/issues/4022

TL;DR: `typeof null === 'object'` therefore if `oldValue` is `null` and `newValue` is an object then line 73 throws an error.