### PR TITLE
AG-6647 - Fix Pie Chart initial resize.

### DIFF
--- a/charts-packages/ag-charts-community/src/chart/chart.ts
+++ b/charts-packages/ag-charts-community/src/chart/chart.ts
@@ -407,9 +407,9 @@ export abstract class Chart extends Observable {
 
         const scene = new Scene(document);
         this.scene = scene;
+        this.autoSize = true; // Triggers width/height calc - needs to happen before root group assignment.
         scene.root = root;
         scene.container = element;
-        this.autoSize = true;
 
         this.padding.addEventListener('layoutChange', this.scheduleLayout, this);
 

--- a/charts-packages/ag-charts-community/src/chart/themes/chartTheme.ts
+++ b/charts-packages/ag-charts-community/src/chart/themes/chartTheme.ts
@@ -189,9 +189,6 @@ export class ChartTheme {
 
     private static getChartDefaults() {
         return {
-            width: 600,
-            height: 300,
-            autoSize: true,
             background: {
                 visible: true,
                 fill: 'white'

--- a/charts-packages/ag-charts-community/src/util/sizeMonitor.ts
+++ b/charts-packages/ag-charts-community/src/util/sizeMonitor.ts
@@ -16,6 +16,7 @@ export class SizeMonitor {
     static init() {
         const NativeResizeObserver = (window as any).ResizeObserver;
 
+        
         if (NativeResizeObserver) {
             this.resizeObserver = new NativeResizeObserver((entries: any) => {
                 for (const entry of entries) {
@@ -26,9 +27,7 @@ export class SizeMonitor {
         } else { // polyfill (more reliable even in browsers that support ResizeObserver)
             const step = () => {
                 this.elements.forEach((entry, element) => {
-                    const width = element.clientWidth ? element.clientWidth : 0;
-                    const height = element.clientHeight ? element.clientHeight : 0;
-                    this.checkSize(entry, element, width, height);
+                    this.checkClientSize(element, entry);
                 });
             }
             window.setInterval(step, 100);
@@ -56,6 +55,9 @@ export class SizeMonitor {
             this.resizeObserver.observe(element);
         }
         this.elements.set(element, {cb});
+
+        // Ensure first size callback happens synchronously.
+        this.checkClientSize(element, {cb});
     }
 
     static unobserve(element: HTMLElement) {
@@ -63,5 +65,11 @@ export class SizeMonitor {
             this.resizeObserver.unobserve(element);
         }
         this.elements.delete(element);
+    }
+
+    static checkClientSize(element: HTMLElement, entry: Entry) {
+        const width = element.clientWidth ? element.clientWidth : 0;
+        const height = element.clientHeight ? element.clientHeight : 0;
+        this.checkSize(entry, element, width, height);
     }
 }


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-6647

Attempts to fix the initial rendering of pie charts for a couple of frames at the wrong size.

Root causes:
- `ChartTheme` was setting `width` and `height` properties, despite `autoSize: true` being the intrinsic default - this triggered multiple re-evaluations during option application due to effectively flip-flopping on whether we're rendering a fixed size canvas or one tied to the containing element dimensions.
- There was a race between two triggers for `Scene.render()` calls:
  - Assignment of `scene.root = root` in the `Chart` constructor was triggering a rendering cycle before the size of the container was established as a side-effect of the `this.autoSize = true` assignment, which was racing with...
  - First callback by the `SizeMonitor.observe()` which was being called asynchrnoulsy, and triggering another rendering cycle.

Fixes:
- Remove hardcoded `width` and `height` from the base theme to prevent spurious `autoSize` flip-flopping.
- Re-orders the call to `this.autoSize = true` vs. `scene.root = root` so canvas size can be established before the first render - this is assisted by....
- Forcing the first `SizeMonitor.observe()` callback to happen synchronously.
