### PR TITLE
Feat/4154 make rownode generic

### DIFF
--- a/community-modules/core/src/ts/entities/gridOptions.ts
+++ b/community-modules/core/src/ts/entities/gridOptions.ts
@@ -1,18 +1,18 @@
 /************************************************************************************************
  * If you change the GridOptions interface, you must also update PropertyKeys to be consistent. *
  ************************************************************************************************/
-import { RowNode } from "./rowNode";
-import { GridApi } from "../gridApi";
-import { ColumnApi } from "../columnController/columnApi";
-import { Column } from "./column";
-import { IViewportDatasource } from "../interfaces/iViewportDatasource";
-import { ICellRenderer, ICellRendererComp, ICellRendererFunc } from "../rendering/cellRenderers/iCellRenderer";
-import { ColDef, ColGroupDef, IAggFunc, SuppressKeyboardEventParams } from "./colDef";
-import { IDatasource } from "../interfaces/iDatasource";
-import { CellPosition } from "./cellPosition";
-import { IDateComp } from "../rendering/dateComponent";
-import { IServerSideDatasource } from "../interfaces/iServerSideDatasource";
-import { CsvExportParams, ProcessCellForExportParams, ProcessHeaderForExportParams } from "../interfaces/exportParams";
+import { RowNode } from './rowNode';
+import { GridApi } from '../gridApi';
+import { ColumnApi } from '../columnController/columnApi';
+import { Column } from './column';
+import { IViewportDatasource } from '../interfaces/iViewportDatasource';
+import { ICellRenderer, ICellRendererComp, ICellRendererFunc } from '../rendering/cellRenderers/iCellRenderer';
+import { ColDef, ColGroupDef, IAggFunc, SuppressKeyboardEventParams } from './colDef';
+import { IDatasource } from '../interfaces/iDatasource';
+import { CellPosition } from './cellPosition';
+import { IDateComp } from '../rendering/dateComponent';
+import { IServerSideDatasource } from '../interfaces/iServerSideDatasource';
+import { CsvExportParams, ProcessCellForExportParams, ProcessHeaderForExportParams } from '../interfaces/exportParams';
 import {
     BodyScrollEvent,
     CellClickedEvent,
@@ -79,19 +79,24 @@ import {
     ToolPanelVisibleChangedEvent,
     ViewportChangedEvent,
     VirtualColumnsChangedEvent,
-    VirtualRowRemovedEvent
-} from "../events";
-import { IComponent } from "../interfaces/iComponent";
-import { AgGridRegisteredComponentInput } from "../components/framework/userComponentRegistry";
-import { ILoadingOverlayComp } from "../rendering/overlays/loadingOverlayComponent";
-import { INoRowsOverlayComp } from "../rendering/overlays/noRowsOverlayComponent";
-import { StatusPanelDef } from "../interfaces/iStatusPanel";
-import { SideBarDef } from "./sideBar";
-import { ChartMenuOptions, ChartOptions, ChartType } from "../interfaces/iChartOptions";
-import {AgChartOptions, AgChartTheme, AgChartThemeOptions, AgChartThemeOverrides} from "../interfaces/iAgChartOptions";
-import { HeaderPosition } from "../headerRendering/header/headerPosition";
+    VirtualRowRemovedEvent,
+} from '../events';
+import { IComponent } from '../interfaces/iComponent';
+import { AgGridRegisteredComponentInput } from '../components/framework/userComponentRegistry';
+import { ILoadingOverlayComp } from '../rendering/overlays/loadingOverlayComponent';
+import { INoRowsOverlayComp } from '../rendering/overlays/noRowsOverlayComponent';
+import { StatusPanelDef } from '../interfaces/iStatusPanel';
+import { SideBarDef } from './sideBar';
+import { ChartMenuOptions, ChartOptions, ChartType } from '../interfaces/iChartOptions';
+import {
+    AgChartOptions,
+    AgChartTheme,
+    AgChartThemeOptions,
+    AgChartThemeOverrides,
+} from '../interfaces/iAgChartOptions';
+import { HeaderPosition } from '../headerRendering/header/headerPosition';
 
-export interface GridOptions {
+export interface GridOptions<T = any> {
     /*******************************************************************************************************
      * If you change the properties on this interface, you must also update PropertyKeys to be consistent. *
      *******************************************************************************************************/
@@ -202,7 +207,7 @@ export interface GridOptions {
     allowShowChangeAfterFilter?: boolean;
     quickFilterText?: string;
     cacheQuickFilter?: boolean;
-    aggFuncs?: { [key: string]: IAggFunc; };
+    aggFuncs?: { [key: string]: IAggFunc };
     suppressColumnVirtualisation?: boolean;
     functionsReadOnly?: boolean;
     functionsPassive?: boolean;
@@ -313,7 +318,7 @@ export interface GridOptions {
     keepDetailRows?: boolean;
     keepDetailRowsCount?: number;
     isRowMaster?: IsRowMaster;
-    detailCellRenderer?: { new(): ICellRendererComp; } | ICellRendererFunc | string;
+    detailCellRenderer?: { new (): ICellRendererComp } | ICellRendererFunc | string;
     detailCellRendererFramework?: any;
     detailCellRendererParams?: any;
     detailRowAutoHeight?: boolean;
@@ -324,7 +329,7 @@ export interface GridOptions {
     pinnedBottomRowData?: any[];
     sideBar?: SideBarDef | string | boolean;
     columnDefs?: (ColDef | ColGroupDef)[];
-    columnTypes?: { [key: string]: ColDef; };
+    columnTypes?: { [key: string]: ColDef };
     datasource?: IDatasource;
     viewportDatasource?: IViewportDatasource;
     serverSideDatasource?: IServerSideDatasource;
@@ -343,15 +348,15 @@ export interface GridOptions {
     // callbacks
     paginationNumberFormatter?: (params: PaginationNumberFormatterParams) => string;
     postProcessPopup?: (params: PostProcessPopupParams) => void;
-    frameworkComponents?: { [p: string]: { new(): any; }; } | any;
-    components?: { [p: string]: AgGridRegisteredComponentInput<IComponent<any>>; };
-    dateComponent?: string | { new(): IDateComp; };
+    frameworkComponents?: { [p: string]: { new (): any } } | any;
+    components?: { [p: string]: AgGridRegisteredComponentInput<IComponent<any>> };
+    dateComponent?: string | { new (): IDateComp };
     dateComponentFramework?: any;
-    groupRowRenderer?: { new(): ICellRendererComp; } | ICellRendererFunc | string;
+    groupRowRenderer?: { new (): ICellRendererComp } | ICellRendererFunc | string;
     groupRowRendererFramework?: any;
     groupRowRendererParams?: any;
     /** @deprecated - this is now groupRowRendererParams.innerRenderer */
-    groupRowInnerRenderer?: { new(): ICellRendererComp; } | ICellRendererFunc | string;
+    groupRowInnerRenderer?: { new (): ICellRendererComp } | ICellRendererFunc | string;
     /** @deprecated - this is now groupRowRendererParams.innerRendererFramework */
     groupRowInnerRendererFramework?: any;
     createChartContainer?: (params: ChartRef) => void;
@@ -362,8 +367,8 @@ export interface GridOptions {
     doesExternalFilterPass?(node: RowNode): boolean;
 
     getRowStyle?: Function;
-    getRowClass?: (params: any) => (string | string[]);
-    rowClassRules?: { [cssClassName: string]: (((params: any) => boolean) | string); };
+    getRowClass?: (params: any) => string | string[];
+    rowClassRules?: { [cssClassName: string]: ((params: any) => boolean) | string };
     getRowHeight?: Function;
     sendToClipboard?: (params: any) => void;
     processDataFromClipboard?: (params: ProcessDataFromClipboardParams) => string[][] | null;
@@ -377,19 +382,19 @@ export interface GridOptions {
     getDocument?: () => Document;
     defaultGroupSortComparator?: (nodeA: RowNode, nodeB: RowNode) => number;
 
-    loadingCellRenderer?: { new(): ICellRenderer; } | string;
+    loadingCellRenderer?: { new (): ICellRenderer } | string;
     loadingCellRendererFramework?: any;
     loadingCellRendererParams?: any;
 
-    loadingOverlayComponent?: { new(): ILoadingOverlayComp; } | string;
+    loadingOverlayComponent?: { new (): ILoadingOverlayComp } | string;
     loadingOverlayComponentFramework?: any;
     loadingOverlayComponentParams?: any;
 
-    noRowsOverlayComponent?: { new(): INoRowsOverlayComp; } | string;
+    noRowsOverlayComponent?: { new (): INoRowsOverlayComp } | string;
     noRowsOverlayComponentFramework?: any;
     noRowsOverlayComponentParams?: any;
 
-    fullWidthCellRenderer?: { new(): ICellRendererComp; } | ICellRendererFunc | string;
+    fullWidthCellRenderer?: { new (): ICellRendererComp } | ICellRendererFunc | string;
     fullWidthCellRendererFramework?: any;
     fullWidthCellRendererParams?: any;
 
@@ -406,7 +411,7 @@ export interface GridOptions {
     getContextMenuItems?: GetContextMenuItems;
     getMainMenuItems?: GetMainMenuItems;
     getChartToolbarItems?: GetChartToolbarItems;
-    getRowNodeId?: GetRowNodeIdFunc;
+    getRowNodeId?: GetRowNodeIdFunc<T>;
 
     getChildCount?(dataItem: any): number;
 
@@ -581,7 +586,7 @@ export interface GridOptions {
     onGridSizeChanged?(event: any): void;
 
     // apis, set by the grid on init
-    api?: GridApi | null; // change to typed
+    api?: GridApi<T> | null; // change to typed
     columnApi?: ColumnApi | null; // change to typed
 }
 
@@ -678,8 +683,8 @@ export interface GetMainMenuItems {
     (params: GetMainMenuItemsParams): (string | MenuItemDef)[];
 }
 
-export interface GetRowNodeIdFunc {
-    (data: any): string;
+export interface GetRowNodeIdFunc<T> {
+    (data: T): string;
 }
 
 export interface ProcessRowParams {

--- a/community-modules/core/src/ts/entities/rowNode.ts
+++ b/community-modules/core/src/ts/entities/rowNode.ts
@@ -30,23 +30,23 @@ export interface SetSelectedParams {
     groupSelectsFiltered?: boolean;
 }
 
-export interface RowNodeEvent extends AgEvent {
-    node: RowNode;
+export interface RowNodeEvent<T = any> extends AgEvent {
+    node: RowNode<T>;
 }
 
-export interface DataChangedEvent extends RowNodeEvent {
-    oldData: any;
-    newData: any;
+export interface DataChangedEvent<T = any> extends RowNodeEvent<T> {
+    oldData: T;
+    newData: T;
     update: boolean;
 }
 
-export interface CellChangedEvent extends RowNodeEvent {
+export interface CellChangedEvent<T = any> extends RowNodeEvent<T> {
     column: Column;
     newValue: any;
     oldValue: any;
 }
 
-export class RowNode implements IEventEmitter {
+export class RowNode<T = any> implements IEventEmitter {
 
     public static ID_PREFIX_ROW_GROUP = 'row-group-';
     public static ID_PREFIX_TOP_PINNED = 't-';
@@ -79,7 +79,7 @@ export class RowNode implements IEventEmitter {
     @Autowired('selectionController') private selectionController: SelectionController;
     @Autowired('columnController') private columnController: ColumnController;
     @Autowired('valueService') private valueService: ValueService;
-    @Autowired('rowModel') private rowModel: IRowModel;
+    @Autowired('rowModel') private rowModel: IRowModel<T>;
     @Autowired('context') private context: Context;
     @Autowired('valueCache') private valueCache: ValueCache;
     @Autowired('columnApi') private columnApi: ColumnApi;
@@ -96,10 +96,10 @@ export class RowNode implements IEventEmitter {
     public aggData: any;
 
     /** The user provided data */
-    public data: any;
+    public data: T;
 
     /** The parent node to this node, or empty if top level */
-    public parent: RowNode | null;
+    public parent: RowNode<T> | null;
 
     /** How many levels this node is from the top */
     public level: number;
@@ -166,7 +166,7 @@ export class RowNode implements IEventEmitter {
     public stub: boolean;
 
     /** All user provided nodes */
-    public allLeafChildren: RowNode[];
+    public allLeafChildren: RowNode<T>[];
 
     /** Groups only - Children of this group */
     public childrenAfterGroup: RowNode[];
@@ -214,7 +214,7 @@ export class RowNode implements IEventEmitter {
      * a copy where daemon=true. */
     public daemon: boolean;
 
-    /** True by default - can be overridden via gridOptions.isRowSelectable(rowNode) */
+    /** True by default - can be overridden via gridOptions.isRowSelectable(RowNode) */
     public selectable = true;
 
     /** Used by the value service, stores values for a particular change detection turn. */
@@ -238,7 +238,7 @@ export class RowNode implements IEventEmitter {
     private selected = false;
     private eventService: EventService;
 
-    public setData(data: any): void {
+    public setData(data: T): void {
         const oldData = this.data;
 
         this.data = data;
@@ -246,7 +246,7 @@ export class RowNode implements IEventEmitter {
         this.updateDataOnDetailNode();
         this.checkRowSelectable();
 
-        const event: DataChangedEvent = this.createDataChangedEvent(data, oldData, false);
+        const event: DataChangedEvent<T> = this.createDataChangedEvent(data, oldData, false);
 
         this.dispatchLocalEvent(event);
     }
@@ -260,7 +260,7 @@ export class RowNode implements IEventEmitter {
         }
     }
 
-    private createDataChangedEvent(newData: any, oldData: any, update: boolean): DataChangedEvent {
+    private createDataChangedEvent(newData: T, oldData: T, update: boolean): DataChangedEvent<T> {
         return {
             type: RowNode.EVENT_DATA_CHANGED,
             node: this,
@@ -282,7 +282,7 @@ export class RowNode implements IEventEmitter {
     // guaranteed that the data is the same entity (so grid doesn't need to worry about the id of the
     // underlying data changing, hence doesn't need to worry about selection). the grid, upon receiving
     // dataChanged event, will refresh the cells rather than rip them all out (so user can show transitions).
-    public updateData(data: any): void {
+    public updateData(data: T): void {
         const oldData = this.data;
 
         this.data = data;
@@ -290,7 +290,7 @@ export class RowNode implements IEventEmitter {
         this.checkRowSelectable();
         this.updateDataOnDetailNode();
 
-        const event: DataChangedEvent = this.createDataChangedEvent(data, oldData, true);
+        const event: DataChangedEvent<T> = this.createDataChangedEvent(data, oldData, true);
 
         this.dispatchLocalEvent(event);
     }
@@ -321,7 +321,7 @@ export class RowNode implements IEventEmitter {
         return oldNode;
     }
 
-    public setDataAndId(data: any, id: string | undefined): void {
+    public setDataAndId(data: T, id: string | undefined): void {
         const oldNode = exists(this.id) ? this.createDaemonNode() : null;
         const oldData = this.data;
 
@@ -331,7 +331,7 @@ export class RowNode implements IEventEmitter {
         this.selectionController.syncInRowNode(this, oldNode);
         this.checkRowSelectable();
 
-        const event: DataChangedEvent = this.createDataChangedEvent(data, oldData, false);
+        const event: DataChangedEvent<T> = this.createDataChangedEvent(data, oldData, false);
 
         this.dispatchLocalEvent(event);
     }
@@ -891,7 +891,7 @@ export class RowNode implements IEventEmitter {
         this.dispatchLocalEvent(this.createLocalRowEvent(RowNode.EVENT_MOUSE_LEAVE));
     }
 
-    public getFirstChildOfFirstChild(rowGroupColumn: Column | null): RowNode {
+    public getFirstChildOfFirstChild(rowGroupColumn: Column | null): RowNode<T> {
         let currentRowNode: RowNode = this;
         let isCandidate = true;
         let foundFirstChildPath = false;

--- a/community-modules/core/src/ts/events.ts
+++ b/community-modules/core/src/ts/events.ts
@@ -29,8 +29,8 @@ export interface AgEvent {
     type: string;
 }
 
-export interface AgGridEvent extends AgEvent {
-    api: GridApi;
+export interface AgGridEvent<T = any> extends AgEvent {
+    api: GridApi<T>;
     columnApi: ColumnApi;
 }
 
@@ -38,29 +38,29 @@ export interface ToolPanelVisibleChangedEvent extends AgGridEvent {
     source: string | undefined;
 }
 
-export interface AnimationQueueEmptyEvent extends AgGridEvent { }
+export interface AnimationQueueEmptyEvent extends AgGridEvent {}
 
-export interface ColumnPivotModeChangedEvent extends AgGridEvent { }
+export interface ColumnPivotModeChangedEvent extends AgGridEvent {}
 
-export interface VirtualColumnsChangedEvent extends AgGridEvent { }
+export interface VirtualColumnsChangedEvent extends AgGridEvent {}
 
 export interface ColumnEverythingChangedEvent extends AgGridEvent {
     source: string;
 }
 
-export interface NewColumnsLoadedEvent extends AgGridEvent { }
+export interface NewColumnsLoadedEvent extends AgGridEvent {}
 
-export interface GridColumnsChangedEvent extends AgGridEvent { }
+export interface GridColumnsChangedEvent extends AgGridEvent {}
 
-export interface DisplayedColumnsChangedEvent extends AgGridEvent { }
+export interface DisplayedColumnsChangedEvent extends AgGridEvent {}
 
-export interface RowDataChangedEvent extends AgGridEvent { }
+export interface RowDataChangedEvent extends AgGridEvent {}
 
-export interface RowDataUpdatedEvent extends AgGridEvent { }
+export interface RowDataUpdatedEvent extends AgGridEvent {}
 
-export interface PinnedRowDataChangedEvent extends AgGridEvent { }
+export interface PinnedRowDataChangedEvent extends AgGridEvent {}
 
-export interface SelectionChangedEvent extends AgGridEvent { }
+export interface SelectionChangedEvent extends AgGridEvent {}
 
 export interface FilterChangedEvent extends AgGridEvent {
     afterDataChange?: boolean;
@@ -78,28 +78,28 @@ export interface FilterOpenedEvent extends AgGridEvent {
     eGui: HTMLElement;
 }
 
-export interface SortChangedEvent extends AgGridEvent { }
+export interface SortChangedEvent extends AgGridEvent {}
 
-export interface GridReadyEvent extends AgGridEvent { }
+export interface GridReadyEvent extends AgGridEvent {}
 
-export interface DisplayedColumnsWidthChangedEvent extends AgGridEvent { } // not documented
-export interface ColumnHoverChangedEvent extends AgGridEvent { } // not documented
-export interface BodyHeightChangedEvent extends AgGridEvent { } // not documented
+export interface DisplayedColumnsWidthChangedEvent extends AgGridEvent {} // not documented
+export interface ColumnHoverChangedEvent extends AgGridEvent {} // not documented
+export interface BodyHeightChangedEvent extends AgGridEvent {} // not documented
 
 // this event is 'odd one out' as it should have properties for all the properties
 // in gridOptions that can be bound by the framework. for example, the gridOptions
 // has 'rowData', so this property should have 'rowData' also, so that when the row
 // data changes via the framework bound property, this event has that attribute set.
-export interface ComponentStateChangedEvent extends AgGridEvent { }
+export interface ComponentStateChangedEvent extends AgGridEvent {}
 
 export interface DragEvent extends AgGridEvent {
     type: string;
     target: HTMLElement;
 }
 
-export interface DragStartedEvent extends DragEvent { }
+export interface DragStartedEvent extends DragEvent {}
 
-export interface DragStoppedEvent extends DragEvent { }
+export interface DragStoppedEvent extends DragEvent {}
 
 // For internal use only.
 // This event allows us to detect when other inputs in the same named group are changed, so for example we can ensure
@@ -126,13 +126,13 @@ export interface RowDragEvent extends AgGridEvent {
     overNode: RowNode;
 }
 
-export interface RowDragEnterEvent extends RowDragEvent { }
+export interface RowDragEnterEvent extends RowDragEvent {}
 
-export interface RowDragEndEvent extends RowDragEvent { }
+export interface RowDragEndEvent extends RowDragEvent {}
 
-export interface RowDragMoveEvent extends RowDragEvent { }
+export interface RowDragMoveEvent extends RowDragEvent {}
 
-export interface RowDragLeaveEvent extends RowDragEvent { }
+export interface RowDragLeaveEvent extends RowDragEvent {}
 
 export interface PasteStartEvent extends AgGridEvent {
     source: string;
@@ -142,8 +142,7 @@ export interface PasteEndEvent extends AgGridEvent {
     source: string;
 }
 
-export interface FillStartEvent extends AgGridEvent {
-}
+export interface FillStartEvent extends AgGridEvent {}
 
 export interface FillEndEvent extends AgGridEvent {
     initialRange: CellRange;
@@ -216,8 +215,7 @@ export interface PaginationChangedEvent extends AgGridEvent {
     newPage: boolean;
 }
 
-export interface PaginationPixelOffsetChangedEvent extends AgGridEvent {
-}
+export interface PaginationPixelOffsetChangedEvent extends AgGridEvent {}
 
 // this does not extent CellEvent as the focus service doesn't keep a reference to
 // the rowNode.
@@ -242,26 +240,26 @@ export interface ExpandCollapseAllEvent extends AgGridEvent {
 /**---------------*/
 
 export type ColumnEventType =
-    "sizeColumnsToFit" |
-    "autosizeColumns" |
-    "alignedGridChanged" |
-    "filterChanged" |
-    "filterDestroyed" |
-    "gridOptionsChanged" |
-    "gridInitializing" |
-    "toolPanelDragAndDrop" |
-    "toolPanelUi" |
-    "uiColumnMoved" |
-    "uiColumnResized" |
-    "uiColumnDragged" |
-    "uiColumnExpanded" |
-    "uiColumnSorted" |
-    "contextMenu" |
-    "columnMenu" |
-    "rowModelUpdated" |
-    "api" |
-    "flex" |
-    "pivotChart";
+    | 'sizeColumnsToFit'
+    | 'autosizeColumns'
+    | 'alignedGridChanged'
+    | 'filterChanged'
+    | 'filterDestroyed'
+    | 'gridOptionsChanged'
+    | 'gridInitializing'
+    | 'toolPanelDragAndDrop'
+    | 'toolPanelUi'
+    | 'uiColumnMoved'
+    | 'uiColumnResized'
+    | 'uiColumnDragged'
+    | 'uiColumnExpanded'
+    | 'uiColumnSorted'
+    | 'contextMenu'
+    | 'columnMenu'
+    | 'rowModelUpdated'
+    | 'api'
+    | 'flex'
+    | 'pivotChart';
 
 export interface ColumnEvent extends AgGridEvent {
     column: Column | null;
@@ -274,11 +272,11 @@ export interface ColumnResizedEvent extends ColumnEvent {
     flexColumns: Column[];
 }
 
-export interface ColumnPivotChangedEvent extends ColumnEvent { }
+export interface ColumnPivotChangedEvent extends ColumnEvent {}
 
-export interface ColumnRowGroupChangedEvent extends ColumnEvent { }
+export interface ColumnRowGroupChangedEvent extends ColumnEvent {}
 
-export interface ColumnValueChangedEvent extends ColumnEvent { }
+export interface ColumnValueChangedEvent extends ColumnEvent {}
 
 export interface ColumnMovedEvent extends ColumnEvent {
     toIndex: number | undefined;
@@ -309,19 +307,19 @@ export interface RowGroupOpenedEvent extends RowEvent {
     expanded: boolean;
 }
 
-export interface RowValueChangedEvent extends RowEvent { }
+export interface RowValueChangedEvent extends RowEvent {}
 
-export interface RowSelectedEvent extends RowEvent { }
+export interface RowSelectedEvent extends RowEvent {}
 
-export interface VirtualRowRemovedEvent extends RowEvent { }
+export interface VirtualRowRemovedEvent extends RowEvent {}
 
-export interface RowClickedEvent extends RowEvent { }
+export interface RowClickedEvent extends RowEvent {}
 
-export interface RowDoubleClickedEvent extends RowEvent { }
+export interface RowDoubleClickedEvent extends RowEvent {}
 
-export interface RowEditingStartedEvent extends RowEvent { }
+export interface RowEditingStartedEvent extends RowEvent {}
 
-export interface RowEditingStoppedEvent extends RowEvent { }
+export interface RowEditingStoppedEvent extends RowEvent {}
 
 /**------------*/
 
@@ -333,23 +331,23 @@ export interface CellEvent extends RowEvent {
     value: any;
 }
 
-export interface CellKeyDownEvent extends CellEvent { }
+export interface CellKeyDownEvent extends CellEvent {}
 
-export interface CellKeyPressEvent extends CellEvent { }
+export interface CellKeyPressEvent extends CellEvent {}
 
-export interface CellClickedEvent extends CellEvent { }
+export interface CellClickedEvent extends CellEvent {}
 
-export interface CellMouseDownEvent extends CellEvent { }
+export interface CellMouseDownEvent extends CellEvent {}
 
-export interface CellDoubleClickedEvent extends CellEvent { }
+export interface CellDoubleClickedEvent extends CellEvent {}
 
-export interface CellMouseOverEvent extends CellEvent { }
+export interface CellMouseOverEvent extends CellEvent {}
 
-export interface CellMouseOutEvent extends CellEvent { }
+export interface CellMouseOutEvent extends CellEvent {}
 
-export interface CellContextMenuEvent extends CellEvent { }
+export interface CellContextMenuEvent extends CellEvent {}
 
-export interface CellEditingStartedEvent extends CellEvent { }
+export interface CellEditingStartedEvent extends CellEvent {}
 
 export interface CellEditingStoppedEvent extends CellEvent {
     oldValue: any;
@@ -368,14 +366,14 @@ export interface ColumnRequestEvent extends AgGridEvent {
     columns: Column[];
 }
 
-export interface ColumnRowGroupChangeRequestEvent extends ColumnRequestEvent { }
+export interface ColumnRowGroupChangeRequestEvent extends ColumnRequestEvent {}
 
-export interface ColumnPivotChangeRequestEvent extends ColumnRequestEvent { }
+export interface ColumnPivotChangeRequestEvent extends ColumnRequestEvent {}
 
-export interface ColumnValueChangeRequestEvent extends ColumnRequestEvent { }
+export interface ColumnValueChangeRequestEvent extends ColumnRequestEvent {}
 
 export interface ColumnAggFuncChangeRequestEvent extends ColumnRequestEvent {
     aggFunc: any;
 }
 
-export interface ScrollVisibilityChangedEvent extends AgGridEvent { } // not documented
+export interface ScrollVisibilityChangedEvent extends AgGridEvent {} // not documented

--- a/community-modules/core/src/ts/gridOptionsWrapper.ts
+++ b/community-modules/core/src/ts/gridOptionsWrapper.ts
@@ -89,7 +89,7 @@ export interface PropertyChangedEvent extends AgEvent {
 }
 
 @Bean('gridOptionsWrapper')
-export class GridOptionsWrapper {
+export class GridOptionsWrapper<T = any> {
     private static MIN_COL_WIDTH = 10;
 
     public static PROP_HEADER_HEIGHT = 'headerHeight';
@@ -131,7 +131,7 @@ export class GridOptionsWrapper {
 
     private destroyed = false;
 
-    private agWire(@Qualifier('gridApi') gridApi: GridApi, @Qualifier('columnApi') columnApi: ColumnApi): void {
+    private agWire(@Qualifier('gridApi') gridApi: GridApi<T>, @Qualifier('columnApi') columnApi: ColumnApi): void {
         this.gridOptions.api = gridApi;
         this.gridOptions.columnApi = columnApi;
         this.checkForDeprecated();
@@ -700,7 +700,7 @@ export class GridOptionsWrapper {
         return this.gridOptions.getBusinessKeyForNode;
     }
 
-    public getApi(): GridApi | undefined | null {
+    public getApi(): GridApi<T> | undefined | null {
         return this.gridOptions.api;
     }
 
@@ -1113,7 +1113,7 @@ export class GridOptionsWrapper {
         return this.gridOptions.getMainMenuItems;
     }
 
-    public getRowNodeIdFunc(): GetRowNodeIdFunc | undefined {
+    public getRowNodeIdFunc(): GetRowNodeIdFunc<T> | undefined {
         return this.gridOptions.getRowNodeId;
     }
 

--- a/community-modules/core/src/ts/interfaces/iClientSideRowModel.ts
+++ b/community-modules/core/src/ts/interfaces/iClientSideRowModel.ts
@@ -5,10 +5,10 @@ import { RefreshModelParams } from './refreshModelParams';
 import { RowNode } from '../entities/rowNode';
 import { ChangedPath } from '../utils/changedPath';
 
-export interface IClientSideRowModel extends IRowModel {
-    updateRowData(rowDataTran: RowDataTransaction, rowNodeOrder?: { [id: string]: number; }): RowNodeTransaction | null;
-    setRowData(rowData: any[]): void;
-    refreshModel(params: RefreshModelParams): void;
+export interface IClientSideRowModel<T = any> extends IRowModel<T> {
+    updateRowData(rowDataTran: RowDataTransaction<T>, rowNodeOrder?: { [id: string]: number; }): RowNodeTransaction<T> | null;
+    setRowData(rowData: T[] | undefined): void;
+    refreshModel(params: RefreshModelParams<T>): void;
     expandOrCollapseAll(expand: boolean): void;
     forEachLeafNode(callback: (node: RowNode, index: number) => void): void;
     forEachNode(callback: (node: RowNode, index: number) => void): void;
@@ -16,14 +16,14 @@ export interface IClientSideRowModel extends IRowModel {
     forEachNodeAfterFilterAndSort(callback: (node: RowNode, index: number) => void): void;
     resetRowHeights(): void;
     onRowHeightChanged(): void;
-    batchUpdateRowData(rowDataTransaction: RowDataTransaction, callback?: (res: RowNodeTransaction) => void): void;
+    batchUpdateRowData(rowDataTransaction: RowDataTransaction, callback?: (res: RowNodeTransaction<T>) => void): void;
     flushAsyncTransactions(): void;
-    getRootNode(): RowNode;
+    getRootNode(): RowNode<T>;
     doAggregate(changedPath?: ChangedPath): void;
-    getTopLevelNodes(): RowNode[] | null;
+    getTopLevelNodes(): RowNode<T>[] | null;
     forEachPivotNode(callback: (node: RowNode, index: number) => void): void;
     ensureRowsAtPixel(rowNode: RowNode[], pixel: number, increment: number): boolean;
     highlightRowAtPixel(rowNode: RowNode | null, pixel?: number): void;
     getHighlightPosition(pixel: number, rowNode?: RowNode): 'above' | 'below';
-    getLastHighlightedRowNode(): RowNode | null;
+    getLastHighlightedRowNode(): RowNode<T> | null;
 }

--- a/community-modules/core/src/ts/interfaces/iRowModel.ts
+++ b/community-modules/core/src/ts/interfaces/iRowModel.ts
@@ -6,13 +6,13 @@ export interface RowBounds {
     rowIndex?: number;
 }
 
-export interface IRowModel {
+export interface IRowModel<T = any> {
 
     /** Returns the rowNode at the given index. */
-    getRow(index: number): RowNode | null;
+    getRow(index: number): RowNode<T> | null;
 
     /** Returns the rowNode for given id. */
-    getRowNode(id: string): RowNode | null;
+    getRowNode(id: string): RowNode<T> | null;
 
     /** This is legacy, not used by ag-Grid, but keeping for backward compatibility */
     getRowCount(): number;
@@ -39,11 +39,11 @@ export interface IRowModel {
 
     /** Returns all rows in range that should be selected. If there is a gap in range (non ClientSideRowModel) then
      *  then no rows should be returned  */
-    getNodesInRangeForSelection(first: RowNode, last: RowNode): RowNode[];
+    getNodesInRangeForSelection(first: RowNode<T>, last: RowNode<T>): RowNode<T>[];
 
     /** Iterate through each node. What this does depends on the model type. For clientSide, goes through
      * all nodes. For pagination, goes through current page. For virtualPage, goes through what's loaded in memory. */
-    forEachNode(callback: (rowNode: RowNode, index: number) => void): void;
+    forEachNode(callback: (rowNode: RowNode<T>, index: number) => void): void;
 
     /** The base class returns the type. We use this instead of 'instanceof' as the client might provide
      * their own implementation of the models in the future. */

--- a/community-modules/core/src/ts/interfaces/refreshModelParams.ts
+++ b/community-modules/core/src/ts/interfaces/refreshModelParams.ts
@@ -1,6 +1,6 @@
 import { RowNodeTransaction } from "./rowNodeTransaction";
 
-export interface RefreshModelParams {
+export interface RefreshModelParams<T = any> {
     // how much of the pipeline to execute
     step: number;
     // what state to reset the groups back to after the refresh
@@ -13,7 +13,7 @@ export interface RefreshModelParams {
     // if true, then rows we are editing will be kept
     keepEditingRows?: boolean;
     // if doing delta updates, this has the changes that were done
-    rowNodeTransactions?: (RowNodeTransaction | null)[];
+    rowNodeTransactions?: (RowNodeTransaction<T> | null)[];
     // if doing delta updates, this has the order of the nodes
     rowNodeOrder?: { [id: string]: number };
     // true user called setRowData() (or a new page in pagination). the grid scrolls

--- a/community-modules/core/src/ts/interfaces/rowDataTransaction.ts
+++ b/community-modules/core/src/ts/interfaces/rowDataTransaction.ts
@@ -1,6 +1,6 @@
-export interface RowDataTransaction {
+export interface RowDataTransaction<T = any> {
     addIndex?: number;
-    add?: any[];
-    remove?: any[];
-    update?: any[];
+    add?: T[];
+    remove?: T[];
+    update?: T[];
 }

--- a/community-modules/core/src/ts/interfaces/rowNodeTransaction.ts
+++ b/community-modules/core/src/ts/interfaces/rowNodeTransaction.ts
@@ -1,7 +1,7 @@
 import {RowNode} from "../entities/rowNode";
 
-export interface RowNodeTransaction {
-    add: RowNode[];
-    remove: RowNode[];
-    update: RowNode[];
+export interface RowNodeTransaction<T = any> {
+    add: RowNode<T>[];
+    remove: RowNode<T>[];
+    update: RowNode<T>[];
 }

--- a/community-modules/core/src/ts/modules/rowNodeCache/rowNodeBlock.ts
+++ b/community-modules/core/src/ts/modules/rowNodeCache/rowNodeBlock.ts
@@ -14,7 +14,7 @@ export interface LoadCompleteEvent extends AgEvent {
     lastRow: number;
 }
 
-export abstract class RowNodeBlock extends BeanStub implements IRowNodeBlock {
+export abstract class RowNodeBlock<T = any> extends BeanStub implements IRowNodeBlock {
 
     public static EVENT_LOAD_COMPLETE = 'loadComplete';
 
@@ -33,7 +33,7 @@ export abstract class RowNodeBlock extends BeanStub implements IRowNodeBlock {
     private readonly blockNumber: number;
     private readonly startRow: number;
     private readonly endRow: number;
-    public rowNodes: RowNode[];
+    public rowNodes: RowNode<T>[];
 
     private rowNodeCacheParams: RowNodeCacheParams;
 
@@ -48,7 +48,7 @@ export abstract class RowNodeBlock extends BeanStub implements IRowNodeBlock {
     // local index is the same as the display index, so the override just calls
     // getRowUsingLocalIndex(). however for server side row model, they are different, hence
     // server side row model does logic before calling getRowUsingLocalIndex().
-    public abstract getRow(displayIndex: number): RowNode | null;
+    public abstract getRow(displayIndex: number): RowNode<T> | null;
 
     // returns the node id prefix, which is essentially the id of the cache
     // that the block belongs to. this is used for debugging purposes, where the
@@ -120,7 +120,7 @@ export abstract class RowNodeBlock extends BeanStub implements IRowNodeBlock {
         return this.lastAccessed;
     }
 
-    public getRowUsingLocalIndex(rowIndex: number, dontTouchLastAccessed = false): RowNode {
+    public getRowUsingLocalIndex(rowIndex: number, dontTouchLastAccessed = false): RowNode<T> {
         if (!dontTouchLastAccessed) {
             this.lastAccessed = this.rowNodeCacheParams.lastAccessedSequence.next();
         }
@@ -160,19 +160,19 @@ export abstract class RowNodeBlock extends BeanStub implements IRowNodeBlock {
         return this.state;
     }
 
-    public setRowNode(rowIndex: number, rowNode: RowNode): void {
+    public setRowNode(rowIndex: number, rowNode: RowNode<T>): void {
         const localIndex = rowIndex - this.startRow;
         this.rowNodes[localIndex] = rowNode;
     }
 
-    public setBlankRowNode(rowIndex: number): RowNode {
+    public setBlankRowNode(rowIndex: number): RowNode<T> {
         const newRowNode = this.createBlankRowNode(rowIndex);
         const localIndex = rowIndex - this.startRow;
         this.rowNodes[localIndex] = newRowNode;
         return newRowNode;
     }
 
-    public setNewData(rowIndex: number, dataItem: any): RowNode {
+    public setNewData(rowIndex: number, dataItem: T): RowNode<T> {
         const newRowNode = this.setBlankRowNode(rowIndex);
 
         this.setDataAndId(newRowNode, dataItem, this.startRow + rowIndex);

--- a/community-modules/core/src/ts/rendering/cellRenderers/iCellRenderer.ts
+++ b/community-modules/core/src/ts/rendering/cellRenderers/iCellRenderer.ts
@@ -5,14 +5,14 @@ import { Column } from "../../entities/column";
 import { GridApi } from "../../gridApi";
 import { ColumnApi } from "../../columnController/columnApi";
 
-export interface ICellRendererParams {
+export interface ICellRendererParams<T = any> {
     value: any;
     valueFormatted: any;
     getValue: () => any;
     setValue: (value: any) => void;
     formatValue: (value: any) => any;
-    data: any;
-    node: RowNode;
+    data: T;
+    node: RowNode<T>;
     colDef: ColDef;
     column: Column;
     $scope: any;

--- a/community-modules/infinite-row-model/src/infiniteRowModel/infiniteRowModel.ts
+++ b/community-modules/infinite-row-model/src/infiniteRowModel/infiniteRowModel.ts
@@ -27,7 +27,7 @@ import {
 import { InfiniteCache, InfiniteCacheParams } from "./infiniteCache";
 
 @Bean('rowModel')
-export class InfiniteRowModel extends BeanStub implements IInfiniteRowModel {
+export class InfiniteRowModel<T = any> extends BeanStub implements IInfiniteRowModel {
 
     @Autowired('gridOptionsWrapper') private readonly gridOptionsWrapper: GridOptionsWrapper;
     @Autowired('filterManager') private readonly filterManager: FilterManager;
@@ -144,7 +144,7 @@ export class InfiniteRowModel extends BeanStub implements IInfiniteRowModel {
         return !!this.infiniteCache;
     }
 
-    public getNodesInRangeForSelection(firstInRange: RowNode, lastInRange: RowNode): RowNode[] {
+    public getNodesInRangeForSelection(firstInRange: RowNode<T>, lastInRange: RowNode<T>): RowNode<T>[] {
         return this.infiniteCache ? this.infiniteCache.getRowNodesInRange(firstInRange, lastInRange) : [];
     }
 
@@ -249,12 +249,12 @@ export class InfiniteRowModel extends BeanStub implements IInfiniteRowModel {
         this.eventService.dispatchEvent(event);
     }
 
-    public getRow(rowIndex: number): RowNode | null {
+    public getRow(rowIndex: number): RowNode<T> | null {
         return this.infiniteCache ? this.infiniteCache.getRow(rowIndex) : null;
     }
 
-    public getRowNode(id: string): RowNode | null {
-        let result: RowNode | null = null;
+    public getRowNode(id: string): RowNode<T> | null {
+        let result: RowNode<T> | null = null;
         this.forEachNode(rowNode => {
             if (rowNode.id === id) {
                 result = rowNode;
@@ -263,7 +263,7 @@ export class InfiniteRowModel extends BeanStub implements IInfiniteRowModel {
         return result;
     }
 
-    public forEachNode(callback: (rowNode: RowNode, index: number) => void): void {
+    public forEachNode(callback: (rowNode: RowNode<T>, index: number) => void): void {
         if (this.infiniteCache) {
             this.infiniteCache.forEachNodeDeep(callback, new NumberSequence());
         }

--- a/enterprise-modules/server-side-row-model/src/serverSideRowModel/serverSideBlock.ts
+++ b/enterprise-modules/server-side-row-model/src/serverSideRowModel/serverSideBlock.ts
@@ -22,7 +22,7 @@ import {
 
 import { ServerSideCache, ServerSideCacheParams } from "./serverSideCache";
 
-export class ServerSideBlock extends RowNodeBlock {
+export class ServerSideBlock<T = any> extends RowNodeBlock<T> {
 
     @Autowired('columnController') private columnController: ColumnController;
     @Autowired('valueService') private valueService: ValueService;
@@ -41,7 +41,7 @@ export class ServerSideBlock extends RowNodeBlock {
     private params: ServerSideCacheParams;
     private parentCache: ServerSideCache;
 
-    private parentRowNode: RowNode;
+    private parentRowNode: RowNode<T>;
 
     private level: number;
     private groupLevel: boolean | undefined;
@@ -55,7 +55,7 @@ export class ServerSideBlock extends RowNodeBlock {
 
     public static readonly DefaultBlockSize = 100;
 
-    constructor(pageNumber: number, parentRowNode: RowNode, params: ServerSideCacheParams, parentCache: ServerSideCache) {
+    constructor(pageNumber: number, parentRowNode: RowNode<T>, params: ServerSideCacheParams, parentCache: ServerSideCache) {
         super(pageNumber, params);
         this.params = params;
         this.parentRowNode = parentRowNode;
@@ -112,7 +112,7 @@ export class ServerSideBlock extends RowNodeBlock {
         return this.nodeIdPrefix;
     }
 
-    public getRow(displayRowIndex: number): RowNode | null {
+    public getRow(displayRowIndex: number): RowNode<T> | null {
         let bottomPointer = this.getStartRow();
 
         // the end row depends on whether all this block is used or not. if the virtual row count
@@ -164,7 +164,7 @@ export class ServerSideBlock extends RowNodeBlock {
     protected setDataAndId(rowNode: RowNode, data: any, index: number): void {
         rowNode.stub = false;
 
-        if (_.exists(data)) {
+        if (_.exists(data)) { 
             // if the user is not providing id's, then we build an id based on the index.
             // for infinite scrolling, the index is used on it's own. for Server Side Row Model,
             // we combine the index with the level and group key, so that the id is

--- a/enterprise-modules/server-side-row-model/src/serverSideRowModel/serverSideRowModel.ts
+++ b/enterprise-modules/server-side-row-model/src/serverSideRowModel/serverSideRowModel.ts
@@ -34,17 +34,17 @@ import { ServerSideCache, ServerSideCacheParams } from "./serverSideCache";
 import { ServerSideBlock } from "./serverSideBlock";
 
 @Bean('rowModel')
-export class ServerSideRowModel extends BeanStub implements IServerSideRowModel {
+export class ServerSideRowModel<T = any> extends BeanStub implements IServerSideRowModel {
 
     @Autowired('gridOptionsWrapper') private gridOptionsWrapper: GridOptionsWrapper;
     @Autowired('columnController') private columnController: ColumnController;
     @Autowired('filterManager') private filterManager: FilterManager;
     @Autowired('sortController') private sortController: SortController;
-    @Autowired('gridApi') private gridApi: GridApi;
+    @Autowired('gridApi') private gridApi: GridApi<T>;
     @Autowired('columnApi') private columnApi: ColumnApi;
     @Autowired('rowRenderer') private rowRenderer: RowRenderer;
 
-    private rootNode: RowNode;
+    private rootNode: RowNode<T>;
     private datasource: IServerSideDatasource | undefined;
 
     private rowHeight: number;
@@ -442,7 +442,7 @@ export class ServerSideRowModel extends BeanStub implements IServerSideRowModel 
         cache.forEachNodeDeep(rowNode => rowNode.clearRowTop(), numberSequence);
     }
 
-    public getRow(index: number): RowNode | null {
+    public getRow(index: number): RowNode<T> | null {
         if (this.cacheExists()) {
             return this.rootNode.childrenCache!.getRow(index);
         }
@@ -535,15 +535,15 @@ export class ServerSideRowModel extends BeanStub implements IServerSideRowModel 
         this.executeOnCache(route, cache => cache.purgeCache());
     }
 
-    public getNodesInRangeForSelection(firstInRange: RowNode, lastInRange: RowNode): RowNode[] {
+    public getNodesInRangeForSelection(firstInRange: RowNode<T>, lastInRange: RowNode<T>): RowNode<T>[] {
         if (_.exists(lastInRange) && firstInRange.parent !== lastInRange.parent) {
             return [];
         }
         return firstInRange.parent!.childrenCache!.getRowNodesInRange(lastInRange, firstInRange);
     }
 
-    public getRowNode(id: string): RowNode | null {
-        let result: RowNode | null = null;
+    public getRowNode(id: string): RowNode<T> | null {
+        let result: RowNode<T> | null = null;
         this.forEachNode(rowNode => {
             if (rowNode.id === id) {
                 result = rowNode;
@@ -662,10 +662,10 @@ export class ServerSideRowModel extends BeanStub implements IServerSideRowModel 
         return _.exists(this.rootNode) && _.exists(this.rootNode.childrenCache);
     }
 
-    private createDetailNode(masterNode: RowNode): RowNode {
+    private createDetailNode(masterNode: RowNode<T>): RowNode<T> {
         if (_.exists(masterNode.detailNode)) { return masterNode.detailNode; }
 
-        const detailNode = new RowNode();
+        const detailNode = new RowNode<T>();
 
         this.getContext().createBean(detailNode);
 

--- a/enterprise-modules/viewport-row-model/src/viewportRowModel/viewportRowModel.ts
+++ b/enterprise-modules/viewport-row-model/src/viewportRowModel/viewportRowModel.ts
@@ -19,10 +19,10 @@ import {
 } from "@ag-grid-community/core";
 
 @Bean('rowModel')
-export class ViewportRowModel extends BeanStub implements IRowModel {
+export class ViewportRowModel<T = any> extends BeanStub implements IRowModel<T> {
 
     @Autowired('gridOptionsWrapper') private gridOptionsWrapper: GridOptionsWrapper;
-    @Autowired('gridApi') private gridApi: GridApi;
+    @Autowired('gridApi') private gridApi: GridApi<T>;
     @Autowired('columnApi') private columnApi: ColumnApi;
     @Autowired('rowRenderer') private rowRenderer: RowRenderer;
 
@@ -32,7 +32,7 @@ export class ViewportRowModel extends BeanStub implements IRowModel {
 
     // datasource tells us this
     private rowCount = -1;
-    private rowNodesByIndex: {[index: number]: RowNode} = {};
+    private rowNodesByIndex: {[index: number]: RowNode<T>} = {};
     private rowHeight: number;
     private viewportDatasource: IViewportDatasource;
 
@@ -134,7 +134,7 @@ export class ViewportRowModel extends BeanStub implements IRowModel {
         return Constants.ROW_MODEL_TYPE_VIEWPORT;
     }
 
-    public getRow(rowIndex: number): RowNode {
+    public getRow(rowIndex: number): RowNode<T> {
         if (!this.rowNodesByIndex[rowIndex]) {
             this.rowNodesByIndex[rowIndex] = this.createBlankRowNode(rowIndex);
         }
@@ -142,8 +142,8 @@ export class ViewportRowModel extends BeanStub implements IRowModel {
         return this.rowNodesByIndex[rowIndex];
     }
 
-    public getRowNode(id: string): RowNode | null {
-        let result: RowNode | null = null;
+    public getRowNode(id: string): RowNode<T> | null {
+        let result: RowNode<T> | null = null;
         this.forEachNode(rowNode => {
             if (rowNode.id === id) {
                 result = rowNode;
@@ -191,7 +191,7 @@ export class ViewportRowModel extends BeanStub implements IRowModel {
         return this.rowCount > 0;
     }
 
-    public getNodesInRangeForSelection(firstInRange: RowNode, lastInRange: RowNode): RowNode[] {
+    public getNodesInRangeForSelection(firstInRange: RowNode<T>, lastInRange: RowNode<T>): RowNode<T>[] {
         const firstIndex = _.missing(firstInRange) ? 0 : firstInRange.rowIndex;
         const lastIndex = lastInRange.rowIndex;
 
@@ -200,7 +200,7 @@ export class ViewportRowModel extends BeanStub implements IRowModel {
 
         if (firstNodeOutOfRange || lastNodeOutOfRange) { return []; }
 
-        const result: RowNode[] = [];
+        const result: RowNode<T>[] = [];
 
         const startIndex = firstIndex <= lastIndex ? firstIndex : lastIndex;
         const endIndex = firstIndex <= lastIndex ? lastIndex : firstIndex;
@@ -212,7 +212,7 @@ export class ViewportRowModel extends BeanStub implements IRowModel {
         return result;
     }
 
-    public forEachNode(callback: (rowNode: RowNode, index: number) => void): void {
+    public forEachNode(callback: (rowNode: RowNode<T>, index: number) => void): void {
         let callbackCount = 0;
 
         Object.keys(this.rowNodesByIndex).forEach(indexStr => {


### PR DESCRIPTION
For feature #4154 I was thinking about something along the lines of this draft PR

<img width="653" alt="Screenshot 2020-10-27 at 08 10 34" src="https://user-images.githubusercontent.com/904479/97274005-f2bc0200-182b-11eb-983d-f0752508d511.png">

It's probably a naive example and can be taken a lot further (e.g. determining the columns based on the data type)

Would also be nice to type the props for the Grid components