### PR TITLE
Ag 3944 add existing but missing interfaces

### DIFF
--- a/community-modules/angular/projects/ag-grid-angular/src/lib/ag-grid-angular.component.ts
+++ b/community-modules/angular/projects/ag-grid-angular/src/lib/ag-grid-angular.component.ts
@@ -141,7 +141,8 @@ import {
     ProcessRowParams,
     ProcessCellForExportParams,
     ProcessHeaderForExportParams,
-    ProcessChartOptionsParams
+    ProcessChartOptionsParams,
+    RowClassParams
 } from "@ag-grid-community/core";
 
 import {AngularFrameworkOverrides} from "./angularFrameworkOverrides";
@@ -291,11 +292,11 @@ export class AgGridAngular implements AfterViewInit {
     @Input() public chartThemes: string[] | undefined = undefined;
     @Input() public components: { [p: string]: any; } | undefined = undefined;
     @Input() public frameworkComponents: { [p: string]: { new(): any; }; } | any | undefined = undefined;
-    @Input() public rowStyle: any | undefined = undefined;
+    @Input() public rowStyle: { [cssClassName: string]: string } | undefined = undefined;
     @Input() public context: any | undefined = undefined;
     @Input() public autoGroupColumnDef: ColDef | undefined = undefined;
-    @Input() public localeText: any | undefined = undefined;
-    @Input() public icons: any | undefined = undefined;
+    @Input() public localeText: { [key: string]: string } | undefined = undefined;
+    @Input() public icons: { [key: string]: Function | string; } | undefined = undefined;
     @Input() public datasource: IDatasource | undefined = undefined;
     @Input() public serverSideDatasource: IServerSideDatasource | undefined = undefined;
     @Input() public viewportDatasource: IViewportDatasource | undefined = undefined;
@@ -308,7 +309,7 @@ export class AgGridAngular implements AfterViewInit {
     @Input() public defaultCsvExportParams: CsvExportParams | undefined = undefined;
     @Input() public defaultExcelExportParams: ExcelExportParams | undefined = undefined;
     @Input() public columnTypes: { [key: string]: ColDef; } | undefined = undefined;
-    @Input() public rowClassRules: { [cssClassName: string]: (((params: any) => boolean) | string); } | undefined = undefined;
+    @Input() public rowClassRules: { [cssClassName: string]: (((params: RowClassParams) => boolean) | string); } | undefined = undefined;
     @Input() public detailCellRendererParams: any | undefined = undefined;
     @Input() public loadingCellRendererParams: any | undefined = undefined;
     @Input() public loadingOverlayComponentParams: any | undefined = undefined;
@@ -380,7 +381,7 @@ export class AgGridAngular implements AfterViewInit {
     @Input() public isExternalFilterPresent: () =>  boolean | undefined = undefined;
     @Input() public getRowHeight: Function | undefined = undefined;
     @Input() public doesExternalFilterPass: (node: RowNode) =>  boolean | undefined = undefined;
-    @Input() public getRowClass: (params: any) => (string | string[]) | undefined = undefined;
+    @Input() public getRowClass: (params: RowClassParams) => (string | string[]) | undefined = undefined;
     @Input() public getRowStyle: Function | undefined = undefined;
     @Input() public getContextMenuItems: GetContextMenuItems | undefined = undefined;
     @Input() public getMainMenuItems: GetMainMenuItems | undefined = undefined;
@@ -394,7 +395,7 @@ export class AgGridAngular implements AfterViewInit {
     @Input() public processSecondaryColDef: (colDef: ColDef) =>  void | undefined = undefined;
     @Input() public processSecondaryColGroupDef: (colGroupDef: ColGroupDef) =>  void | undefined = undefined;
     @Input() public getBusinessKeyForNode: (node: RowNode) =>  string | undefined = undefined;
-    @Input() public sendToClipboard: (params: any) => void | undefined = undefined;
+    @Input() public sendToClipboard: (params: { data: string }) => void | undefined = undefined;
     @Input() public navigateToNextHeader: (params: NavigateToNextHeaderParams) => HeaderPosition | undefined = undefined;
     @Input() public tabToNextHeader: (params: TabToNextHeaderParams) => HeaderPosition | undefined = undefined;
     @Input() public navigateToNextCell: (params: NavigateToNextCellParams) => CellPosition | undefined = undefined;

--- a/community-modules/angular/projects/ag-grid-angular/src/lib/ag-grid-column.component.ts
+++ b/community-modules/angular/projects/ag-grid-angular/src/lib/ag-grid-column.component.ts
@@ -1,4 +1,4 @@
-import { CellClassParams, CellClickedEvent, CellContextMenuEvent, CellDoubleClickedEvent, CellEditorSelectorFunc, CellRendererSelectorFunc, CheckboxSelectionCallbackParams, ColDef, ColGroupDef, ColSpanParams, ColumnsMenuParams, DndSourceCallbackParams, EditableCallbackParams, GetQuickFilterTextParams, IAggFunc, ICellEditorComp, ICellRendererComp, ICellRendererFunc, IHeaderGroupComp, IRowDragItem, ITooltipComp, ITooltipParams, RowDragCallbackParams, RowNode, RowSpanParams, SuppressHeaderKeyboardEventParams, SuppressKeyboardEventParams, SuppressNavigableCallbackParams, SuppressPasteCallbackParams, ValueFormatterParams, ValueGetterParams, ValueParserParams, ValueSetterParams } from "@ag-grid-community/core";
+import { CellClassParams, CellClickedEvent, CellContextMenuEvent, CellDoubleClickedEvent, CellEditorSelectorFunc, CellRendererSelectorFunc, CheckboxSelectionCallbackParams, ColDef, ColGroupDef, ColSpanParams, ColumnsMenuParams, DndSourceCallbackParams, EditableCallbackParams, GetQuickFilterTextParams, IAggFunc, ICellEditorComp, ICellRendererComp, ICellRendererFunc, IHeaderGroupComp, IRowDragItem, ITooltipComp, ITooltipParams, RowDragCallbackParams, RowNode, RowSpanParams, SuppressHeaderKeyboardEventParams, SuppressKeyboardEventParams, SuppressNavigableCallbackParams, SuppressPasteCallbackParams, ValueFormatterParams, ValueGetterParams, ValueParserParams, ValueSetterParams, NewValueParams, HeaderCheckboxSelectionCallbackParams } from "@ag-grid-community/core";
 import { Component, ContentChildren, Input, QueryList } from "@angular/core";
 
 @Component({
@@ -46,11 +46,11 @@ export class AgGridColumn {
     @Input() public allowedAggFuncs: string[] | undefined = undefined;
     @Input() public menuTabs: string[] | undefined = undefined;
     @Input() public cellClassRules: { [cssClassName: string]: (Function | string); } | undefined = undefined;
-    @Input() public icons: { [key: string]: string; } | undefined = undefined;
+    @Input() public icons: { [key: string]: Function | string; } | undefined = undefined;
     @Input() public headerGroupComponent: string | { new(): IHeaderGroupComp; } | undefined = undefined;
     @Input() public headerGroupComponentFramework: any | undefined = undefined;
     @Input() public headerGroupComponentParams: any | undefined = undefined;
-    @Input() public cellStyle: {} | ((params: any) => {}) | undefined = undefined;
+    @Input() public cellStyle: {} | ((params: CellClassParams) => {}) | undefined = undefined;
     @Input() public cellRendererParams: any | undefined = undefined;
     @Input() public cellEditorFramework: any | undefined = undefined;
     @Input() public cellEditorParams: any | undefined = undefined;
@@ -124,7 +124,7 @@ export class AgGridColumn {
     @Input() public colSpan: (params: ColSpanParams) => number | undefined = undefined;
     @Input() public rowSpan: (params: RowSpanParams) => number | undefined = undefined;
     @Input() public getQuickFilterText: (params: GetQuickFilterTextParams) => string | undefined = undefined;
-    @Input() public newValueHandler: (params: any) => boolean | undefined = undefined;
+    @Input() public newValueHandler: (params: NewValueParams) => boolean | undefined = undefined;
     @Input() public onCellValueChanged: Function | undefined = undefined;
     @Input() public onCellClicked: (event: CellClickedEvent) => void | undefined = undefined;
     @Input() public onCellDoubleClicked: (event: CellDoubleClickedEvent) => void | undefined = undefined;
@@ -145,7 +145,7 @@ export class AgGridColumn {
     @Input() public pivot: boolean | undefined = undefined;
     @Input() public initialPivot: boolean | undefined = undefined;
     @Input() public checkboxSelection: boolean | ((params: CheckboxSelectionCallbackParams) => boolean) | undefined = undefined;
-    @Input() public headerCheckboxSelection: boolean | ((params: any) => boolean) | undefined = undefined;
+    @Input() public headerCheckboxSelection: boolean | ((params: HeaderCheckboxSelectionCallbackParams) => boolean) | undefined = undefined;
     @Input() public headerCheckboxSelectionFilteredOnly: boolean | undefined = undefined;
     @Input() public suppressMenu: boolean | undefined = undefined;
     @Input() public suppressMovable: boolean | undefined = undefined;

--- a/community-modules/core/src/ts/entities/colDef.ts
+++ b/community-modules/core/src/ts/entities/colDef.ts
@@ -169,7 +169,7 @@ export interface ColDef extends AbstractColDef, IFilterDef {
     cellClass?: string | string[] | ((cellClassParams: CellClassParams) => string | string[]);
 
     /** An object of css values. Or a function returning an object of css values. */
-    cellStyle?: {} | ((params: any) => {});
+    cellStyle?: {} | ((params: CellClassParams) => {});
 
     /** A function for rendering a cell. */
     cellRenderer?: { new(): ICellRendererComp; } | ICellRendererFunc | string;
@@ -238,7 +238,7 @@ export interface ColDef extends AbstractColDef, IFilterDef {
     checkboxSelection?: boolean | ((params: CheckboxSelectionCallbackParams) => boolean);
 
     /** If true, a 'select all' checkbox will be put into the header */
-    headerCheckboxSelection?: boolean | ((params: any) => boolean);
+    headerCheckboxSelection?: boolean | ((params: HeaderCheckboxSelectionCallbackParams) => boolean);
 
     /** If true, the header checkbox selection will work on filtered items*/
     headerCheckboxSelectionFilteredOnly?: boolean;
@@ -324,7 +324,7 @@ export interface ColDef extends AbstractColDef, IFilterDef {
      * Return true if the update was successful, or false if not.
      * If false, then skips the UI refresh and no events are emitted.
      * Return false if the values are the same (ie no update). */
-    newValueHandler?: (params: any) => boolean;
+    newValueHandler?: (params: NewValueParams) => boolean;
 
     /** If true, this cell will be in editing mode after first click. */
     singleClickEdit?: boolean;
@@ -356,7 +356,7 @@ export interface ColDef extends AbstractColDef, IFilterDef {
     onCellContextMenu?: (event: CellContextMenuEvent) => void;
 
     /** Icons for this column. Leave blank to use default. */
-    icons?: { [key: string]: string; };
+    icons?: { [key: string]: Function | string; };
 
     /** If true, grid will flash cell after cell is refreshed */
     enableCellChangeFlash?: boolean;
@@ -402,6 +402,12 @@ export interface DndSourceCallbackParams extends ColumnFunctionCallbackParams {}
 export interface EditableCallbackParams extends ColumnFunctionCallbackParams {}
 export interface SuppressPasteCallbackParams extends ColumnFunctionCallbackParams {}
 export interface SuppressNavigableCallbackParams extends ColumnFunctionCallbackParams {}
+export interface HeaderCheckboxSelectionCallbackParams {
+    column: Column;
+    colDef: ColDef;
+    api: GridApi | null | undefined;
+    columnApi: ColumnApi | null | undefined;
+}
 
 /**
  * @deprecated

--- a/community-modules/core/src/ts/entities/gridOptions.ts
+++ b/community-modules/core/src/ts/entities/gridOptions.ts
@@ -162,7 +162,7 @@ export interface GridOptions {
     stopEditingWhenCellsLoseFocus?: boolean;
 
     debug?: boolean;
-    icons?: any; // should be typed
+    icons?: { [key: string]: Function | string; };
     angularCompileRows?: boolean;
     angularCompileFilters?: boolean;
 
@@ -285,7 +285,7 @@ export interface GridOptions {
     };
 
     // just set once
-    localeText?: any;
+    localeText?: { [key: string]: string };
     localeTextFunc?: (key: string, defaultValue: string) => string;
     suppressAnimationFrame?: boolean;
     defaultColGroupDef?: ColGroupDef;
@@ -320,7 +320,7 @@ export interface GridOptions {
 
     // changeable, but no immediate impact
     context?: any;
-    rowStyle?: any;
+    rowStyle?: { [cssClassName: string]: string };
     rowClass?: string | string[];
     groupDefaultExpanded?: number;
     alignedGrids?: GridOptions[];
@@ -389,10 +389,10 @@ export interface GridOptions {
     doesExternalFilterPass?(node: RowNode): boolean;
 
     getRowStyle?: Function;
-    getRowClass?: (params: any) => (string | string[]);
-    rowClassRules?: { [cssClassName: string]: (((params: any) => boolean) | string); };
+    getRowClass?: (params: RowClassParams) => (string | string[]);
+    rowClassRules?: { [cssClassName: string]: (((params: RowClassParams) => boolean) | string); };
     getRowHeight?: Function;
-    sendToClipboard?: (params: any) => void;
+    sendToClipboard?: (params: { data: string }) => void;
     processDataFromClipboard?: (params: ProcessDataFromClipboardParams) => string[][] | null;
 
     navigateToNextHeader?: (params: NavigateToNextHeaderParams) => HeaderPosition;

--- a/community-modules/core/src/ts/main.ts
+++ b/community-modules/core/src/ts/main.ts
@@ -324,6 +324,7 @@ export {
     EditableCallbackParams,
     SuppressPasteCallbackParams,
     SuppressNavigableCallbackParams,
+    HeaderCheckboxSelectionCallbackParams,
     ColumnsMenuParams,
     // deprecated params
     IsColumnFunc,

--- a/grid-packages/ag-grid-angular/projects/ag-grid-angular/src/lib/ag-grid-angular.component.ts
+++ b/grid-packages/ag-grid-angular/projects/ag-grid-angular/src/lib/ag-grid-angular.component.ts
@@ -141,7 +141,8 @@ import {
     ProcessRowParams,
     ProcessCellForExportParams,
     ProcessHeaderForExportParams,
-    ProcessChartOptionsParams
+    ProcessChartOptionsParams,
+    RowClassParams
 } from "ag-grid-community";
 
 import {AngularFrameworkOverrides} from "./angularFrameworkOverrides";
@@ -291,11 +292,11 @@ export class AgGridAngular implements AfterViewInit {
     @Input() public chartThemes: string[] | undefined = undefined;
     @Input() public components: { [p: string]: any; } | undefined = undefined;
     @Input() public frameworkComponents: { [p: string]: { new(): any; }; } | any | undefined = undefined;
-    @Input() public rowStyle: any | undefined = undefined;
+    @Input() public rowStyle: { [cssClassName: string]: string } | undefined = undefined;
     @Input() public context: any | undefined = undefined;
     @Input() public autoGroupColumnDef: ColDef | undefined = undefined;
-    @Input() public localeText: any | undefined = undefined;
-    @Input() public icons: any | undefined = undefined;
+    @Input() public localeText: { [key: string]: string } | undefined = undefined;
+    @Input() public icons: { [key: string]: Function | string; } | undefined = undefined;
     @Input() public datasource: IDatasource | undefined = undefined;
     @Input() public serverSideDatasource: IServerSideDatasource | undefined = undefined;
     @Input() public viewportDatasource: IViewportDatasource | undefined = undefined;
@@ -308,7 +309,7 @@ export class AgGridAngular implements AfterViewInit {
     @Input() public defaultCsvExportParams: CsvExportParams | undefined = undefined;
     @Input() public defaultExcelExportParams: ExcelExportParams | undefined = undefined;
     @Input() public columnTypes: { [key: string]: ColDef; } | undefined = undefined;
-    @Input() public rowClassRules: { [cssClassName: string]: (((params: any) => boolean) | string); } | undefined = undefined;
+    @Input() public rowClassRules: { [cssClassName: string]: (((params: RowClassParams) => boolean) | string); } | undefined = undefined;
     @Input() public detailCellRendererParams: any | undefined = undefined;
     @Input() public loadingCellRendererParams: any | undefined = undefined;
     @Input() public loadingOverlayComponentParams: any | undefined = undefined;
@@ -380,7 +381,7 @@ export class AgGridAngular implements AfterViewInit {
     @Input() public isExternalFilterPresent: () =>  boolean | undefined = undefined;
     @Input() public getRowHeight: Function | undefined = undefined;
     @Input() public doesExternalFilterPass: (node: RowNode) =>  boolean | undefined = undefined;
-    @Input() public getRowClass: (params: any) => (string | string[]) | undefined = undefined;
+    @Input() public getRowClass: (params: RowClassParams) => (string | string[]) | undefined = undefined;
     @Input() public getRowStyle: Function | undefined = undefined;
     @Input() public getContextMenuItems: GetContextMenuItems | undefined = undefined;
     @Input() public getMainMenuItems: GetMainMenuItems | undefined = undefined;
@@ -394,7 +395,7 @@ export class AgGridAngular implements AfterViewInit {
     @Input() public processSecondaryColDef: (colDef: ColDef) =>  void | undefined = undefined;
     @Input() public processSecondaryColGroupDef: (colGroupDef: ColGroupDef) =>  void | undefined = undefined;
     @Input() public getBusinessKeyForNode: (node: RowNode) =>  string | undefined = undefined;
-    @Input() public sendToClipboard: (params: any) => void | undefined = undefined;
+    @Input() public sendToClipboard: (params: { data: string }) => void | undefined = undefined;
     @Input() public navigateToNextHeader: (params: NavigateToNextHeaderParams) => HeaderPosition | undefined = undefined;
     @Input() public tabToNextHeader: (params: TabToNextHeaderParams) => HeaderPosition | undefined = undefined;
     @Input() public navigateToNextCell: (params: NavigateToNextCellParams) => CellPosition | undefined = undefined;

--- a/grid-packages/ag-grid-angular/projects/ag-grid-angular/src/lib/ag-grid-column.component.ts
+++ b/grid-packages/ag-grid-angular/projects/ag-grid-angular/src/lib/ag-grid-column.component.ts
@@ -1,4 +1,4 @@
-import { CellClassParams, CellClickedEvent, CellContextMenuEvent, CellDoubleClickedEvent, CellEditorSelectorFunc, CellRendererSelectorFunc, CheckboxSelectionCallbackParams, ColDef, ColGroupDef, ColSpanParams, ColumnsMenuParams, DndSourceCallbackParams, EditableCallbackParams, GetQuickFilterTextParams, IAggFunc, ICellEditorComp, ICellRendererComp, ICellRendererFunc, IHeaderGroupComp, IRowDragItem, ITooltipComp, ITooltipParams, RowDragCallbackParams, RowNode, RowSpanParams, SuppressHeaderKeyboardEventParams, SuppressKeyboardEventParams, SuppressNavigableCallbackParams, SuppressPasteCallbackParams, ValueFormatterParams, ValueGetterParams, ValueParserParams, ValueSetterParams } from "ag-grid-community";
+import { CellClassParams, CellClickedEvent, CellContextMenuEvent, CellDoubleClickedEvent, CellEditorSelectorFunc, CellRendererSelectorFunc, CheckboxSelectionCallbackParams, ColDef, ColGroupDef, ColSpanParams, ColumnsMenuParams, DndSourceCallbackParams, EditableCallbackParams, GetQuickFilterTextParams, IAggFunc, ICellEditorComp, ICellRendererComp, ICellRendererFunc, IHeaderGroupComp, IRowDragItem, ITooltipComp, ITooltipParams, RowDragCallbackParams, RowNode, RowSpanParams, SuppressHeaderKeyboardEventParams, SuppressKeyboardEventParams, SuppressNavigableCallbackParams, SuppressPasteCallbackParams, ValueFormatterParams, ValueGetterParams, ValueParserParams, ValueSetterParams, NewValueParams, HeaderCheckboxSelectionCallbackParams } from "ag-grid-community";
 import { Component, ContentChildren, Input, QueryList } from "@angular/core";
 
 @Component({
@@ -46,11 +46,11 @@ export class AgGridColumn {
     @Input() public allowedAggFuncs: string[] | undefined = undefined;
     @Input() public menuTabs: string[] | undefined = undefined;
     @Input() public cellClassRules: { [cssClassName: string]: (Function | string); } | undefined = undefined;
-    @Input() public icons: { [key: string]: string; } | undefined = undefined;
+    @Input() public icons: { [key: string]: Function | string; } | undefined = undefined;
     @Input() public headerGroupComponent: string | { new(): IHeaderGroupComp; } | undefined = undefined;
     @Input() public headerGroupComponentFramework: any | undefined = undefined;
     @Input() public headerGroupComponentParams: any | undefined = undefined;
-    @Input() public cellStyle: {} | ((params: any) => {}) | undefined = undefined;
+    @Input() public cellStyle: {} | ((params: CellClassParams) => {}) | undefined = undefined;
     @Input() public cellRendererParams: any | undefined = undefined;
     @Input() public cellEditorFramework: any | undefined = undefined;
     @Input() public cellEditorParams: any | undefined = undefined;
@@ -124,7 +124,7 @@ export class AgGridColumn {
     @Input() public colSpan: (params: ColSpanParams) => number | undefined = undefined;
     @Input() public rowSpan: (params: RowSpanParams) => number | undefined = undefined;
     @Input() public getQuickFilterText: (params: GetQuickFilterTextParams) => string | undefined = undefined;
-    @Input() public newValueHandler: (params: any) => boolean | undefined = undefined;
+    @Input() public newValueHandler: (params: NewValueParams) => boolean | undefined = undefined;
     @Input() public onCellValueChanged: Function | undefined = undefined;
     @Input() public onCellClicked: (event: CellClickedEvent) => void | undefined = undefined;
     @Input() public onCellDoubleClicked: (event: CellDoubleClickedEvent) => void | undefined = undefined;
@@ -145,7 +145,7 @@ export class AgGridColumn {
     @Input() public pivot: boolean | undefined = undefined;
     @Input() public initialPivot: boolean | undefined = undefined;
     @Input() public checkboxSelection: boolean | ((params: CheckboxSelectionCallbackParams) => boolean) | undefined = undefined;
-    @Input() public headerCheckboxSelection: boolean | ((params: any) => boolean) | undefined = undefined;
+    @Input() public headerCheckboxSelection: boolean | ((params: HeaderCheckboxSelectionCallbackParams) => boolean) | undefined = undefined;
     @Input() public headerCheckboxSelectionFilteredOnly: boolean | undefined = undefined;
     @Input() public suppressMenu: boolean | undefined = undefined;
     @Input() public suppressMovable: boolean | undefined = undefined;

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/column-properties/properties.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/column-properties/properties.json
@@ -409,6 +409,10 @@
                 "name": "Customising the Columns Menu Tab",
                 "url": "/column-menu/#customising-the-columns-menu-tab"
             }
+        },
+        "icons": {
+            "type": "object",
+            "description": "[Icons](/custom-icons/) to use inside the column instead of the grid's default icons."
         }
     },
     "columnGroupsOnly": {

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/row-styles/index.md
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/row-styles/index.md
@@ -83,7 +83,7 @@ interface RowClassParams {
     node: RowNode;
     // The index of the row about to be rendered
     rowIndex: number;
-    // If compiling to Angular, is the row's child scope, otherwise null.
+    // If compiling to AngularJs, is the row's child scope, otherwise null.
     $scope: any;
     // A reference to the AG Grid API.
     api: GridApi;


### PR DESCRIPTION
Been through GridOptions and ColDef and replaced a number of `any` options with their existing type where this is obvious from the source code. 