### PR TITLE
[core] Introduce a default value parser that preserves the data type

### DIFF
--- a/community-modules/core/src/ts/rendering/cellComp.ts
+++ b/community-modules/core/src/ts/rendering/cellComp.ts
@@ -1386,6 +1386,23 @@ export class CellComp extends Component implements TooltipParentComp {
         }
     }
 
+    private defaultValueParser(params: NewValueParams) {
+        // The default value parser attempts to preserve the type of the field
+        // if the field is a Number or BigInt
+
+        if (typeof params.oldValue === 'number') {
+            let tryParseNumber = Number(params.newValue)
+            if (!Number.isNaN(tryParseNumber)) return tryParseNumber
+
+        } else if (typeof params.oldValue === 'bigint') {
+            try {
+                return BigInt(params.newValue)
+            } catch {
+                return params.newValue;
+            }
+        }
+        return params.newValue;
+    }
     private parseValue(newValue: any): any {
         const colDef = this.getComponentHolder();
         const params: NewValueParams = {
@@ -1402,7 +1419,7 @@ export class CellComp extends Component implements TooltipParentComp {
 
         const valueParser = colDef.valueParser;
 
-        return exists(valueParser) ? this.beans.expressionService.evaluate(valueParser, params) : newValue;
+        return exists(valueParser) ? this.beans.expressionService.evaluate(valueParser, params) : this.defaultValueParser(params);
     }
 
     public focusCell(forceBrowserFocus = false): void {


### PR DESCRIPTION
Context:

When the user updates a cell value via the default editor, the resulting value is always a string. If the column participates in numeric operations e.g. as an aggregate value, the resulting aggregates will be invalid (due to use of the addition operator on strings) or the value may be refused.

Steps to reproduce:

* Open the ag-grid example page: https://www.ag-grid.com/example.php
* Add Country to row groups
* Add "Bank balance" to aggregate values
* Expand a country group and update the first value in its children
* Update the value for a second time.

Expectation: The second update works

Result: The second update is ignored (the editor produces a string which is rejected)

Various alternative options considered, including their pros and cons can be found in this gist: https://gist.github.com/spion/b095cf835d9703367280da356fbde487