### PR TITLE
Use more precise viewport width in sizeColumnsToFit.

### DIFF
--- a/community-modules/core/src/ts/gridPanel/gridPanel.ts
+++ b/community-modules/core/src/ts/gridPanel/gridPanel.ts
@@ -1060,7 +1060,7 @@ export class GridPanel extends Component {
     // method will call itself if no available width. this covers if the grid
     // isn't visible, but is just about to be visible.
     public sizeColumnsToFit(nextTimeout?: number) {
-        const availableWidth = this.eBodyViewport.clientWidth;
+        const availableWidth = this.eBodyViewport.getBoundingClientRect().width;
 
         if (availableWidth > 0) {
             this.columnController.sizeColumnsToFit(availableWidth, "sizeColumnsToFit");


### PR DESCRIPTION
 clientWidth rounded to the nearest integer, causing a horizontal scrollbar if that rounding increased the width. Some browsers handled this correctly, but was causing a horizontal scrollbar 50% of the time on Firefox. Might be related to #2911 , as the same temporary fix for that worked for me. (.ag-center-cols-viewport {overflow: hidden;})

There were several other areas in the code I found that similarly use clientWidth instead of getBoundingRect().width - it might be worth taking a look at those, in order to do things consistently throughout (and potentially fix other bugs). This should be the minimal change to fix the horizontal scrollbar after sizeColumnsToFit.