### PR TITLE
Removing deprecated division symbol

### DIFF
--- a/community-modules/core/src/styles/ag-theme-alpine/sass/_ag-theme-alpine-mixin.scss
+++ b/community-modules/core/src/styles/ag-theme-alpine/sass/_ag-theme-alpine-mixin.scss
@@ -99,7 +99,7 @@
 
     .ag-charts-format-top-level-group-toolbar {
         margin-top: ag-param(grid-size);
-        @include ag-theme-rtl((padding-left: ag-param(icon-size) / 2 + ag-param(grid-size) * 2));
+        @include ag-theme-rtl((padding-left: ag-param(icon-size) * 0.5 + ag-param(grid-size) * 2));
     }
 
     .ag-charts-format-sub-level-group {
@@ -245,14 +245,14 @@
         @include ag-color-property(background-color, control-panel-background-color);
         border-left: dashed 1px;
         @include ag-color-property(border-left-color, border-color);
-        margin-left: ag-param(icon-size) / 2;
-        padding-left: ag-param(icon-size) / 2;
+        margin-left: ag-param(icon-size) * 0.5;
+        padding-left: ag-param(icon-size) * 0.5;
         margin-right: ag-param(grid-size) * 2;
     }
 
     .ag-set-filter-list {
-        padding-top: ag-param(grid-size) / 2;
-        padding-bottom: ag-param(grid-size) / 2;
+        padding-top: ag-param(grid-size) * 0.5;
+        padding-bottom: ag-param(grid-size) * 0.5;
     }
 
     .ag-layout-auto-height, .ag-layout-print {

--- a/community-modules/core/src/styles/ag-theme-balham/sass/_ag-theme-balham-mixin.scss
+++ b/community-modules/core/src/styles/ag-theme-balham/sass/_ag-theme-balham-mixin.scss
@@ -123,7 +123,7 @@
     }
 
     .ag-chart-tab {
-        padding-top: ag-param(grid-size) / 2;
+        padding-top: ag-param(grid-size) * 0.5;
     }
 
     .ag-charts-format-sub-level-group-item {

--- a/community-modules/core/src/styles/ag-theme-base/sass/parts/_column-drop.scss
+++ b/community-modules/core/src/styles/ag-theme-base/sass/parts/_column-drop.scss
@@ -7,7 +7,7 @@
         @include ag-color-property(background, chip-background-color);
         border-radius: ag-param(grid-size) * 4;
         height: ag-param(grid-size) * 4;
-        padding: 0 ag-param(grid-size) / 2;
+        padding: 0 ag-param(grid-size) * 0.5;
     }
 
     .ag-column-drop-cell-text {
@@ -17,7 +17,7 @@
     .ag-column-drop-cell-button {
         min-width: ag-param(grid-size) * 4;
 
-        margin: 0 ag-param(grid-size) / 2;
+        margin: 0 ag-param(grid-size) * 0.5;
         @include ag-color-property(color, secondary-foreground-color);
     }
     

--- a/community-modules/core/src/styles/ag-theme-base/sass/parts/_filter-tool-panel.scss
+++ b/community-modules/core/src/styles/ag-theme-base/sass/parts/_filter-tool-panel.scss
@@ -22,8 +22,8 @@
     }
 
     .ag-filter-toolpanel-group-item {
-        margin-top: ag-param(grid-size) / 2;
-        margin-bottom: ag-param(grid-size) / 2;
+        margin-top: ag-param(grid-size) * 0.5;
+        margin-bottom: ag-param(grid-size) * 0.5;
     }
 
     .ag-filter-toolpanel-search {

--- a/community-modules/core/src/styles/ag-theme-base/sass/parts/_header.scss
+++ b/community-modules/core/src/styles/ag-theme-base/sass/parts/_header.scss
@@ -78,7 +78,7 @@
             display: block;
             width: ag-param(header-column-separator-width);
             height: ag-param(header-column-separator-height);
-            top: calc(50% - #{ag-param(header-column-separator-height) / 2});
+            top: calc(50% - #{ag-param(header-column-separator-height) * 0.5});
             @include ag-color-property(background-color, header-column-separator-color);
 
             @include ag-theme-rtl(( right: 0 ));
@@ -96,10 +96,10 @@
             position: absolute;
             z-index: 1;
             display: block;
-            left: calc(50% - #{ag-param(header-column-resize-handle-width) / 2});
+            left: calc(50% - #{ag-param(header-column-resize-handle-width) * 0.5});
             width: ag-param(header-column-resize-handle-width);
             height: ag-param(header-column-resize-handle-height);
-            top: calc(50% - #{ag-param(header-column-resize-handle-height) / 2});
+            top: calc(50% - #{ag-param(header-column-resize-handle-height) * 0.5});
             @include ag-color-property(background-color, header-column-resize-handle-color);
         }
 

--- a/community-modules/core/src/styles/ag-theme-base/sass/parts/_widgets.scss
+++ b/community-modules/core/src/styles/ag-theme-base/sass/parts/_widgets.scss
@@ -243,7 +243,7 @@
     }
 
     .group-item {
-        margin: ag-param(grid-size) / 2 0;
+        margin: ag-param(grid-size) * 0.5 0;
     }
 
     .ag-label {
@@ -252,7 +252,7 @@
     }
 
     .ag-label-align-top .ag-label {
-        margin-bottom: ag-param(grid-size) / 2;
+        margin-bottom: ag-param(grid-size) * 0.5;
     }
 
     .ag-slider-field,
@@ -490,7 +490,7 @@
     }
 
     .ag-column-select-virtual-list-viewport {
-        padding: (ag-param(widget-container-vertical-padding) / 2) 0px;
+        padding: (ag-param(widget-container-vertical-padding) * 0.5) 0px;
     }
 
     .ag-column-select-virtual-list-item {
@@ -624,7 +624,7 @@
     width: ag-param(toggle-button-width);
     height: ag-param(toggle-button-height);
     @include ag-color-property(background-color, toggle-button-off-background-color);
-    border-radius: ag-param(toggle-button-height) / 2;
+    border-radius: ag-param(toggle-button-height) * 0.5;
     position: relative;
     flex: none;
     border: $border-width solid;
@@ -660,7 +660,7 @@
         height: ag-param(toggle-button-height);
         width: ag-param(toggle-button-height);
         @include ag-color-property(background-color, toggle-button-switch-background-color);
-        border-radius: ag-param(toggle-button-height) / 2;
+        border-radius: ag-param(toggle-button-height) * 0.5;
         transition: left 100ms;
         border: $border-width solid;
         @include ag-color-property(border-color, toggle-button-switch-border-color);

--- a/community-modules/core/src/styles/ag-theme-classic/sass/_ag-theme-classic.scss
+++ b/community-modules/core/src/styles/ag-theme-classic/sass/_ag-theme-classic.scss
@@ -43,7 +43,7 @@
     }
 
     .ag-tabs-body {
-        margin: ag-param(grid-size) / 2 0;
+        margin: ag-param(grid-size) * 0.5 0;
     }
 
     .ag-tab-selected {

--- a/community-modules/core/src/styles/ag-theme-material/sass/_ag-theme-material-mixin.scss
+++ b/community-modules/core/src/styles/ag-theme-material/sass/_ag-theme-material-mixin.scss
@@ -29,7 +29,7 @@
     }
 
     .ag-tabs-body {
-        padding: ag-param(grid-size) / 2 0;
+        padding: ag-param(grid-size) * 0.5 0;
     }
 
     .ag-tabs-body .ag-menu-list {

--- a/community-modules/core/src/styles/mixins/_ag-theme-params.scss
+++ b/community-modules/core/src/styles/mixins/_ag-theme-params.scss
@@ -11,6 +11,8 @@
 
 // Define a derived parameter. Derived values are lazily evaluated. This function is
 // sugar for defining a data structure to record the derived value's parameters.
+@use "sass:math";
+
 @function ag-derived(
     $reference-name,
     $times: null,
@@ -310,7 +312,7 @@ $-ag-params: null !default;
 @function -ag-operator-function-divide($params, $lhs, $rhs) {
     $lhs: -ag-require-type($lhs, "number", "value before $divide");
     $rhs: -ag-require-type($rhs, "number", "argument to $divide");
-    @return $lhs / $rhs;
+    @return math.div($lhs, $rhs);
 }
 
 @function -ag-operator-function-plus($params, $lhs, $rhs) {

--- a/dist/styles/ag-theme-alpine/sass/_ag-theme-alpine-mixin.scss
+++ b/dist/styles/ag-theme-alpine/sass/_ag-theme-alpine-mixin.scss
@@ -96,7 +96,7 @@
 
     .ag-charts-format-top-level-group-toolbar {
         margin-top: ag-param(grid-size);
-        @include ag-theme-rtl((padding-left: ag-param(icon-size) / 2 + ag-param(grid-size) * 2));
+        @include ag-theme-rtl((padding-left: ag-param(icon-size) * 0.5 + ag-param(grid-size) * 2));
     }
 
     .ag-charts-format-sub-level-group {
@@ -247,14 +247,14 @@
         @include ag-color-property(background-color, control-panel-background-color);
         border-left: dashed 1px;
         @include ag-color-property(border-left-color, border-color);
-        margin-left: ag-param(icon-size) / 2;
-        padding-left: ag-param(icon-size) / 2;
+        margin-left: ag-param(icon-size) * 0.5;
+        padding-left: ag-param(icon-size) * 0.5;
         margin-right: ag-param(grid-size) * 2;
     }
 
     .ag-set-filter-list {
-        padding-top: ag-param(grid-size) / 2;
-        padding-bottom: ag-param(grid-size) / 2;
+        padding-top: ag-param(grid-size) * 0.5;
+        padding-bottom: ag-param(grid-size) * 0.5;
     }
 
     .ag-layout-auto-height, .ag-layout-print {

--- a/dist/styles/ag-theme-balham/sass/_ag-theme-balham-mixin.scss
+++ b/dist/styles/ag-theme-balham/sass/_ag-theme-balham-mixin.scss
@@ -123,7 +123,7 @@
     }
 
     .ag-chart-tab {
-        padding-top: ag-param(grid-size) / 2;
+        padding-top: ag-param(grid-size) * 0.5;
     }
 
     .ag-charts-format-sub-level-group-item {

--- a/dist/styles/ag-theme-base/sass/parts/_column-drop.scss
+++ b/dist/styles/ag-theme-base/sass/parts/_column-drop.scss
@@ -7,7 +7,7 @@
         @include ag-color-property(background, chip-background-color);
         border-radius: ag-param(grid-size) * 4;
         height: ag-param(grid-size) * 4;
-        padding: 0 ag-param(grid-size) / 2;
+        padding: 0 ag-param(grid-size) * 0.5;
     }
 
     .ag-column-drop-cell-text {
@@ -17,7 +17,7 @@
     .ag-column-drop-cell-button {
         min-width: ag-param(grid-size) * 4;
 
-        margin: 0 ag-param(grid-size) / 2;
+        margin: 0 ag-param(grid-size) * 0.5;
         @include ag-color-property(color, secondary-foreground-color);
     }
     

--- a/dist/styles/ag-theme-base/sass/parts/_filter-tool-panel.scss
+++ b/dist/styles/ag-theme-base/sass/parts/_filter-tool-panel.scss
@@ -22,8 +22,8 @@
     }
 
     .ag-filter-toolpanel-group-item {
-        margin-top: ag-param(grid-size) / 2;
-        margin-bottom: ag-param(grid-size) / 2;
+        margin-top: ag-param(grid-size) * 0.5;
+        margin-bottom: ag-param(grid-size) * 0.5;
     }
 
     .ag-filter-toolpanel-search {

--- a/dist/styles/ag-theme-base/sass/parts/_header.scss
+++ b/dist/styles/ag-theme-base/sass/parts/_header.scss
@@ -78,7 +78,7 @@
             display: block;
             width: ag-param(header-column-separator-width);
             height: ag-param(header-column-separator-height);
-            top: calc(50% - #{ag-param(header-column-separator-height) / 2});
+            top: calc(50% - #{ag-param(header-column-separator-height) * 0.5});
             @include ag-color-property(background-color, header-column-separator-color);
 
             @include ag-theme-rtl(( right: 0 ));
@@ -96,10 +96,10 @@
             position: absolute;
             z-index: 1;
             display: block;
-            left: calc(50% - #{ag-param(header-column-resize-handle-width) / 2});
+            left: calc(50% - #{ag-param(header-column-resize-handle-width) * 0.5});
             width: ag-param(header-column-resize-handle-width);
             height: ag-param(header-column-resize-handle-height);
-            top: calc(50% - #{ag-param(header-column-resize-handle-height) / 2});
+            top: calc(50% - #{ag-param(header-column-resize-handle-height) * 0.5});
             @include ag-color-property(background-color, header-column-resize-handle-color);
         }
 

--- a/dist/styles/ag-theme-base/sass/parts/_widgets.scss
+++ b/dist/styles/ag-theme-base/sass/parts/_widgets.scss
@@ -243,7 +243,7 @@
     }
 
     .group-item {
-        margin: ag-param(grid-size) / 2 0;
+        margin: ag-param(grid-size) * 0.5 0;
     }
 
     .ag-label {
@@ -252,7 +252,7 @@
     }
 
     .ag-label-align-top .ag-label {
-        margin-bottom: ag-param(grid-size) / 2;
+        margin-bottom: ag-param(grid-size) * 0.5;
     }
 
     .ag-slider-field,
@@ -490,7 +490,7 @@
     }
 
     .ag-column-select-virtual-list-viewport {
-        padding: (ag-param(widget-container-vertical-padding) / 2) 0px;
+        padding: (ag-param(widget-container-vertical-padding) * 0.5) 0px;
     }
 
     .ag-column-select-virtual-list-item {
@@ -624,7 +624,7 @@
     width: ag-param(toggle-button-width);
     height: ag-param(toggle-button-height);
     @include ag-color-property(background-color, toggle-button-off-background-color);
-    border-radius: ag-param(toggle-button-height) / 2;
+    border-radius: ag-param(toggle-button-height) * 0.5;
     position: relative;
     flex: none;
     border: $border-width solid;
@@ -660,7 +660,7 @@
         height: ag-param(toggle-button-height);
         width: ag-param(toggle-button-height);
         @include ag-color-property(background-color, toggle-button-switch-background-color);
-        border-radius: ag-param(toggle-button-height) / 2;
+        border-radius: ag-param(toggle-button-height) * 0.5;
         transition: left 100ms;
         border: $border-width solid;
         @include ag-color-property(border-color, toggle-button-switch-border-color);

--- a/dist/styles/ag-theme-classic/sass/_ag-theme-classic.scss
+++ b/dist/styles/ag-theme-classic/sass/_ag-theme-classic.scss
@@ -43,7 +43,7 @@
     }
 
     .ag-tabs-body {
-        margin: ag-param(grid-size) / 2 0;
+        margin: ag-param(grid-size) * 0.5 0;
     }
 
     .ag-tab-selected {

--- a/dist/styles/ag-theme-material/sass/_ag-theme-material-mixin.scss
+++ b/dist/styles/ag-theme-material/sass/_ag-theme-material-mixin.scss
@@ -29,7 +29,7 @@
     }
 
     .ag-tabs-body {
-        padding: ag-param(grid-size) / 2 0;
+        padding: ag-param(grid-size) * 0.5 0;
     }
 
     .ag-tabs-body .ag-menu-list {

--- a/dist/styles/mixins/_ag-theme-params.scss
+++ b/dist/styles/mixins/_ag-theme-params.scss
@@ -11,6 +11,8 @@
 
 // Define a derived parameter. Derived values are lazily evaluated. This function is
 // sugar for defining a data structure to record the derived value's parameters.
+@use "sass:math";
+
 @function ag-derived(
     $reference-name,
     $times: null,
@@ -310,7 +312,7 @@ $-ag-params: null !default;
 @function -ag-operator-function-divide($params, $lhs, $rhs) {
     $lhs: -ag-require-type($lhs, "number", "value before $divide");
     $rhs: -ag-require-type($rhs, "number", "argument to $divide");
-    @return $lhs / $rhs;
+    @return math.div($lhs, $rhs);
 }
 
 @function -ag-operator-function-plus($params, $lhs, $rhs) {


### PR DESCRIPTION
This PR resolves https://github.com/ag-grid/ag-grid/issues/4543

This is the result of running `sass-migrator division **/*.scss`

https://www.npmjs.com/package/sass-migrator