### PR TITLE
AG-6507 - Re-enable AgChartV2.test.ts suite

### DIFF
--- a/charts-packages/ag-charts-community/src/chart/agChartV2.test.ts
+++ b/charts-packages/ag-charts-community/src/chart/agChartV2.test.ts
@@ -106,7 +106,7 @@ const EXAMPLES: Record<string, TestCase> = {
     },
 };
 
-describe.skip('AgChartV2', () => {
+describe('AgChartV2', () => {
     describe('#create', () => {
         beforeEach(() => {
             console.warn = jest.fn();

--- a/charts-packages/ag-charts-community/src/scene/path.test.ts
+++ b/charts-packages/ag-charts-community/src/scene/path.test.ts
@@ -271,5 +271,22 @@ L8.382999999999997,9.807
 Z`;
 
     const path = Path2D.fromString(pathString);
-    expect(path.toPrettyString()).toBe(expectedPathString);
+    expectPathStringMatches(expectedPathString, path.toPrettyString());
 });
+
+function expectPathStringMatches(expected: string, actual: string) {
+    expect(parsePathString(actual)).toEqual(parsePathString(expected));
+}
+
+function parsePathString(path: string): [string, number[]][] {
+    const decimalPrecision = 6;
+
+    return path.split('\n')
+        .map((line) => {
+            const type = line.substring(0, 1);
+            const params = line.substring(1).split(',')
+                .map((v) => Number(v.substring(0, v.indexOf('.') + decimalPrecision)));
+
+            return [type, params];
+        });
+}


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-6507

Re-enables AgChartV2.test.ts - unfortunately I wasn't able to reproduce the issue that caused the original problem on CI on either MacOS or Ubuntu/Linux (via Docker image).

Bonus:
- Fixes `path.test.ts` on Docker by reducing accuracy of path tests slightly (expected values are now accurate to 6 d.p. to account for micro floating-point calculation variations).