### PR TITLE
Add 'rowFillExtraWidth' option to grid to handle extra area on grid.

### DIFF
--- a/community-modules/angular/projects/ag-grid-angular/src/lib/ag-grid-angular.component.ts
+++ b/community-modules/angular/projects/ag-grid-angular/src/lib/ag-grid-angular.component.ts
@@ -438,6 +438,7 @@ export class AgGridAngular implements AfterViewInit {
     @Input() public showOpenedGroup : any = undefined;
     @Input() public suppressClipboardApi : any = undefined;
     @Input() public suppressModelUpdateAfterUpdateTransaction : any = undefined;
+    @Input() public rowFillExtraWidth: boolean = undefined;
 
     @Output() public columnEverythingChanged: EventEmitter<any> = new EventEmitter<any>();
     @Output() public newColumnsLoaded: EventEmitter<any> = new EventEmitter<any>();

--- a/community-modules/core/src/ts/entities/gridOptions.ts
+++ b/community-modules/core/src/ts/entities/gridOptions.ts
@@ -149,6 +149,7 @@ export interface GridOptions {
     suppressMenuHide?: boolean;
     singleClickEdit?: boolean;
     suppressClickEdit?: boolean;
+    rowFillExtraWidth?: boolean;
 
     /** Allows user to suppress certain keyboard events */
     suppressKeyboardEvent?: (params: SuppressKeyboardEventParams) => boolean;

--- a/community-modules/core/src/ts/events.ts
+++ b/community-modules/core/src/ts/events.ts
@@ -263,7 +263,8 @@ export type ColumnEventType =
     "rowModelUpdated" |
     "api" |
     "flex" |
-    "pivotChart";
+    "pivotChart" |
+    "fillExtraWidth";
 
 export interface ColumnEvent extends AgGridEvent {
     column: Column | null;

--- a/community-modules/core/src/ts/gridOptionsWrapper.ts
+++ b/community-modules/core/src/ts/gridOptionsWrapper.ts
@@ -1400,6 +1400,10 @@ export class GridOptionsWrapper {
         return isTrue(this.gridOptions.tooltipMouseTrack);
     }
 
+    public isRowFillExtraWidth() {
+        return isTrue(this.gridOptions.rowFillExtraWidth);
+    }
+
     public isSuppressModelUpdateAfterUpdateTransaction(): boolean {
         return isTrue(this.gridOptions.suppressModelUpdateAfterUpdateTransaction);
     }

--- a/community-modules/core/src/ts/gridPanel/gridPanel.ts
+++ b/community-modules/core/src/ts/gridPanel/gridPanel.ts
@@ -376,6 +376,7 @@ export class GridPanel extends Component {
                 this.columnController.refreshFlexedColumns(
                     { viewportWidth: this.centerWidth, updateBodyWidths: true, fireResizedEvent: true }
                 );
+                this.columnController.fillExtraWidth();
             }
         } else {
             this.bodyHeight = 0;

--- a/community-modules/core/src/ts/propertyKeys.ts
+++ b/community-modules/core/src/ts/propertyKeys.ts
@@ -60,7 +60,7 @@ export class PropertyKeys {
         'undoRedoCellEditing', 'allowDragFromColumnsToolPanel', 'immutableData', 'immutableColumns', 'pivotSuppressAutoColumn',
         'suppressExpandablePivotGroups', 'applyColumnDefOrder', 'debounceVerticalScrollbar', 'detailRowAutoHeight',
         'serverSideFilteringAlwaysResets', 'suppressAggFilteredOnly', 'showOpenedGroup', 'suppressClipboardApi',
-        'suppressModelUpdateAfterUpdateTransaction'
+        'suppressModelUpdateAfterUpdateTransaction','rowFillExtraWidth'
     ];
 
     /** You do not need to include event callbacks in this list, as they are generated automatically. */

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/grid-properties/properties.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/grid-properties/properties.json
@@ -1031,6 +1031,10 @@
         "suppressBrowserResizeObserver": {
             "default": false,
             "description": "The grid will check for `ResizeObserver` and use it if it exists in the browser, otherwise it will use the grid's alternative implementation. Some users reported issues with Chrome's `ResizeObserver`. Use this property to always use the grid's alternative implementation should such problems exist."
+        },
+        "rowFillExtraWidth": {
+            "default": false,
+            "description": "The grid's row will fill all width of the grid if sum of width of columns are less than width of grid. otherwise there is an empty space in extra area."
         }
     }
 }

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/grid-properties/properties.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/grid-properties/properties.json
@@ -1034,7 +1034,7 @@
         },
         "rowFillExtraWidth": {
             "default": false,
-            "description": "The grid's row will fill all width of the grid if sum of width of columns are less than width of grid. otherwise there is an empty space in extra area."
+            "description": "The grid's row will fill all width of the grid if the sum of the width of columns is less than the width of the grid. otherwise, there is an empty space in the extra area."
         }
     }
 }


### PR DESCRIPTION
Add the `rowFillExtraWidth` option to the grid to handle this issue #4302.

If `rowFillExtraWidth` set to the `true` the grid's row will fill all width of the grid if the sum of the width of columns is less than the width of the grid. otherwise, there is an empty space in the extra area.
