### PR TITLE
Support custom debounce time and backspace in select editor search

### DIFF
--- a/community-modules/core/src/ts/interfaces/iRichCellEditorParams.ts
+++ b/community-modules/core/src/ts/interfaces/iRichCellEditorParams.ts
@@ -7,4 +7,5 @@ export interface IRichCellEditorParams extends ICellEditorParams {
     values: CellValue[];
     cellHeight: number;
     cellRenderer: {new(): ICellRendererComp} | ICellRendererFunc | string;
+    searchDebounce ?: number;
 }

--- a/enterprise-modules/rich-select/src/richSelect/richSelectCellEditor.ts
+++ b/enterprise-modules/rich-select/src/richSelect/richSelectCellEditor.ts
@@ -91,7 +91,7 @@ export class RichSelectCellEditor extends PopupComponent implements ICellEditor 
         this.addManagedListener(virtualListGui, 'click', this.onClick.bind(this));
         this.addManagedListener(virtualListGui, 'mousemove', this.onMouseMove.bind(this));
 
-        this.clearSearchString = _.debounce(this.clearSearchString, 300);
+        this.clearSearchString = _.debounce(this.clearSearchString, params.searchDebounce || 300);
 
         if (_.exists(params.charPress)) {
             this.searchText(params.charPress as string);
@@ -132,14 +132,19 @@ export class RichSelectCellEditor extends PopupComponent implements ICellEditor 
     }
 
     private searchText(key: KeyboardEvent | string) {
-        if (typeof key !== 'string') {
-            if (!_.isCharacterKey(key)) {
-                return;
-            }
-            key = key.key as string;
+        const key = event.which || event.keyCode;
+        if (key === KeyCode.BACKSPACE) {
+            this.searchString = this.searchString.slice(0, -1);
         }
-
-        this.searchString += key;
+        else {
+            if (typeof key !== 'string') {
+                if (!_.isCharacterKey(key)) {
+                    return;
+                }
+                key = key.key as string;
+            }
+            this.searchString += key;
+        }
         this.runSearch();
         this.clearSearchString();
     }

--- a/enterprise-modules/rich-select/src/richSelect/richSelectCellEditor.ts
+++ b/enterprise-modules/rich-select/src/richSelect/richSelectCellEditor.ts
@@ -131,19 +131,19 @@ export class RichSelectCellEditor extends PopupComponent implements ICellEditor 
         }
     }
 
-    private searchText(key: KeyboardEvent | string) {
+    private searchText(event: KeyboardEvent | string) {
         const key = event.which || event.keyCode;
         if (key === KeyCode.BACKSPACE) {
             this.searchString = this.searchString.slice(0, -1);
         }
         else {
-            if (typeof key !== 'string') {
-                if (!_.isCharacterKey(key)) {
+            if (typeof event !== 'string') {
+                if (!_.isCharacterKey(event)) {
                     return;
                 }
-                key = key.key as string;
+                event = event.key as string;
             }
-            this.searchString += key;
+            this.searchString += event;
         }
         this.runSearch();
         this.clearSearchString();


### PR DESCRIPTION
It is difficult to enter more than 2 or 3 characters before the search string is cleared, so it would be helpful to make this configurable