### PR TITLE
AG-6548 - Charts API Explorer make chart max size dynamic

### DIFF
--- a/grid-packages/ag-grid-docs/documentation/src/components/charts-api-explorer/Editors.tsx
+++ b/grid-packages/ag-grid-docs/documentation/src/components/charts-api-explorer/Editors.tsx
@@ -8,6 +8,145 @@ import { HuePicker, AlphaPicker } from 'react-color';
 import classnames from 'classnames';
 import { doOnEnter } from '../key-handlers';
 import styles from './Editors.module.scss';
+import { JsonProperty, JsonModelProperty } from '../expandable-snippet/model';
+
+const FONT_WEIGHT_EDITOR_PROPS = {
+    default: 'normal',
+    breakIndex: 4,
+    options: ['normal', 'bold', 'bolder', 'lighter', '100', '200', '300', '400', '500', '600', '700', '800', '900'],
+};
+
+const FONT_STYLE_EDITOR_PROPS = {
+    default: 'normal',
+    options: ['normal', 'italic', 'oblique'],
+};
+
+const FONT_FAMILY_EDITOR_PROPS = {
+    default: 'Verdana, sans-serif',
+    suggestions: ['Verdana, sans-serif', 'Arial, sans-serif', 'Times New Roman, serif'],
+};
+
+const FONT_SIZE_EDITOR_PROPS = {
+    default: 12,
+    min: 1,
+    max: 30,
+    unit: 'px',
+};
+
+const OPACITY_PROPS = {
+    min: 0,
+    max: 1,
+};
+
+export const getPrimitivePropertyEditor = (desc: JsonProperty) => {
+    if (desc.type === 'array') {
+        return ArrayEditor;
+    }
+
+    if (desc.type === 'primitive' && desc.aliasType != null) {
+        switch (desc.aliasType) {
+            case 'CssColor':
+                return ColourEditor;
+            case 'PixelSize':
+            case 'Opacity':
+                return NumberEditor;
+            case 'FontFamily':
+            case 'FontStyle':
+            case 'FontWeight':
+                return PresetEditor;
+        }
+    }
+
+    switch (desc.tsType) {
+        case 'string':
+            return StringEditor;
+        case 'number':
+            return NumberEditor;
+        case 'boolean':
+            return BooleanEditor;
+    }
+
+    return null;
+};
+
+export const getPrimitiveEditor = ({ meta, desc }: JsonModelProperty) => {
+    let editor: any;
+    let editorProps: Record<string, any> = {};
+    
+    if (desc.type === 'primitive' && desc.aliasType != null) {
+        switch (desc.aliasType) {
+            case 'CssColor':
+                return { editor: ColourEditor, editorProps: { ...meta } };
+            case 'PixelSize':
+                return { editor: NumberEditor, editorProps: { ...meta, unit: 'px' } };
+            case 'Opacity':
+                return { editor: NumberEditor, editorProps: { ...OPACITY_PROPS, ...meta } };
+            case 'FontFamily':
+                return {
+                    editor: PresetEditor,
+                    editorProps: {
+                        ...FONT_FAMILY_EDITOR_PROPS,
+                        ...meta,
+                    },
+                };
+            case 'FontSize':
+                return {
+                    editor: NumberEditor,
+                    editorProps: {
+                        ...FONT_SIZE_EDITOR_PROPS,
+                        ...meta,
+                    },
+                };
+            case 'FontStyle':
+                return {
+                    editor: PresetEditor,
+                    editorProps: {
+                        ...FONT_STYLE_EDITOR_PROPS,
+                        ...meta,
+                    },
+                };
+            case 'FontWeight':
+                return {
+                    editor: PresetEditor,
+                    editorProps: {
+                        ...FONT_WEIGHT_EDITOR_PROPS,
+                        ...meta,
+                    },
+                };
+        }
+    }
+
+    if (desc.tsType.indexOf(' | ') >= 0) {
+        const options = desc.tsType.split(' | ').map((v) => v.substring(1, v.length - 1));
+
+        if (options.every((v) => /^[a-z-]*$/.test(v))) {
+            return { editor: PresetEditor, editorProps: { ...meta, options } };
+        }
+    }
+
+    if (meta?.options != null || meta?.suggestions != null) {
+        editor = PresetEditor;
+    } else {
+        editor = getPrimitivePropertyEditor(desc);
+    }
+
+    if (editor === NumberEditor && meta != null) {
+        setStepEditorProp(editorProps, meta);
+    }
+
+    return { editor, editorProps: { ...meta, ...editorProps } };
+};
+
+const setStepEditorProp = (editorProps: Record<string, any>, { min, max }: JsonModelProperty['meta']) => {
+    if (min == null || max == null) {
+        return;
+    }
+    if (max - min <= 1) {
+        editorProps.step = 0.05;
+    } else if (max - min <= 10) {
+        editorProps.step = 0.1;
+    }
+};
 
 export const NumberEditor = ({ value, min, max, step, unit, onChange }) => {
     const [stateValue, setValueChange] = useState(value || '');

--- a/grid-packages/ag-grid-docs/documentation/src/components/charts-api-explorer/Options.tsx
+++ b/grid-packages/ag-grid-docs/documentation/src/components/charts-api-explorer/Options.tsx
@@ -387,7 +387,7 @@ const generateOptions = ({
         };
 
         if (desc.type === 'primitive' || (desc.type === 'array' && desc.elements.type === 'primitive')) {
-            const { editor, editorProps } = isEditable(name) && getPrimitiveEditor(prop);
+            const { editor, editorProps } = isEditable(name) && getPrimitiveEditor(prop, key);
 
             elements.push(
                 <Option

--- a/grid-packages/ag-grid-docs/documentation/src/components/charts-api-explorer/Options.tsx
+++ b/grid-packages/ag-grid-docs/documentation/src/components/charts-api-explorer/Options.tsx
@@ -6,44 +6,15 @@ import {
     buildModel,
     JsonFunction,
     JsonModel,
-    JsonModelProperty,
     JsonObjectProperty,
     JsonProperty,
     JsonUnionType,
     loadLookups,
 } from '../expandable-snippet/model';
 import { doOnEnter } from '../key-handlers';
-import { ArrayEditor, BooleanEditor, ColourEditor, NumberEditor, PresetEditor, StringEditor } from './Editors';
+import { PresetEditor, getPrimitivePropertyEditor, getPrimitiveEditor } from './Editors';
 import styles from './Options.module.scss';
 import { formatJson } from './utils';
-
-const FONT_WEIGHT_EDITOR_PROPS = {
-    default: 'normal',
-    breakIndex: 4,
-    options: ['normal', 'bold', 'bolder', 'lighter', '100', '200', '300', '400', '500', '600', '700', '800', '900'],
-};
-
-const FONT_STYLE_EDITOR_PROPS = {
-    default: 'normal',
-    options: ['normal', 'italic', 'oblique'],
-};
-
-const FONT_FAMILY_EDITOR_PROPS = {
-    default: 'Verdana, sans-serif',
-    suggestions: ['Verdana, sans-serif', 'Arial, sans-serif', 'Times New Roman, serif'],
-};
-
-const FONT_SIZE_EDITOR_PROPS = {
-    default: 12,
-    min: 1,
-    max: 30,
-    unit: 'px',
-};
-
-const OPACITY_PROPS = {
-    min: 0,
-    max: 1,
-};
 
 const FunctionDefinition = ({ definition }: { definition: JsonFunction }) => {
     const lines = [`function ${definition.tsType};`];
@@ -264,116 +235,6 @@ const Search = ({ value, onChange }) => {
             </div>
         </div>
     );
-};
-
-const setStepEditorProp = (editorProps: Record<string, any>, { min, max }: JsonModelProperty['meta']) => {
-    if (min == null || max == null) {
-        return;
-    }
-    if (max - min <= 1) {
-        editorProps.step = 0.05;
-    } else if (max - min <= 10) {
-        editorProps.step = 0.1;
-    }
-};
-
-const getPrimitivePropertyEditor = (desc: JsonProperty) => {
-    if (desc.type === 'array') {
-        return ArrayEditor;
-    }
-
-    if (desc.type === 'primitive' && desc.aliasType != null) {
-        switch (desc.aliasType) {
-            case 'CssColor':
-                return ColourEditor;
-            case 'PixelSize':
-            case 'Opacity':
-                return NumberEditor;
-            case 'FontFamily':
-            case 'FontStyle':
-            case 'FontWeight':
-                return PresetEditor;
-        }
-    }
-
-    switch (desc.tsType) {
-        case 'string':
-            return StringEditor;
-        case 'number':
-            return NumberEditor;
-        case 'boolean':
-            return BooleanEditor;
-    }
-
-    return null;
-};
-
-const getPrimitiveEditor = ({ meta, desc }: JsonModelProperty) => {
-    let editor: any;
-    let editorProps: Record<string, any> = {};
-
-    if (desc.type === 'primitive' && desc.aliasType != null) {
-        switch (desc.aliasType) {
-            case 'CssColor':
-                return { editor: ColourEditor, editorProps: { ...meta } };
-            case 'PixelSize':
-                return { editor: NumberEditor, editorProps: { ...meta, unit: 'px' } };
-            case 'Opacity':
-                return { editor: NumberEditor, editorProps: { ...OPACITY_PROPS, ...meta } };
-            case 'FontFamily':
-                return {
-                    editor: PresetEditor,
-                    editorProps: {
-                        ...FONT_FAMILY_EDITOR_PROPS,
-                        ...meta,
-                    },
-                };
-            case 'FontSize':
-                return {
-                    editor: NumberEditor,
-                    editorProps: {
-                        ...FONT_SIZE_EDITOR_PROPS,
-                        ...meta,
-                    },
-                };
-            case 'FontStyle':
-                return {
-                    editor: PresetEditor,
-                    editorProps: {
-                        ...FONT_STYLE_EDITOR_PROPS,
-                        ...meta,
-                    },
-                };
-            case 'FontWeight':
-                return {
-                    editor: PresetEditor,
-                    editorProps: {
-                        ...FONT_WEIGHT_EDITOR_PROPS,
-                        ...meta,
-                    },
-                };
-        }
-    }
-
-    if (desc.tsType.indexOf(' | ') >= 0) {
-        const options = desc.tsType.split(' | ').map((v) => v.substring(1, v.length - 1));
-
-        if (options.every((v) => /^[a-z-]*$/.test(v))) {
-            return { editor: PresetEditor, editorProps: { ...meta, options } };
-        }
-    }
-
-    if (meta?.options != null || meta?.suggestions != null) {
-        editor = PresetEditor;
-    } else {
-        editor = getPrimitivePropertyEditor(desc);
-    }
-
-    if (editor === NumberEditor && meta != null) {
-        setStepEditorProp(editorProps, meta);
-    }
-
-    return { editor, editorProps: { ...meta, ...editorProps } };
 };
 
 /**


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-6548

Makes the `width` and `height` editors in the Chart API Explorer honour the dimensions of the chart container element, as per previous implementation.

Bonus:
- Moves the heuristic editor and props selection into `Editors.tsx` (NOTE this is isolated to commit 42a137e51d55dafac4bd1585863bb61d1289cd98 for easier reviewing).