### PR TITLE
removes ag-grid-enterprise license error when running tests

### DIFF
--- a/grid-packages/ag-grid-docs/documentation/src/pages/testing/index.md
+++ b/grid-packages/ag-grid-docs/documentation/src/pages/testing/index.md
@@ -268,6 +268,14 @@ title: "Testing ag-Grid"
 | We will walk through how you can use testing ag-Grid as part of your Angular application,
 | using default build tools provided when using the [Angular CLI](https://cli.angular.io/).
 |
+| ## Configuring ag-grid
+| ### When using ag-grid-enterprise you may see license errors shown on your test run, to prevent that add set your licence in the `test.ts` file
+|
+| ```ts
+| const agGridLicense = 'YOUR LICENSE GOES HERE';
+| LicenseManager.setLicenseKey(agGridLicense);
+| ```
+|
 | ## Configuring the Test Module
 |
 | The first thing we need to do is to add ag-Grid's `AgGridModule` to the `TestBed.configureTestingModule(`:

--- a/grid-packages/ag-grid-docs/documentation/src/pages/testing/index.md
+++ b/grid-packages/ag-grid-docs/documentation/src/pages/testing/index.md
@@ -269,7 +269,7 @@ title: "Testing ag-Grid"
 | using default build tools provided when using the [Angular CLI](https://cli.angular.io/).
 |
 | ## Configuring ag-grid
-| ### When using ag-grid-enterprise you may see license errors shown on your test run, to prevent that add set your licence in the `test.ts` file
+| ### When using ag-grid-enterprise you may see license errors shown on your test run, to prevent that set your licence in the `test.ts` file
 |
 | ```ts
 | const agGridLicense = 'YOUR LICENSE GOES HERE';


### PR DESCRIPTION
When using ag-grid-enterprise the message of an invalid license is displayed on the tests run.

This addresses the issue [Karma Jasmine not detecting the ag-grid-enterprise License #190 ](https://github.com/ag-grid/ag-grid-enterprise/issues/190)
