### PR TITLE
fix tiny typo

### DIFF
--- a/grid-packages/ag-grid-docs/documentation/doc-pages/row-pagination/index.md
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/row-pagination/index.md
@@ -49,7 +49,7 @@ In this example the default pagination settings are changed. Note the following:
 
 ## Example: Custom Pagination Controls
 
-If you set `suppressPaginationPanel=true`, the grid will not show the standard navigation controls for pagination. This is useful is you want to provide your own navigation controls.
+If you set `suppressPaginationPanel=true`, the grid will not show the standard navigation controls for pagination. This is useful if you want to provide your own navigation controls.
 
 In the example below you can see how this works. Note that we are listening to `onPaginationChanged` to update the information about the current pagination status. We also call methods on the pagination API to change the pagination state.
 


### PR DESCRIPTION
Hi, 
I just start using ag-grid and really like the library and the documentation 🙏🏻

While reading the documentation I found a tiny typo, so this is a fix.

Link to relevant page in the documentation: https://www.ag-grid.com/angular-data-grid/row-pagination/
![image](https://user-images.githubusercontent.com/47606575/159493078-e5651572-7891-4ca9-b187-1766c15e55f9.png)

Thank you, Michal Porag.
