### PR TITLE
AG-6119 - Highlight Charts legend items are clickable

### DIFF
--- a/charts-packages/ag-charts-community/src/chart/chart.ts
+++ b/charts-packages/ag-charts-community/src/chart/chart.ts
@@ -1209,7 +1209,7 @@ export abstract class Chart extends Observable {
         const datum = this.legend.getDatumForPoint(offsetX, offsetY);
 
         const pointerInsideLegend = this.legendBBox.containsPoint(offsetX, offsetY);
-        const pointerOverLegendDatum = pointerInsideLegend && datum != null;
+        const pointerOverLegendDatum = pointerInsideLegend && datum !== undefined;
 
         if (!pointerInsideLegend && this.pointerInsideLegend) {
             this.pointerInsideLegend = false;


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-6119

Fix pointer rendering when hovering over a legend item - we now use the the `pointer` cursor type (aka link-hover pointer type).