### PR TITLE
AG-6674 - Fix sparklines label `fontSize` type

### DIFF
--- a/community-modules/core/src/ts/interfaces/iSparklineCellRendererParams.ts
+++ b/community-modules/core/src/ts/interfaces/iSparklineCellRendererParams.ts
@@ -121,7 +121,7 @@ export interface SparklineLabelOptions {
     /** Set to true to enable labels. */
     enabled?: boolean;
     /** Set size of the font. */
-    fontSize?: string;
+    fontSize?: number;
     /** Specify the font for the label text. */
     fontFamily?: string;
     /** Specify the font style for the label text. */

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/doc-interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/doc-interfaces.AUTO.json
@@ -17158,7 +17158,7 @@
     },
     "fontSize": {
       "description": "/** Set size of the font. */",
-      "type": { "returnType": "string", "optional": true }
+      "type": { "returnType": "number", "optional": true }
     },
     "fontFamily": {
       "description": "/** Specify the font for the label text. */",

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/interfaces.AUTO.json
@@ -9731,7 +9731,7 @@
     "meta": {},
     "type": {
       "enabled?": "boolean",
-      "fontSize?": "string",
+      "fontSize?": "number",
       "fontFamily?": "string",
       "fontStyle?": "'normal' | 'italic' | 'oblique'",
       "fontWeight?": "'normal' | 'bold' | 'bolder' | 'lighter' | '100' | '200' | '300' | '400' | '500' | '600' | '700' | '800' | '900'",


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-6674

Correct `fontSize` type to be consistent with the implementation AND standalone charts.