### PR TITLE
AG-6677 - Better null/undefined handling for scatter series charts.

### DIFF
--- a/charts-packages/ag-charts-community/src/axis.ts
+++ b/charts-packages/ag-charts-community/src/axis.ts
@@ -11,7 +11,6 @@ import { Caption } from "./caption";
 import { createId } from "./util/id";
 import { normalizeAngle360, normalizeAngle360Inclusive, toRadians } from "./util/angle";
 import { doOnce } from "./util/function";
-import { ContinuousScale } from "./scale/continuousScale";
 // import { Rect } from "./scene/shape/rect"; // debug (bbox)
 
 enum Tags {


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-6677

Completely removes scatter series datum from the plotted chart which are missing either an xKey or yKey value.