### PR TITLE
AG-6549 - Add override json validation.

### DIFF
--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/api.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/api.json
@@ -343,13 +343,15 @@
     }
   },
   "AgHierarchyChartOptions": {
-    "ordering": {
-      "type": "high",
-      "data": "high",
-      "container": "high",
-      "axes": "high",
-      "series": "high",
-      "theme": "low"
+    "meta": {
+      "ordering": {
+        "type": "high",
+        "data": "high",
+        "container": "high",
+        "axes": "high",
+        "series": "high",
+        "theme": "low"
+      }
     },
     "data": {
       "isRequired": true

--- a/grid-packages/ag-grid-docs/documentation/src/components/documentation-overrides.test.ts
+++ b/grid-packages/ag-grid-docs/documentation/src/components/documentation-overrides.test.ts
@@ -15,6 +15,7 @@ jest.mock('./use-json-file-nodes');
  *          sort |
  *          uniq
  * )
+ * ```
  */
 const OVERRIDES_TO_TEST = [
     'charts-api/api.json',

--- a/grid-packages/ag-grid-docs/documentation/src/components/documentation-overrides.test.ts
+++ b/grid-packages/ag-grid-docs/documentation/src/components/documentation-overrides.test.ts
@@ -42,6 +42,7 @@ const BASE_PATH = './doc-pages';
 describe('Documentation Overrides Sanity Check', () => {
     let interfaces: {};
     let docInterfaces: {};
+    let originalConsoleWarn;
 
     beforeAll(() => {
         interfaces = JSON.parse(fs.readFileSync(`${BASE_PATH}/grid-api/interfaces.AUTO.json`).toString());
@@ -49,11 +50,12 @@ describe('Documentation Overrides Sanity Check', () => {
     });
 
     beforeEach(() => {
+        originalConsoleWarn = console.warn;
         console.warn = jest.fn();
     });
 
     afterEach(() => {
-        expect(console.warn).not.toBeCalled();
+        console.warn = originalConsoleWarn;
     });
 
     describe.each(OVERRIDES_TO_TEST)('Verify %s', (override) => {

--- a/grid-packages/ag-grid-docs/documentation/src/components/documentation-overrides.test.ts
+++ b/grid-packages/ag-grid-docs/documentation/src/components/documentation-overrides.test.ts
@@ -1,0 +1,74 @@
+import { beforeAll, beforeEach, describe, expect, it, jest, afterEach } from '@jest/globals';
+import * as fs from 'fs';
+import { getJsonFromFile } from './documentation-helpers';
+import { loadLookups } from './expandable-snippet/model';
+
+jest.mock('./documentation-helpers');
+jest.mock('./use-json-file-nodes');
+
+/**
+ * Generated using:
+ * ```bash
+ * (
+ *      cd grid-packages/ag-grid-docs/documentation &&
+ *          find . -name \*.md -exec grep -oi "overridesrc=[a-zA-Z\\.\"\'/\\-]*" \{\} \; |
+ *          sort |
+ *          uniq
+ * )
+ */
+const OVERRIDES_TO_TEST = [
+    'charts-api/api.json',
+    'component-date/resources/dateParams.json',
+    'filter-date/resources/date-filter-params.json',
+    'filter-number/resources/number-filter-params.json',
+    'filter-provided/resources/provided-filters.json',
+    'filter-text/resources/text-filter-params.json',
+    'filter-multi/resources/multi-filter.json',
+    'filter-set-api/resources/iSetFilter.json',
+    'filter-set/resources/set-filter-params.json',
+    'group-cell-renderer/group-cell-renderer.json',
+    'integrated-charts-api-cross-filter-chart/resources/cross-filter-api.json',
+    'integrated-charts-api-pivot-chart/resources/chart-api.json',
+    'integrated-charts-api-range-chart/resources/chart-api.json',
+    'side-bar/resources/sideBar.json',
+    'sparklines-area-customisation/resources/area-sparkline-api.json',
+    'sparklines-bar-customisation/resources/bar-sparkline-api.json',
+    'sparklines-column-customisation/resources/column-sparkline-api.json',
+    'sparklines-line-customisation/resources/line-sparkline-api.json',
+    'sparklines-tooltips/resources/sparkline-tooltip-api.json',
+];
+const BASE_PATH = './doc-pages';
+
+describe('Documentation Overrides Sanity Check', () => {
+    let interfaces: {};
+    let docInterfaces: {};
+
+    beforeAll(() => {
+        interfaces = JSON.parse(fs.readFileSync(`${BASE_PATH}/grid-api/interfaces.AUTO.json`).toString());
+        docInterfaces = JSON.parse(fs.readFileSync(`${BASE_PATH}/grid-api/doc-interfaces.AUTO.json`).toString());
+    });
+
+    beforeEach(() => {
+        console.warn = jest.fn();
+    });
+
+    afterEach(() => {
+        expect(console.warn).not.toBeCalled();
+    });
+
+    describe.each(OVERRIDES_TO_TEST)('Verify %s', (override) => {
+        beforeEach(() => {
+            const overrides = JSON.parse(fs.readFileSync(`${BASE_PATH}/${override}`).toString());
+
+            (getJsonFromFile as any)
+                .mockReturnValueOnce(interfaces)
+                .mockReturnValueOnce(docInterfaces)
+                .mockReturnValueOnce(overrides);
+        });
+
+        it('should load and parse without error', () => {
+            expect(() => loadLookups(override)).not.toThrowError();
+            expect(console.warn).not.toBeCalled();
+        });
+    });
+});


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-6549

Adds test coverage to all doc override JSON files, specifically to detect:
- Overrides for types that no longer exist or have mismatched names.
- Overrides for properties that don't exist.

The intent is to put some CI-time safeguards into place for drift in manually maintained JSON files vs. the types they decorate, especially since the recent Chart API documentation improvements rely on the correctness of these overrides.

Bonus:
- Fixes one mismatching override which should have been embedded in a `meta` property.