### PR TITLE
AG-6119 - Fix Integrated Charts proxy override of cursor style unless necessary.

### DIFF
--- a/enterprise-modules/charts/src/charts/chartComp/chartTitle/titleEdit.ts
+++ b/enterprise-modules/charts/src/charts/chartComp/chartTitle/titleEdit.ts
@@ -61,12 +61,17 @@ export class TitleEdit extends Component {
             }
         });
 
+        let wasInTitle = false;
         const destroyMouseMoveListener = this.addManagedListener(canvas, 'mousemove', event => {
             const { title } = chart;
 
-            const inTitle = title && title.enabled && title.node.containsPoint(event.offsetX, event.offsetY);
+            const inTitle = !!(title && title.enabled && title.node.containsPoint(event.offsetX, event.offsetY));
 
-            canvas.style.cursor = inTitle ? 'pointer' : '';
+            if (wasInTitle !== inTitle) {
+                canvas.style.cursor = inTitle ? 'pointer' : '';
+            }
+
+            wasInTitle = inTitle;
         });
 
         this.destroyableChartListeners = [


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-6119

Integrated charts proxy was forcing the setting of `style.cursor` on every mouse-move event, which was overwriting standalone charts updates - preventing legend hover style changes in the first case.