### PR TITLE
AG-6769 - Add Charts Axis Label autoRotateAngle property.

### DIFF
--- a/charts-packages/ag-charts-community/src/axis.ts
+++ b/charts-packages/ag-charts-community/src/axis.ts
@@ -91,11 +91,15 @@ export class AxisLabel {
     rotation: number = 0;
 
     /**
-     * If specified and axis labels collide, they are rotated so that they are positioned at the
-     * supplied angle. This is enabled by default for category axes at an angle of 45 degrees.
-     * If the `rotation` property is specified, it takes precedence.
+     * If specified and axis labels may collide, they are rotated to reduce collisions. If the
+     * `rotation` property is specified, it takes precedence.
      */
-    autoRotate: boolean | number | undefined = undefined;
+    autoRotate: boolean | undefined = undefined;
+
+    /**
+     * Rotation angle to use when autoRotate is applied.
+     */
+    autoRotateAngle: number = 335;
 
     /**
      * By default labels and ticks are positioned to the left of the axis line.
@@ -509,10 +513,10 @@ export class Axis<S extends Scale<D, number>, D = any> {
         let {totalLength: totalLabelLength, rotate} = calculateLabelsLength(labelBboxes, useWidth);
 
         this._labelAutoRotated = false;
-        if (!labelRotation && label.autoRotate != null && label.autoRotate !== false && rotate) {
+        if (!labelRotation && label.autoRotate === true && rotate) {
             // When no user label rotation angle has been specified and the width of any label exceeds the average tick gap (`rotate` is `true`),
             // automatically rotate the labels
-            labelAutoRotation = normalizeAngle360(toRadians(typeof label.autoRotate === 'number' ? label.autoRotate : 335));
+            labelAutoRotation = normalizeAngle360(toRadians(label.autoRotateAngle));
             this._labelAutoRotated = true;
         }
 

--- a/charts-packages/ag-charts-community/src/chart/agChartOptions.ts
+++ b/charts-packages/ag-charts-community/src/chart/agChartOptions.ts
@@ -440,8 +440,10 @@ export interface AgAxisLabelOptions {
     color?: CssColor;
     /** The rotation of the axis labels in degrees. Note: for integrated charts the default is 335 degrees, unless the axis shows grouped or default categories (indexes). The first row of labels in a grouped category axis is rotated perpendicular to the axis line. */
     rotation?: number;
-    /** If specified and axis labels collide, they are rotated so that they are positioned at the supplied angle. This is enabled by default for category axes at an angle of 335 degrees. If the `rotation` property is specified, it takes precedence. */
-    autoRotate?: boolean | number;
+    /** If specified and axis labels may collide, they are rotated so that they are positioned at the supplied angle. This is enabled by default for category. If the `rotation` property is specified, it takes precedence. */
+    autoRotate?: boolean;
+    /** If autoRotate is enabled, specifies the rotation angle to use when autoRotate is activated. Defaults to an angle of 335 degrees if unspecified. */
+    autoRotateAngle?: number;
     // mirrored?: boolean;
     // parallel?: boolean;
     /** Format string used when rendering labels for time axes. */

--- a/community-modules/core/src/ts/interfaces/iAgChartOptions.ts
+++ b/community-modules/core/src/ts/interfaces/iAgChartOptions.ts
@@ -440,8 +440,10 @@ export interface AgAxisLabelOptions {
     color?: CssColor;
     /** The rotation of the axis labels in degrees. Note: for integrated charts the default is 335 degrees, unless the axis shows grouped or default categories (indexes). The first row of labels in a grouped category axis is rotated perpendicular to the axis line. */
     rotation?: number;
-    /** If specified and axis labels collide, they are rotated so that they are positioned at the supplied angle. This is enabled by default for category axes at an angle of 335 degrees. If the `rotation` property is specified, it takes precedence. */
-    autoRotate?: boolean | number;
+    /** If specified and axis labels may collide, they are rotated so that they are positioned at the supplied angle. This is enabled by default for category. If the `rotation` property is specified, it takes precedence. */
+    autoRotate?: boolean;
+    /** If autoRotate is enabled, specifies the rotation angle to use when autoRotate is activated. Defaults to an angle of 335 degrees if unspecified. */
+    autoRotateAngle?: number;
     // mirrored?: boolean;
     // parallel?: boolean;
     /** Format string used when rendering labels for time axes. */

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/api.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/api.json
@@ -521,16 +521,13 @@
       "unit": "&deg;"
     },
     "autoRotate": {
+      "default": false
+    },
+    "autoRotateAngle": {
       "default": 335,
       "min": -359,
       "max": 359,
-      "unit": "&deg;",
-      "options": [
-        false,
-        true,
-        25,
-        335
-      ]
+      "unit": "&deg;"
     },
     "format": {
       "type": "string",

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/doc-interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/doc-interfaces.AUTO.json
@@ -1202,8 +1202,12 @@
       "type": { "returnType": "number", "optional": true }
     },
     "autoRotate": {
-      "description": "/** If specified and axis labels collide, they are rotated so that they are positioned at the supplied angle. This is enabled by default for category axes at an angle of 335 degrees. If the `rotation` property is specified, it takes precedence. */",
-      "type": { "returnType": "boolean | number", "optional": true }
+      "description": "/** If specified and axis labels may collide, they are rotated so that they are positioned at the supplied angle. This is enabled by default for category. If the `rotation` property is specified, it takes precedence. */",
+      "type": { "returnType": "boolean", "optional": true }
+    },
+    "autoRotateAngle": {
+      "description": "/** If autoRotate is enabled, specifies the rotation angle to use when autoRotate is activated. Defaults to an angle of 335 degrees if unspecified. */",
+      "type": { "returnType": "number", "optional": true }
     },
     "format": {
       "description": "/** Format string used when rendering labels for time axes. */",

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
@@ -787,7 +787,8 @@
       "padding?": "PixelSize",
       "color?": "CssColor",
       "rotation?": "number",
-      "autoRotate?": "boolean | number",
+      "autoRotate?": "boolean",
+      "autoRotateAngle?": "number",
       "format?": "string",
       "formatter?": "(params: AgAxisLabelFormatterParams) => string"
     },
@@ -799,7 +800,8 @@
       "padding?": "/** Padding in pixels between the axis label and the tick. */",
       "color?": "/** The colour to use for the labels */",
       "rotation?": "/** The rotation of the axis labels in degrees. Note: for integrated charts the default is 335 degrees, unless the axis shows grouped or default categories (indexes). The first row of labels in a grouped category axis is rotated perpendicular to the axis line. */",
-      "autoRotate?": "/** If specified and axis labels collide, they are rotated so that they are positioned at the supplied angle. This is enabled by default for category axes at an angle of 335 degrees. If the `rotation` property is specified, it takes precedence. */",
+      "autoRotate?": "/** If specified and axis labels may collide, they are rotated so that they are positioned at the supplied angle. This is enabled by default for category. If the `rotation` property is specified, it takes precedence. */",
+      "autoRotateAngle?": "/** If autoRotate is enabled, specifies the rotation angle to use when autoRotate is activated. Defaults to an angle of 335 degrees if unspecified. */",
       "format?": "/** Format string used when rendering labels for time axes. */",
       "formatter?": "/** Function used to render axis labels. If `value` is a number, `fractionDigits` will also be provided, which indicates the number of fractional digits used in the step between ticks; for example, a tick step of `0.0005` would have `fractionDigits` set to `4` */"
     }

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-axes/index.md
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-axes/index.md
@@ -317,8 +317,8 @@ labels.
 Three rotation approaches are available:
 - No rotation. X-axis labels are parallel to the axis, Y-axis labels are perpendicular.
 - Setting a fixed rotation from the axis via the `rotation` property.
-- Setting an automatically applied rotation from the axis via the `autoRotate` property. Rotation is applied if any
-  label will be wider than the gap between ticks.
+- Enabling automatic rotation via the `autoRotate` property, and optionally specifying an angle from the axis via the 
+  `autoRotateAngle` property. Rotation is applied if any label will be wider than the gap between ticks.
 
 Label skipping is performed automatically when we decide there is a high likelihood of collisions.
 
@@ -327,7 +327,7 @@ Label skipping is performed automatically when we decide there is a high likelih
 | of this happening out-of-the-box. The more uniform the size of labels, the more accurate it will be.
 
 If `autoRotate` is enabled, rotation will be attempted first to find a label fit, before label skipping applies.
-Category axes have `autoRotate` enabled by default with a setting of `335`.
+Category axes have `autoRotate` enabled by default with the default `autoRotateAngle` of `335`.
 
 The following example demonstrates label rotation and skipping:
 - There is a grab handle in the bottom right to allow resizing of the chart to see how labels change with available

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/doc-interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/doc-interfaces.AUTO.json
@@ -11502,8 +11502,12 @@
       "type": { "returnType": "number", "optional": true }
     },
     "autoRotate": {
-      "description": "/** If specified and axis labels collide, they are rotated so that they are positioned at the supplied angle. This is enabled by default for category axes at an angle of 335 degrees. If the `rotation` property is specified, it takes precedence. */",
-      "type": { "returnType": "boolean | number", "optional": true }
+      "description": "/** If specified and axis labels may collide, they are rotated so that they are positioned at the supplied angle. This is enabled by default for category. If the `rotation` property is specified, it takes precedence. */",
+      "type": { "returnType": "boolean", "optional": true }
+    },
+    "autoRotateAngle": {
+      "description": "/** If autoRotate is enabled, specifies the rotation angle to use when autoRotate is activated. Defaults to an angle of 335 degrees if unspecified. */",
+      "type": { "returnType": "number", "optional": true }
     },
     "format": {
       "description": "/** Format string used when rendering labels for time axes. */",

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/interfaces.AUTO.json
@@ -6647,7 +6647,8 @@
       "padding?": "PixelSize",
       "color?": "CssColor",
       "rotation?": "number",
-      "autoRotate?": "boolean | number",
+      "autoRotate?": "boolean",
+      "autoRotateAngle?": "number",
       "format?": "string",
       "formatter?": "(params: AgAxisLabelFormatterParams) => string"
     },
@@ -6659,7 +6660,8 @@
       "padding?": "/** Padding in pixels between the axis label and the tick. */",
       "color?": "/** The colour to use for the labels */",
       "rotation?": "/** The rotation of the axis labels in degrees. Note: for integrated charts the default is 335 degrees, unless the axis shows grouped or default categories (indexes). The first row of labels in a grouped category axis is rotated perpendicular to the axis line. */",
-      "autoRotate?": "/** If specified and axis labels collide, they are rotated so that they are positioned at the supplied angle. This is enabled by default for category axes at an angle of 335 degrees. If the `rotation` property is specified, it takes precedence. */",
+      "autoRotate?": "/** If specified and axis labels may collide, they are rotated so that they are positioned at the supplied angle. This is enabled by default for category. If the `rotation` property is specified, it takes precedence. */",
+      "autoRotateAngle?": "/** If autoRotate is enabled, specifies the rotation angle to use when autoRotate is activated. Defaults to an angle of 335 degrees if unspecified. */",
       "format?": "/** Format string used when rendering labels for time axes. */",
       "formatter?": "/** Function used to render axis labels. If `value` is a number, `fractionDigits` will also be provided, which indicates the number of fractional digits used in the step between ticks; for example, a tick step of `0.0005` would have `fractionDigits` set to `4` */"
     }


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-6769

Splits the union type of `autoRotate` into two distinct properties:
- `autoRotate: boolean` to toggle auto-rotation on/off.
- `autoRotateAngle: number` to configure the angle auto-rotation should use (defaults to `335`).

Tested:
- Plunker example for Label rotation.
  - Adhoc addition of `autoRotateAngle`.
- Chart API explorer.
  -  Edit in Plunker with adhoc addition of `autoRotateAngle`.