### PR TITLE
Fix ignored return value from getPopupPosition

### DIFF
--- a/community-modules/core/src/ts/rendering/cell/cellComp.ts
+++ b/community-modules/core/src/ts/rendering/cell/cellComp.ts
@@ -513,7 +513,7 @@ export class CellComp extends Component implements TooltipParentComp {
             keepWithinBounds: true
         };
 
-        const positionCallback = position === 'under' ?
+        const positionCallback = positionToUse === 'under' ?
             popupService.positionPopupUnderComponent.bind(popupService, positionParams)
             : popupService.positionPopupOverComponent.bind(popupService, positionParams);
 


### PR DESCRIPTION
Since version 26 the return value from getPopupPosition gets ignored, resulting in the cell editor using the default value 'over'.