### PR TITLE
AG-6568 - Add chart api open in plunker functionality

### DIFF
--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api-explorer/examples/baseline/data.js
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api-explorer/examples/baseline/data.js
@@ -1,0 +1,34 @@
+function getData() {
+  return [
+    {
+      month: "Jan",
+      revenue: 155,
+      profit: 33,
+    },
+    {
+      month: "Feb",
+      revenue: 123,
+      profit: 35.5,
+    },
+    {
+      month: "Mar",
+      revenue: 172.5,
+      profit: 41,
+    },
+    {
+      month: "Apr",
+      revenue: 94,
+      profit: 29,
+    },
+    {
+      month: "May",
+      revenue: 112.5,
+      profit: 37,
+    },
+    {
+      month: "Jun",
+      revenue: 148,
+      profit: 41.5,
+    },
+  ]
+}

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api-explorer/examples/baseline/index.html
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api-explorer/examples/baseline/index.html
@@ -1,0 +1,1 @@
+<div id="myChart" style="height: 100%;"></div>

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api-explorer/examples/baseline/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api-explorer/examples/baseline/main.ts
@@ -1,0 +1,10 @@
+import { AgChartOptions } from 'ag-charts-community'
+import * as agCharts from 'ag-charts-community'
+
+const options: AgChartOptions = {
+  container: document.getElementById('myChart'),
+  data: getData(),
+  // INSERT OPTIONS HERE.
+}
+
+agCharts.AgChart.create(options)

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api-explorer/index.md
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api-explorer/index.md
@@ -3,3 +3,8 @@ title: "API Explorer"
 ---
 
 <charts-api-explorer></charts-api-explorer>
+
+<div style="display: none;">
+    <!-- Needs to be referenced from a markdown file to be generated. Used by the <charts-api-explorer /> tag above. -->
+    <chart-example title='Baseline Chart' name='baseline' type='generated'></chart-example>
+</div>

--- a/grid-packages/ag-grid-docs/documentation/src/components/charts-api-explorer/ChartsApiExplorer.module.scss
+++ b/grid-packages/ag-grid-docs/documentation/src/components/charts-api-explorer/ChartsApiExplorer.module.scss
@@ -39,4 +39,11 @@
         overflow: auto;
         height: 50%;
     }
+
+    &__launcher {
+        height: 40px;
+        background: lightgray;
+        margin: 0px 10px 5px 10px;
+        text-align: right;
+    }
 }

--- a/grid-packages/ag-grid-docs/documentation/src/components/charts-api-explorer/ChartsApiExplorer.tsx
+++ b/grid-packages/ag-grid-docs/documentation/src/components/charts-api-explorer/ChartsApiExplorer.tsx
@@ -5,6 +5,7 @@ import { Options } from './Options';
 import { ChartTypeSelector } from './ChartTypeSelector';
 import { CodeView } from './CodeView';
 import styles from './ChartsApiExplorer.module.scss';
+import { Launcher } from './Launcher';
 
 const createOptionsJson = (chartType, options) => {
     const optionsHasAxes = (options.axes && Object.keys(options.axes).length > 0);
@@ -183,6 +184,7 @@ export const ChartsApiExplorer = ({ framework }) => {
                     </div>
                 </div>
                 <div className={styles['explorer-container__right']}>
+                    <div className={styles['explorer-container__launcher']}><Launcher framework={framework} options={optionsJson} /></div>
                     <div className={styles['explorer-container__chart']}><Chart options={optionsJson} /></div>
                     <div className={styles['explorer-container__code']}><CodeView framework={framework} options={optionsJson} /></div>
                 </div>

--- a/grid-packages/ag-grid-docs/documentation/src/components/charts-api-explorer/Editors.tsx
+++ b/grid-packages/ag-grid-docs/documentation/src/components/charts-api-explorer/Editors.tsx
@@ -6,34 +6,47 @@
 import React, { useState } from 'react';
 import { HuePicker, AlphaPicker } from 'react-color';
 import classnames from 'classnames';
+
+import { FontFamily, FontWeight, FontStyle, FontSize, Opacity } from 'ag-charts-community';
+
 import { doOnEnter } from '../key-handlers';
 import styles from './Editors.module.scss';
 import { JsonProperty, JsonModelProperty } from '../expandable-snippet/model';
 
-const FONT_WEIGHT_EDITOR_PROPS = {
+type AliasTypePops<T> = {
+    default?: T,
+    options?: T[],
+    suggestions?: T[],
+    breakIndex?: number,
+    min?: T,
+    max?: T,
+    unit?: string,
+};
+
+const FONT_WEIGHT_EDITOR_PROPS: AliasTypePops<FontWeight> = {
     default: 'normal',
     breakIndex: 4,
     options: ['normal', 'bold', 'bolder', 'lighter', '100', '200', '300', '400', '500', '600', '700', '800', '900'],
 };
 
-const FONT_STYLE_EDITOR_PROPS = {
+const FONT_STYLE_EDITOR_PROPS: AliasTypePops<FontStyle> = {
     default: 'normal',
     options: ['normal', 'italic', 'oblique'],
 };
 
-const FONT_FAMILY_EDITOR_PROPS = {
+const FONT_FAMILY_EDITOR_PROPS: AliasTypePops<FontFamily> = {
     default: 'Verdana, sans-serif',
     suggestions: ['Verdana, sans-serif', 'Arial, sans-serif', 'Times New Roman, serif'],
 };
 
-const FONT_SIZE_EDITOR_PROPS = {
+const FONT_SIZE_EDITOR_PROPS: AliasTypePops<FontSize> = {
     default: 12,
     min: 1,
     max: 30,
     unit: 'px',
 };
 
-const OPACITY_PROPS = {
+const OPACITY_PROPS: AliasTypePops<Opacity> = {
     min: 0,
     max: 1,
 };

--- a/grid-packages/ag-grid-docs/documentation/src/components/charts-api-explorer/Launcher.module.scss
+++ b/grid-packages/ag-grid-docs/documentation/src/components/charts-api-explorer/Launcher.module.scss
@@ -1,0 +1,3 @@
+.menu-item {
+    padding: 8px;
+}

--- a/grid-packages/ag-grid-docs/documentation/src/components/charts-api-explorer/Launcher.tsx
+++ b/grid-packages/ag-grid-docs/documentation/src/components/charts-api-explorer/Launcher.tsx
@@ -1,0 +1,136 @@
+import React from 'react';
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faExternalLinkAlt } from "@fortawesome/free-solid-svg-icons";
+
+import { AgChartOptions } from "ag-charts-community";
+
+import styles from './Launcher.module.scss';
+import { openPlunker, getExampleInfo } from "../example-runner/helpers";
+import { doOnEnter } from "../key-handlers";
+import { useExampleFileNodes } from '../example-runner/use-example-file-nodes';
+
+interface LauncherProps {
+    framework: string;
+    options: AgChartOptions;
+}
+
+export const Launcher = ({ framework, options }: LauncherProps) => {
+    const exampleInfo = buildExampleInfo(framework, options);
+
+    return <>
+        <div
+            className={styles['menu-item']}
+            onClick={() => openPlunker(exampleInfo)}
+            onKeyDown={e => doOnEnter(e, () => openPlunker(exampleInfo))}
+            role="button"
+            tabIndex={0}
+        >
+            <FontAwesomeIcon icon={faExternalLinkAlt} fixedWidth />
+        </div>
+    </>
+};
+
+interface ExampleFile {
+    base: string;
+    content?: Promise<string>;
+    relativePath: string;
+    publicURL: string;
+}
+
+interface ExampleInfo {
+    title: string;
+    sourcePath: string;
+    framework: string;
+    internalFramework: string;
+    boilerplatePath: string;
+    getFiles(...args: any[]): ExampleFile[];
+}
+
+const determineFrameworks = (framework: string) => {
+    let useFunctionalReact = false;
+    let useVue3 = false;
+    let useTypescript = false;
+    let mainFile = 'main.js';
+
+    switch (framework) {
+        case 'javascript':
+        case 'vue':
+            break;
+        case 'angular':
+            mainFile = 'app.component.ts';
+            break;
+        case 'react':
+            mainFile = 'index.jsx';
+            break;
+        default:
+            console.warn(`AG Grid Docs - unable to determine internalFramework for: ${framework}`);
+            framework = 'javascript';
+    }
+
+    return { framework, useFunctionalReact, useVue3, useTypescript, mainFile };
+};
+
+const applyChartOptions = (name: string, source: string, options: AgChartOptions) => {
+    const toInject = Object.entries(options)
+        .filter(([_, value]) => value !== undefined)
+        .map(([name, value]) => `  ${name}: ${JSON.stringify(value, null, 2)}`)
+        .join(',\n');
+    
+    const modifiedSource = source.replace('  // INSERT OPTIONS HERE.', toInject);
+
+    return Promise.resolve(modifiedSource);
+}
+
+const mutateMainFile = (file: ExampleFile, options: AgChartOptions) => {
+    return {
+        ...file,
+        content: fetch(file.publicURL)
+            .then(response => response.text())
+            .then(source => applyChartOptions(file.base, source, options)),
+    };
+};
+
+const mutateExampleInfo = (exampleInfo: ExampleInfo, mainFile: string, options: AgChartOptions) => {
+    return {
+        ...exampleInfo,
+        // Patch main file with options configuration.
+        getFiles: (...args) => {
+            return exampleInfo.getFiles(...args)
+                .map((file) => {
+                    if (file.base.endsWith(mainFile)) {
+                        return mutateMainFile(file, options);
+                    }
+
+                    return file;
+                });
+        },
+    }
+};
+
+const buildExampleInfo = (providedFramework: string, options: AgChartOptions): ExampleInfo => {
+    const { framework, useFunctionalReact, useVue3, useTypescript, mainFile } = determineFrameworks(providedFramework);
+    const library = 'charts';
+    const pageName = 'charts-api-explorer';
+    const exampleName = 'baseline';
+    const title = 'Charts API Explorer Generated Example';
+    const type = 'generated';
+    const exampleOptions = {};
+    const exampleImportType = 'modules';
+
+    const exampleInfo: ExampleInfo = getExampleInfo(
+        useExampleFileNodes(),
+        library,
+        pageName,
+        exampleName,
+        title,
+        type,
+        exampleOptions,
+        framework,
+        useFunctionalReact,
+        useVue3,
+        useTypescript,
+        exampleImportType,
+    );
+
+    return mutateExampleInfo(exampleInfo, mainFile, options);
+};

--- a/grid-packages/ag-grid-docs/documentation/src/components/example-runner/helpers.js
+++ b/grid-packages/ag-grid-docs/documentation/src/components/example-runner/helpers.js
@@ -134,7 +134,8 @@ export const getExampleFiles = exampleInfo => {
         .map(node => ({
             path: node.relativePath.replace(sourcePath, ''),
             publicURL: node.publicURL,
-            isFramework: false
+            isFramework: false,
+            content: node.content,
         }));
 
     getFrameworkFiles(framework, internalFramework).forEach(file => filesForExample.push({
@@ -149,9 +150,11 @@ export const getExampleFiles = exampleInfo => {
     filesForExample.filter(f => f.path !== 'index.html').forEach(f => {
         files[f.path] = null; // preserve ordering
 
-        const promise = fetch(f.publicURL)
-            .then(response => response.text())
-            .then(source => files[f.path] = { source, isFramework: f.isFramework });
+        const sourcePromise = (f.content ?? fetch(f.publicURL).then(response => response.text()));
+        const promise = sourcePromise
+            .then(source => {
+                files[f.path] = { source, isFramework: f.isFramework }
+            });
 
         promises.push(promise);
     });


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-6568

Adds an open-in-Plunker button above the Chart API Explorer chart preview area.

Uses a generated example as the basis for the Plunkers produced, aiming to perform a simple text substitution to inject the user-created options.

Screenshot of new button:
![Screenshot 2022-03-28 at 12 31 22](https://user-images.githubusercontent.com/17544187/160389172-d0ad941b-fac9-426f-8638-e70bcb00a3f9.png)
