### PR TITLE
Fix errors due to this.cellComp being undefined in refreshCell

### DIFF
--- a/community-modules/core/src/ts/rendering/cell/cellCtrl.ts
+++ b/community-modules/core/src/ts/rendering/cell/cellCtrl.ts
@@ -645,10 +645,6 @@ export class CellCtrl extends BeanStub {
     }
 
     public onCellChanged(event: CellChangedEvent): void {
-        // because of async in React, the cellComp may not be set yet, if no cellComp then we are
-        // yet to initialise the cell, so no need to refresh.
-        if (!this.cellComp) { return; }
-
         const eventImpactsThisCell = event.column === this.column;
 
         if (eventImpactsThisCell) {
@@ -663,6 +659,10 @@ export class CellCtrl extends BeanStub {
     // + rowCtrl: api refreshCells() {animate: true/false}
     // + rowRenderer: api softRefreshView() {}
     public refreshCell(params?: { suppressFlash?: boolean, newData?: boolean, forceRefresh?: boolean; }) {
+        // because of async in React, the cellComp may not be set yet, if no cellComp then we are
+        // yet to initialise the cell, so no need to refresh.
+        if (!this.cellComp) { return; }
+
         // if we are in the middle of 'stopEditing', then we don't refresh here, as refresh gets called explicitly
         if (this.suppressRefreshCell || this.editing) { return; }
 


### PR DESCRIPTION
Fixes #5085.

I'm not familiar with the ag-grid codebase, but this fixes the crashes and seems to work correctly as far as I can tell (although I tested this by making the corresponding change in the generated JavaScript, I haven't got the build working).