### PR TITLE
AG-6487 - Fix area series marker defaults.

### DIFF
--- a/charts-packages/ag-charts-community/src/chart/agChartOptions.ts
+++ b/charts-packages/ag-charts-community/src/chart/agChartOptions.ts
@@ -128,15 +128,15 @@ export interface AgTimeAxisThemeOptions
         AgCartesianAxisThemeOptions<AgTimeAxisOptions> {}
 
 export interface AgCartesianAxesTheme {
-    /** This extends the [common axis configuration](/charts-api-themes/#reference-axis) with options specific to number axes. */
+    /** This extends the common axis configuration with options specific to number axes. */
     number?: AgNumberAxisThemeOptions;
-    /** This extends the [common axis configuration](/charts-api-themes/#reference-axis) with options specific to number axes. */
+    /** This extends the common axis configuration with options specific to number axes. */
     log?: AgLogAxisThemeOptions;
-    /** This extends the [common axis configuration](/charts-api-themes/#reference-axes) with options specific to category axes. */
+    /** This extends the common axis configuration with options specific to category axes. */
     category?: AgCategoryAxisThemeOptions;
-    /** This extends the [common axis configuration](/charts-api-themes/#reference-axis) with options specific to grouped category axes. Currently there are no additional options beyond the common configuration. */
+    /** This extends the common axis configuration with options specific to grouped category axes. Currently there are no additional options beyond the common configuration. */
     groupedCategory?: AgGroupedCategoryAxisThemeOptions;
-    /** This extends the [common axis configuration](/charts-api-themes/#reference-axis) with options specific to time axes. */
+    /** This extends the common axis configuration with options specific to time axes. */
     time?: AgTimeAxisThemeOptions;
 }
 

--- a/charts-packages/ag-charts-community/src/chart/agChartOptions.ts
+++ b/charts-packages/ag-charts-community/src/chart/agChartOptions.ts
@@ -657,6 +657,8 @@ export interface AgCartesianSeriesMarker extends AgSeriesMarker {
     formatter?: AgCartesianSeriesMarkerFormatter;
 }
 
+export interface AgAreaSeriesMarker extends AgCartesianSeriesMarker {}
+
 export interface AgSeriesTooltip {
     /** Whether or not to show tooltips when the series are hovered over. */
     enabled?: boolean;
@@ -764,7 +766,7 @@ export interface AgAreaSeriesLabelOptions extends AgChartLabelOptions {
 export interface AgAreaSeriesOptions extends AgBaseSeriesOptions {
     type?: 'area';
     /** Configuration for the markers used in the series. */
-    marker?: AgCartesianSeriesMarker;
+    marker?: AgAreaSeriesMarker;
     /** The number to normalise the area stacks to. For example, if `normalizedTo` is set to `100`, the stacks will all be scaled proportionally so that their total height is always 100. */
     normalizedTo?: number;
     /** The key to use to retrieve x-values from the data. */

--- a/community-modules/core/src/ts/interfaces/iAgChartOptions.ts
+++ b/community-modules/core/src/ts/interfaces/iAgChartOptions.ts
@@ -657,6 +657,8 @@ export interface AgCartesianSeriesMarker extends AgSeriesMarker {
     formatter?: AgCartesianSeriesMarkerFormatter;
 }
 
+export interface AgAreaSeriesMarker extends AgCartesianSeriesMarker {}
+
 export interface AgSeriesTooltip {
     /** Whether or not to show tooltips when the series are hovered over. */
     enabled?: boolean;
@@ -764,7 +766,7 @@ export interface AgAreaSeriesLabelOptions extends AgChartLabelOptions {
 export interface AgAreaSeriesOptions extends AgBaseSeriesOptions {
     type?: 'area';
     /** Configuration for the markers used in the series. */
-    marker?: AgCartesianSeriesMarker;
+    marker?: AgAreaSeriesMarker;
     /** The number to normalise the area stacks to. For example, if `normalizedTo` is set to `100`, the stacks will all be scaled proportionally so that their total height is always 100. */
     normalizedTo?: number;
     /** The key to use to retrieve x-values from the data. */

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/api.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/api.json
@@ -845,6 +845,11 @@
       "unit": "px"
     }
   },
+  "AgAreaSeriesMarker": {
+    "enabled": {
+      "default": false
+    }
+  },
   "AgPieSeriesOptions": {
     "angleKey": {
       "isRequired": true

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/doc-interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/doc-interfaces.AUTO.json
@@ -11249,6 +11249,51 @@
       "type": { "returnType": "number", "optional": true }
     }
   },
+  "AgAreaSeriesMarker": {
+    "formatter": {
+      "description": "/** Function used to return formatting for individual markers, based on the supplied information. If the current marker is highlighted, the `highlighted` property will be set to `true`; make sure to check this if you want to differentiate between the highlighted and un-highlighted states. */",
+      "type": {
+        "returnType": "AgCartesianSeriesMarkerFormatter",
+        "optional": true
+      }
+    },
+    "enabled": {
+      "description": "/** Whether or not to show markers. */",
+      "type": { "returnType": "boolean", "optional": true }
+    },
+    "shape": {
+      "description": "/** The shape to use for the markers. You can also supply a custom marker by providing a `Marker` subclass. */",
+      "type": { "returnType": "string | (new () => any)", "optional": true }
+    },
+    "size": {
+      "description": "/** The size in pixels of the markers. */",
+      "type": { "returnType": "number", "optional": true }
+    },
+    "maxSize": {
+      "description": "/** For series where the size of the marker is determined by the data, this determines the largest size a marker can be in pixels. */",
+      "type": { "returnType": "number", "optional": true }
+    },
+    "fill": {
+      "description": "/** The colour to use for marker fills. If this is not specified, the markers will take their fill from the series. */",
+      "type": { "returnType": "string", "optional": true }
+    },
+    "stroke": {
+      "description": "/** The colour to use for marker strokes. If this is not specified, the markers will take their stroke from the series. */",
+      "type": { "returnType": "string", "optional": true }
+    },
+    "strokeWidth": {
+      "description": "/** The width in pixels of the marker stroke. If this is not specified, the markers will take their stroke width from the series. */",
+      "type": { "returnType": "number", "optional": true }
+    },
+    "fillOpacity": {
+      "description": "/** */",
+      "type": { "returnType": "number", "optional": true }
+    },
+    "strokeOpacity": {
+      "description": "/** */",
+      "type": { "returnType": "number", "optional": true }
+    }
+  },
   "AgSeriesTooltip": {
     "enabled": {
       "description": "/** Whether or not to show tooltips when the series are hovered over. */",
@@ -11578,7 +11623,7 @@
     "type": { "type": { "returnType": "'area'", "optional": true } },
     "marker": {
       "description": "/** Configuration for the markers used in the series. */",
-      "type": { "returnType": "AgCartesianSeriesMarker", "optional": true }
+      "type": { "returnType": "AgAreaSeriesMarker", "optional": true }
     },
     "normalizedTo": {
       "description": "/** The number to normalise the area stacks to. For example, if `normalizedTo` is set to `100`, the stacks will all be scaled proportionally so that their total height is always 100. */",

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/interfaces.AUTO.json
@@ -6622,6 +6622,33 @@
       "strokeOpacity?": "/** */"
     }
   },
+  "AgAreaSeriesMarker": {
+    "meta": {},
+    "type": {
+      "formatter?": "AgCartesianSeriesMarkerFormatter",
+      "enabled?": "boolean",
+      "shape?": "string | (new () => any)",
+      "size?": "number",
+      "maxSize?": "number",
+      "fill?": "string",
+      "stroke?": "string",
+      "strokeWidth?": "number",
+      "fillOpacity?": "number",
+      "strokeOpacity?": "number"
+    },
+    "docs": {
+      "formatter?": "/** Function used to return formatting for individual markers, based on the supplied information. If the current marker is highlighted, the `highlighted` property will be set to `true`; make sure to check this if you want to differentiate between the highlighted and un-highlighted states. */",
+      "enabled?": "/** Whether or not to show markers. */",
+      "shape?": "/** The shape to use for the markers. You can also supply a custom marker by providing a `Marker` subclass. */",
+      "size?": "/** The size in pixels of the markers. */",
+      "maxSize?": "/** For series where the size of the marker is determined by the data, this determines the largest size a marker can be in pixels. */",
+      "fill?": "/** The colour to use for marker fills. If this is not specified, the markers will take their fill from the series. */",
+      "stroke?": "/** The colour to use for marker strokes. If this is not specified, the markers will take their stroke from the series. */",
+      "strokeWidth?": "/** The width in pixels of the marker stroke. If this is not specified, the markers will take their stroke width from the series. */",
+      "fillOpacity?": "/** */",
+      "strokeOpacity?": "/** */"
+    }
+  },
   "AgSeriesTooltip": {
     "meta": {},
     "type": { "enabled?": "boolean" },
@@ -6828,7 +6855,7 @@
     "meta": { "doc": "/** Configuration for area series. */" },
     "type": {
       "type?": "'area'",
-      "marker?": "AgCartesianSeriesMarker",
+      "marker?": "AgAreaSeriesMarker",
       "normalizedTo?": "number",
       "xKey?": "string",
       "yKeys?": "string[]",

--- a/grid-packages/ag-grid-docs/documentation/src/components/expandable-snippet/ExpandableSnippet.tsx
+++ b/grid-packages/ag-grid-docs/documentation/src/components/expandable-snippet/ExpandableSnippet.tsx
@@ -564,7 +564,7 @@ function formatPropertyDocumentation(meta: Omit<JsonModel['properties'][number],
         [ formatJsDocString(documentation.trim()) ] :
         [];
 
-    if (defaultValue) {
+    if (meta.hasOwnProperty('default')) {
         result.push('Default: `' + JSON.stringify(defaultValue) + '`');
     }
     

--- a/grid-packages/ag-grid-docs/documentation/src/components/expandable-snippet/model.ts
+++ b/grid-packages/ag-grid-docs/documentation/src/components/expandable-snippet/model.ts
@@ -178,9 +178,11 @@ export function buildModel(
             deprecated,
             required,
             documentation,
-            default: def,
             desc: resolveType(declaredType, interfaceLookup, codeLookup, { typeStack }, config),
         };
+        if (metaProp && metaProp.hasOwnProperty('default')) {
+            result.properties[prop].default = def;
+        }
     });
 
     if (ordering) {


### PR DESCRIPTION
Part of https://ag-grid.atlassian.net/browse/AG-6487.

Fixes the `AgAreaSeriesOptions.marker.enabled` default value, as it varied between scatter, line and area series.

Bonus:
- Fixes rendering of `Falsey` default values.
- Re-synchronoises `iAgChartOptions.ts` with `agChartOptions.ts`.