### PR TITLE
Fix cellClassRules quadratic perf

### DIFF
--- a/community-modules/core/src/ts/styling/stylingService.ts
+++ b/community-modules/core/src/ts/styling/stylingService.ts
@@ -37,15 +37,15 @@ export class StylingService extends BeanStub {
                 if (singleClass == null || singleClass.trim() == '') { return; }
                 resultOfRule ? classesToApply[singleClass] = true : classesToRemove[singleClass] = true;
             });
-
-            // we remove all classes first, then add all classes second,
-            // in case a class appears in more than one rule, this means it will be added
-            // if appears in at least one truthy rule
-            if (onNotApplicableClass) {
-                Object.keys(classesToRemove).forEach(onNotApplicableClass);
-            }
-            Object.keys(classesToApply).forEach(onApplicableClass);
         }
+
+        // we remove all classes first, then add all classes second,
+        // in case a class appears in more than one rule, this means it will be added
+        // if appears in at least one truthy rule
+        if (onNotApplicableClass) {
+            Object.keys(classesToRemove).forEach(onNotApplicableClass);
+        }
+        Object.keys(classesToApply).forEach(onApplicableClass);
     }
 
     public getStaticCellClasses(colDef: ColDef, params: CellClassParams): string[] {


### PR DESCRIPTION
I was investigating some rendering perf issues in our app. Turns out we were spending a lot of time in `processClassRules`. (To be fair, we're doing silly things with ~25 cell class rules that aren't actually useful.) I came across this code.

Currently it is (accidentally?!) quadratic. With every iteration of the loop we remove and add all previous (unique) classes. The comment makes me think that's not necessary. We can collect classes and only apply them at the very end. This also matches the scope of `classesToApply` and `classesToRemove`.

I believe this is what @ceolter intended in 6eec566babc8e33d185ab8cd24ab858a96793856 all along, the `}` just got misplaced. Note though that I haven't actually executed a grid instance with this patch applied, so I'm opening this as a draft PR.