### PR TITLE
AG-5243 - Allow setting axis label auto rotate to avoid category axis…

### DIFF
--- a/charts-packages/ag-charts-community/src/axis.ts
+++ b/charts-packages/ag-charts-community/src/axis.ts
@@ -92,9 +92,14 @@ export class AxisLabel {
     rotation: number = 0;
 
     /**
+     * By default, if the category axis labels collide, they are rotated so that they are positioned perpendicular to the horizontal axis line to reduce overlap.
+     */
+    autoRotate: boolean = true;
+
+    /**
      * By default labels and ticks are positioned to the left of the axis line.
      * `true` positions the labels to the right of the axis line.
-     * However, if the axis is rotated, its easier to think in terms
+     * However, if the axis is rotated, it's easier to think in terms
      * of this side or the opposite side, rather than left and right.
      * We use the term `mirror` for conciseness, although it's not
      * true mirroring - for example, when a label is rotated, so that
@@ -387,8 +392,8 @@ export class Axis<S extends Scale<D, number>, D = any> {
         const requestedRangeMin = Math.min(requestedRange[0], requestedRange[1]);
         const requestedRangeMax = Math.max(requestedRange[0], requestedRange[1]);
         const rotation = toRadians(this.rotation);
-        const parallelLabels = label.parallel;
         const labelRotation = normalizeAngle360(toRadians(label.rotation));
+        let parallelLabels = label.parallel;
 
         group.translationX = this.translation.x;
         group.translationY = this.translation.y;
@@ -414,7 +419,7 @@ export class Axis<S extends Scale<D, number>, D = any> {
 
         const regularFlipRotation = normalizeAngle360(rotation - Math.PI / 2);
         // Flip if the axis rotation angle is in the top hemisphere.
-        const regularFlipFlag = !labelRotation && regularFlipRotation >= 0 && regularFlipRotation <= Math.PI ? -1 : 1;
+        let regularFlipFlag = !labelRotation && regularFlipRotation >= 0 && regularFlipRotation <= Math.PI ? -1 : 1;
 
         const alignFlag = labelRotation >= 0 && labelRotation <= Math.PI ? -1 : 1;
 
@@ -499,6 +504,8 @@ export class Axis<S extends Scale<D, number>, D = any> {
         this.fractionDigits = (ticks as any).fractionDigits >= 0 ? (ticks as any).fractionDigits : 0;
 
         // Update properties that affect the size of the axis labels and measure the labels
+        const labelBboxes: Map<string, BBox> = new Map();
+
         const labelSelection = groupSelection.selectByClass(Text)
             .each((node, datum, index) => {
                 node.fontStyle = label.fontStyle;
@@ -506,45 +513,72 @@ export class Axis<S extends Scale<D, number>, D = any> {
                 node.fontSize = label.fontSize;
                 node.fontFamily = label.fontFamily;
                 node.fill = label.color;
-                node.textBaseline = parallelLabels && !labelRotation
-                    ? (sideFlag * parallelFlipFlag === -1 ? 'hanging' : 'bottom')
-                    : 'middle';
                 node.text = this.formatTickDatum(datum, index);
 
-                node.textAlign = parallelLabels
-                    ? labelRotation ? (sideFlag * alignFlag === -1 ? 'end' : 'start') : 'center'
-                    : sideFlag * regularFlipFlag === -1 ? 'end' : 'start';
+                labelBboxes.set(node.id, node.computeBBox());
             });
 
         const labelX = sideFlag * (tick.size + label.padding);
-        const autoRotation = parallelLabels
-            ? parallelFlipFlag * Math.PI / 2
-            : (regularFlipFlag === -1 ? Math.PI : 0);
-
-        const labelBboxes: Map<string, BBox> = new Map();
-        labelSelection.each(label => {
-            label.x = labelX;
-            label.rotationCenterX = labelX;
-            label.rotation = autoRotation + labelRotation;
-            label.visible = true;
-
-            labelBboxes.set(label.id, label.computeBBox());
-        });
 
         // Only consider a fraction of the total range to allow more space for each label
         const fractionOfRange = 0.8;
         const availableRange = (requestedRangeMax - requestedRangeMin) * fractionOfRange;
 
-        const calculateLabelsLength = (bboxes: Map<string, BBox>, parallel: boolean) => {
+        const calculateLabelsLength = (bboxes: Map<string, BBox>, useWidth: boolean) => {
             let totalLength = 0;
             for (let [labelId, bbox] of bboxes.entries()) {
-                totalLength += (parallel ? bbox.width : bbox.height);
+                totalLength += (useWidth ? bbox.width : bbox.height);
             }
             return totalLength;
         }
 
+        let useWidth = parallelLabels; // When the labels are parallel to the axis line, use the width of the text to calculate the total length of all labels
+
+        if (labelRotation) {
+            // If the specified label rotation angle results in a non-parallel orientation, use the height of the texts to calculate the total length of all labels
+            if (parallelLabels) {
+                useWidth = labelRotation === Math.PI || labelRotation === -Math.PI ? true : false;
+            } else {
+                useWidth = labelRotation === Math.PI / 2 || labelRotation === -Math.PI / 2 ? true : false;
+            }
+        }
+
+        let totalLabelLength = calculateLabelsLength(labelBboxes, useWidth);
+
+        if (label.autoRotate) {
+            const isContinuous = scale instanceof ContinuousScale;
+            const isDiscreteWithParallelLabels = !labelRotation && parallelLabels && !isContinuous;
+
+            if (isDiscreteWithParallelLabels && totalLabelLength > availableRange) {
+                // When the axis is a horizontal category axis (with parallel labels), and no user rotation angle has been specified,
+                // and the available range is not sufficient for parallel labels,
+                // display the labels perpendicular to the horizontal axis line
+                parallelLabels = false;
+                regularFlipFlag = 1;
+                useWidth = false;
+                totalLabelLength = calculateLabelsLength(labelBboxes, useWidth);
+            }
+        }
+
+        const autoRotation = parallelLabels
+            ? parallelFlipFlag * Math.PI / 2
+            : (regularFlipFlag === -1 ? Math.PI : 0);
+
+        labelSelection.each(label => {
+            label.textBaseline = parallelLabels && !labelRotation
+                ? (sideFlag * parallelFlipFlag === -1 ? 'hanging' : 'bottom')
+                : 'middle';
+            label.textAlign = parallelLabels
+                ? labelRotation ? (sideFlag * alignFlag === -1 ? 'end' : 'start') : 'center'
+                : sideFlag * regularFlipFlag === -1 ? 'end' : 'start';
+
+            label.x = labelX;
+            label.rotationCenterX = labelX;
+            label.rotation = autoRotation + labelRotation;
+            label.visible = true;
+        });
+
         if (availableRange >= 0) {
-            let totalLabelLength = calculateLabelsLength(labelBboxes, parallelLabels);
             let visible = true;
 
             // Remove half the labels if they overlap
@@ -559,7 +593,7 @@ export class Axis<S extends Scale<D, number>, D = any> {
                     visible = !visible;
                 });
 
-                totalLabelLength = calculateLabelsLength(labelBboxes, parallelLabels);
+                totalLabelLength = calculateLabelsLength(labelBboxes, useWidth);
             }
         }
 


### PR DESCRIPTION
This PR is for https://ag-grid.atlassian.net/browse/AG-5243

The intent is to allow the user to specify an `autoRotate` axis label property, which is `true` by default and applies to horizontal category axes (in the X direction).

When `autoRotate` is `true`, rotate the labels to prevent overlap when the chart width/height is too small, or when labels are too large. This applies to `category` axis type and is only relevant for horizontal axes as this is the case were the labels would otherwise be placed parallel to the axis line.

The approach is to modify the `parallelLabels` and `regularFlipFlag` to alter the orientation of the lables. If the total length of all labels in the new orientation still exceeds the available axis range, half the labels are removed iteratively until the length of visible labels is not larger than the available space. This change was made as part of https://github.com/ag-grid/ag-grid/pull/5112.

Note that this also only applies if the user has not explicitly specified a label rotation angle in the options.