### PR TITLE
Fix ag-grid-react peer dependencies for 27.2.0

### DIFF
--- a/community-modules/react/package.json
+++ b/community-modules/react/package.json
@@ -75,7 +75,7 @@
     "prop-types": "^15.8.1"
   },
   "peerDependencies": {
-    "@ag-grid-community/core": "~27.1.0",
+    "@ag-grid-community/core": "~27.2.0",
     "react": "^16.3.0 || ^17.0.0 || ^18.0.0",
     "react-dom": "^16.3.0 || ^17.0.0 || ^18.0.0"
   },


### PR DESCRIPTION
At the moment, ag-grid-react@27.2.0 cannot be installed with @ag-grid-community/core@27.2.0 because of the minor version required in peer depencencies. It should be updated to match the dev dependencies and allow all ag-grid packages to be installed at the latest version.