### PR TITLE
docs(testing): adds row click unit test for angular

### DIFF
--- a/grid-packages/ag-grid-docs/documentation/doc-pages/testing/index.md
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/testing/index.md
@@ -342,6 +342,28 @@ title: "Testing AG Grid"
 | });
 | ```
 |
+| ## Testing Row click Event
+|
+| To test the `rowClicked` event, you must use `waitForAsync` and `whenStable`. If you are using angular 9, use `async` instead of `waitForAsync`.
+|
+| For example, given the following code:
+|
+| ```ts
+| describe('When click in a row', () => {
+|     it('it should call done service', waitForAsync(() => {
+|         const spyDoneTasksService = spyOn(tasksService, 'done');    
+|         const firstColumn = fixture.debugElement.query(By.css('.ag-cell-value'));
+| 
+|         firstColumn.nativeElement.click();
+|         fixture.detectChanges();
+| 
+|         fixture.whenStable().then(() => {
+|             expect(spyDoneTasksService).toHaveBeenCalled();
+|         })
+|     }));
+| })
+| ```
+|
 | ## Testing User Supplied Components
 |
 | The easiest way to test user supplied components is to access them via the grid API.


### PR DESCRIPTION
## Overview

This pull request adds an example of how to test a function called from `rowClick` event. In the last few days, I searched a lot about that and I couldn't find a solution on google.

I talked with @StephenCooper and he helped me find this solution with `waitForAsync` and `whenStable`.

I'd like to put this example on documentation for helping more developers. Feel free to edit what will be necessary.

Ps: fakeAsync with tick() or flush() don't work in this context.


