### PR TITLE
Use getRootNode() instead of document to be compatible with WebComponents #4561

### DIFF
--- a/community-modules/core/src/ts/filter/provided/date/defaultDateComponent.ts
+++ b/community-modules/core/src/ts/filter/provided/date/defaultDateComponent.ts
@@ -38,7 +38,7 @@ export class DefaultDateComponent extends Component implements IDateComp {
         this.addManagedListener(inputElement, 'mousedown', () => inputElement.focus());
 
         this.addManagedListener(this.eDateInput.getInputElement(), 'input', e => {
-            if (e.target !== document.activeElement) { return; }
+            if (e.target !== e.target.getRootNode().activeElement) { return; }
 
             params.onDateChanged();
         });


### PR DESCRIPTION
This modification fixes the problem described in ticket #4561