### PR TITLE
Fix documented default value for rowBuffer

### DIFF
--- a/grid-packages/ag-grid-docs/documentation/doc-pages/grid-properties/properties.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/grid-properties/properties.json
@@ -954,7 +954,7 @@
             }
         },
         "rowBuffer": {
-            "default": 20,
+            "default": 10,
             "description": "The number of rows rendered outside the scrollable viewable area the grid renders. Having a buffer means the grid will have rows ready to show as the user slowly scrolls vertically."
         },
         "alignedGrids": {


### PR DESCRIPTION
The const ROW_BUFFER_SIZE, which is defined to be 10, holds the default value.