### PR TITLE
AG-6586 - Prototype AJV-based Chart Options Validation

### DIFF
--- a/charts-packages/ag-charts-community/generate-ajv.js
+++ b/charts-packages/ag-charts-community/generate-ajv.js
@@ -3,6 +3,7 @@ const { join, resolve } = require('path');
 const Ajv = require('ajv');
 const standaloneCode = require('ajv/dist/standalone').default;
 const tjs = require('typescript-json-schema');
+const uglifyjs = require('uglify-js');
 
 const DEBUG = process.argv.includes('--debug');
 
@@ -15,48 +16,112 @@ const sources = [
 
 const outputs = [
     { path: 'src', code: { es5: true } }, // Needed for docs Webpack build. We .gitignore this file.
-    { path: 'dist/cjs/es5', code: { es5: true } },
-    { path: 'dist/cjs/es6', code: {} },
+    { path: 'dist/cjs/es5', code: { es5: true, esm: false } },
+    { path: 'dist/cjs/es6', code: { es5: false, esm: false } },
     { path: 'dist/esm/es5', code: { es5: true, esm: true } },
-    { path: 'dist/esm/es6', code: { esm: true } },
+    { path: 'dist/esm/es6', code: { es5: false, esm: true } },
 ];
 
-function visit(object, cb) {
+function visit(object, cb, path = '#') {
     Object.entries(object).forEach(([prop, value]) => {
-        if (cb(prop, value) === false) {
+        const visitResult = cb(prop, value, path);
+        const { rename, update } = visitResult;
+
+        if (visitResult === false) {
             delete object[prop];
-        } else if (typeof value === 'object') {
-            visit(value, cb);
+            return;
+        } else if (rename != null) {
+            object[rename] = object[prop];
+            delete object[prop];
+            prop = rename;
+        } else if (update != null) {
+            object[prop] = update;
+        }
+
+        if (typeof value === 'object') {
+            visit(value, cb, `${path}/${prop}`);
         }
     });
 }
 
-function cleanSchema(schema) {
-    visit(schema, (prop, value) => {
-        return prop !== 'description';
+function cleanJsonSchema(schema) {
+    let count = 0;
+    let nameCache = {};
+
+    visit(schema, (prop, value, parentPath) => {
+        if (prop === 'description') {
+            // Remove descriptions.
+            return false;
+        }
+
+        if (parentPath === '#/definitions') {
+            // Rename definitions to optimise JSONSchema size.
+            const propPath = `${parentPath}/${prop}`;
+            if (nameCache[propPath] == null) {
+                nameCache[propPath] = `#/definitions/${count++}`;
+            }
+            
+            return { rename: nameCache[propPath].split('/')[2] };
+        }
+
+        if (prop === '$ref') {
+            // Update references to renamed definitions.
+            if (nameCache[value] == null) {
+                nameCache[value] = `#/definitions/${count++}`;
+            }
+
+            return { update: nameCache[value] };
+        }
+
+        return true;
     });
+
+    return nameCache;
 }
 
+function normaliseAjvCode(code) {
+    // Inject some constants to reduce repetition.
+    const constants = {D: "#/definitions/"};
+    code = code.replace(/"#\/definitions\//g, 'D+"');
+
+    // Inject constants.
+    const constantJs = Object.entries(constants)
+        .reduce((out, [name, value]) => {
+            out += `var ${name}="${value}";`;
+            return out;
+        }, '');
+    code = code.replace('"use strict";', `"use strict";${constantJs}`);
+
+    return code;
+}
+
+let exitCode = 0;
 sources.forEach(({ path, rootType }) => {
     const inputFilename = `src/${path}`;
     const schemaFilename = path.replace(/\.ts$/, '.jsonschema');
+    const ajvFilename = path.replace(/\.ts$/, '.ajv.raw.js');
+    const outputModuleName = path.replace(/\.ts$/, '.ajv').split('/').pop();
     const outputFilename = path.replace(/\.ts$/, '.ajv.js');
     const tsdFilename = path.replace(/\.ts$/, '.ajv.d.ts');
     const tsjProgram = tjs.getProgramFromFiles(
         [resolve(inputFilename)],
         {
-            strictNullChecks: true,
+            // strictNullChecks: true,
         },
         './src'
     );
     const tsjSettings = {
+        topRef: true,
         required: true,
         noExtraProps: true,
+        aliasRefs: true,
     };
     const schema = tjs.generateSchema(tsjProgram, typeof rootType === 'string' ? rootType : '*', tsjSettings);
-    cleanSchema(schema);
+    const remappedSchemaIds = cleanJsonSchema(schema);
     if (DEBUG) {
-        fs.writeFileSync(join(__dirname, 'src', schemaFilename), JSON.stringify(schema, null, 2));
+        const debugFilename = join(__dirname, 'src', schemaFilename);
+        fs.writeFileSync(debugFilename, JSON.stringify(schema, null, 2));
+        console.log(` Debug ${debugFilename.replace(__dirname, '.')} ...`);
     }
 
     let schemaConfig = undefined;
@@ -65,36 +130,53 @@ sources.forEach(({ path, rootType }) => {
     } else {
         const rootTypeArray = typeof rootType === 'string' ? [rootType] : rootType;
         schemaConfig = rootTypeArray.reduce((out, next) => {
-            out[`validate${next}`] = `#/definitions/${next}`;
+            out[`validate${next}`] = remappedSchemaIds[`#/definitions/${next}`];
             return out;
         }, {});
     }
 
     outputs.forEach(({ path: outputPath, code }) => {
-        const sizeOptimisationOptions = {
-            inlineRefs: false,
-            loopEnum: 1,
-            loopRequired: 1,
-            meta: false,
-            validateSchema: false,
-            messages: false,
-        };
         const ajv = new Ajv({
             schemas: [schema],
-            code: { source: true, optimize: true, ...code },
+            code: { source: true, lines: false, optimize: true, ...code },
             strict: true,
             strictSchema: true,
             allowUnionTypes: true,
-            ...sizeOptimisationOptions,
+            // Size optimisations below here.
+            inlineRefs: false,
+            meta: false,
+            validateSchema: false,
+            messages: false,
         });
-        const moduleCode = standaloneCode(ajv, schemaConfig);
+        const moduleCode = normaliseAjvCode(standaloneCode(ajv, schemaConfig));
+        const minifiedResult = uglifyjs.minify(
+            { main: moduleCode },
+            {
+                compress: {
+                    passes: 5,
+                },
+                // mangle: {
+                //     properties: true,
+                //     reserved: Object.keys(schemaConfig),
+                // },
+                // wrap: outputModuleName,
+            },
+        );
+
+        if (minifiedResult.error) {
+            console.error(minifiedResult.error);
+            exitCode = 10;
+            return;
+        }
+        const minifiedCode = minifiedResult.code;
+
         const fullOutputPath = join(__dirname, outputPath, outputFilename);
 
         // create the dist folders if they don't exist - ie on a clean build
         const distPath = fullOutputPath.substring(0, fullOutputPath.lastIndexOf('/'));
         if (!fs.existsSync(distPath)) {
             fs.mkdirSync(distPath, { recursive: true });
-            console.log(`Created ${distPath.replace(__dirname, '.')}...`);
+            console.log(`Created ${distPath.replace(__dirname, '.')} ...`);
         }
 
         // copy the declaration file - it won't be done by TSC
@@ -102,10 +184,17 @@ sources.forEach(({ path, rootType }) => {
         const outputTsd = join(__dirname, outputPath, tsdFilename);
         if (fs.existsSync(inputTsd) && !fs.existsSync(outputTsd)) {
             fs.copyFileSync(inputTsd, outputTsd);
-            console.log(`Copied ${outputTsd.replace(__dirname, '.')}...`);
+            console.log(`Copied ${outputTsd.replace(__dirname, '.')} ...`);
         }
 
-        fs.writeFileSync(fullOutputPath, moduleCode);
-        console.log(` Built ${fullOutputPath.replace(__dirname, '.')}...`);
+        if (DEBUG) {
+            const debugFilename = fullOutputPath.replace(/.js$/, '.debug.js');
+            fs.writeFileSync(debugFilename, moduleCode);
+            console.log(` Debug ${debugFilename.replace(__dirname, '.')} ...`);
+        }
+        fs.writeFileSync(fullOutputPath, minifiedCode);
+        console.log(` Built ${fullOutputPath.replace(__dirname, '.')} (${Math.round(minifiedCode.length / 1024)}K) ...`);
     });
 });
+
+process.exit(exitCode);

--- a/charts-packages/ag-charts-community/generate-ajv.js
+++ b/charts-packages/ag-charts-community/generate-ajv.js
@@ -1,0 +1,115 @@
+const fs = require('fs');
+const { join, resolve } = require('path');
+const Ajv = require('ajv');
+const standaloneCode = require('ajv/dist/standalone').default;
+const tjs = require('typescript-json-schema');
+
+const DEBUG = process.argv.includes('--debug');
+
+const sources = [
+    {
+        path: 'chart/agChartOptions.ts', 
+        rootType: ['AgChartOptions']
+    },
+];
+
+const outputs = [
+    { path: 'src', code: { es5: true } }, // Needed for docs Webpack build. We .gitignore this file.
+    { path: 'dist/cjs/es5', code: { es5: true } },
+    { path: 'dist/cjs/es6', code: {} },
+    { path: 'dist/esm/es5', code: { es5: true, esm: true } },
+    { path: 'dist/esm/es6', code: { esm: true } },
+];
+
+function visit(object, cb) {
+    Object.entries(object)
+        .forEach(([prop, value]) => {
+            if (cb(prop, value) === false) {
+                delete object[prop];
+            } else if (typeof value === 'object') {
+                visit(value, cb);
+            }
+        });
+}
+
+function cleanSchema(schema) {
+    visit(schema, (prop, value) => {
+        return prop !== 'description';
+    });
+}
+
+sources.forEach(({path, rootType}) => {
+    const inputFilename = `src/${path}`;
+    const schemaFilename = path.replace(/\.ts$/, '.jsonschema');
+    const outputFilename = path.replace(/\.ts$/, '.ajv.js');
+    const tsdFilename = path.replace(/\.ts$/, '.ajv.d.ts');
+    const tsjProgram = tjs.getProgramFromFiles(
+        [resolve(inputFilename)],
+        {
+            strictNullChecks: true,
+        },
+        './src'
+    );
+    const tsjSettings = {
+        required: true,
+        noExtraProps: true,
+    };
+    const schema = tjs.generateSchema(tsjProgram, typeof rootType === 'string' ? rootType : '*', tsjSettings);
+    cleanSchema(schema);
+    if (DEBUG) {
+        fs.writeFileSync(join(__dirname, 'src', schemaFilename), JSON.stringify(schema, null, 2));
+    }
+
+    let schemaConfig = undefined;
+    if (rootType === '*') {
+        // Skip.
+    } else {
+        const rootTypeArray = typeof rootType === 'string' ? [rootType] : rootType;
+        schemaConfig = rootTypeArray.reduce(
+            (out, next) => {
+                out[`validate${next}`] = `#/definitions/${next}`;
+                return out;
+            },
+            {},
+        );
+    }
+
+    outputs.forEach(({ path: outputPath, code }) => {
+        const sizeOptimisationOptions = {
+            inlineRefs: false,
+            loopEnum: 1,
+            loopRequired: 1,
+            meta: false,
+            validateSchema: false,
+            messages: false,
+        };
+        const ajv = new Ajv({
+            schemas: [schema],
+            code: { source: true, optimize: true, ...code },
+            strict: true,
+            strictSchema: true,
+            allowUnionTypes: true,
+            ...sizeOptimisationOptions,
+        });
+        const moduleCode = standaloneCode(ajv, schemaConfig);
+        const fullOutputPath = join(__dirname, outputPath, outputFilename);
+
+        // create the dist folders if they don't exist - ie on a clean build
+        const distPath = fullOutputPath.substring(0, fullOutputPath.lastIndexOf("/"));
+        if(!fs.existsSync(distPath)) {
+            fs.mkdirSync(distPath, { recursive: true });
+            console.log(`Created ${distPath.replace(__dirname, '.')}...`);
+        }
+
+       // copy the declaration file - it won't be done by TSC
+       const inputTsd = join(__dirname, 'src', tsdFilename);
+       const outputTsd = join(__dirname, outputPath, tsdFilename);
+       if(fs.existsSync(inputTsd) && !fs.existsSync(outputTsd)) {
+           fs.copyFileSync(inputTsd, outputTsd);
+           console.log(`Copied ${outputTsd.replace(__dirname, '.')}...`);
+        }
+
+        fs.writeFileSync(fullOutputPath, moduleCode);
+        console.log(` Built ${fullOutputPath.replace(__dirname, '.')}...`);
+    });
+});

--- a/charts-packages/ag-charts-community/generate-ajv.js
+++ b/charts-packages/ag-charts-community/generate-ajv.js
@@ -8,8 +8,8 @@ const DEBUG = process.argv.includes('--debug');
 
 const sources = [
     {
-        path: 'chart/agChartOptions.ts', 
-        rootType: ['AgChartOptions']
+        path: 'chart/agChartOptions.ts',
+        rootType: ['AgChartOptions'],
     },
 ];
 
@@ -22,14 +22,13 @@ const outputs = [
 ];
 
 function visit(object, cb) {
-    Object.entries(object)
-        .forEach(([prop, value]) => {
-            if (cb(prop, value) === false) {
-                delete object[prop];
-            } else if (typeof value === 'object') {
-                visit(value, cb);
-            }
-        });
+    Object.entries(object).forEach(([prop, value]) => {
+        if (cb(prop, value) === false) {
+            delete object[prop];
+        } else if (typeof value === 'object') {
+            visit(value, cb);
+        }
+    });
 }
 
 function cleanSchema(schema) {
@@ -38,7 +37,7 @@ function cleanSchema(schema) {
     });
 }
 
-sources.forEach(({path, rootType}) => {
+sources.forEach(({ path, rootType }) => {
     const inputFilename = `src/${path}`;
     const schemaFilename = path.replace(/\.ts$/, '.jsonschema');
     const outputFilename = path.replace(/\.ts$/, '.ajv.js');
@@ -65,13 +64,10 @@ sources.forEach(({path, rootType}) => {
         // Skip.
     } else {
         const rootTypeArray = typeof rootType === 'string' ? [rootType] : rootType;
-        schemaConfig = rootTypeArray.reduce(
-            (out, next) => {
-                out[`validate${next}`] = `#/definitions/${next}`;
-                return out;
-            },
-            {},
-        );
+        schemaConfig = rootTypeArray.reduce((out, next) => {
+            out[`validate${next}`] = `#/definitions/${next}`;
+            return out;
+        }, {});
     }
 
     outputs.forEach(({ path: outputPath, code }) => {
@@ -95,18 +91,18 @@ sources.forEach(({path, rootType}) => {
         const fullOutputPath = join(__dirname, outputPath, outputFilename);
 
         // create the dist folders if they don't exist - ie on a clean build
-        const distPath = fullOutputPath.substring(0, fullOutputPath.lastIndexOf("/"));
-        if(!fs.existsSync(distPath)) {
+        const distPath = fullOutputPath.substring(0, fullOutputPath.lastIndexOf('/'));
+        if (!fs.existsSync(distPath)) {
             fs.mkdirSync(distPath, { recursive: true });
             console.log(`Created ${distPath.replace(__dirname, '.')}...`);
         }
 
-       // copy the declaration file - it won't be done by TSC
-       const inputTsd = join(__dirname, 'src', tsdFilename);
-       const outputTsd = join(__dirname, outputPath, tsdFilename);
-       if(fs.existsSync(inputTsd) && !fs.existsSync(outputTsd)) {
-           fs.copyFileSync(inputTsd, outputTsd);
-           console.log(`Copied ${outputTsd.replace(__dirname, '.')}...`);
+        // copy the declaration file - it won't be done by TSC
+        const inputTsd = join(__dirname, 'src', tsdFilename);
+        const outputTsd = join(__dirname, outputPath, tsdFilename);
+        if (fs.existsSync(inputTsd) && !fs.existsSync(outputTsd)) {
+            fs.copyFileSync(inputTsd, outputTsd);
+            console.log(`Copied ${outputTsd.replace(__dirname, '.')}...`);
         }
 
         fs.writeFileSync(fullOutputPath, moduleCode);

--- a/charts-packages/ag-charts-community/package.json
+++ b/charts-packages/ag-charts-community/package.json
@@ -10,8 +10,9 @@
     "test": "export FONTCONFIG_PATH=$PWD/src/chart/test ; export FONTCONFIG_FILE=$PWD/src/chart/test/fonts.conf ; export PANGOCAIRO_BACKEND=fontconfig ; npx jest",
     "build-cjs": "npx tsc -p tsconfig.cjs.es5.json && npx tsc -p tsconfig.cjs.es6.json",
     "build-esm": "npx tsc -p tsconfig.esm.es5.json && npx tsc -p tsconfig.esm.es6.json",
+    "build-ajv": "node ./generate-ajv.js",
     "package": "node ../../module-build/rollup/build.js --bundlePrefix ag-charts-community --umdModuleName agCharts",
-    "build": "npm run build-cjs && npm run build-esm && npm run hash",
+    "build": "npm run build-ajv && npm run build-cjs && npm run build-esm && npm run hash",
     "watch": "npx tsc -p tsconfig.json --watch",
     "hash": "sh ../../scripts/hashDirectory.sh > .hash"
   },
@@ -57,6 +58,7 @@
     "@types/jest": "^25.2.1",
     "@types/jest-image-snapshot": "^4.3.1",
     "@types/pixelmatch": "^5.2.4",
+    "ajv": "^8.11.0",
     "canvas": "^2.9.0",
     "eslint": "^6.8.0",
     "eslint-plugin-compat": "^3.5.1",
@@ -68,7 +70,8 @@
     "raf": "3.4.1",
     "rimraf": "3.0.2",
     "ts-jest": "^25.4.0",
-    "typescript": "~3.7.7"
+    "typescript": "~3.7.7",
+    "typescript-json-schema": "^0.53.0"
   },
   "publishConfig": {
     "access": "public"

--- a/charts-packages/ag-charts-community/package.json
+++ b/charts-packages/ag-charts-community/package.json
@@ -59,6 +59,7 @@
     "@types/jest-image-snapshot": "^4.3.1",
     "@types/pixelmatch": "^5.2.4",
     "ajv": "^8.11.0",
+    "ajv-keywords": "^5.1.0",
     "canvas": "^2.9.0",
     "eslint": "^6.8.0",
     "eslint-plugin-compat": "^3.5.1",
@@ -69,6 +70,7 @@
     "pixelmatch": "^5.2.1",
     "raf": "3.4.1",
     "rimraf": "3.0.2",
+    "terser": "^5.12.1",
     "ts-jest": "^25.4.0",
     "typescript": "~3.7.7",
     "typescript-json-schema": "^0.53.0"

--- a/charts-packages/ag-charts-community/src/chart/.gitignore
+++ b/charts-packages/ag-charts-community/src/chart/.gitignore
@@ -1,2 +1,5 @@
 # Ignore auto-generated file.
 agChartOptions.ajv.js
+
+# Don't ignore this versioned .d.ts.
+!agChartOptions.ajv.d.ts

--- a/charts-packages/ag-charts-community/src/chart/.gitignore
+++ b/charts-packages/ag-charts-community/src/chart/.gitignore
@@ -1,0 +1,2 @@
+# Ignore auto-generated file.
+agChartOptions.ajv.js

--- a/charts-packages/ag-charts-community/src/chart/agChartOptions.ajv.d.ts
+++ b/charts-packages/ag-charts-community/src/chart/agChartOptions.ajv.d.ts
@@ -1,0 +1,20 @@
+import { AgChartOptions, AgCartesianChartOptions, AgPolarChartOptions, AgHierarchyChartOptions } from "./agChartOptions";
+
+interface AjvErrors {
+    instancePath: string;
+    keyword: 'type' | 'enum' | 'anyOf' | 'additionalProperties';
+    message: string;
+    params: {
+        type?: string;
+        allowedValues?: string[];
+        additionalProperty?: string;
+    };
+    schemaPath: string;
+}
+
+type AjvValidationFunction<T> = {
+    (input: any): input is T;
+    errors?: AjvErrors[];
+}
+
+export const validateAgChartOptions: AjvValidationFunction<AgChartOptions>;

--- a/charts-packages/ag-charts-community/src/chart/agChartOptions.ts
+++ b/charts-packages/ag-charts-community/src/chart/agChartOptions.ts
@@ -37,6 +37,9 @@ export type Opacity = number;
 /** Alias to denote that a value is a measurement in pixels. */
 export type PixelSize = number;
 
+/** Alias for an actual HTMLElement. */
+type HTMLElement = any;
+
 export interface AgChartThemePalette {
     /** The array of fills to be used. */
     fills: string[];

--- a/charts-packages/ag-charts-community/tsconfig.esm.es6.json
+++ b/charts-packages/ag-charts-community/tsconfig.esm.es6.json
@@ -15,5 +15,5 @@
   "exclude": [
     "**/*.test.ts",
     "**/test/*.ts",
-]
+  ]
 }

--- a/community-modules/core/src/ts/interfaces/iAgChartOptions.ts
+++ b/community-modules/core/src/ts/interfaces/iAgChartOptions.ts
@@ -37,6 +37,9 @@ export type Opacity = number;
 /** Alias to denote that a value is a measurement in pixels. */
 export type PixelSize = number;
 
+/** Alias for an actual HTMLElement. */
+type HTMLElement = any;
+
 export interface AgChartThemePalette {
     /** The array of fills to be used. */
     fills: string[];

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/doc-interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/doc-interfaces.AUTO.json
@@ -10284,6 +10284,7 @@
   "CssColor": {},
   "Opacity": {},
   "PixelSize": {},
+  "HTMLElement": {},
   "AgChartThemePalette": {
     "fills": {
       "description": "/** The array of fills to be used. */",

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/interfaces.AUTO.json
@@ -5877,6 +5877,7 @@
   "CssColor": { "meta": { "isTypeAlias": true }, "type": "string" },
   "Opacity": { "meta": { "isTypeAlias": true }, "type": "number" },
   "PixelSize": { "meta": { "isTypeAlias": true }, "type": "number" },
+  "HTMLElement": { "meta": { "isTypeAlias": true }, "type": "any" },
   "AgChartThemePalette": {
     "meta": {},
     "type": { "fills": "string[]", "strokes": "string[]" },


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-6586

**WIP DO NOT MERGE**

Investigation into the feasibility of using `ajv` to validation Charts `AgChartOptions` structures.

Implementation detail:
- Introduces a build step (see `generate-ajv.js`) which takes `agChartOptions.ts` as the source of truth and:
  - Uses `typescript-json-schema` to create a matching JSONSchema of the options interface contract.
  - Uses `ajv` to create a standalone validator of that JSONSchema.
- During `AgChartsV2` execution, if we detect that we're in a development environment then perform the validation.

Performance:
- Anecdotally validation takes 1-2ms from a few spot checks on examples.

TODO:
- [x] Work out kinks with `webpack` build - can't find generated `.js` modules at present.
- [ ] Determine if we can lazy-load the AJV validator code, as after optimisation it's still ~400KB (before gzip). Maybe consider a distinct module?
- [ ] Get all tests to pass (some are failing validation!).
- [ ] Consider moving general code (e.g. `generate-ajv.js` and the error reduction code in `AgChartV2.ts`) to somewhere it could be re-used?