### PR TITLE
Allow ranged deselection.

### DIFF
--- a/community-modules/core/src/ts/rendering/checkboxSelectionComponent.ts
+++ b/community-modules/core/src/ts/rendering/checkboxSelectionComponent.ts
@@ -50,15 +50,17 @@ export class CheckboxSelectionComponent extends Component {
         this.eCheckbox.setInputAriaLabel(`Press Space to toggle row selection (${stateName})`);
     }
 
-    private onCheckedClicked(): number {
+    private onCheckedClicked(event: MouseEvent): number {
         const groupSelectsFiltered = this.gridOptionsWrapper.isGroupSelectsFiltered();
-        const updatedCount = this.rowNode.setSelectedParams({ newValue: false, groupSelectsFiltered: groupSelectsFiltered });
+        const updatedCount = this.rowNode.setSelectedParams({ newValue: false, canBeRangeSelect: true, rangeSelect: event.shiftKey, groupSelectsFiltered: groupSelectsFiltered });
+        this.eCheckbox.setValue(this.rowNode.isSelected(), true);
         return updatedCount;
     }
 
     private onUncheckedClicked(event: MouseEvent): number {
         const groupSelectsFiltered = this.gridOptionsWrapper.isGroupSelectsFiltered();
-        const updatedCount = this.rowNode.setSelectedParams({ newValue: true, rangeSelect: event.shiftKey, groupSelectsFiltered: groupSelectsFiltered });
+        const updatedCount = this.rowNode.setSelectedParams({ newValue: true, canBeRangeSelect: true, rangeSelect: event.shiftKey, groupSelectsFiltered: groupSelectsFiltered });
+        this.eCheckbox.setValue(this.rowNode.isSelected(), true);
         return updatedCount;
     }
 
@@ -83,7 +85,7 @@ export class CheckboxSelectionComponent extends Component {
             } else if (params.selected) {
                 this.onUncheckedClicked(params.event || {});
             } else {
-                this.onCheckedClicked();
+                this.onCheckedClicked(params.event || {});
             }
         });
 


### PR DESCRIPTION
A customer intended to select large numbers of rows, and also intended to allow
users to deselect parts of these ranges.

The existing functionality only supported adding rows to a range selection.
This feature allows the user to `click`, then `shift+click` in any
direction on the grid, allowing for ranged selection and deselection of nodes.

Because `RowNode.setSelected` may be triggered programatically (ie when updating
rows without a user interaction), we prevent the range selection from happening.

When the user toggles the selection of a row via checkbox, with the `shift` key
held down, we allow the range selection or deselection to occur.
