### PR TITLE
AG-6761 - Add label auto-rotate & skip docs

### DIFF
--- a/charts-packages/ag-charts-community/src/axis.ts
+++ b/charts-packages/ag-charts-community/src/axis.ts
@@ -454,7 +454,7 @@ export class Axis<S extends Scale<D, number>, D = any> {
             .attrFn('visible', function (node) {
                 const min = Math.floor(requestedRangeMin);
                 const max = Math.ceil(requestedRangeMax);
-                return node.translationY >= min && node.translationY <= max;
+                return (min !== max) && node.translationY >= min && node.translationY <= max;
             });
 
         // `ticks instanceof NumericTicks` doesn't work here, so we feature detect.

--- a/charts-packages/ag-charts-community/src/chart/agChartOptions.ts
+++ b/charts-packages/ag-charts-community/src/chart/agChartOptions.ts
@@ -440,7 +440,7 @@ export interface AgAxisLabelOptions {
     color?: CssColor;
     /** The rotation of the axis labels in degrees. Note: for integrated charts the default is 335 degrees, unless the axis shows grouped or default categories (indexes). The first row of labels in a grouped category axis is rotated perpendicular to the axis line. */
     rotation?: number;
-    /** If specified and axis labels collide, they are rotated so that they are positioned at the supplied angle. This is enabled by default for category axes at an angle of 45 degrees. If the `rotation` property is specified, it takes precedence. */
+    /** If specified and axis labels collide, they are rotated so that they are positioned at the supplied angle. This is enabled by default for category axes at an angle of 335 degrees. If the `rotation` property is specified, it takes precedence. */
     autoRotate?: boolean | number;
     // mirrored?: boolean;
     // parallel?: boolean;

--- a/community-modules/core/src/ts/interfaces/iAgChartOptions.ts
+++ b/community-modules/core/src/ts/interfaces/iAgChartOptions.ts
@@ -440,7 +440,7 @@ export interface AgAxisLabelOptions {
     color?: CssColor;
     /** The rotation of the axis labels in degrees. Note: for integrated charts the default is 335 degrees, unless the axis shows grouped or default categories (indexes). The first row of labels in a grouped category axis is rotated perpendicular to the axis line. */
     rotation?: number;
-    /** If specified and axis labels collide, they are rotated so that they are positioned at the supplied angle. This is enabled by default for category axes at an angle of 45 degrees. If the `rotation` property is specified, it takes precedence. */
+    /** If specified and axis labels collide, they are rotated so that they are positioned at the supplied angle. This is enabled by default for category axes at an angle of 335 degrees. If the `rotation` property is specified, it takes precedence. */
     autoRotate?: boolean | number;
     // mirrored?: boolean;
     // parallel?: boolean;

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/api.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/api.json
@@ -520,6 +520,18 @@
       "max": 359,
       "unit": "&deg;"
     },
+    "autoRotate": {
+      "default": 335,
+      "min": -359,
+      "max": 359,
+      "unit": "&deg;",
+      "options": [
+        false,
+        true,
+        25,
+        335
+      ]
+    },
     "format": {
       "type": "string",
       "more": {

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/doc-interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/doc-interfaces.AUTO.json
@@ -1202,7 +1202,7 @@
       "type": { "returnType": "number", "optional": true }
     },
     "autoRotate": {
-      "description": "/** If specified and axis labels collide, they are rotated so that they are positioned at the supplied angle. This is enabled by default for category axes at an angle of 45 degrees. If the `rotation` property is specified, it takes precedence. */",
+      "description": "/** If specified and axis labels collide, they are rotated so that they are positioned at the supplied angle. This is enabled by default for category axes at an angle of 335 degrees. If the `rotation` property is specified, it takes precedence. */",
       "type": { "returnType": "boolean | number", "optional": true }
     },
     "format": {

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
@@ -799,7 +799,7 @@
       "padding?": "/** Padding in pixels between the axis label and the tick. */",
       "color?": "/** The colour to use for the labels */",
       "rotation?": "/** The rotation of the axis labels in degrees. Note: for integrated charts the default is 335 degrees, unless the axis shows grouped or default categories (indexes). The first row of labels in a grouped category axis is rotated perpendicular to the axis line. */",
-      "autoRotate?": "/** If specified and axis labels collide, they are rotated so that they are positioned at the supplied angle. This is enabled by default for category axes at an angle of 45 degrees. If the `rotation` property is specified, it takes precedence. */",
+      "autoRotate?": "/** If specified and axis labels collide, they are rotated so that they are positioned at the supplied angle. This is enabled by default for category axes at an angle of 335 degrees. If the `rotation` property is specified, it takes precedence. */",
       "format?": "/** Format string used when rendering labels for time axes. */",
       "formatter?": "/** Function used to render axis labels. If `value` is a number, `fractionDigits` will also be provided, which indicates the number of fractional digits used in the step between ticks; for example, a tick step of `0.0005` would have `fractionDigits` set to `4` */"
     }

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-axes/examples/axis-label-rotation/data.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-axes/examples/axis-label-rotation/data.ts
@@ -25,6 +25,7 @@ const countries = [
     'Uruguay',
     'Belgium',
 ];
+countries.sort();
 
 export function getData(): any[] {
     return years.map((year, idx) => ({

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-axes/examples/axis-label-rotation/data.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-axes/examples/axis-label-rotation/data.ts
@@ -1,0 +1,35 @@
+const years: number[] = [];
+for (let year = 2005; year <= 2022; year++) {
+    years.push(year);
+}
+
+const countries = [
+    'Ireland',
+    'Spain',
+    'United Kingdom',
+    'France',
+    'Germany',
+    'Luxembourg',
+    'Sweden',
+    'Norway',
+    'Italy',
+    'Greece',
+    'Iceland',
+    'Portugal',
+    'Malta',
+    'Brazil',
+    'Argentina',
+    'Colombia',
+    'Peru',
+    'Venezuela',
+    'Uruguay',
+    'Belgium',
+];
+
+export function getData(): any[] {
+    return years.map((year, idx) => ({
+        year,
+        country: countries[idx],
+        value: Math.round(Math.random() * 1000),
+    }));
+}

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-axes/examples/axis-label-rotation/index.html
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-axes/examples/axis-label-rotation/index.html
@@ -1,0 +1,12 @@
+<div class="wrapper">
+    <div id="toolPanel">
+        <button onclick="reset()">Reset to defaults</button>
+        <button onclick="disableRotation()">No rotation</button>
+        <button onclick="fixedRotation()">Fixed rotation</button>
+        <button onclick="autoRotation()">Auto rotation</button>
+        <br />
+        <button onclick="uniformLabels()">Uniform labels</button>
+        <button onclick="irregularLabels()">Irregular labels</button>
+    </div>
+    <div id="myChart"></div>
+</div>

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-axes/examples/axis-label-rotation/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-axes/examples/axis-label-rotation/main.ts
@@ -1,0 +1,95 @@
+import { AgCartesianChartOptions, AgBarSeriesOptions } from 'ag-charts-community'
+import * as agCharts from 'ag-charts-community'
+import { getData } from './data';
+
+const byYearData = getData();
+
+let columnSeries: AgBarSeriesOptions = {
+  type: 'column',
+  xKey: 'year',
+  yKey: 'value',
+};
+const options: AgCartesianChartOptions = {
+  container: document.getElementById('myChart'),
+  data: byYearData,
+  series: [columnSeries],
+  axes: [
+    {
+      type: 'category',
+      position: 'bottom',
+    },
+    {
+      type: 'number',
+      position: 'left',
+      label: {
+        formatter: (params) => {
+          return params.value + '%'
+        },
+      },
+    },
+  ],
+  legend: {
+    enabled: false,
+  },
+}
+
+const chart = agCharts.AgChart.create(options);
+
+function reset() {
+  const element = document.getElementById('myChart')!;
+  element.style.width = '';
+  element.style.height = '';
+
+  options.axes?.forEach((axis) => {
+    axis.label = {
+      ...(axis.label || {}),
+    };
+    delete axis.label['rotation'];
+    delete axis.label['autoRotate'];
+  });
+  columnSeries.xKey = 'year';
+  agCharts.AgChart.update(chart, options);
+}
+
+function disableRotation() {
+  options.axes?.forEach((axis) => {
+    axis.label = {
+      ...(axis.label || {}),
+      autoRotate: false,
+    };
+    delete axis.label['rotation'];
+  });
+  agCharts.AgChart.update(chart, options);
+}
+
+function fixedRotation() {
+  options.axes?.forEach((axis) => {
+    axis.label = {
+      ...(axis.label || {}),
+      rotation: 45,
+      autoRotate: false,
+    };
+  });
+  agCharts.AgChart.update(chart, options);
+}
+
+function autoRotation() {
+  options.axes?.forEach((axis) => {
+    axis.label = {
+      ...(axis.label || {}),
+      autoRotate: true,
+    };
+    delete axis.label['rotation'];
+  });
+  agCharts.AgChart.update(chart, options);
+}
+
+function uniformLabels() {
+  columnSeries.xKey = 'year';
+  agCharts.AgChart.update(chart, options);
+}
+
+function irregularLabels() {
+  columnSeries.xKey = 'country';
+  agCharts.AgChart.update(chart, options);
+}

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-axes/examples/axis-label-rotation/styles.css
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-axes/examples/axis-label-rotation/styles.css
@@ -1,0 +1,22 @@
+.wrapper {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+}
+
+#toolPanel {
+    text-align: center;
+}
+
+.spacer {
+    display: inline-block;
+    min-width: 20px;
+}
+
+#myChart {
+    height: 100%;
+    /* border: 2px solid; */
+    resize: both;
+    overflow: auto;
+    padding: 20px;
+}

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-axes/index.md
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-axes/index.md
@@ -146,7 +146,9 @@ The example below demonstrates how the `count` property of the number axis can b
 
 ## Axis Labels
 
-The axis renders a label next to every tick to show the tick's value. Chart axis labels support the same font and colour options as the axis title. Additionally, the distance of the labels from the ticks and their rotation can be configured via the `padding` and `rotation` properties respectively.
+The axis renders a label next to every tick to show the tick's value. Chart axis labels support the same font and colour options as the axis title. Additionally, the distance of the labels from the ticks and their rotation can be configured via the `padding`, `rotation` and `autoRotate` properties respectively.
+
+### Label Formatting
 
 A label formatter function can be used to change the value displayed in the label. It's a handy feature when you need to show units next to values or format number values to a certain precision, for example.
 
@@ -156,8 +158,6 @@ A label formatter function receives a single `params` object which contains:
 - the `index` of the label in the data array
 - the number of `fractionDigits`, if the value is a number
 - the default label `formatter`, if the axis is a time axis
-
-### Example: Label Formatter
 
 For example, to add `'%'` units next to number values, you can use the following formatter function:
 
@@ -169,7 +169,7 @@ formatter: function(params) {
 
 <chart-example title='Axis Label Formatter' name='axis-label-formatter' type='generated'></chart-example>
 
-### Number Label Format String
+#### Number Label Format String
 
 For number axes, a format string can be provided, which will be used to format the numbers for display as axis labels.
 The format string may contain the following directives, which reflect those from Python's <a href="https://docs.python.org/3/library/string.html#format-specification-mini-language" target="_blank">format specification</a>:
@@ -216,8 +216,6 @@ Where:
 |If you want to have a formatted value in the middle of some string, you have to wrap it in `#{}`,
 | so that it's clear where the number format begins and ends. For example: `I'm #{0>2.0f} years old`.
 
-### Example: Number Label Format
-
 The `label` config of the left axis in the example below uses the `'🌧️ #{0>2.1f} °C'` specifier string for the `format` property to format numbers as integers padded to left with zeros to achieve a consistent 2-digit width.
 
 Notice that we wrapped the number format in `#{}` since we want to prepend the formatted value with the weather icon
@@ -225,7 +223,7 @@ and to append the units used at the end.
 
 <chart-example title='Number Axis Label Format' name='number-axis-label-format' type='generated'></chart-example>
 
-### Example: Number Currency Format
+#### Number Currency Format
 
 Let's take a look at another example that illustrates a common requirement of formatting numbers as currency. Note that we are using:
 - the `s` SI prefix directive to shorten big numbers by using smaller numbers in combination with units,
@@ -248,7 +246,7 @@ and replace the SI units with the currency ones `.replace('k', 'K').replace('G',
 
 <chart-example title='Number Axis Currency Format' name='number-axis-currency-format' type='generated'></chart-example>
 
-### Time Label Format String
+#### Time Label Format String
 
 For time axes, a format string can be provided, which will be used to format the dates for display as axis labels. The format string may contain the following directives, which reflect those from Python's <a href="https://strftime.org/" target="_blank">strftime</a>:
 
@@ -289,7 +287,7 @@ For `%W`, all days in a new year preceding the first Monday are considered to be
 
 For `%V`, per the strftime man page:
 
-| In this system, weeks start on a Monday, and are numbered from 01, for the first week, up to 52 or 53, for the last week. Week 1 is the first week where four or more days fall within the new year (or, synonymously, week 01 is: the first week of the year that contains a Thursday; or, the week that has 4 January in it).
+In this system, weeks start on a Monday, and are numbered from 01, for the first week, up to 52 or 53, for the last week. Week 1 is the first week where four or more days fall within the new year (or, synonymously, week 01 is: the first week of the year that contains a Thursday; or, the week that has 4 January in it).
 
 The `%` sign indicating a directive may be immediately followed by a padding modifier:
 
@@ -298,8 +296,6 @@ The `%` sign indicating a directive may be immediately followed by a padding mod
 1. (nothing) - disable padding
 
 If no padding modifier is specified, the default is `0` for all directives except `%e`, which defaults to `_`.
-
-### Example: Time Label Format
 
 The `label` config of the bottom axis in the example below uses the `'%b&nbsp;%Y'` specifier string for the `format` property to format dates as the abbreviated name of the month followed by the full year.
 
@@ -312,6 +308,33 @@ from the default `agCharts.time.month` interval by using its `every` method. Swi
 will make the time axis place ticks every other month.
 
 <chart-example title='Time Axis Label Format' name='time-axis-label-format' type='generated'></chart-example>
+
+### Label Rotation & Skipping
+
+Label rotation allows a trade-off to be made between space occupied by the axis, series area, and readability of the axis
+labels.
+
+Three rotation approaches are available:
+- No rotation. X-axis labels are parallel to the axis, Y-axis labels are perpendicular.
+- Setting a fixed rotation from the axis via the `rotation` property.
+- Setting an automatically applied rotation from the axis via the `autoRotate` property. Rotation is applied if any
+  label will be wider than the gap between ticks.
+
+Label skipping is performed automatically if there is not enough space for a label to be displayed within the space
+allocated to an axis tick interval.
+
+If `autoRotate` is enabled, rotation will be attempted first to find a label fit, before label skipping applies.
+Category axes have `autoRotate` enabled by default with a setting of `335`.
+
+The following example demonstrates label rotation and skipping:
+- There is a grab handle in the bottom right to allow resizing of the chart to see how labels change with available
+  space.
+- Initially both axes have defaults applied. The X-axis is a category axis so `autoRotate` is enabled by default.
+- The first row of buttons at the top change the configuration of both axes to allow all rotation behaviours to be
+  viewed.
+- The second row of buttons allow switching between X-axis types and labels.
+
+<chart-example title='Axis Label Rotation & Skipping' name='axis-label-rotation' type='generated'></chart-example>
 
 ## Axis Grid Lines
 

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-axes/index.md
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-axes/index.md
@@ -320,12 +320,11 @@ Three rotation approaches are available:
 - Setting an automatically applied rotation from the axis via the `autoRotate` property. Rotation is applied if any
   label will be wider than the gap between ticks.
 
-Label skipping is performed automatically if there is not enough space for a label to be displayed within the space
-allocated to an axis tick interval.
+Label skipping is performed automatically when we decide there is a high likelihood of collisions.
 
 [[note]]
 | Label skipping isn't guaranteed to avoid overlapping labels, but will significantly reduce the chance
-| of this happening.
+| of this happening out-of-the-box. The more uniform the size of labels, the more accurate it will be.
 
 If `autoRotate` is enabled, rotation will be attempted first to find a label fit, before label skipping applies.
 Category axes have `autoRotate` enabled by default with a setting of `335`.

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-axes/index.md
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-axes/index.md
@@ -323,6 +323,10 @@ Three rotation approaches are available:
 Label skipping is performed automatically if there is not enough space for a label to be displayed within the space
 allocated to an axis tick interval.
 
+[[note]]
+| Label skipping isn't guaranteed to avoid overlapping labels, but will significantly reduce the chance
+| of this happening.
+
 If `autoRotate` is enabled, rotation will be attempted first to find a label fit, before label skipping applies.
 Category axes have `autoRotate` enabled by default with a setting of `335`.
 

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/doc-interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/doc-interfaces.AUTO.json
@@ -11467,7 +11467,7 @@
       "type": { "returnType": "number", "optional": true }
     },
     "autoRotate": {
-      "description": "/** If specified and axis labels collide, they are rotated so that they are positioned at the supplied angle. This is enabled by default for category axes at an angle of 45 degrees. If the `rotation` property is specified, it takes precedence. */",
+      "description": "/** If specified and axis labels collide, they are rotated so that they are positioned at the supplied angle. This is enabled by default for category axes at an angle of 335 degrees. If the `rotation` property is specified, it takes precedence. */",
       "type": { "returnType": "boolean | number", "optional": true }
     },
     "format": {

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/interfaces.AUTO.json
@@ -6636,7 +6636,7 @@
       "padding?": "/** Padding in pixels between the axis label and the tick. */",
       "color?": "/** The colour to use for the labels */",
       "rotation?": "/** The rotation of the axis labels in degrees. Note: for integrated charts the default is 335 degrees, unless the axis shows grouped or default categories (indexes). The first row of labels in a grouped category axis is rotated perpendicular to the axis line. */",
-      "autoRotate?": "/** If specified and axis labels collide, they are rotated so that they are positioned at the supplied angle. This is enabled by default for category axes at an angle of 45 degrees. If the `rotation` property is specified, it takes precedence. */",
+      "autoRotate?": "/** If specified and axis labels collide, they are rotated so that they are positioned at the supplied angle. This is enabled by default for category axes at an angle of 335 degrees. If the `rotation` property is specified, it takes precedence. */",
       "format?": "/** Format string used when rendering labels for time axes. */",
       "formatter?": "/** Function used to render axis labels. If `value` is a number, `fractionDigits` will also be provided, which indicates the number of fractional digits used in the step between ticks; for example, a tick step of `0.0005` would have `fractionDigits` set to `4` */"
     }

--- a/grid-packages/ag-grid-docs/documentation/src/components/charts-api-explorer/Editors.tsx
+++ b/grid-packages/ag-grid-docs/documentation/src/components/charts-api-explorer/Editors.tsx
@@ -172,7 +172,7 @@ export const getPrimitiveEditor = ({ meta, desc }: JsonModelProperty, key: strin
             .filter((v) => v.startsWith("'") && v.endsWith("'"))
             .map((v) => v.substring(1, v.length - 1));
 
-        if (options.every((v) => /^[a-z-]*$/.test(v))) {
+        if (options.length > 0 && options.every((v) => /^[a-z-]*$/.test(v))) {
             return { editor: PresetEditor, editorProps: { ...meta, options } };
         }
     }


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-6761

Adds docs and an example that demonstrate how `rotation`, `autoRotate` and label skipping interact together.