### PR TITLE
AG-6654 - Charts API Explorer Caching + Visual Improvements

### DIFF
--- a/charts-packages/ag-charts-community/src/chart/agChartOptions.ts
+++ b/charts-packages/ag-charts-community/src/chart/agChartOptions.ts
@@ -381,6 +381,7 @@ export interface AgBaseChartOptions {
     legend?: AgChartLegendOptions;
     /** A map of event names to event listeners. */
     listeners?: AgBaseChartListeners;
+    /** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide a `AgChartTheme` instance to customise. */
     theme?: string | AgChartTheme; // | ChartTheme
 }
 

--- a/charts-packages/ag-charts-community/src/chart/agChartOptions.ts
+++ b/charts-packages/ag-charts-community/src/chart/agChartOptions.ts
@@ -381,7 +381,7 @@ export interface AgBaseChartOptions {
     legend?: AgChartLegendOptions;
     /** A map of event names to event listeners. */
     listeners?: AgBaseChartListeners;
-    /** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide a `AgChartTheme` instance to customise. */
+    /** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide an `AgChartTheme` instance to customise. */
     theme?: string | AgChartTheme; // | ChartTheme
 }
 

--- a/charts-packages/ag-charts-community/src/chart/agChartOptions.ts
+++ b/charts-packages/ag-charts-community/src/chart/agChartOptions.ts
@@ -28,6 +28,8 @@ export type AgChartThemeName =
     | 'ag-vivid'
     | 'ag-vivid-dark';
 
+export type MarkerShape = 'circle' | 'cross' | 'diamond' | 'heart' | 'plus' | 'triangle' | any;
+
 /** Alias to denote that a value should be a CSS-compliant color string, such as `#FFFFFF` or `rgb(255, 255, 255)` or `white`. */
 export type CssColor = string;
 
@@ -278,7 +280,7 @@ export interface AgChartLegendMarkerOptions {
     /** The size in pixels of the markers in the legend. */
     size?: PixelSize;
     /** If set, overrides the marker shape from the series and the legend will show the specified marker shape instead. If not set, will use a marker shape matching the shape from the series, or fall back to `'square'` if there is none. */
-    shape?: string | (new () => any); // Remove the (new () => any) eventually.
+    shape?: MarkerShape;
     /** The padding in pixels between a legend marker and the corresponding label. */
     padding?: PixelSize;
     /** The width in pixels of the stroke for markers in the legend. */
@@ -636,7 +638,7 @@ export interface AgSeriesMarker {
     /** Whether or not to show markers. */
     enabled?: boolean;
     /** The shape to use for the markers. You can also supply a custom marker by providing a `Marker` subclass. */
-    shape?: string | (new () => any);
+    shape?: MarkerShape;
     /** The size in pixels of the markers. */
     size?: PixelSize;
     /** For series where the size of the marker is determined by the data, this determines the largest size a marker can be in pixels. */

--- a/community-modules/core/src/ts/interfaces/iAgChartOptions.ts
+++ b/community-modules/core/src/ts/interfaces/iAgChartOptions.ts
@@ -381,6 +381,7 @@ export interface AgBaseChartOptions {
     legend?: AgChartLegendOptions;
     /** A map of event names to event listeners. */
     listeners?: AgBaseChartListeners;
+    /** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide a `AgChartTheme` instance to customise. */
     theme?: string | AgChartTheme; // | ChartTheme
 }
 

--- a/community-modules/core/src/ts/interfaces/iAgChartOptions.ts
+++ b/community-modules/core/src/ts/interfaces/iAgChartOptions.ts
@@ -381,7 +381,7 @@ export interface AgBaseChartOptions {
     legend?: AgChartLegendOptions;
     /** A map of event names to event listeners. */
     listeners?: AgBaseChartListeners;
-    /** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide a `AgChartTheme` instance to customise. */
+    /** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide an `AgChartTheme` instance to customise. */
     theme?: string | AgChartTheme; // | ChartTheme
 }
 

--- a/community-modules/core/src/ts/interfaces/iAgChartOptions.ts
+++ b/community-modules/core/src/ts/interfaces/iAgChartOptions.ts
@@ -28,6 +28,8 @@ export type AgChartThemeName =
     | 'ag-vivid'
     | 'ag-vivid-dark';
 
+export type MarkerShape = 'circle' | 'cross' | 'diamond' | 'heart' | 'plus' | 'triangle' | any;
+
 /** Alias to denote that a value should be a CSS-compliant color string, such as `#FFFFFF` or `rgb(255, 255, 255)` or `white`. */
 export type CssColor = string;
 
@@ -278,7 +280,7 @@ export interface AgChartLegendMarkerOptions {
     /** The size in pixels of the markers in the legend. */
     size?: PixelSize;
     /** If set, overrides the marker shape from the series and the legend will show the specified marker shape instead. If not set, will use a marker shape matching the shape from the series, or fall back to `'square'` if there is none. */
-    shape?: string | (new () => any); // Remove the (new () => any) eventually.
+    shape?: MarkerShape;
     /** The padding in pixels between a legend marker and the corresponding label. */
     padding?: PixelSize;
     /** The width in pixels of the stroke for markers in the legend. */
@@ -636,7 +638,7 @@ export interface AgSeriesMarker {
     /** Whether or not to show markers. */
     enabled?: boolean;
     /** The shape to use for the markers. You can also supply a custom marker by providing a `Marker` subclass. */
-    shape?: string | (new () => any);
+    shape?: MarkerShape;
     /** The size in pixels of the markers. */
     size?: PixelSize;
     /** For series where the size of the marker is determined by the data, this determines the largest size a marker can be in pixels. */

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/api.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/api.json
@@ -309,6 +309,22 @@
     },
     "series": {
       "type": "AgCartesianSeriesOptions[]"
+    },
+    "theme": {
+      "default": "ag-default",
+      "options": [
+        "ag-default",
+        "ag-material",
+        "ag-pastel",
+        "ag-solar",
+        "ag-vivid",
+        "ag-default-dark",
+        "ag-material-dark",
+        "ag-pastel-dark",
+        "ag-solar-dark",
+        "ag-vivid-dark"
+      ],
+      "breakIndex": 5
     }
   },
   "AgPolarChartOptions": {
@@ -340,6 +356,22 @@
     },
     "series": {
       "type": "AgPolarSeriesOptions[]"
+    },
+    "theme": {
+      "default": "ag-default",
+      "options": [
+        "ag-default",
+        "ag-material",
+        "ag-pastel",
+        "ag-solar",
+        "ag-vivid",
+        "ag-default-dark",
+        "ag-material-dark",
+        "ag-pastel-dark",
+        "ag-solar-dark",
+        "ag-vivid-dark"
+      ],
+      "breakIndex": 5
     }
   },
   "AgHierarchyChartOptions": {
@@ -371,6 +403,22 @@
     },
     "series": {
       "type": "AgHierarchySeriesOptions[]"
+    },
+    "theme": {
+      "default": "ag-default",
+      "options": [
+        "ag-default",
+        "ag-material",
+        "ag-pastel",
+        "ag-solar",
+        "ag-vivid",
+        "ag-default-dark",
+        "ag-material-dark",
+        "ag-pastel-dark",
+        "ag-solar-dark",
+        "ag-vivid-dark"
+      ],
+      "breakIndex": 5
     }
   },
   "AgNumberAxisOptions": {

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/doc-interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/doc-interfaces.AUTO.json
@@ -226,7 +226,7 @@
       "type": { "returnType": "AgBaseChartListeners", "optional": true }
     },
     "theme": {
-      "description": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide a `AgChartTheme` instance to customise. */",
+      "description": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide an `AgChartTheme` instance to customise. */",
       "type": { "returnType": "string | AgChartTheme", "optional": true }
     }
   },
@@ -285,7 +285,7 @@
       "type": { "returnType": "AgBaseChartListeners", "optional": true }
     },
     "theme": {
-      "description": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide a `AgChartTheme` instance to customise. */",
+      "description": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide an `AgChartTheme` instance to customise. */",
       "type": { "returnType": "string | AgChartTheme", "optional": true }
     }
   },
@@ -344,7 +344,7 @@
       "type": { "returnType": "AgBaseChartListeners", "optional": true }
     },
     "theme": {
-      "description": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide a `AgChartTheme` instance to customise. */",
+      "description": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide an `AgChartTheme` instance to customise. */",
       "type": { "returnType": "string | AgChartTheme", "optional": true }
     }
   },
@@ -1088,7 +1088,7 @@
       "type": { "returnType": "AgBaseChartListeners", "optional": true }
     },
     "theme": {
-      "description": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide a `AgChartTheme` instance to customise. */",
+      "description": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide an `AgChartTheme` instance to customise. */",
       "type": { "returnType": "string | AgChartTheme", "optional": true }
     }
   },
@@ -2990,7 +2990,7 @@
       "type": { "returnType": "AgBaseChartListeners", "optional": true }
     },
     "theme": {
-      "description": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide a `AgChartTheme` instance to customise. */",
+      "description": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide an `AgChartTheme` instance to customise. */",
       "type": { "returnType": "string | AgChartTheme", "optional": true }
     }
   },
@@ -3052,7 +3052,7 @@
       "type": { "returnType": "AgBaseChartListeners", "optional": true }
     },
     "theme": {
-      "description": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide a `AgChartTheme` instance to customise. */",
+      "description": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide an `AgChartTheme` instance to customise. */",
       "type": { "returnType": "string | AgChartTheme", "optional": true }
     }
   },
@@ -3111,7 +3111,7 @@
       "type": { "returnType": "AgBaseChartListeners", "optional": true }
     },
     "theme": {
-      "description": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide a `AgChartTheme` instance to customise. */",
+      "description": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide an `AgChartTheme` instance to customise. */",
       "type": { "returnType": "string | AgChartTheme", "optional": true }
     }
   },

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/doc-interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/doc-interfaces.AUTO.json
@@ -23,6 +23,7 @@
   "FontFamily": {},
   "FontSize": {},
   "AgChartThemeName": {},
+  "MarkerShape": {},
   "CssColor": {},
   "Opacity": {},
   "PixelSize": {},
@@ -913,7 +914,7 @@
     },
     "shape": {
       "description": "/** If set, overrides the marker shape from the series and the legend will show the specified marker shape instead. If not set, will use a marker shape matching the shape from the series, or fall back to `'square'` if there is none. */",
-      "type": { "returnType": "string | (new () => any)", "optional": true }
+      "type": { "returnType": "MarkerShape", "optional": true }
     },
     "padding": {
       "description": "/** The padding in pixels between a legend marker and the corresponding label. */",
@@ -1585,7 +1586,7 @@
     },
     "shape": {
       "description": "/** The shape to use for the markers. You can also supply a custom marker by providing a `Marker` subclass. */",
-      "type": { "returnType": "string | (new () => any)", "optional": true }
+      "type": { "returnType": "MarkerShape", "optional": true }
     },
     "size": {
       "description": "/** The size in pixels of the markers. */",
@@ -1655,7 +1656,7 @@
     },
     "shape": {
       "description": "/** The shape to use for the markers. You can also supply a custom marker by providing a `Marker` subclass. */",
-      "type": { "returnType": "string | (new () => any)", "optional": true }
+      "type": { "returnType": "MarkerShape", "optional": true }
     },
     "size": {
       "description": "/** The size in pixels of the markers. */",
@@ -1700,7 +1701,7 @@
     },
     "shape": {
       "description": "/** The shape to use for the markers. You can also supply a custom marker by providing a `Marker` subclass. */",
-      "type": { "returnType": "string | (new () => any)", "optional": true }
+      "type": { "returnType": "MarkerShape", "optional": true }
     },
     "size": {
       "description": "/** The size in pixels of the markers. */",

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/doc-interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/doc-interfaces.AUTO.json
@@ -226,6 +226,7 @@
       "type": { "returnType": "AgBaseChartListeners", "optional": true }
     },
     "theme": {
+      "description": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide a `AgChartTheme` instance to customise. */",
       "type": { "returnType": "string | AgChartTheme", "optional": true }
     }
   },
@@ -284,6 +285,7 @@
       "type": { "returnType": "AgBaseChartListeners", "optional": true }
     },
     "theme": {
+      "description": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide a `AgChartTheme` instance to customise. */",
       "type": { "returnType": "string | AgChartTheme", "optional": true }
     }
   },
@@ -342,6 +344,7 @@
       "type": { "returnType": "AgBaseChartListeners", "optional": true }
     },
     "theme": {
+      "description": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide a `AgChartTheme` instance to customise. */",
       "type": { "returnType": "string | AgChartTheme", "optional": true }
     }
   },
@@ -1085,6 +1088,7 @@
       "type": { "returnType": "AgBaseChartListeners", "optional": true }
     },
     "theme": {
+      "description": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide a `AgChartTheme` instance to customise. */",
       "type": { "returnType": "string | AgChartTheme", "optional": true }
     }
   },
@@ -2986,6 +2990,7 @@
       "type": { "returnType": "AgBaseChartListeners", "optional": true }
     },
     "theme": {
+      "description": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide a `AgChartTheme` instance to customise. */",
       "type": { "returnType": "string | AgChartTheme", "optional": true }
     }
   },
@@ -3047,6 +3052,7 @@
       "type": { "returnType": "AgBaseChartListeners", "optional": true }
     },
     "theme": {
+      "description": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide a `AgChartTheme` instance to customise. */",
       "type": { "returnType": "string | AgChartTheme", "optional": true }
     }
   },
@@ -3105,6 +3111,7 @@
       "type": { "returnType": "AgBaseChartListeners", "optional": true }
     },
     "theme": {
+      "description": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide a `AgChartTheme` instance to customise. */",
       "type": { "returnType": "string | AgChartTheme", "optional": true }
     }
   },

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
@@ -162,7 +162,7 @@
       "tooltip?": "/** Global configuration that applies to all tooltips in the chart. */",
       "legend?": "/** Configuration for the chart legend. */",
       "listeners?": "/** A map of event names to event listeners. */",
-      "theme?": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide a `AgChartTheme` instance to customise. */"
+      "theme?": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide an `AgChartTheme` instance to customise. */"
     }
   },
   "AgPolarThemeOptions": {
@@ -197,7 +197,7 @@
       "tooltip?": "/** Global configuration that applies to all tooltips in the chart. */",
       "legend?": "/** Configuration for the chart legend. */",
       "listeners?": "/** A map of event names to event listeners. */",
-      "theme?": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide a `AgChartTheme` instance to customise. */"
+      "theme?": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide an `AgChartTheme` instance to customise. */"
     }
   },
   "AgHierarchyThemeOptions": {
@@ -232,7 +232,7 @@
       "tooltip?": "/** Global configuration that applies to all tooltips in the chart. */",
       "legend?": "/** Configuration for the chart legend. */",
       "listeners?": "/** A map of event names to event listeners. */",
-      "theme?": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide a `AgChartTheme` instance to customise. */"
+      "theme?": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide an `AgChartTheme` instance to customise. */"
     }
   },
   "AgNumberAxisThemeOptions": {
@@ -703,7 +703,7 @@
       "tooltip?": "/** Global configuration that applies to all tooltips in the chart. */",
       "legend?": "/** Configuration for the chart legend. */",
       "listeners?": "/** A map of event names to event listeners. */",
-      "theme?": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide a `AgChartTheme` instance to customise. */"
+      "theme?": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide an `AgChartTheme` instance to customise. */"
     }
   },
   "AgBaseAxisOptions": {
@@ -2012,7 +2012,7 @@
       "tooltip?": "/** Global configuration that applies to all tooltips in the chart. */",
       "legend?": "/** Configuration for the chart legend. */",
       "listeners?": "/** A map of event names to event listeners. */",
-      "theme?": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide a `AgChartTheme` instance to customise. */"
+      "theme?": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide an `AgChartTheme` instance to customise. */"
     }
   },
   "AgPolarChartOptions": {
@@ -2049,7 +2049,7 @@
       "tooltip?": "/** Global configuration that applies to all tooltips in the chart. */",
       "legend?": "/** Configuration for the chart legend. */",
       "listeners?": "/** A map of event names to event listeners. */",
-      "theme?": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide a `AgChartTheme` instance to customise. */"
+      "theme?": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide an `AgChartTheme` instance to customise. */"
     }
   },
   "AgHierarchyChartOptions": {
@@ -2086,7 +2086,7 @@
       "tooltip?": "/** Global configuration that applies to all tooltips in the chart. */",
       "legend?": "/** Configuration for the chart legend. */",
       "listeners?": "/** A map of event names to event listeners. */",
-      "theme?": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide a `AgChartTheme` instance to customise. */"
+      "theme?": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide an `AgChartTheme` instance to customise. */"
     }
   },
   "AgChartOptions": {

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
@@ -36,6 +36,10 @@
     "meta": { "isTypeAlias": true },
     "type": "'ag-default' | 'ag-default-dark' | 'ag-material' | 'ag-material-dark' | 'ag-pastel' | 'ag-pastel-dark' | 'ag-solar' | 'ag-solar-dark' | 'ag-vivid' | 'ag-vivid-dark'"
   },
+  "MarkerShape": {
+    "meta": { "isTypeAlias": true },
+    "type": "'circle' | 'cross' | 'diamond' | 'heart' | 'plus' | 'triangle' | any"
+  },
   "CssColor": { "meta": { "isTypeAlias": true }, "type": "string" },
   "Opacity": { "meta": { "isTypeAlias": true }, "type": "number" },
   "PixelSize": { "meta": { "isTypeAlias": true }, "type": "number" },
@@ -572,7 +576,7 @@
     "meta": {},
     "type": {
       "size?": "PixelSize",
-      "shape?": "string | (new () => any)",
+      "shape?": "MarkerShape",
       "padding?": "PixelSize",
       "strokeWidth?": "PixelSize"
     },
@@ -1091,7 +1095,7 @@
     "meta": {},
     "type": {
       "enabled?": "boolean",
-      "shape?": "string | (new () => any)",
+      "shape?": "MarkerShape",
       "size?": "PixelSize",
       "maxSize?": "PixelSize",
       "fill?": "CssColor",
@@ -1154,7 +1158,7 @@
     "type": {
       "formatter?": "AgCartesianSeriesMarkerFormatter",
       "enabled?": "boolean",
-      "shape?": "string | (new () => any)",
+      "shape?": "MarkerShape",
       "size?": "PixelSize",
       "maxSize?": "PixelSize",
       "fill?": "CssColor",
@@ -1181,7 +1185,7 @@
     "type": {
       "formatter?": "AgCartesianSeriesMarkerFormatter",
       "enabled?": "boolean",
-      "shape?": "string | (new () => any)",
+      "shape?": "MarkerShape",
       "size?": "PixelSize",
       "maxSize?": "PixelSize",
       "fill?": "CssColor",

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
@@ -161,7 +161,8 @@
       "subtitle?": "/** Configuration for the subtitle shown beneath the chart title. Note: a subtitle will only be shown if a title is also present. */",
       "tooltip?": "/** Global configuration that applies to all tooltips in the chart. */",
       "legend?": "/** Configuration for the chart legend. */",
-      "listeners?": "/** A map of event names to event listeners. */"
+      "listeners?": "/** A map of event names to event listeners. */",
+      "theme?": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide a `AgChartTheme` instance to customise. */"
     }
   },
   "AgPolarThemeOptions": {
@@ -195,7 +196,8 @@
       "subtitle?": "/** Configuration for the subtitle shown beneath the chart title. Note: a subtitle will only be shown if a title is also present. */",
       "tooltip?": "/** Global configuration that applies to all tooltips in the chart. */",
       "legend?": "/** Configuration for the chart legend. */",
-      "listeners?": "/** A map of event names to event listeners. */"
+      "listeners?": "/** A map of event names to event listeners. */",
+      "theme?": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide a `AgChartTheme` instance to customise. */"
     }
   },
   "AgHierarchyThemeOptions": {
@@ -229,7 +231,8 @@
       "subtitle?": "/** Configuration for the subtitle shown beneath the chart title. Note: a subtitle will only be shown if a title is also present. */",
       "tooltip?": "/** Global configuration that applies to all tooltips in the chart. */",
       "legend?": "/** Configuration for the chart legend. */",
-      "listeners?": "/** A map of event names to event listeners. */"
+      "listeners?": "/** A map of event names to event listeners. */",
+      "theme?": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide a `AgChartTheme` instance to customise. */"
     }
   },
   "AgNumberAxisThemeOptions": {
@@ -699,7 +702,8 @@
       "subtitle?": "/** Configuration for the subtitle shown beneath the chart title. Note: a subtitle will only be shown if a title is also present. */",
       "tooltip?": "/** Global configuration that applies to all tooltips in the chart. */",
       "legend?": "/** Configuration for the chart legend. */",
-      "listeners?": "/** A map of event names to event listeners. */"
+      "listeners?": "/** A map of event names to event listeners. */",
+      "theme?": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide a `AgChartTheme` instance to customise. */"
     }
   },
   "AgBaseAxisOptions": {
@@ -2007,7 +2011,8 @@
       "subtitle?": "/** Configuration for the subtitle shown beneath the chart title. Note: a subtitle will only be shown if a title is also present. */",
       "tooltip?": "/** Global configuration that applies to all tooltips in the chart. */",
       "legend?": "/** Configuration for the chart legend. */",
-      "listeners?": "/** A map of event names to event listeners. */"
+      "listeners?": "/** A map of event names to event listeners. */",
+      "theme?": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide a `AgChartTheme` instance to customise. */"
     }
   },
   "AgPolarChartOptions": {
@@ -2043,7 +2048,8 @@
       "subtitle?": "/** Configuration for the subtitle shown beneath the chart title. Note: a subtitle will only be shown if a title is also present. */",
       "tooltip?": "/** Global configuration that applies to all tooltips in the chart. */",
       "legend?": "/** Configuration for the chart legend. */",
-      "listeners?": "/** A map of event names to event listeners. */"
+      "listeners?": "/** A map of event names to event listeners. */",
+      "theme?": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide a `AgChartTheme` instance to customise. */"
     }
   },
   "AgHierarchyChartOptions": {
@@ -2079,7 +2085,8 @@
       "subtitle?": "/** Configuration for the subtitle shown beneath the chart title. Note: a subtitle will only be shown if a title is also present. */",
       "tooltip?": "/** Global configuration that applies to all tooltips in the chart. */",
       "legend?": "/** Configuration for the chart legend. */",
-      "listeners?": "/** A map of event names to event listeners. */"
+      "listeners?": "/** A map of event names to event listeners. */",
+      "theme?": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide a `AgChartTheme` instance to customise. */"
     }
   },
   "AgChartOptions": {

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/doc-interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/doc-interfaces.AUTO.json
@@ -10484,6 +10484,7 @@
       "type": { "returnType": "AgBaseChartListeners", "optional": true }
     },
     "theme": {
+      "description": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide a `AgChartTheme` instance to customise. */",
       "type": { "returnType": "string | AgChartTheme", "optional": true }
     }
   },
@@ -10542,6 +10543,7 @@
       "type": { "returnType": "AgBaseChartListeners", "optional": true }
     },
     "theme": {
+      "description": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide a `AgChartTheme` instance to customise. */",
       "type": { "returnType": "string | AgChartTheme", "optional": true }
     }
   },
@@ -10600,6 +10602,7 @@
       "type": { "returnType": "AgBaseChartListeners", "optional": true }
     },
     "theme": {
+      "description": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide a `AgChartTheme` instance to customise. */",
       "type": { "returnType": "string | AgChartTheme", "optional": true }
     }
   },
@@ -11343,6 +11346,7 @@
       "type": { "returnType": "AgBaseChartListeners", "optional": true }
     },
     "theme": {
+      "description": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide a `AgChartTheme` instance to customise. */",
       "type": { "returnType": "string | AgChartTheme", "optional": true }
     }
   },
@@ -13244,6 +13248,7 @@
       "type": { "returnType": "AgBaseChartListeners", "optional": true }
     },
     "theme": {
+      "description": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide a `AgChartTheme` instance to customise. */",
       "type": { "returnType": "string | AgChartTheme", "optional": true }
     }
   },
@@ -13305,6 +13310,7 @@
       "type": { "returnType": "AgBaseChartListeners", "optional": true }
     },
     "theme": {
+      "description": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide a `AgChartTheme` instance to customise. */",
       "type": { "returnType": "string | AgChartTheme", "optional": true }
     }
   },
@@ -13363,6 +13369,7 @@
       "type": { "returnType": "AgBaseChartListeners", "optional": true }
     },
     "theme": {
+      "description": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide a `AgChartTheme` instance to customise. */",
       "type": { "returnType": "string | AgChartTheme", "optional": true }
     }
   },

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/doc-interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/doc-interfaces.AUTO.json
@@ -10484,7 +10484,7 @@
       "type": { "returnType": "AgBaseChartListeners", "optional": true }
     },
     "theme": {
-      "description": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide a `AgChartTheme` instance to customise. */",
+      "description": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide an `AgChartTheme` instance to customise. */",
       "type": { "returnType": "string | AgChartTheme", "optional": true }
     }
   },
@@ -10543,7 +10543,7 @@
       "type": { "returnType": "AgBaseChartListeners", "optional": true }
     },
     "theme": {
-      "description": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide a `AgChartTheme` instance to customise. */",
+      "description": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide an `AgChartTheme` instance to customise. */",
       "type": { "returnType": "string | AgChartTheme", "optional": true }
     }
   },
@@ -10602,7 +10602,7 @@
       "type": { "returnType": "AgBaseChartListeners", "optional": true }
     },
     "theme": {
-      "description": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide a `AgChartTheme` instance to customise. */",
+      "description": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide an `AgChartTheme` instance to customise. */",
       "type": { "returnType": "string | AgChartTheme", "optional": true }
     }
   },
@@ -11346,7 +11346,7 @@
       "type": { "returnType": "AgBaseChartListeners", "optional": true }
     },
     "theme": {
-      "description": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide a `AgChartTheme` instance to customise. */",
+      "description": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide an `AgChartTheme` instance to customise. */",
       "type": { "returnType": "string | AgChartTheme", "optional": true }
     }
   },
@@ -13248,7 +13248,7 @@
       "type": { "returnType": "AgBaseChartListeners", "optional": true }
     },
     "theme": {
-      "description": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide a `AgChartTheme` instance to customise. */",
+      "description": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide an `AgChartTheme` instance to customise. */",
       "type": { "returnType": "string | AgChartTheme", "optional": true }
     }
   },
@@ -13310,7 +13310,7 @@
       "type": { "returnType": "AgBaseChartListeners", "optional": true }
     },
     "theme": {
-      "description": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide a `AgChartTheme` instance to customise. */",
+      "description": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide an `AgChartTheme` instance to customise. */",
       "type": { "returnType": "string | AgChartTheme", "optional": true }
     }
   },
@@ -13369,7 +13369,7 @@
       "type": { "returnType": "AgBaseChartListeners", "optional": true }
     },
     "theme": {
-      "description": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide a `AgChartTheme` instance to customise. */",
+      "description": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide an `AgChartTheme` instance to customise. */",
       "type": { "returnType": "string | AgChartTheme", "optional": true }
     }
   },

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/doc-interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/doc-interfaces.AUTO.json
@@ -10281,6 +10281,7 @@
   "FontFamily": {},
   "FontSize": {},
   "AgChartThemeName": {},
+  "MarkerShape": {},
   "CssColor": {},
   "Opacity": {},
   "PixelSize": {},
@@ -11171,7 +11172,7 @@
     },
     "shape": {
       "description": "/** If set, overrides the marker shape from the series and the legend will show the specified marker shape instead. If not set, will use a marker shape matching the shape from the series, or fall back to `'square'` if there is none. */",
-      "type": { "returnType": "string | (new () => any)", "optional": true }
+      "type": { "returnType": "MarkerShape", "optional": true }
     },
     "padding": {
       "description": "/** The padding in pixels between a legend marker and the corresponding label. */",
@@ -11843,7 +11844,7 @@
     },
     "shape": {
       "description": "/** The shape to use for the markers. You can also supply a custom marker by providing a `Marker` subclass. */",
-      "type": { "returnType": "string | (new () => any)", "optional": true }
+      "type": { "returnType": "MarkerShape", "optional": true }
     },
     "size": {
       "description": "/** The size in pixels of the markers. */",
@@ -11913,7 +11914,7 @@
     },
     "shape": {
       "description": "/** The shape to use for the markers. You can also supply a custom marker by providing a `Marker` subclass. */",
-      "type": { "returnType": "string | (new () => any)", "optional": true }
+      "type": { "returnType": "MarkerShape", "optional": true }
     },
     "size": {
       "description": "/** The size in pixels of the markers. */",
@@ -11958,7 +11959,7 @@
     },
     "shape": {
       "description": "/** The shape to use for the markers. You can also supply a custom marker by providing a `Marker` subclass. */",
-      "type": { "returnType": "string | (new () => any)", "optional": true }
+      "type": { "returnType": "MarkerShape", "optional": true }
     },
     "size": {
       "description": "/** The size in pixels of the markers. */",

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/interfaces.AUTO.json
@@ -5999,7 +5999,8 @@
       "subtitle?": "/** Configuration for the subtitle shown beneath the chart title. Note: a subtitle will only be shown if a title is also present. */",
       "tooltip?": "/** Global configuration that applies to all tooltips in the chart. */",
       "legend?": "/** Configuration for the chart legend. */",
-      "listeners?": "/** A map of event names to event listeners. */"
+      "listeners?": "/** A map of event names to event listeners. */",
+      "theme?": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide a `AgChartTheme` instance to customise. */"
     }
   },
   "AgPolarThemeOptions": {
@@ -6033,7 +6034,8 @@
       "subtitle?": "/** Configuration for the subtitle shown beneath the chart title. Note: a subtitle will only be shown if a title is also present. */",
       "tooltip?": "/** Global configuration that applies to all tooltips in the chart. */",
       "legend?": "/** Configuration for the chart legend. */",
-      "listeners?": "/** A map of event names to event listeners. */"
+      "listeners?": "/** A map of event names to event listeners. */",
+      "theme?": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide a `AgChartTheme` instance to customise. */"
     }
   },
   "AgHierarchyThemeOptions": {
@@ -6067,7 +6069,8 @@
       "subtitle?": "/** Configuration for the subtitle shown beneath the chart title. Note: a subtitle will only be shown if a title is also present. */",
       "tooltip?": "/** Global configuration that applies to all tooltips in the chart. */",
       "legend?": "/** Configuration for the chart legend. */",
-      "listeners?": "/** A map of event names to event listeners. */"
+      "listeners?": "/** A map of event names to event listeners. */",
+      "theme?": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide a `AgChartTheme` instance to customise. */"
     }
   },
   "AgNumberAxisThemeOptions": {
@@ -6537,7 +6540,8 @@
       "subtitle?": "/** Configuration for the subtitle shown beneath the chart title. Note: a subtitle will only be shown if a title is also present. */",
       "tooltip?": "/** Global configuration that applies to all tooltips in the chart. */",
       "legend?": "/** Configuration for the chart legend. */",
-      "listeners?": "/** A map of event names to event listeners. */"
+      "listeners?": "/** A map of event names to event listeners. */",
+      "theme?": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide a `AgChartTheme` instance to customise. */"
     }
   },
   "AgBaseAxisOptions": {
@@ -7845,7 +7849,8 @@
       "subtitle?": "/** Configuration for the subtitle shown beneath the chart title. Note: a subtitle will only be shown if a title is also present. */",
       "tooltip?": "/** Global configuration that applies to all tooltips in the chart. */",
       "legend?": "/** Configuration for the chart legend. */",
-      "listeners?": "/** A map of event names to event listeners. */"
+      "listeners?": "/** A map of event names to event listeners. */",
+      "theme?": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide a `AgChartTheme` instance to customise. */"
     }
   },
   "AgPolarChartOptions": {
@@ -7881,7 +7886,8 @@
       "subtitle?": "/** Configuration for the subtitle shown beneath the chart title. Note: a subtitle will only be shown if a title is also present. */",
       "tooltip?": "/** Global configuration that applies to all tooltips in the chart. */",
       "legend?": "/** Configuration for the chart legend. */",
-      "listeners?": "/** A map of event names to event listeners. */"
+      "listeners?": "/** A map of event names to event listeners. */",
+      "theme?": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide a `AgChartTheme` instance to customise. */"
     }
   },
   "AgHierarchyChartOptions": {
@@ -7917,7 +7923,8 @@
       "subtitle?": "/** Configuration for the subtitle shown beneath the chart title. Note: a subtitle will only be shown if a title is also present. */",
       "tooltip?": "/** Global configuration that applies to all tooltips in the chart. */",
       "legend?": "/** Configuration for the chart legend. */",
-      "listeners?": "/** A map of event names to event listeners. */"
+      "listeners?": "/** A map of event names to event listeners. */",
+      "theme?": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide a `AgChartTheme` instance to customise. */"
     }
   },
   "AgChartOptions": {

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/interfaces.AUTO.json
@@ -6000,7 +6000,7 @@
       "tooltip?": "/** Global configuration that applies to all tooltips in the chart. */",
       "legend?": "/** Configuration for the chart legend. */",
       "listeners?": "/** A map of event names to event listeners. */",
-      "theme?": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide a `AgChartTheme` instance to customise. */"
+      "theme?": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide an `AgChartTheme` instance to customise. */"
     }
   },
   "AgPolarThemeOptions": {
@@ -6035,7 +6035,7 @@
       "tooltip?": "/** Global configuration that applies to all tooltips in the chart. */",
       "legend?": "/** Configuration for the chart legend. */",
       "listeners?": "/** A map of event names to event listeners. */",
-      "theme?": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide a `AgChartTheme` instance to customise. */"
+      "theme?": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide an `AgChartTheme` instance to customise. */"
     }
   },
   "AgHierarchyThemeOptions": {
@@ -6070,7 +6070,7 @@
       "tooltip?": "/** Global configuration that applies to all tooltips in the chart. */",
       "legend?": "/** Configuration for the chart legend. */",
       "listeners?": "/** A map of event names to event listeners. */",
-      "theme?": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide a `AgChartTheme` instance to customise. */"
+      "theme?": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide an `AgChartTheme` instance to customise. */"
     }
   },
   "AgNumberAxisThemeOptions": {
@@ -6541,7 +6541,7 @@
       "tooltip?": "/** Global configuration that applies to all tooltips in the chart. */",
       "legend?": "/** Configuration for the chart legend. */",
       "listeners?": "/** A map of event names to event listeners. */",
-      "theme?": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide a `AgChartTheme` instance to customise. */"
+      "theme?": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide an `AgChartTheme` instance to customise. */"
     }
   },
   "AgBaseAxisOptions": {
@@ -7850,7 +7850,7 @@
       "tooltip?": "/** Global configuration that applies to all tooltips in the chart. */",
       "legend?": "/** Configuration for the chart legend. */",
       "listeners?": "/** A map of event names to event listeners. */",
-      "theme?": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide a `AgChartTheme` instance to customise. */"
+      "theme?": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide an `AgChartTheme` instance to customise. */"
     }
   },
   "AgPolarChartOptions": {
@@ -7887,7 +7887,7 @@
       "tooltip?": "/** Global configuration that applies to all tooltips in the chart. */",
       "legend?": "/** Configuration for the chart legend. */",
       "listeners?": "/** A map of event names to event listeners. */",
-      "theme?": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide a `AgChartTheme` instance to customise. */"
+      "theme?": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide an `AgChartTheme` instance to customise. */"
     }
   },
   "AgHierarchyChartOptions": {
@@ -7924,7 +7924,7 @@
       "tooltip?": "/** Global configuration that applies to all tooltips in the chart. */",
       "legend?": "/** Configuration for the chart legend. */",
       "listeners?": "/** A map of event names to event listeners. */",
-      "theme?": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide a `AgChartTheme` instance to customise. */"
+      "theme?": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide an `AgChartTheme` instance to customise. */"
     }
   },
   "AgChartOptions": {

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/interfaces.AUTO.json
@@ -5874,6 +5874,10 @@
     "meta": { "isTypeAlias": true },
     "type": "'ag-default' | 'ag-default-dark' | 'ag-material' | 'ag-material-dark' | 'ag-pastel' | 'ag-pastel-dark' | 'ag-solar' | 'ag-solar-dark' | 'ag-vivid' | 'ag-vivid-dark'"
   },
+  "MarkerShape": {
+    "meta": { "isTypeAlias": true },
+    "type": "'circle' | 'cross' | 'diamond' | 'heart' | 'plus' | 'triangle' | any"
+  },
   "CssColor": { "meta": { "isTypeAlias": true }, "type": "string" },
   "Opacity": { "meta": { "isTypeAlias": true }, "type": "number" },
   "PixelSize": { "meta": { "isTypeAlias": true }, "type": "number" },
@@ -6410,7 +6414,7 @@
     "meta": {},
     "type": {
       "size?": "PixelSize",
-      "shape?": "string | (new () => any)",
+      "shape?": "MarkerShape",
       "padding?": "PixelSize",
       "strokeWidth?": "PixelSize"
     },
@@ -6929,7 +6933,7 @@
     "meta": {},
     "type": {
       "enabled?": "boolean",
-      "shape?": "string | (new () => any)",
+      "shape?": "MarkerShape",
       "size?": "PixelSize",
       "maxSize?": "PixelSize",
       "fill?": "CssColor",
@@ -6992,7 +6996,7 @@
     "type": {
       "formatter?": "AgCartesianSeriesMarkerFormatter",
       "enabled?": "boolean",
-      "shape?": "string | (new () => any)",
+      "shape?": "MarkerShape",
       "size?": "PixelSize",
       "maxSize?": "PixelSize",
       "fill?": "CssColor",
@@ -7019,7 +7023,7 @@
     "type": {
       "formatter?": "AgCartesianSeriesMarkerFormatter",
       "enabled?": "boolean",
-      "shape?": "string | (new () => any)",
+      "shape?": "MarkerShape",
       "size?": "PixelSize",
       "maxSize?": "PixelSize",
       "fill?": "CssColor",

--- a/grid-packages/ag-grid-docs/documentation/src/components/charts-api-explorer/ChartsApiExplorer.module.scss
+++ b/grid-packages/ag-grid-docs/documentation/src/components/charts-api-explorer/ChartsApiExplorer.module.scss
@@ -12,15 +12,19 @@
         display: flex;
         flex-direction: row;
         flex: 1 1 auto;
-        overflow: hidden;
+        overflow-x: scroll;
+        overflow-y: hidden;
     }
 
     &__left {
         width: 40%;
+        min-width: 350px;
     }
 
     &__right {
         width: 60%;
+        min-width: 350px;
+        overflow-y: scroll;
     }
 
     &__options {
@@ -34,6 +38,7 @@
         position: relative;
         overflow: hidden;
         height: 50%;
+        min-height: 250px;
     }
 
     &__code {

--- a/grid-packages/ag-grid-docs/documentation/src/components/charts-api-explorer/Editors.tsx
+++ b/grid-packages/ag-grid-docs/documentation/src/components/charts-api-explorer/Editors.tsx
@@ -168,7 +168,9 @@ export const getPrimitiveEditor = ({ meta, desc }: JsonModelProperty, key: strin
     }
 
     if (desc.tsType.indexOf(' | ') >= 0) {
-        const options = desc.tsType.split(' | ').map((v) => v.substring(1, v.length - 1));
+        const options = desc.tsType.split(' | ')
+            .filter((v) => v.startsWith("'") && v.endsWith("'"))
+            .map((v) => v.substring(1, v.length - 1));
 
         if (options.every((v) => /^[a-z-]*$/.test(v))) {
             return { editor: PresetEditor, editorProps: { ...meta, options } };


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-6654

Primary changes:
- During re-render we are reloading and rebuilding the entire `JsonModel` - this change seeks to remove this calculation from the re-render path by introducing caching. (https://github.com/ag-grid/ag-grid/pull/5070/commits/1011e6526b721fa5743895a3806110745e78de51)
- Fixes small-screen rendering of the API Explorer - we no longer continue squishing things to the point of uselessness, but add scroll-bars to allow the content to be moved into view. (https://github.com/ag-grid/ag-grid/pull/5070/commits/aaae9d3f5f6d1dea8628cbbfc1971def6f3eae4e)
- Makes the chart `theme` configurable interactively and adds JSDoc description for the field to improve self-documentation. (https://github.com/ag-grid/ag-grid/pull/5070/commits/c81b4bd403cff5751f175113abc2171b18af952e)

Bonus:
- Improves marker shape typings. (https://github.com/ag-grid/ag-grid/pull/5070/commits/28ab806f6a53cc8516abc94b0aa74a382c5e562f)
- Fixes an edge case in the rendering of primitive unions, where we previously assumed all elements were string literal types. (https://github.com/ag-grid/ag-grid/pull/5070/commits/c0b19e9d8f5f640006eefab0d3b11f4cfcdac011)

Theme option beforehand:
<img width="528" alt="Screenshot 2022-04-07 at 12 17 45" src="https://user-images.githubusercontent.com/17544187/162187506-31172050-c10b-4f5c-8802-49ea110565fa.png">

Theme option after:
<img width="523" alt="Screenshot 2022-04-07 at 12 17 53" src="https://user-images.githubusercontent.com/17544187/162187551-0ec2d653-1a02-46f1-8ab5-763acb42bd88.png">

