### PR TITLE
AG-6440 - Cleanup ExpandableSnippet rendering.

### DIFF
--- a/grid-packages/ag-grid-docs/documentation/src/components/expandable-snippet/ExpandableSnippet.module.scss
+++ b/grid-packages/ag-grid-docs/documentation/src/components/expandable-snippet/ExpandableSnippet.module.scss
@@ -40,7 +40,18 @@ $indent: 24px;
     }
 
     .expander {
-        color: #358ccb;
+        height: 0.8rem;
+        width: 1rem;
+        color: #212529;
+    }
+
+    .expander-bar {
+        position: absolute;
+        width: 3px;
+        bottom: 1px;
+        left: -12px;
+        top: 17px;
+        background: #e8e9ea;
     }
 
     .property-name {
@@ -50,7 +61,7 @@ $indent: 24px;
         .expander {
             position: absolute;
             left: -18px;
-            top: 1px;
+            top: 3px;
             font-weight: normal;
         }
     }
@@ -60,8 +71,9 @@ $indent: 24px;
 
         .expander {
             position: absolute;
-            left: -16px;
-            top: 2px;
+            left: -18px;
+            top: 3px;
+            font-weight: normal;
         }
     }
 

--- a/grid-packages/ag-grid-docs/documentation/src/components/expandable-snippet/ExpandableSnippet.tsx
+++ b/grid-packages/ag-grid-docs/documentation/src/components/expandable-snippet/ExpandableSnippet.tsx
@@ -1,13 +1,13 @@
 import React, { Fragment, useState } from "react";
 import classnames from 'classnames';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faPlus, faMinus, faChevronCircleDown, faChevronCircleUp } from '@fortawesome/free-solid-svg-icons';
+import { faChevronRight } from '@fortawesome/free-solid-svg-icons';
 
 import { formatJsDocString, convertMarkdown } from "../documentation-helpers";
 import styles from "./ExpandableSnippet.module.scss";
 import codeStyles from '../Code.module.scss';
 
-import { buildModel, JsonModel, JsonProperty, JsonUnionType, loadLookups, JsonModelProperty, JsonObjectProperty, JsonPrimitiveProperty, JsonArray, JsonFunction } from "./model";
+import { buildModel, JsonModel, JsonProperty, JsonUnionType, loadLookups, JsonObjectProperty, JsonPrimitiveProperty, JsonArray, JsonFunction } from "./model";
 
 const DEFAULT_JSON_NODES_EXPANDED = false;
 
@@ -62,6 +62,7 @@ const BuildSnippet: React.FC<BuildSnippetParams> = ({
     config = {},
 }) => {
     return renderObjectBreadcrumb(breadcrumbs, () => <Fragment>
+        <FontAwesomeIcon icon={faChevronRight} className={styles['node-expander']} symbol="node-expander" />
         <div className={styles['json-object']} role="presentation">
             <ModelSnippet model={model} config={config} path={[]}></ModelSnippet>
         </div>
@@ -172,6 +173,7 @@ function renderUnionNestedObject(
         return (
             <Fragment key={discriminatorType}>
                 <span onClick={() => setExpanded(!isExpanded)} className={styles["expandable"]}>
+                    {isExpanded && <div className={classnames(styles['expander-bar'])}></div>}
                     <span className={classnames('token', 'punctuation', styles['union-type-object'])}>
                         {isExpanded && renderJsonNodeExpander(isExpanded)}
                         {' { '}
@@ -197,6 +199,7 @@ function renderUnionNestedObject(
     return (
         <Fragment key={index}>
             <span onClick={() => setExpanded(!isExpanded)} className={styles["expandable"]}>
+                {isExpanded && <div className={classnames(styles['expander-bar'])}></div>}
                 <span className={classnames('token', 'punctuation', styles['union-type-object'])}>
                     {renderJsonNodeExpander(isExpanded)}
                     {' {'}
@@ -358,13 +361,9 @@ function maybeRenderModelDocumentation(
 
 function renderJsonNodeExpander(isExpanded: boolean) {
     return (
-        <FontAwesomeIcon
-            icon={isExpanded ? faMinus : faPlus}
-            className={classnames(
-                styles['expander'],
-            )}
-            role="button"
-        />
+        <Fragment>
+            <svg className={classnames(styles['expander'], { 'fa-rotate-90': isExpanded })}><use href="#node-expander" role="button"/></svg>
+        </Fragment>
     );
 }
 
@@ -379,6 +378,7 @@ function renderPropertyDeclaration(
     const { required } = propDesc;
     return (
         <Fragment>
+            {expandable && <div className={classnames(styles['expander-bar'])}></div>}
             <span className={classnames('token', 'name', styles[style])}>
                 {expandable && renderJsonNodeExpander(isExpanded)}
                 {propName}

--- a/grid-packages/ag-grid-docs/documentation/src/components/expandable-snippet/__snapshots__/ExpandableSnippet.test.tsx.snap
+++ b/grid-packages/ag-grid-docs/documentation/src/components/expandable-snippet/__snapshots__/ExpandableSnippet.test.tsx.snap
@@ -11,6 +11,32 @@ exports[`ExpandableSnippet renders HTML as expected 1`] = `
     <code
       className="language-ts"
     >
+      <svg
+        style={
+          Object {
+            "display": "none",
+          }
+        }
+      >
+        <symbol
+          aria-hidden="true"
+          className="svg-inline--fa fa-chevron-right fa-w-10 node-expander"
+          data-icon="chevron-right"
+          data-prefix="fas"
+          focusable="false"
+          id="node-expander"
+          role="img"
+          style={Object {}}
+          viewBox="0 0 320 512"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M285.476 272.971L91.132 467.314c-9.373 9.373-24.569 9.373-33.941 0l-22.667-22.667c-9.357-9.357-9.375-24.522-.04-33.901L188.505 256 34.484 101.255c-9.335-9.379-9.317-24.544.04-33.901l22.667-22.667c9.373-9.373 24.569-9.373 33.941 0L285.475 239.03c9.373 9.372 9.373 24.568.001 33.941z"
+            fill="currentColor"
+            style={Object {}}
+          />
+        </symbol>
+      </svg>
       <div
         className="json-object"
         role="presentation"
@@ -205,24 +231,18 @@ exports[`ExpandableSnippet renders HTML as expected 1`] = `
           onClick={[Function]}
           role="presentation"
         >
+          <div
+            className="expander-bar"
+          />
           <span
             className="token name property-name"
           >
             <svg
-              aria-hidden="true"
-              className="svg-inline--fa fa-minus fa-w-14 expander"
-              data-icon="minus"
-              data-prefix="fas"
-              focusable="false"
-              role="button"
-              style={Object {}}
-              viewBox="0 0 448 512"
-              xmlns="http://www.w3.org/2000/svg"
+              className="expander fa-rotate-90"
             >
-              <path
-                d="M416 208H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h384c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
-                fill="currentColor"
-                style={Object {}}
+              <use
+                href="#node-expander"
+                role="button"
               />
             </svg>
             objectArray
@@ -291,24 +311,18 @@ exports[`ExpandableSnippet renders HTML as expected 1`] = `
                 onClick={[Function]}
                 role="presentation"
               >
+                <div
+                  className="expander-bar"
+                />
                 <span
                   className="token name property-name"
                 >
                   <svg
-                    aria-hidden="true"
-                    className="svg-inline--fa fa-minus fa-w-14 expander"
-                    data-icon="minus"
-                    data-prefix="fas"
-                    focusable="false"
-                    role="button"
-                    style={Object {}}
-                    viewBox="0 0 448 512"
-                    xmlns="http://www.w3.org/2000/svg"
+                    className="expander fa-rotate-90"
                   >
-                    <path
-                      d="M416 208H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h384c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
-                      fill="currentColor"
-                      style={Object {}}
+                    <use
+                      href="#node-expander"
+                      role="button"
                     />
                   </svg>
                   resultObject
@@ -443,24 +457,18 @@ exports[`ExpandableSnippet renders HTML as expected 1`] = `
           onClick={[Function]}
           role="presentation"
         >
+          <div
+            className="expander-bar"
+          />
           <span
             className="token name property-name"
           >
             <svg
-              aria-hidden="true"
-              className="svg-inline--fa fa-minus fa-w-14 expander"
-              data-icon="minus"
-              data-prefix="fas"
-              focusable="false"
-              role="button"
-              style={Object {}}
-              viewBox="0 0 448 512"
-              xmlns="http://www.w3.org/2000/svg"
+              className="expander fa-rotate-90"
             >
-              <path
-                d="M416 208H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h384c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
-                fill="currentColor"
-                style={Object {}}
+              <use
+                href="#node-expander"
+                role="button"
               />
             </svg>
             typeUnion
@@ -495,24 +503,18 @@ exports[`ExpandableSnippet renders HTML as expected 1`] = `
                   className="expandable"
                   onClick={[Function]}
                 >
+                  <div
+                    className="expander-bar"
+                  />
                   <span
                     className="token punctuation union-type-object"
                   >
                     <svg
-                      aria-hidden="true"
-                      className="svg-inline--fa fa-minus fa-w-14 expander"
-                      data-icon="minus"
-                      data-prefix="fas"
-                      focusable="false"
-                      role="button"
-                      style={Object {}}
-                      viewBox="0 0 448 512"
-                      xmlns="http://www.w3.org/2000/svg"
+                      className="expander fa-rotate-90"
                     >
-                      <path
-                        d="M416 208H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h384c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
-                        fill="currentColor"
-                        style={Object {}}
+                      <use
+                        href="#node-expander"
+                        role="button"
                       />
                     </svg>
                      { 
@@ -587,24 +589,18 @@ exports[`ExpandableSnippet renders HTML as expected 1`] = `
                       onClick={[Function]}
                       role="presentation"
                     >
+                      <div
+                        className="expander-bar"
+                      />
                       <span
                         className="token name property-name"
                       >
                         <svg
-                          aria-hidden="true"
-                          className="svg-inline--fa fa-minus fa-w-14 expander"
-                          data-icon="minus"
-                          data-prefix="fas"
-                          focusable="false"
-                          role="button"
-                          style={Object {}}
-                          viewBox="0 0 448 512"
-                          xmlns="http://www.w3.org/2000/svg"
+                          className="expander fa-rotate-90"
                         >
-                          <path
-                            d="M416 208H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h384c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
-                            fill="currentColor"
-                            style={Object {}}
+                          <use
+                            href="#node-expander"
+                            role="button"
                           />
                         </svg>
                         nestedProperty
@@ -667,24 +663,18 @@ exports[`ExpandableSnippet renders HTML as expected 1`] = `
                             onClick={[Function]}
                             role="presentation"
                           >
+                            <div
+                              className="expander-bar"
+                            />
                             <span
                               className="token name property-name"
                             >
                               <svg
-                                aria-hidden="true"
-                                className="svg-inline--fa fa-minus fa-w-14 expander"
-                                data-icon="minus"
-                                data-prefix="fas"
-                                focusable="false"
-                                role="button"
-                                style={Object {}}
-                                viewBox="0 0 448 512"
-                                xmlns="http://www.w3.org/2000/svg"
+                                className="expander fa-rotate-90"
                               >
-                                <path
-                                  d="M416 208H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h384c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
-                                  fill="currentColor"
-                                  style={Object {}}
+                                <use
+                                  href="#node-expander"
+                                  role="button"
                                 />
                               </svg>
                               resultObject
@@ -865,24 +855,18 @@ exports[`ExpandableSnippet renders HTML as expected 1`] = `
                   className="expandable"
                   onClick={[Function]}
                 >
+                  <div
+                    className="expander-bar"
+                  />
                   <span
                     className="token punctuation union-type-object"
                   >
                     <svg
-                      aria-hidden="true"
-                      className="svg-inline--fa fa-minus fa-w-14 expander"
-                      data-icon="minus"
-                      data-prefix="fas"
-                      focusable="false"
-                      role="button"
-                      style={Object {}}
-                      viewBox="0 0 448 512"
-                      xmlns="http://www.w3.org/2000/svg"
+                      className="expander fa-rotate-90"
                     >
-                      <path
-                        d="M416 208H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h384c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
-                        fill="currentColor"
-                        style={Object {}}
+                      <use
+                        href="#node-expander"
+                        role="button"
                       />
                     </svg>
                      { 
@@ -957,24 +941,18 @@ exports[`ExpandableSnippet renders HTML as expected 1`] = `
                       onClick={[Function]}
                       role="presentation"
                     >
+                      <div
+                        className="expander-bar"
+                      />
                       <span
                         className="token name property-name"
                       >
                         <svg
-                          aria-hidden="true"
-                          className="svg-inline--fa fa-minus fa-w-14 expander"
-                          data-icon="minus"
-                          data-prefix="fas"
-                          focusable="false"
-                          role="button"
-                          style={Object {}}
-                          viewBox="0 0 448 512"
-                          xmlns="http://www.w3.org/2000/svg"
+                          className="expander fa-rotate-90"
                         >
-                          <path
-                            d="M416 208H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h384c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
-                            fill="currentColor"
-                            style={Object {}}
+                          <use
+                            href="#node-expander"
+                            role="button"
                           />
                         </svg>
                         nestedProperty
@@ -1037,24 +1015,18 @@ exports[`ExpandableSnippet renders HTML as expected 1`] = `
                             onClick={[Function]}
                             role="presentation"
                           >
+                            <div
+                              className="expander-bar"
+                            />
                             <span
                               className="token name property-name"
                             >
                               <svg
-                                aria-hidden="true"
-                                className="svg-inline--fa fa-minus fa-w-14 expander"
-                                data-icon="minus"
-                                data-prefix="fas"
-                                focusable="false"
-                                role="button"
-                                style={Object {}}
-                                viewBox="0 0 448 512"
-                                xmlns="http://www.w3.org/2000/svg"
+                                className="expander fa-rotate-90"
                               >
-                                <path
-                                  d="M416 208H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h384c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
-                                  fill="currentColor"
-                                  style={Object {}}
+                                <use
+                                  href="#node-expander"
+                                  role="button"
                                 />
                               </svg>
                               resultObject
@@ -1235,24 +1207,18 @@ exports[`ExpandableSnippet renders HTML as expected 1`] = `
                   className="expandable"
                   onClick={[Function]}
                 >
+                  <div
+                    className="expander-bar"
+                  />
                   <span
                     className="token punctuation union-type-object"
                   >
                     <svg
-                      aria-hidden="true"
-                      className="svg-inline--fa fa-minus fa-w-14 expander"
-                      data-icon="minus"
-                      data-prefix="fas"
-                      focusable="false"
-                      role="button"
-                      style={Object {}}
-                      viewBox="0 0 448 512"
-                      xmlns="http://www.w3.org/2000/svg"
+                      className="expander fa-rotate-90"
                     >
-                      <path
-                        d="M416 208H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h384c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
-                        fill="currentColor"
-                        style={Object {}}
+                      <use
+                        href="#node-expander"
+                        role="button"
                       />
                     </svg>
                      { 
@@ -1327,24 +1293,18 @@ exports[`ExpandableSnippet renders HTML as expected 1`] = `
                       onClick={[Function]}
                       role="presentation"
                     >
+                      <div
+                        className="expander-bar"
+                      />
                       <span
                         className="token name property-name"
                       >
                         <svg
-                          aria-hidden="true"
-                          className="svg-inline--fa fa-minus fa-w-14 expander"
-                          data-icon="minus"
-                          data-prefix="fas"
-                          focusable="false"
-                          role="button"
-                          style={Object {}}
-                          viewBox="0 0 448 512"
-                          xmlns="http://www.w3.org/2000/svg"
+                          className="expander fa-rotate-90"
                         >
-                          <path
-                            d="M416 208H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h384c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
-                            fill="currentColor"
-                            style={Object {}}
+                          <use
+                            href="#node-expander"
+                            role="button"
                           />
                         </svg>
                         nestedProperty
@@ -1407,24 +1367,18 @@ exports[`ExpandableSnippet renders HTML as expected 1`] = `
                             onClick={[Function]}
                             role="presentation"
                           >
+                            <div
+                              className="expander-bar"
+                            />
                             <span
                               className="token name property-name"
                             >
                               <svg
-                                aria-hidden="true"
-                                className="svg-inline--fa fa-minus fa-w-14 expander"
-                                data-icon="minus"
-                                data-prefix="fas"
-                                focusable="false"
-                                role="button"
-                                style={Object {}}
-                                viewBox="0 0 448 512"
-                                xmlns="http://www.w3.org/2000/svg"
+                                className="expander fa-rotate-90"
                               >
-                                <path
-                                  d="M416 208H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h384c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
-                                  fill="currentColor"
-                                  style={Object {}}
+                                <use
+                                  href="#node-expander"
+                                  role="button"
                                 />
                               </svg>
                               resultObject
@@ -1605,24 +1559,18 @@ exports[`ExpandableSnippet renders HTML as expected 1`] = `
           onClick={[Function]}
           role="presentation"
         >
+          <div
+            className="expander-bar"
+          />
           <span
             className="token name property-name"
           >
             <svg
-              aria-hidden="true"
-              className="svg-inline--fa fa-minus fa-w-14 expander"
-              data-icon="minus"
-              data-prefix="fas"
-              focusable="false"
-              role="button"
-              style={Object {}}
-              viewBox="0 0 448 512"
-              xmlns="http://www.w3.org/2000/svg"
+              className="expander fa-rotate-90"
             >
-              <path
-                d="M416 208H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h384c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
-                fill="currentColor"
-                style={Object {}}
+              <use
+                href="#node-expander"
+                role="button"
               />
             </svg>
             typeUnionArray
@@ -1658,24 +1606,18 @@ exports[`ExpandableSnippet renders HTML as expected 1`] = `
                   className="expandable"
                   onClick={[Function]}
                 >
+                  <div
+                    className="expander-bar"
+                  />
                   <span
                     className="token punctuation union-type-object"
                   >
                     <svg
-                      aria-hidden="true"
-                      className="svg-inline--fa fa-minus fa-w-14 expander"
-                      data-icon="minus"
-                      data-prefix="fas"
-                      focusable="false"
-                      role="button"
-                      style={Object {}}
-                      viewBox="0 0 448 512"
-                      xmlns="http://www.w3.org/2000/svg"
+                      className="expander fa-rotate-90"
                     >
-                      <path
-                        d="M416 208H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h384c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
-                        fill="currentColor"
-                        style={Object {}}
+                      <use
+                        href="#node-expander"
+                        role="button"
                       />
                     </svg>
                      { 
@@ -1750,24 +1692,18 @@ exports[`ExpandableSnippet renders HTML as expected 1`] = `
                       onClick={[Function]}
                       role="presentation"
                     >
+                      <div
+                        className="expander-bar"
+                      />
                       <span
                         className="token name property-name"
                       >
                         <svg
-                          aria-hidden="true"
-                          className="svg-inline--fa fa-minus fa-w-14 expander"
-                          data-icon="minus"
-                          data-prefix="fas"
-                          focusable="false"
-                          role="button"
-                          style={Object {}}
-                          viewBox="0 0 448 512"
-                          xmlns="http://www.w3.org/2000/svg"
+                          className="expander fa-rotate-90"
                         >
-                          <path
-                            d="M416 208H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h384c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
-                            fill="currentColor"
-                            style={Object {}}
+                          <use
+                            href="#node-expander"
+                            role="button"
                           />
                         </svg>
                         nestedProperty
@@ -1830,24 +1766,18 @@ exports[`ExpandableSnippet renders HTML as expected 1`] = `
                             onClick={[Function]}
                             role="presentation"
                           >
+                            <div
+                              className="expander-bar"
+                            />
                             <span
                               className="token name property-name"
                             >
                               <svg
-                                aria-hidden="true"
-                                className="svg-inline--fa fa-minus fa-w-14 expander"
-                                data-icon="minus"
-                                data-prefix="fas"
-                                focusable="false"
-                                role="button"
-                                style={Object {}}
-                                viewBox="0 0 448 512"
-                                xmlns="http://www.w3.org/2000/svg"
+                                className="expander fa-rotate-90"
                               >
-                                <path
-                                  d="M416 208H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h384c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
-                                  fill="currentColor"
-                                  style={Object {}}
+                                <use
+                                  href="#node-expander"
+                                  role="button"
                                 />
                               </svg>
                               resultObject
@@ -2028,24 +1958,18 @@ exports[`ExpandableSnippet renders HTML as expected 1`] = `
                   className="expandable"
                   onClick={[Function]}
                 >
+                  <div
+                    className="expander-bar"
+                  />
                   <span
                     className="token punctuation union-type-object"
                   >
                     <svg
-                      aria-hidden="true"
-                      className="svg-inline--fa fa-minus fa-w-14 expander"
-                      data-icon="minus"
-                      data-prefix="fas"
-                      focusable="false"
-                      role="button"
-                      style={Object {}}
-                      viewBox="0 0 448 512"
-                      xmlns="http://www.w3.org/2000/svg"
+                      className="expander fa-rotate-90"
                     >
-                      <path
-                        d="M416 208H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h384c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
-                        fill="currentColor"
-                        style={Object {}}
+                      <use
+                        href="#node-expander"
+                        role="button"
                       />
                     </svg>
                      { 
@@ -2120,24 +2044,18 @@ exports[`ExpandableSnippet renders HTML as expected 1`] = `
                       onClick={[Function]}
                       role="presentation"
                     >
+                      <div
+                        className="expander-bar"
+                      />
                       <span
                         className="token name property-name"
                       >
                         <svg
-                          aria-hidden="true"
-                          className="svg-inline--fa fa-minus fa-w-14 expander"
-                          data-icon="minus"
-                          data-prefix="fas"
-                          focusable="false"
-                          role="button"
-                          style={Object {}}
-                          viewBox="0 0 448 512"
-                          xmlns="http://www.w3.org/2000/svg"
+                          className="expander fa-rotate-90"
                         >
-                          <path
-                            d="M416 208H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h384c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
-                            fill="currentColor"
-                            style={Object {}}
+                          <use
+                            href="#node-expander"
+                            role="button"
                           />
                         </svg>
                         nestedProperty
@@ -2200,24 +2118,18 @@ exports[`ExpandableSnippet renders HTML as expected 1`] = `
                             onClick={[Function]}
                             role="presentation"
                           >
+                            <div
+                              className="expander-bar"
+                            />
                             <span
                               className="token name property-name"
                             >
                               <svg
-                                aria-hidden="true"
-                                className="svg-inline--fa fa-minus fa-w-14 expander"
-                                data-icon="minus"
-                                data-prefix="fas"
-                                focusable="false"
-                                role="button"
-                                style={Object {}}
-                                viewBox="0 0 448 512"
-                                xmlns="http://www.w3.org/2000/svg"
+                                className="expander fa-rotate-90"
                               >
-                                <path
-                                  d="M416 208H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h384c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
-                                  fill="currentColor"
-                                  style={Object {}}
+                                <use
+                                  href="#node-expander"
+                                  role="button"
                                 />
                               </svg>
                               resultObject
@@ -2398,24 +2310,18 @@ exports[`ExpandableSnippet renders HTML as expected 1`] = `
                   className="expandable"
                   onClick={[Function]}
                 >
+                  <div
+                    className="expander-bar"
+                  />
                   <span
                     className="token punctuation union-type-object"
                   >
                     <svg
-                      aria-hidden="true"
-                      className="svg-inline--fa fa-minus fa-w-14 expander"
-                      data-icon="minus"
-                      data-prefix="fas"
-                      focusable="false"
-                      role="button"
-                      style={Object {}}
-                      viewBox="0 0 448 512"
-                      xmlns="http://www.w3.org/2000/svg"
+                      className="expander fa-rotate-90"
                     >
-                      <path
-                        d="M416 208H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h384c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
-                        fill="currentColor"
-                        style={Object {}}
+                      <use
+                        href="#node-expander"
+                        role="button"
                       />
                     </svg>
                      { 
@@ -2490,24 +2396,18 @@ exports[`ExpandableSnippet renders HTML as expected 1`] = `
                       onClick={[Function]}
                       role="presentation"
                     >
+                      <div
+                        className="expander-bar"
+                      />
                       <span
                         className="token name property-name"
                       >
                         <svg
-                          aria-hidden="true"
-                          className="svg-inline--fa fa-minus fa-w-14 expander"
-                          data-icon="minus"
-                          data-prefix="fas"
-                          focusable="false"
-                          role="button"
-                          style={Object {}}
-                          viewBox="0 0 448 512"
-                          xmlns="http://www.w3.org/2000/svg"
+                          className="expander fa-rotate-90"
                         >
-                          <path
-                            d="M416 208H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h384c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
-                            fill="currentColor"
-                            style={Object {}}
+                          <use
+                            href="#node-expander"
+                            role="button"
                           />
                         </svg>
                         nestedProperty
@@ -2570,24 +2470,18 @@ exports[`ExpandableSnippet renders HTML as expected 1`] = `
                             onClick={[Function]}
                             role="presentation"
                           >
+                            <div
+                              className="expander-bar"
+                            />
                             <span
                               className="token name property-name"
                             >
                               <svg
-                                aria-hidden="true"
-                                className="svg-inline--fa fa-minus fa-w-14 expander"
-                                data-icon="minus"
-                                data-prefix="fas"
-                                focusable="false"
-                                role="button"
-                                style={Object {}}
-                                viewBox="0 0 448 512"
-                                xmlns="http://www.w3.org/2000/svg"
+                                className="expander fa-rotate-90"
                               >
-                                <path
-                                  d="M416 208H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h384c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
-                                  fill="currentColor"
-                                  style={Object {}}
+                                <use
+                                  href="#node-expander"
+                                  role="button"
                                 />
                               </svg>
                               resultObject
@@ -2804,24 +2698,18 @@ exports[`ExpandableSnippet renders HTML as expected 1`] = `
           onClick={[Function]}
           role="presentation"
         >
+          <div
+            className="expander-bar"
+          />
           <span
             className="token name property-name"
           >
             <svg
-              aria-hidden="true"
-              className="svg-inline--fa fa-minus fa-w-14 expander"
-              data-icon="minus"
-              data-prefix="fas"
-              focusable="false"
-              role="button"
-              style={Object {}}
-              viewBox="0 0 448 512"
-              xmlns="http://www.w3.org/2000/svg"
+              className="expander fa-rotate-90"
             >
-              <path
-                d="M416 208H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h384c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
-                fill="currentColor"
-                style={Object {}}
+              <use
+                href="#node-expander"
+                role="button"
               />
             </svg>
             complexFn
@@ -2849,24 +2737,18 @@ exports[`ExpandableSnippet renders HTML as expected 1`] = `
                 onClick={[Function]}
                 role="presentation"
               >
+                <div
+                  className="expander-bar"
+                />
                 <span
                   className="token name property-name"
                 >
                   <svg
-                    aria-hidden="true"
-                    className="svg-inline--fa fa-minus fa-w-14 expander"
-                    data-icon="minus"
-                    data-prefix="fas"
-                    focusable="false"
-                    role="button"
-                    style={Object {}}
-                    viewBox="0 0 448 512"
-                    xmlns="http://www.w3.org/2000/svg"
+                    className="expander fa-rotate-90"
                   >
-                    <path
-                      d="M416 208H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h384c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
-                      fill="currentColor"
-                      style={Object {}}
+                    <use
+                      href="#node-expander"
+                      role="button"
                     />
                   </svg>
                   test
@@ -2899,24 +2781,18 @@ exports[`ExpandableSnippet renders HTML as expected 1`] = `
                       onClick={[Function]}
                       role="presentation"
                     >
+                      <div
+                        className="expander-bar"
+                      />
                       <span
                         className="token name property-name"
                       >
                         <svg
-                          aria-hidden="true"
-                          className="svg-inline--fa fa-minus fa-w-14 expander"
-                          data-icon="minus"
-                          data-prefix="fas"
-                          focusable="false"
-                          role="button"
-                          style={Object {}}
-                          viewBox="0 0 448 512"
-                          xmlns="http://www.w3.org/2000/svg"
+                          className="expander fa-rotate-90"
                         >
-                          <path
-                            d="M416 208H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h384c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
-                            fill="currentColor"
-                            style={Object {}}
+                          <use
+                            href="#node-expander"
+                            role="button"
                           />
                         </svg>
                         param4
@@ -3143,24 +3019,18 @@ exports[`ExpandableSnippet renders HTML as expected 1`] = `
           onClick={[Function]}
           role="presentation"
         >
+          <div
+            className="expander-bar"
+          />
           <span
             className="token name property-name"
           >
             <svg
-              aria-hidden="true"
-              className="svg-inline--fa fa-minus fa-w-14 expander"
-              data-icon="minus"
-              data-prefix="fas"
-              focusable="false"
-              role="button"
-              style={Object {}}
-              viewBox="0 0 448 512"
-              xmlns="http://www.w3.org/2000/svg"
+              className="expander fa-rotate-90"
             >
-              <path
-                d="M416 208H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h384c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
-                fill="currentColor"
-                style={Object {}}
+              <use
+                href="#node-expander"
+                role="button"
               />
             </svg>
             simpleOmit
@@ -3198,24 +3068,18 @@ exports[`ExpandableSnippet renders HTML as expected 1`] = `
                 onClick={[Function]}
                 role="presentation"
               >
+                <div
+                  className="expander-bar"
+                />
                 <span
                   className="token name property-name"
                 >
                   <svg
-                    aria-hidden="true"
-                    className="svg-inline--fa fa-minus fa-w-14 expander"
-                    data-icon="minus"
-                    data-prefix="fas"
-                    focusable="false"
-                    role="button"
-                    style={Object {}}
-                    viewBox="0 0 448 512"
-                    xmlns="http://www.w3.org/2000/svg"
+                    className="expander fa-rotate-90"
                   >
-                    <path
-                      d="M416 208H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h384c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
-                      fill="currentColor"
-                      style={Object {}}
+                    <use
+                      href="#node-expander"
+                      role="button"
                     />
                   </svg>
                   resultObject
@@ -3345,24 +3209,18 @@ exports[`ExpandableSnippet renders HTML as expected 1`] = `
           onClick={[Function]}
           role="presentation"
         >
+          <div
+            className="expander-bar"
+          />
           <span
             className="token name property-name"
           >
             <svg
-              aria-hidden="true"
-              className="svg-inline--fa fa-minus fa-w-14 expander"
-              data-icon="minus"
-              data-prefix="fas"
-              focusable="false"
-              role="button"
-              style={Object {}}
-              viewBox="0 0 448 512"
-              xmlns="http://www.w3.org/2000/svg"
+              className="expander fa-rotate-90"
             >
-              <path
-                d="M416 208H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h384c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
-                fill="currentColor"
-                style={Object {}}
+              <use
+                href="#node-expander"
+                role="button"
               />
             </svg>
             complexOmit
@@ -3430,24 +3288,18 @@ exports[`ExpandableSnippet renders HTML as expected 1`] = `
                 onClick={[Function]}
                 role="presentation"
               >
+                <div
+                  className="expander-bar"
+                />
                 <span
                   className="token name property-name"
                 >
                   <svg
-                    aria-hidden="true"
-                    className="svg-inline--fa fa-minus fa-w-14 expander"
-                    data-icon="minus"
-                    data-prefix="fas"
-                    focusable="false"
-                    role="button"
-                    style={Object {}}
-                    viewBox="0 0 448 512"
-                    xmlns="http://www.w3.org/2000/svg"
+                    className="expander fa-rotate-90"
                   >
-                    <path
-                      d="M416 208H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h384c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
-                      fill="currentColor"
-                      style={Object {}}
+                    <use
+                      href="#node-expander"
+                      role="button"
                     />
                   </svg>
                   param4
@@ -3643,24 +3495,18 @@ exports[`ExpandableSnippet renders HTML as expected 1`] = `
                 onClick={[Function]}
                 role="presentation"
               >
+                <div
+                  className="expander-bar"
+                />
                 <span
                   className="token name property-name"
                 >
                   <svg
-                    aria-hidden="true"
-                    className="svg-inline--fa fa-minus fa-w-14 expander"
-                    data-icon="minus"
-                    data-prefix="fas"
-                    focusable="false"
-                    role="button"
-                    style={Object {}}
-                    viewBox="0 0 448 512"
-                    xmlns="http://www.w3.org/2000/svg"
+                    className="expander fa-rotate-90"
                   >
-                    <path
-                      d="M416 208H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h384c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
-                      fill="currentColor"
-                      style={Object {}}
+                    <use
+                      href="#node-expander"
+                      role="button"
                     />
                   </svg>
                   resultObject


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-6440

Applies the following tweaks to the `ExpandableSnippet` rendering (now used for Standalone Charts API docs since 27.1.0):
- Switches to use of a chevron for the node expander, for consistency with the rest of the AG Grid documentation.
- Adds a line under the chevron to help visually indicate the scope of expanded content.
- Removes repeated SVG rendering for FontAwesome icons.

Before:
![Screenshot 2022-03-15 at 12 36 14](https://user-images.githubusercontent.com/17544187/158378940-4860f324-e46a-4605-816b-6aac58cf055c.png)

After:
![Screenshot 2022-03-15 at 12 36 32](https://user-images.githubusercontent.com/17544187/158378993-633bbdbf-aec1-46be-8c98-324136e0ed2b.png)
