### PR TITLE
AG-6507 - Stub HdpiCanvas Canvas creation for Charts visual tests.

### DIFF
--- a/charts-packages/ag-charts-community/src/chart/agChartV2.test.ts
+++ b/charts-packages/ag-charts-community/src/chart/agChartV2.test.ts
@@ -11,6 +11,8 @@ import {
     combineAssertions,
     hoverAction,
     IMAGE_SNAPSHOT_DEFAULTS,
+    setupMockCanvas,
+    CANVAS_TO_BUFFER_DEFAULTS,
 } from './test/utils';
 
 expect.extend({ toMatchImageSnapshot });
@@ -106,7 +108,9 @@ const EXAMPLES: Record<string, TestCase> = {
     },
 };
 
-describe.skip('AgChartV2', () => {
+describe('AgChartV2', () => {
+    let ctx = setupMockCanvas();
+
     describe('#create', () => {
         beforeEach(() => {
             console.warn = jest.fn();
@@ -127,10 +131,7 @@ describe.skip('AgChartV2', () => {
                 const compare = async () => {
                     await waitForChartStability(chart);
 
-                    const canvas = chart.scene.canvas;
-                    const imageDataUrl = canvas.getDataURL('image/png');
-                    const imageData = Buffer.from(imageDataUrl.split(',')[1], 'base64');
-
+                    const imageData = ctx.nodeCanvas.toBuffer('image/png', CANVAS_TO_BUFFER_DEFAULTS);
                     (expect(imageData) as any).toMatchImageSnapshot(IMAGE_SNAPSHOT_DEFAULTS);
                 };
 

--- a/charts-packages/ag-charts-community/src/chart/galleryExamples.test.ts
+++ b/charts-packages/ag-charts-community/src/chart/galleryExamples.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, beforeEach, afterEach, jest } from '@jest/globals';
 import { toMatchImageSnapshot } from 'jest-image-snapshot';
+
 import { AgChartOptions } from './agChartOptions';
 import { AgChartV2 } from './agChartV2';
 import { Chart } from './chart';
@@ -11,6 +12,8 @@ import {
     polarChartAssertions,
     hierarchyChartAssertions,
     IMAGE_SNAPSHOT_DEFAULTS,
+    setupMockCanvas,
+    CANVAS_TO_BUFFER_DEFAULTS,
 } from './test/utils';
 
 expect.extend({ toMatchImageSnapshot });
@@ -129,6 +132,8 @@ const EXAMPLES: Record<string, TestCase> = {
 
 describe('Gallery Examples', () => {
     describe('AgChartV2#create', () => {
+        let ctx = setupMockCanvas();
+
         beforeEach(() => {
             console.warn = jest.fn();
         });
@@ -148,10 +153,7 @@ describe('Gallery Examples', () => {
                 const compare = async () => {
                     await waitForChartStability(chart);
 
-                    const canvas = chart.scene.canvas;
-                    const imageDataUrl = canvas.getDataURL('image/png');
-                    const imageData = Buffer.from(imageDataUrl.split(',')[1], 'base64');
-
+                    const imageData = ctx.nodeCanvas.toBuffer('image/png', CANVAS_TO_BUFFER_DEFAULTS);
                     (expect(imageData) as any).toMatchImageSnapshot(IMAGE_SNAPSHOT_DEFAULTS);
                 };
 

--- a/charts-packages/ag-charts-community/src/chart/test/utils.ts
+++ b/charts-packages/ag-charts-community/src/chart/test/utils.ts
@@ -1,10 +1,12 @@
-import { expect } from '@jest/globals';
+import { expect, beforeEach, afterEach, jest } from '@jest/globals';
 import { Chart } from "../chart";
 import { CartesianChart } from '../cartesianChart';
 import { PolarChart } from '../polarChart';
 import { HierarchyChart } from '../hierarchyChart';
+import { Canvas, createCanvas, PngConfig, registerFont } from 'canvas';
 
-export const IMAGE_SNAPSHOT_DEFAULTS = { failureThreshold: 10, failureThresholdType: "percent" };
+export const IMAGE_SNAPSHOT_DEFAULTS = { failureThreshold: 0, failureThresholdType: "percent" };
+export const CANVAS_TO_BUFFER_DEFAULTS: PngConfig = { compressionLevel: 0, filters: (Canvas as any).PNG_NO_FILTERS };
 
 export function repeat<T>(value: T, count: number): T[] {
     const result = new Array(count);
@@ -89,4 +91,42 @@ export function combineAssertions(...assertions: ((chart: Chart) => void)[]) {
             await assertion(chart);
         }
     }
+}
+
+export function setupMockCanvas(): { nodeCanvas?: Canvas } {
+    let realCreateElement: typeof document.createElement;
+    let ctx: { nodeCanvas?: Canvas } = {};
+
+    beforeEach(() => {
+        ctx.nodeCanvas = createCanvas(800, 600);
+
+        realCreateElement = document.createElement;
+        document.createElement = jest.fn(
+            (element, options) => {
+                if (element === 'canvas') {
+                    const mockedElement = realCreateElement.call(document, element, options);
+                    mockedElement.getContext = (p) => { 
+                        const context2d = ctx.nodeCanvas.getContext(p, { alpha: false });
+                        context2d.patternQuality = 'good';
+                        context2d.quality = 'good';
+                        context2d.textDrawingMode = 'path';
+                        context2d.antialias = 'subpixel';
+                
+                        return context2d as any;
+                    };
+
+                    return mockedElement;
+                }
+
+                return realCreateElement.call(document, element, options);
+            },
+        );
+    });
+
+    afterEach(() => {
+        document.createElement = realCreateElement;
+        ctx.nodeCanvas = null;
+    });
+
+    return ctx;
 }


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-6507

Follow-up to #4982 - stub `Canvas` creation to try and fix test failure on CI.

Also opens the door for more `canvas` tweaking to support https://ag-grid.atlassian.net/browse/AG-6481.