### PR TITLE
AG-6569 - Add Chart API Explorer full-screen display.

### DIFF
--- a/grid-packages/ag-grid-docs/documentation/src/components/charts-api-explorer/Chart.module.scss
+++ b/grid-packages/ag-grid-docs/documentation/src/components/charts-api-explorer/Chart.module.scss
@@ -14,4 +14,22 @@
         box-sizing: border-box;
         overflow: hidden;
     }
+
+    &.fullscreen {
+        background: white;
+        position: fixed;
+        top: 0px;
+        left: 0px;
+        width: 100vw;
+        height: 100vh;
+        z-index: 200;
+        padding: 0;
+    }
+}
+
+.close {
+    position: fixed;
+    top: 0px;
+    right: 2px;
+    z-index: 201;
 }

--- a/grid-packages/ag-grid-docs/documentation/src/components/charts-api-explorer/Chart.module.scss
+++ b/grid-packages/ag-grid-docs/documentation/src/components/charts-api-explorer/Chart.module.scss
@@ -16,7 +16,6 @@
     }
 
     &.fullscreen {
-        background: white;
         position: fixed;
         top: 0px;
         left: 0px;
@@ -24,6 +23,7 @@
         height: 100vh;
         z-index: 200;
         padding: 0;
+        background: white;
     }
 }
 

--- a/grid-packages/ag-grid-docs/documentation/src/components/charts-api-explorer/Chart.tsx
+++ b/grid-packages/ag-grid-docs/documentation/src/components/charts-api-explorer/Chart.tsx
@@ -1,13 +1,18 @@
 import React from 'react';
 import { AgChartOptions } from 'ag-charts-community';
+import classnames from 'classnames';
+
 import { data, series } from './templates';
 import { deepClone } from './utils';
 import styles from './Chart.module.scss';
+import { doOnEnter, doOnEscape } from '../key-handlers';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faCompress } from '@fortawesome/free-solid-svg-icons';
 
 /**
  * This renders the chart inside the Standalone Charts API Explorer.
  */
-export class Chart extends React.Component<{ options: AgChartOptions }> {
+export class Chart extends React.Component<{ options: AgChartOptions, fullScreen: boolean, setFullScreen(o: boolean) }> {
     chart: React.RefObject<HTMLDivElement>;
     chartInstance = undefined;
     animationFrameId = 0;
@@ -56,6 +61,25 @@ export class Chart extends React.Component<{ options: AgChartOptions }> {
     }
 
     render() {
-        return <div id="chart-container" className={styles['chart']} ref={this.chart}></div>;
+        const cssClasses = classnames(styles['chart'], {[styles['fullscreen']]: this.props.fullScreen});
+        return <>
+            <div
+                id="chart-container"
+                className={cssClasses}
+                ref={this.chart}
+                onKeyDown={e => doOnEscape(e, () => this.props.setFullScreen(false))}
+            >
+            </div>
+            {this.props.fullScreen && <div
+                className={styles['close']}
+                onClick={() => this.props.setFullScreen(false)}
+                onKeyDown={e => doOnEnter(e, () => this.props.setFullScreen(false))}
+                role="button"
+                tabIndex={0}
+            >
+                <FontAwesomeIcon icon={faCompress} fixedWidth title="Exit chart fullscreen" />
+            </div>
+        }
+        </>;
     }
 }

--- a/grid-packages/ag-grid-docs/documentation/src/components/charts-api-explorer/ChartsApiExplorer.module.scss
+++ b/grid-packages/ag-grid-docs/documentation/src/components/charts-api-explorer/ChartsApiExplorer.module.scss
@@ -6,6 +6,7 @@
     border-radius: 5px;
     display: flex;
     flex-direction: column;
+    overflow: hidden;
 
     &__body {
         display: flex;
@@ -19,10 +20,11 @@
     }
 
     &__right {
-        flex: 1 1 auto;
+        width: 60%;
     }
 
     &__options {
+        margin: 0 0 10px 10px;
         position: relative;
         overflow: hidden;
         height: 100%;
@@ -35,15 +37,33 @@
     }
 
     &__code {
-        padding-top: 1rem;
         overflow: auto;
         height: 50%;
     }
 
     &__launcher {
+        position: relative;
+        top: -5px;
         height: 40px;
-        background: lightgray;
-        margin: 0px 10px 5px 10px;
+        background: #d0d4d6;
         text-align: right;
+    }
+
+    &.fullscreen {
+        background: white;
+        position: fixed;
+        top: 0px;
+        left: 0px;
+        width: 100vw;
+        height: 100vh;
+        z-index: 100;
+
+        &__left {
+            width: 500px;
+        }
+
+        &__right {
+            width: calc(100vw - 500px);
+        }
     }
 }

--- a/grid-packages/ag-grid-docs/documentation/src/components/charts-api-explorer/ChartsApiExplorer.module.scss
+++ b/grid-packages/ag-grid-docs/documentation/src/components/charts-api-explorer/ChartsApiExplorer.module.scss
@@ -45,8 +45,9 @@
         position: relative;
         top: -5px;
         height: 40px;
-        background: #d0d4d6;
+        background: linear-gradient(to bottom right, #0084e7, #0067b4);
         text-align: right;
+        color: white;
     }
 
     &.fullscreen {

--- a/grid-packages/ag-grid-docs/documentation/src/components/charts-api-explorer/ChartsApiExplorer.module.scss
+++ b/grid-packages/ag-grid-docs/documentation/src/components/charts-api-explorer/ChartsApiExplorer.module.scss
@@ -51,13 +51,13 @@
     }
 
     &.fullscreen {
-        background: white;
         position: fixed;
         top: 0px;
         left: 0px;
         width: 100vw;
         height: 100vh;
         z-index: 100;
+        background: white;
 
         &__left {
             width: 500px;

--- a/grid-packages/ag-grid-docs/documentation/src/components/charts-api-explorer/ChartsApiExplorer.tsx
+++ b/grid-packages/ag-grid-docs/documentation/src/components/charts-api-explorer/ChartsApiExplorer.tsx
@@ -1,5 +1,5 @@
-import React, { useState, useEffect } from 'react';
-import { getTemplates } from './templates';
+import React, { useState } from 'react';
+import classnames from 'classnames';
 import { Chart } from './Chart';
 import { Options } from './Options';
 import { ChartTypeSelector } from './ChartTypeSelector';
@@ -95,8 +95,6 @@ const createOptionsJson = (chartType, options) => {
     return json;
 };
 
-const isFullScreen = () => window.self === window.top;
-
 /**
  * The Standalone Charts API Explorer is an interactive tool for exploring the charts API. The user can change different
  * settings and see how they affect the appearance of the chart, and it will generate the code they would need to use in
@@ -106,8 +104,8 @@ export const ChartsApiExplorer = ({ framework }) => {
     const [chartType, setChartType] = useState('bar');
     const [options, setOptions] = useState({});
     const [defaults, setDefaults] = useState({});
-    const [boilerplateCode] = useState(null);
-    const setFilesJson = useState(null)[1];
+    const [fullScreen, setFullScreen] = useState(false);
+    const [fullScreenGraph, setFullScreenGraph] = useState(false);
 
     const getKeys = expression => expression.split('.');
 
@@ -157,19 +155,16 @@ export const ChartsApiExplorer = ({ framework }) => {
         setOptions({});
     };
 
-    useEffect(() => {
-        if (isFullScreen()) { return; }
-
-        const optionsJson = createOptionsJson(chartType, options);
-        const files = getTemplates(framework, boilerplateCode, optionsJson);
-        setFilesJson(JSON.stringify({ files }));
-        // eslint-disable-next-line
-    }, []);
-
     const optionsJson = createOptionsJson(chartType, options);
 
     return (
-        <div className={styles['explorer-container']}>
+        <div className={classnames(styles['explorer-container'], {[styles['fullscreen']]: fullScreen})}>
+            <div className={styles['explorer-container__launcher']}>
+                <Launcher
+                    options={optionsJson}
+                    {...{framework, fullScreen, fullScreenGraph, setFullScreen, setFullScreenGraph}}
+                />
+            </div>
             <div>
                 <ChartTypeSelector type={chartType} onChange={updateChartType} />
             </div>
@@ -184,8 +179,7 @@ export const ChartsApiExplorer = ({ framework }) => {
                     </div>
                 </div>
                 <div className={styles['explorer-container__right']}>
-                    <div className={styles['explorer-container__launcher']}><Launcher framework={framework} options={optionsJson} /></div>
-                    <div className={styles['explorer-container__chart']}><Chart options={optionsJson} /></div>
+                    <div className={styles['explorer-container__chart']}><Chart options={optionsJson} fullScreen={fullScreenGraph} setFullScreen={setFullScreenGraph} /></div>
                     <div className={styles['explorer-container__code']}><CodeView framework={framework} options={optionsJson} /></div>
                 </div>
             </div>

--- a/grid-packages/ag-grid-docs/documentation/src/components/charts-api-explorer/CodeView.tsx
+++ b/grid-packages/ag-grid-docs/documentation/src/components/charts-api-explorer/CodeView.tsx
@@ -22,8 +22,8 @@ export const CodeView = ({ framework, options }) => {
 };
 
 const VanillaCode = ({ options }) => <>
-    <Code code={['// Create new chart', `chart = AgChart.create(${formatJson(options)});`]} />;
-    <Code code={['// Update existing chart', `AgChart.update(chart, ${formatJson(options)});`]} />;
+    <Code code={['// Create new chart', `chart = AgChart.create(${formatJson(options)});`]} />
+    <Code code={['// Update existing chart', `AgChart.update(chart, ${formatJson(options)});`]} />
 </>;
 
 const ReactCode = ({ options }) =>

--- a/grid-packages/ag-grid-docs/documentation/src/components/charts-api-explorer/Launcher.module.scss
+++ b/grid-packages/ag-grid-docs/documentation/src/components/charts-api-explorer/Launcher.module.scss
@@ -1,3 +1,4 @@
 .menu-item {
     padding: 8px;
+    display: inline-block;
 }

--- a/grid-packages/ag-grid-docs/documentation/src/components/charts-api-explorer/Launcher.tsx
+++ b/grid-packages/ag-grid-docs/documentation/src/components/charts-api-explorer/Launcher.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faExternalLinkAlt } from "@fortawesome/free-solid-svg-icons";
+import { faExternalLinkAlt, faChartLine, faCompress, faExpand, faWindowRestore } from "@fortawesome/free-solid-svg-icons";
 
 import { AgChartOptions } from "ag-charts-community";
 
@@ -12,12 +12,44 @@ import { useExampleFileNodes } from '../example-runner/use-example-file-nodes';
 interface LauncherProps {
     framework: string;
     options: AgChartOptions;
+
+    fullScreen: boolean;
+    setFullScreen(fullScreen: boolean): void;
+
+    fullScreenGraph: boolean;
+    setFullScreenGraph(fullScreenGraph: boolean): void;
 }
 
-export const Launcher = ({ framework, options }: LauncherProps) => {
+export const Launcher = ({ framework, options, fullScreen, setFullScreen, fullScreenGraph, setFullScreenGraph }: LauncherProps) => {
     const exampleInfo = buildExampleInfo(framework, options);
 
     return <>
+        <div
+            className={styles['menu-item']}
+            onClick={() => setFullScreenGraph(!fullScreenGraph)}
+            onKeyDown={e => doOnEnter(e, () => setFullScreenGraph(!fullScreenGraph))}
+            role="button"
+            tabIndex={0}
+        >
+            <FontAwesomeIcon
+                icon={fullScreenGraph ? faCompress : faChartLine }
+                fixedWidth
+                title="Open chart preview fullscreen"
+            />
+        </div>
+        <div
+            className={styles['menu-item']}
+            onClick={() => setFullScreen(!fullScreen)}
+            onKeyDown={e => doOnEnter(e, () => setFullScreen(!fullScreen))}
+            role="button"
+            tabIndex={0}
+        >
+            <FontAwesomeIcon
+                icon={fullScreen ? faCompress : faWindowRestore }
+                fixedWidth
+                title={fullScreen ? "Exit fullscreen" : "Open fullscreen" }
+            />
+        </div>
         <div
             className={styles['menu-item']}
             onClick={() => openPlunker(exampleInfo)}
@@ -25,7 +57,7 @@ export const Launcher = ({ framework, options }: LauncherProps) => {
             role="button"
             tabIndex={0}
         >
-            <FontAwesomeIcon icon={faExternalLinkAlt} fixedWidth />
+            <FontAwesomeIcon icon={faExternalLinkAlt} fixedWidth title="Open in Plunker" />
         </div>
     </>
 };


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-6569

Adds support for opening the Charts API Explorer full-screen:
- The entire explorer component, or...
- The chart preview.

Bonus:
- Fixes some alignment issues I noticed in the Chart API Explorer components.
- Moves the toolbar to the top of the explorer as per out-of-band review feedback.

New toolbar:
![Screenshot 2022-03-28 at 15 42 45](https://user-images.githubusercontent.com/17544187/160423619-98ed1ac0-6577-47a3-9e49-af2998562313.png)

Full-screen:
![Screenshot 2022-03-28 at 15 43 23 1(2)](https://user-images.githubusercontent.com/17544187/160424110-72ef491c-d86e-49c4-923a-fa7e3493b04d.png)

Chart full-screen:
![Screenshot 2022-03-28 at 15 45 37 (2)](https://user-images.githubusercontent.com/17544187/160424317-4a7984ff-6e74-45a8-afd6-fe523a2f9efa.png)

