### PR TITLE
Fix example documentation for cell editor stopping propagation.

### DIFF
--- a/grid-packages/ag-grid-docs/documentation/doc-pages/component-cell-editor/_keyboard-option-1-javascript.md
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/component-cell-editor/_keyboard-option-1-javascript.md
@@ -13,7 +13,7 @@
 |eInputDomElement.addEventListener('keydown', event => {
 |    const key = event.key;
 |
-|    const isNavigationKey = keyCode === KEY_LEFT || 
+|    const isNavigationKey = key === KEY_LEFT || 
 |        key === KEY_RIGHT || 
 |        key === KEY_UP || 
 |        key === KEY_DOWN || 

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/component-cell-editor/_keyboard-option-1-react.md
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/component-cell-editor/_keyboard-option-1-react.md
@@ -25,7 +25,7 @@
 |    onKeyDown(event) {
 |       const key = event.key;
 |
-|        const isNavigationKey = keyCode === KEY_LEFT ||
+|        const isNavigationKey = key === KEY_LEFT ||
 |           key === KEY_RIGHT ||
 |           key === KEY_UP ||
 |           key === KEY_DOWN ||

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/component-cell-editor/_keyboard-option-1-vue.md
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/component-cell-editor/_keyboard-option-1-vue.md
@@ -26,7 +26,7 @@
 |        onKeyDown(event) {
 |           const key = event.key;
 |
-|           const isNavigationKey = keyCode === KEY_LEFT ||
+|           const isNavigationKey = key === KEY_LEFT ||
 |               key === KEY_RIGHT ||
 |               key === KEY_UP ||
 |               key === KEY_DOWN ||


### PR DESCRIPTION
"keyCode" variable was renamed to "key" in a previous commit, but a few instances of "keyCode" remained.