### PR TITLE
AG-6786 - Remove redundant boilerplate change-detection get/set.

### DIFF
--- a/charts-packages/ag-charts-community/src/chart/markerLabel.ts
+++ b/charts-packages/ag-charts-community/src/chart/markerLabel.ts
@@ -126,14 +126,6 @@ export class MarkerLabel extends Group {
         return this.marker.strokeOpacity;
     }
 
-    set opacity(value: number) {
-        this.marker.opacity = value;
-        this.label.opacity = value;
-    }
-    get opacity(): number {
-        return this.marker.opacity;
-    }
-
     private _spacing: number = 8;
     set spacing(value: number) {
         if (this._spacing !== value) {
@@ -152,5 +144,14 @@ export class MarkerLabel extends Group {
         marker.size = markerSize;
 
         this.label.x = markerSize / 2 + this.spacing;
+    }
+
+    render(ctx: CanvasRenderingContext2D, forceRender: boolean): void {
+        // Cannot override field Group.opacity with get/set pair, so
+        // propagate opacity changes here.
+        this.marker.opacity = this.opacity;
+        this.label.opacity = this.opacity;
+
+        super.render(ctx, forceRender);
     }
 }

--- a/charts-packages/ag-charts-community/src/scene/clipRect.ts
+++ b/charts-packages/ag-charts-community/src/scene/clipRect.ts
@@ -1,6 +1,7 @@
-import { Node, RedrawType } from "./node";
+import { Node, RedrawType, SceneChangeDetection } from "./node";
 import { Path2D } from "./path2D";
 import { BBox } from "./bbox";
+import { ScenePathChangeDetection } from "./shape/path";
 
 /**
  * Acts as `Group` node but with specified bounds that form a rectangle.
@@ -21,73 +22,22 @@ export class ClipRect extends Node {
             && point.y >= this.y && point.y <= this.y + this.height;
     }
 
-    private _enabled: boolean = true;
-    set enabled(value: boolean) {
-        if (this._enabled !== value) {
-            this._enabled = value;
-            this.markDirty(RedrawType.MAJOR);
-        }
-    }
-    get enabled(): boolean {
-        return this._enabled;
-    }
+    @SceneChangeDetection({ redraw: RedrawType.MAJOR })
+    enabled: boolean = true;
 
     private _dirtyPath = true;
-    set dirtyPath(value: boolean) {
-        if (this._dirtyPath !== value) {
-            this._dirtyPath = value;
-            if (value) {
-                this.markDirty(RedrawType.MAJOR);
-            }
-        }
-    }
-    get dirtyPath(): boolean {
-        return this._dirtyPath;
-    }
 
-    private _x: number = 0;
-    set x(value: number) {
-        if (this._x !== value) {
-            this._x = value;
-            this.dirtyPath = true;
-        }
-    }
-    get x(): number {
-        return this._x;
-    }
+    @ScenePathChangeDetection()
+    x: number = 0;
 
-    private _y: number = 0;
-    set y(value: number) {
-        if (this._y !== value) {
-            this._y = value;
-            this.dirtyPath = true;
-        }
-    }
-    get y(): number {
-        return this._y;
-    }
+    @ScenePathChangeDetection()
+    y: number = 0;
 
-    private _width: number = 10;
-    set width(value: number) {
-        if (this._width !== value) {
-            this._width = value;
-            this.dirtyPath = true;
-        }
-    }
-    get width(): number {
-        return this._width;
-    }
+    @ScenePathChangeDetection()
+    width: number = 10;
 
-    private _height: number = 10;
-    set height(value: number) {
-        if (this._height !== value) {
-            this._height = value;
-            this.dirtyPath = true;
-        }
-    }
-    get height(): number {
-        return this._height;
-    }
+    @ScenePathChangeDetection()
+    height: number = 10;
 
     updatePath() {
         const path = this.path;
@@ -95,7 +45,7 @@ export class ClipRect extends Node {
         path.clear();
         path.rect(this.x, this.y, this.width, this.height);
 
-        this.dirtyPath = false;
+        this._dirtyPath = false;
     }
 
     computeBBox(): BBox {
@@ -109,7 +59,7 @@ export class ClipRect extends Node {
         }
 
         if (this.enabled) {
-            if (this.dirtyPath) {
+            if (this._dirtyPath) {
                 this.updatePath();
             }
             this.path.draw(ctx);

--- a/charts-packages/ag-charts-community/src/scene/dropShadow.ts
+++ b/charts-packages/ag-charts-community/src/scene/dropShadow.ts
@@ -1,6 +1,4 @@
-import { Observable } from "../util/observable";
-
-export class DropShadow extends Observable {
+export class DropShadow {
     enabled = true;
     color = 'rgba(0, 0, 0, 0.5)';
     xOffset = 0;

--- a/charts-packages/ag-charts-community/src/scene/group.ts
+++ b/charts-packages/ag-charts-community/src/scene/group.ts
@@ -1,4 +1,4 @@
-import { Node, RedrawType } from "./node";
+import { Node, RedrawType, SceneChangeDetection } from "./node";
 import { BBox } from "./bbox";
 import { Matrix } from "./matrix";
 
@@ -13,17 +13,8 @@ export class Group extends Node {
         super.markDirty(type, parentType);
     }
 
-    protected _opacity: number = 1;
-    set opacity(value: number) {
-        value = Math.min(1, Math.max(0, value));
-        if (this._opacity !== value) {
-            this._opacity = value;
-            this.markDirty(RedrawType.MINOR);
-        }
-    }
-    get opacity(): number {
-        return this._opacity;
-    }
+    @SceneChangeDetection({ transform: (v) => Math.min(1, Math.max(0, v)) })
+    opacity: number = 1;
 
     // We consider a group to be boundless, thus any point belongs to it.
     containsPoint(x: number, y: number): boolean {

--- a/charts-packages/ag-charts-community/src/scene/group.ts
+++ b/charts-packages/ag-charts-community/src/scene/group.ts
@@ -13,11 +13,11 @@ export class Group extends Node {
         super.markDirty(type, parentType);
     }
 
-    @SceneChangeDetection({ transform: (v: number) => Math.min(1, Math.max(0, v)) })
+    @SceneChangeDetection({ convertor: (v: number) => Math.min(1, Math.max(0, v)) })
     opacity: number = 1;
 
     // We consider a group to be boundless, thus any point belongs to it.
-    containsPoint(x: number, y: number): boolean {
+    containsPoint(_x: number, _y: number): boolean {
         return true;
     }
 

--- a/charts-packages/ag-charts-community/src/scene/group.ts
+++ b/charts-packages/ag-charts-community/src/scene/group.ts
@@ -13,7 +13,7 @@ export class Group extends Node {
         super.markDirty(type, parentType);
     }
 
-    @SceneChangeDetection({ transform: (v) => Math.min(1, Math.max(0, v)) })
+    @SceneChangeDetection({ transform: (v: number) => Math.min(1, Math.max(0, v)) })
     opacity: number = 1;
 
     // We consider a group to be boundless, thus any point belongs to it.

--- a/charts-packages/ag-charts-community/src/scene/node.ts
+++ b/charts-packages/ag-charts-community/src/scene/node.ts
@@ -21,6 +21,47 @@ export enum RedrawType {
     MAJOR, // Significant change in rendering.
 }
 
+export function SceneChangeDetection(opts?: {
+    redraw?: RedrawType,
+    type?: 'normal' | 'transform' | 'path' | 'font',
+    transform?: (o: any) => any,
+    changeCb?: (o: any) => any,
+}) {
+    const { redraw = RedrawType.TRIVIAL, type = 'normal', changeCb, transform } = opts || {};
+
+    return function (target: any, key: string) {
+        // `target` is either a constructor (static member) or prototype (instance member)
+        const privateKey = `__${key}`;
+
+        if (!target[key]) {
+            Object.defineProperty(target, key, {
+                set: function (value: any) {
+                    const oldValue = this[privateKey];
+                    if (transform) {
+                        value = transform(value);
+                    }
+                    if (value !== oldValue) {
+                        this[privateKey] = value;
+                        if (type === 'normal') {
+                            this.markDirty(redraw);
+                        } else if (type === 'transform') {
+                            this.markDirtyTransform(redraw);
+                        }
+                        if (changeCb) {
+                            changeCb(this);
+                        }
+                    }
+                },
+                get: function (): any {
+                    return this[privateKey];
+                },
+                enumerable: true,
+                configurable: true
+            });
+        }
+    }
+}
+
 /**
  * Abstract scene graph node.
  * Each node can have zero or one parent and belong to zero or one scene.
@@ -78,9 +119,6 @@ export abstract class Node { // Don't confuse with `window.Node`.
     }
 
     private _parent?: Node;
-    _setParent(value?: Node) {
-        this._parent = value;
-    }
     get parent(): Node | undefined {
         return this._parent;
     }
@@ -152,7 +190,7 @@ export abstract class Node { // Don't confuse with `window.Node`.
             this._children.push(node);
             this.childSet[node.id] = true;
 
-            node._setParent(this);
+            node._parent = this;
             node._setScene(this.scene);
         }
 
@@ -174,7 +212,7 @@ export abstract class Node { // Don't confuse with `window.Node`.
         this._children.push(node);
         this.childSet[node.id] = true;
 
-        node._setParent(this);
+        node._parent = this;
         node._setScene(this.scene);
 
         this.markDirty(RedrawType.MAJOR);
@@ -189,7 +227,7 @@ export abstract class Node { // Don't confuse with `window.Node`.
             if (i >= 0) {
                 this._children.splice(i, 1);
                 delete this.childSet[node.id];
-                node._setParent();
+                node._parent = undefined;
                 node._setScene();
                 this.markDirty(RedrawType.MINOR);
 
@@ -220,7 +258,7 @@ export abstract class Node { // Don't confuse with `window.Node`.
             if (i >= 0) {
                 this._children.splice(i, 0, node);
                 this.childSet[node.id] = true;
-                node._setParent(this);
+                node._parent = this;
                 node._setScene(this.scene);
             } else {
                 throw new Error(`${nextNode} has ${parent} as the parent, `
@@ -283,27 +321,11 @@ export abstract class Node { // Don't confuse with `window.Node`.
         this.markDirty(RedrawType.MAJOR);
     }
 
-    private _scalingX: number = 1;
-    set scalingX(value: number) {
-        if (this._scalingX !== value) {
-            this._scalingX = value;
-            this.markDirtyTransform();
-        }
-    }
-    get scalingX(): number {
-        return this._scalingX;
-    }
+    @SceneChangeDetection({ type: 'transform' })
+    scalingX: number = 1;
 
-    private _scalingY: number = 1;
-    set scalingY(value: number) {
-        if (this._scalingY !== value) {
-            this._scalingY = value;
-            this.markDirtyTransform();
-        }
-    }
-    get scalingY(): number {
-        return this._scalingY;
-    }
+    @SceneChangeDetection({ type: 'transform' })
+    scalingY: number = 1;
 
     /**
      * The center of scaling.
@@ -311,65 +333,25 @@ export abstract class Node { // Don't confuse with `window.Node`.
      * determined automatically, as the center of the bounding box
      * of a node.
      */
-    private _scalingCenterX: number | null = null;
-    set scalingCenterX(value: number | null) {
-        if (this._scalingCenterX !== value) {
-            this._scalingCenterX = value;
-            this.markDirtyTransform();
-        }
-    }
-    get scalingCenterX(): number | null {
-        return this._scalingCenterX;
-    }
+    @SceneChangeDetection({ type: 'transform' })
+    scalingCenterX: number | null = null;
 
-    private _scalingCenterY: number | null = null;
-    set scalingCenterY(value: number | null) {
-        if (this._scalingCenterY !== value) {
-            this._scalingCenterY = value;
-            this.markDirtyTransform();
-        }
-    }
-    get scalingCenterY(): number | null {
-        return this._scalingCenterY;
-    }
+    @SceneChangeDetection({ type: 'transform' })
+    scalingCenterY: number | null = null;
 
-    private _rotationCenterX: number | null = null;
-    set rotationCenterX(value: number | null) {
-        if (this._rotationCenterX !== value) {
-            this._rotationCenterX = value;
-            this.markDirtyTransform();
-        }
-    }
-    get rotationCenterX(): number | null {
-        return this._rotationCenterX;
-    }
+    @SceneChangeDetection({ type: 'transform' })
+    rotationCenterX: number | null = null;
 
-    private _rotationCenterY: number | null = null;
-    set rotationCenterY(value: number | null) {
-        if (this._rotationCenterY !== value) {
-            this._rotationCenterY = value;
-            this.markDirtyTransform();
-        }
-    }
-    get rotationCenterY(): number | null {
-        return this._rotationCenterY;
-    }
+    @SceneChangeDetection({ type: 'transform' })
+    rotationCenterY: number | null = null;
 
     /**
      * Rotation angle in radians.
      * The value is set as is. No normalization to the [-180, 180) or [0, 360)
      * interval is performed.
      */
-    private _rotation: number = 0;
-    set rotation(value: number) {
-        if (this._rotation !== value) {
-            this._rotation = value;
-            this.markDirtyTransform();
-        }
-    }
-    get rotation(): number {
-        return this._rotation;
-    }
+    @SceneChangeDetection({ type: 'transform' })
+    rotation: number = 0;
 
     /**
      * For performance reasons the rotation angle's internal representation
@@ -390,27 +372,11 @@ export abstract class Node { // Don't confuse with `window.Node`.
         return this.rotation / Math.PI * 180;
     }
 
-    private _translationX: number = 0;
-    set translationX(value: number) {
-        if (this._translationX !== value) {
-            this._translationX = value;
-            this.markDirtyTransform();
-        }
-    }
-    get translationX(): number {
-        return this._translationX;
-    }
+    @SceneChangeDetection({ type: 'transform' })
+    translationX: number = 0;
 
-    private _translationY: number = 0;
-    set translationY(value: number) {
-        if (this._translationY !== value) {
-            this._translationY = value;
-            this.markDirtyTransform();
-        }
-    }
-    get translationY(): number {
-        return this._translationY;
-    }
+    @SceneChangeDetection({ type: 'transform' })
+    translationY: number = 0;
 
     containsPoint(x: number, y: number): boolean {
         return false;
@@ -565,32 +531,20 @@ export abstract class Node { // Don't confuse with `window.Node`.
         return this._dirty;
     }
 
-    private _visible: boolean = true;
-    set visible(value: boolean) {
-        if (this._visible !== value) {
-            this._visible = value;
-            this.markDirty(RedrawType.MINOR);
-        }
-    }
-    get visible(): boolean {
-        return this._visible;
-    }
+    @SceneChangeDetection({ redraw: RedrawType.MAJOR })
+    visible: boolean = true;
 
     protected dirtyZIndex: boolean = false;
 
-    private _zIndex: number = 0;
-    set zIndex(value: number) {
-        if (this._zIndex !== value) {
-            this._zIndex = value;
-            if (this.parent) {
-                this.parent.dirtyZIndex = true;
+    @SceneChangeDetection({
+        redraw: RedrawType.MINOR,
+        changeCb: (o) => {
+            if (o.parent) {
+                o.parent.dirtyZIndex = true;
             }
-            this.markDirty(RedrawType.MINOR);
-        }
-    }
-    get zIndex(): number {
-        return this._zIndex;
-    }
+        },
+    })
+    zIndex: number = 0;
 
     pointerEvents: PointerEvents = PointerEvents.All;
 }

--- a/charts-packages/ag-charts-community/src/scene/node.ts
+++ b/charts-packages/ag-charts-community/src/scene/node.ts
@@ -24,10 +24,10 @@ export enum RedrawType {
 export function SceneChangeDetection(opts?: {
     redraw?: RedrawType,
     type?: 'normal' | 'transform' | 'path' | 'font',
-    transform?: (o: any) => any,
+    convertor?: (o: any) => any,
     changeCb?: (o: any) => any,
 }) {
-    const { redraw = RedrawType.TRIVIAL, type = 'normal', changeCb, transform } = opts || {};
+    const { redraw = RedrawType.TRIVIAL, type = 'normal', changeCb, convertor } = opts || {};
 
     return function (target: any, key: string) {
         // `target` is either a constructor (static member) or prototype (instance member)
@@ -37,8 +37,8 @@ export function SceneChangeDetection(opts?: {
             Object.defineProperty(target, key, {
                 set: function (value: any) {
                     const oldValue = this[privateKey];
-                    if (transform) {
-                        value = transform(value);
+                    if (convertor) {
+                        value = convertor(value);
                     }
                     if (value !== oldValue) {
                         this[privateKey] = value;

--- a/charts-packages/ag-charts-community/src/scene/shape/arc.ts
+++ b/charts-packages/ag-charts-community/src/scene/shape/arc.ts
@@ -1,5 +1,5 @@
 import { Shape } from "./shape";
-import { Path } from "./path";
+import { Path, ScenePathChangeDetection } from "./path";
 import { BBox } from "../bbox";
 import { normalizeAngle360 } from "../../util/angle";
 import { chainObjects } from "../../util/object";
@@ -28,86 +28,30 @@ export class Arc extends Path {
         this.restoreOwnStyles();
     }
 
-    private _centerX: number = 0;
-    set centerX(value: number) {
-        if (this._centerX !== value) {
-            this._centerX = value;
-            this.dirtyPath = true;
-        }
-    }
-    get centerX(): number {
-        return this._centerX;
-    }
+    @ScenePathChangeDetection()
+    centerX: number = 0;
 
-    private _centerY: number = 0;
-    set centerY(value: number) {
-        if (this._centerY !== value) {
-            this._centerY = value;
-            this.dirtyPath = true;
-        }
-    }
-    get centerY(): number {
-        return this._centerY;
-    }
+    @ScenePathChangeDetection()
+    centerY: number = 0;
 
-    private _radiusX: number = 10;
-    set radiusX(value: number) {
-        if (this._radiusX !== value) {
-            this._radiusX = value;
-            this.dirtyPath = true;
-        }
-    }
-    get radiusX(): number {
-        return this._radiusX;
-    }
+    @ScenePathChangeDetection()
+    radiusX: number = 10;
 
-    private _radiusY: number = 10;
-    set radiusY(value: number) {
-        if (this._radiusY !== value) {
-            this._radiusY = value;
-            this.dirtyPath = true;
-        }
-    }
-    get radiusY(): number {
-        return this._radiusY;
-    }
+    @ScenePathChangeDetection()
+    radiusY: number = 10;
 
-    private _startAngle: number = 0;
-    set startAngle(value: number) {
-        if (this._startAngle !== value) {
-            this._startAngle = value;
-            this.dirtyPath = true;
-        }
-    }
-    get startAngle(): number {
-        return this._startAngle;
-    }
+    @ScenePathChangeDetection()
+    startAngle: number = 0;
 
-    private _endAngle: number = Math.PI * 2;
-    set endAngle(value: number) {
-        if (this._endAngle !== value) {
-            this._endAngle = value;
-            this.dirtyPath = true;
-        }
-    }
-    get endAngle(): number {
-        return this._endAngle;
-    }
+    @ScenePathChangeDetection()
+    endAngle: number = Math.PI * 2;
 
     private get fullPie(): boolean {
         return isEqual(normalizeAngle360(this.startAngle), normalizeAngle360(this.endAngle));
     }
 
-    private _counterClockwise: boolean = false;
-    set counterClockwise(value: boolean) {
-        if (this._counterClockwise !== value) {
-            this._counterClockwise = value;
-            this.dirtyPath = true;
-        }
-    }
-    get counterClockwise(): boolean {
-        return this._counterClockwise;
-    }
+    @ScenePathChangeDetection()
+    counterClockwise: boolean = false;
 
     /**
      * The type of arc to render:
@@ -121,16 +65,8 @@ export class Arc extends Path {
      * doesn't seem to be a compelling reason to do that, when one can just use {@link ArcType.Chord}
      * to create a closed path.
      */
-    private _type: ArcType = ArcType.Open;
-    set type(value: ArcType) {
-        if (this._type !== value) {
-            this._type = value;
-            this.dirtyPath = true;
-        }
-    }
-    get type(): ArcType {
-        return this._type;
-    }
+    @ScenePathChangeDetection()
+    type: ArcType = ArcType.Open;
 
     updatePath(): void {
         const path = this.path;

--- a/charts-packages/ag-charts-community/src/scene/shape/line.ts
+++ b/charts-packages/ag-charts-community/src/scene/shape/line.ts
@@ -1,7 +1,7 @@
 import { Shape } from "./shape";
 import { chainObjects } from "../../util/object";
 import { BBox } from "../bbox";
-import { RedrawType } from "../node";
+import { RedrawType, SceneChangeDetection } from "../node";
 
 export class Line extends Shape {
 
@@ -17,62 +17,17 @@ export class Line extends Shape {
         this.restoreOwnStyles();
     }
 
-    private _x1: number = 0;
-    set x1(value: number) {
-        if (this._x1 !== value) {
-            this._x1 = value;
-            this.markDirty(RedrawType.MAJOR);
-        }
-    }
-    get x1(): number {
-        // TODO: Investigate getter performance further in the context
-        //       of the scene graph.
-        //       In isolated benchmarks using a getter has the same
-        //       performance as a direct property access in Firefox 64.
-        //       But in Chrome 71 the getter is 60% slower than direct access.
-        //       Direct read is 4.5+ times slower in Chrome than it is in Firefox.
-        //       Property access and direct read have the same performance
-        //       in Safari 12, which is 2+ times faster than Firefox at this.
-        // https://jsperf.com/es5-getters-setters-versus-getter-setter-methods/18
-        // This is a know Chrome issue. They say it's not a regression, since
-        // the behavior is observed since M60, but jsperf.com history shows the
-        // 10x slowdown happened between Chrome 48 and Chrome 57.
-        // https://bugs.chromium.org/p/chromium/issues/detail?id=908743
-        return this._x1;
-    }
+    @SceneChangeDetection({ redraw: RedrawType.MAJOR })
+    x1: number = 0;
 
-    private _y1: number = 0;
-    set y1(value: number) {
-        if (this._y1 !== value) {
-            this._y1 = value;
-            this.markDirty(RedrawType.MAJOR);
-        }
-    }
-    get y1(): number {
-        return this._y1;
-    }
+    @SceneChangeDetection({ redraw: RedrawType.MAJOR })
+    y1: number = 0;
 
-    private _x2: number = 0;
-    set x2(value: number) {
-        if (this._x2 !== value) {
-            this._x2 = value;
-            this.markDirty(RedrawType.MAJOR);
-        }
-    }
-    get x2(): number {
-        return this._x2;
-    }
+    @SceneChangeDetection({ redraw: RedrawType.MAJOR })
+    x2: number = 0;
 
-    private _y2: number = 0;
-    set y2(value: number) {
-        if (this._y2 !== value) {
-            this._y2 = value;
-            this.markDirty(RedrawType.MAJOR);
-        }
-    }
-    get y2(): number {
-        return this._y2;
-    }
+    @SceneChangeDetection({ redraw: RedrawType.MAJOR })
+    y2: number = 0;
 
     computeBBox(): BBox {
         return new BBox(

--- a/charts-packages/ag-charts-community/src/scene/shape/rect.ts
+++ b/charts-packages/ag-charts-community/src/scene/shape/rect.ts
@@ -1,9 +1,9 @@
-import { Path } from "./path";
-import { Shape } from "./shape";
+import { Path, ScenePathChangeDetection } from "./path";
 import { BBox } from "../bbox";
 import { LinearGradient } from "../gradient/linearGradient";
 import { Color } from "../../util/color";
 import { RedrawType } from "../node";
+import { Shape } from "./shape";
 
 export enum RectSizing {
     Content,
@@ -14,93 +14,39 @@ export class Rect extends Path {
 
     static className = 'Rect';
 
-    private _x: number = 0;
-    set x(value: number) {
-        if (this._x !== value) {
-            this._x = value;
-            this.dirtyPath = true;
-        }
-    }
-    get x(): number {
-        return this._x;
-    }
+    @ScenePathChangeDetection()
+    x: number = 0;
 
-    private _y: number = 0;
-    set y(value: number) {
-        if (this._y !== value) {
-            this._y = value;
-            this.dirtyPath = true;
-        }
-    }
-    get y(): number {
-        return this._y;
-    }
+    @ScenePathChangeDetection()
+    y: number = 0;
 
-    private _width: number = 10;
-    set width(value: number) {
-        if (this._width !== value) {
-            this._width = value;
-            this.dirtyPath = true;
-        }
-    }
-    get width(): number {
-        return this._width;
-    }
+    @ScenePathChangeDetection()
+    width: number = 10;
 
-    private _height: number = 10;
-    set height(value: number) {
-        if (this._height !== value) {
-            this._height = value;
-            this.dirtyPath = true;
-        }
-    }
-    get height(): number {
-        return this._height;
-    }
+    @ScenePathChangeDetection()
+    height: number = 10;
 
-    private _radius: number = 0;
-    set radius(value: number) {
-        if (this._radius !== value) {
-            this._radius = value;
-            this.dirtyPath = true;
-        }
-    }
-    get radius(): number {
-        return this._radius;
-    }
+    @ScenePathChangeDetection()
+    radius: number = 0;
 
     /**
      * If `true`, the rect is aligned to the pixel grid for crisp looking lines.
      * Animated rects may not look nice with this option enabled, for example
      * when a rect is translated by a sub-pixel value on each frame.
      */
-    private _crisp: boolean = false;
-    set crisp(value: boolean) {
-        if (this._crisp !== value) {
-            this._crisp = value;
-            this.dirtyPath = true;
-        }
-    }
-    get crisp(): boolean {
-        return this._crisp;
-    }
+    @ScenePathChangeDetection()
+    crisp: boolean = false;
 
-    private _gradient: boolean = false;
-    set gradient(value: boolean) {
-        if (this._gradient !== value) {
-            this._gradient = value;
-            this.updateGradientInstance();
-            this.markDirty(RedrawType.TRIVIAL);
-        }
-    }
-    get gradient(): boolean {
-        return this._gradient;
-    }
+    @ScenePathChangeDetection({ changeCb: (r) => r.updateGradientInstance() })
+    gradient: boolean = false;
 
+    private gradientFill?: string;
     private gradientInstance?: LinearGradient;
+
     private updateGradientInstance() {
+        const { fill } = this;
+
         if (this.gradient) {
-            const { fill } = this;
             if (fill) {
                 const gradient = new LinearGradient();
                 gradient.angle = 270;
@@ -116,53 +62,27 @@ export class Rect extends Path {
         } else {
             this.gradientInstance = undefined;
         }
-    }
 
-    set fill(value: string | undefined) {
-        if (this._fill !== value) {
-            this._fill = value;
-            this.updateGradientInstance();
-            this.markDirty(RedrawType.TRIVIAL);
-        }
-    }
-    get fill(): string | undefined {
-        return this._fill;
-    }
-
-    private effectiveStrokeWidth: number = Shape.defaultStyles.strokeWidth;
-    set strokeWidth(value: number) {
-        if (this._strokeWidth !== value) {
-            this._strokeWidth = value;
-            // Normally, when the `lineWidth` changes, we only need to repaint the rect
-            // without updating the path. If the `isCrisp` is set to `true` however,
-            // we need to update the path to make sure the new stroke aligns to
-            // the pixel grid. This is the reason we override the `lineWidth` setter
-            // and getter here.
-            if (this.crisp || this.sizing === RectSizing.Border) {
-                this.dirtyPath = true;
-            } else {
-                this.effectiveStrokeWidth = value;
-                this.markDirty(RedrawType.MINOR);
-            }
-        }
-    }
-    get strokeWidth(): number {
-        return this._strokeWidth;
+        this.gradientFill = fill;
     }
 
     /**
      * Similar to https://developer.mozilla.org/en-US/docs/Web/CSS/box-sizing
      */
-    private _sizing: RectSizing = RectSizing.Content;
-    set sizing(value: RectSizing) {
-        if (this._sizing !== value) {
-            this._sizing = value;
-            this.dirtyPath = true;
+    @ScenePathChangeDetection({ changeCb: (o) => o.updateGradientInstance() })
+    sizing: RectSizing = RectSizing.Content;
+
+    private lastUpdatePathStrokeWidth: number = Shape.defaultStyles.strokeWidth;
+
+    protected isDirtyPath() {
+        if (this.lastUpdatePathStrokeWidth !== this.strokeWidth) {
+            return this.crisp || this.sizing === RectSizing.Border;
         }
+
+        return false;
     }
-    get sizing(): RectSizing {
-        return this._sizing;
-    }
+
+    private effectiveStrokeWidth: number = Shape.defaultStyles.strokeWidth;
 
     protected updatePath() {
         const borderSizing = this.sizing === RectSizing.Border;
@@ -190,6 +110,7 @@ export class Rect extends Path {
         }
 
         this.effectiveStrokeWidth = strokeWidth;
+        this.lastUpdatePathStrokeWidth = this.strokeWidth;
 
         if (this.crisp && !borderSizing) {
             const { alignment: a, align: al } = this;
@@ -211,7 +132,7 @@ export class Rect extends Path {
         return bbox.containsPoint(point.x, point.y);
     }
 
-    isPointInStroke(x: number, y: number): boolean {
+    isPointInStroke(_x: number, _y: number): boolean {
         return false;
     }
 
@@ -223,6 +144,10 @@ export class Rect extends Path {
         const pixelRatio = this.scene.canvas.pixelRatio || 1;
 
         if (this.fill) {
+            if (this.fill !== this.gradientFill) {
+                this.updateGradientInstance();
+            }
+
             if (this.gradientInstance) {
                 ctx.fillStyle = this.gradientInstance.createGradient(ctx, this.computeBBox());
             } else {

--- a/charts-packages/ag-charts-community/src/scene/shape/sector.ts
+++ b/charts-packages/ag-charts-community/src/scene/shape/sector.ts
@@ -1,5 +1,4 @@
-import { Path } from "./path";
-import { Path2D } from "../path2D";
+import { Path, ScenePathChangeDetection } from "./path";
 import { normalizeAngle360 } from "../../util/angle";
 import { isEqual } from "../../util/number";
 import { BBox } from "../bbox";
@@ -8,93 +7,29 @@ export class Sector extends Path {
 
     static className = 'Sector';
 
-    private _centerX: number = 0;
-    set centerX(value: number) {
-        if (this._centerX !== value) {
-            this._centerX = value;
-            this.dirtyPath = true;
-        }
-    }
-    get centerX(): number {
-        return this._centerX;
-    }
+    @ScenePathChangeDetection()
+    centerX: number = 0;
 
-    private _centerY: number = 0;
-    set centerY(value: number) {
-        if (this._centerY !== value) {
-            this._centerY = value;
-            this.dirtyPath = true;
-        }
-    }
-    get centerY(): number {
-        return this._centerY;
-    }
+    @ScenePathChangeDetection()
+    centerY: number = 0;
 
-    private _centerOffset: number = 0;
-    set centerOffset(value: number) {
-        if (this._centerOffset !== value) {
-            this._centerOffset = Math.max(0, value);
-            this.dirtyPath = true;
-        }
-    }
-    get centerOffset(): number {
-        return this._centerOffset;
-    }
+    @ScenePathChangeDetection()
+    centerOffset: number = 0;
 
-    private _innerRadius: number = 10;
-    set innerRadius(value: number) {
-        if (this._innerRadius !== value) {
-            this._innerRadius = value;
-            this.dirtyPath = true;
-        }
-    }
-    get innerRadius(): number {
-        return this._innerRadius;
-    }
+    @ScenePathChangeDetection()
+    innerRadius: number = 10;
 
-    private _outerRadius: number = 20;
-    set outerRadius(value: number) {
-        if (this._outerRadius !== value) {
-            this._outerRadius = value;
-            this.dirtyPath = true;
-        }
-    }
-    get outerRadius(): number {
-        return this._outerRadius;
-    }
+    @ScenePathChangeDetection()
+    outerRadius: number = 20;
 
-    private _startAngle: number = 0;
-    set startAngle(value: number) {
-        if (this._startAngle !== value) {
-            this._startAngle = value;
-            this.dirtyPath = true;
-        }
-    }
-    get startAngle(): number {
-        return this._startAngle;
-    }
+    @ScenePathChangeDetection()
+    startAngle: number = 0;
 
-    private _endAngle: number = Math.PI * 2;
-    set endAngle(value: number) {
-        if (this._endAngle !== value) {
-            this._endAngle = value;
-            this.dirtyPath = true;
-        }
-    }
-    get endAngle(): number {
-        return this._endAngle;
-    }
+    @ScenePathChangeDetection()
+    endAngle: number = Math.PI * 2;
 
-    private _angleOffset: number = 0;
-    set angleOffset(value: number) {
-        if (this._angleOffset !== value) {
-            this._angleOffset = value;
-            this.dirtyPath = true;
-        }
-    }
-    get angleOffset(): number {
-        return this._angleOffset;
-    }
+    @ScenePathChangeDetection()
+    angleOffset: number = 0;
 
     computeBBox(): BBox {
         const radius = this.outerRadius;

--- a/charts-packages/ag-charts-community/src/scene/shape/shape.ts
+++ b/charts-packages/ag-charts-community/src/scene/shape/shape.ts
@@ -140,7 +140,7 @@ export abstract class Shape extends Node {
     @SceneChangeDetection()
     lineJoin: ShapeLineJoin = Shape.defaultStyles.lineJoin;
 
-    @SceneChangeDetection({ transform: (v) => Math.min(1, Math.max(0, v)) })
+    @SceneChangeDetection({ transform: (v: number) => Math.min(1, Math.max(0, v)) })
     opacity: number = Shape.defaultStyles.opacity;
 
     @SceneChangeDetection()

--- a/charts-packages/ag-charts-community/src/scene/shape/shape.ts
+++ b/charts-packages/ag-charts-community/src/scene/shape/shape.ts
@@ -142,7 +142,7 @@ export abstract class Shape extends Node {
 
     @SceneChangeDetection({
         redraw: RedrawType.MINOR,
-        transform: (v: number) => Math.min(1, Math.max(0, v)),
+        convertor: (v: number) => Math.min(1, Math.max(0, v)),
     })
     opacity: number = Shape.defaultStyles.opacity;
 

--- a/charts-packages/ag-charts-community/src/scene/shape/shape.ts
+++ b/charts-packages/ag-charts-community/src/scene/shape/shape.ts
@@ -90,13 +90,13 @@ export abstract class Shape extends Node {
         }
     }
 
-    @SceneChangeDetection()
+    @SceneChangeDetection({ redraw: RedrawType.MINOR })
     fillOpacity: number = 1;
 
-    @SceneChangeDetection()
+    @SceneChangeDetection({ redraw: RedrawType.MINOR })
     strokeOpacity: number = 1;
 
-    @SceneChangeDetection()
+    @SceneChangeDetection({ redraw: RedrawType.MINOR })
     fill: string | undefined = Shape.defaultStyles.fill;
 
     /**
@@ -109,10 +109,10 @@ export abstract class Shape extends Node {
      * The preferred way of making the stroke invisible is setting the `lineWidth` to zero,
      * unless specific looks that is achieved by having an invisible stroke is desired.
      */
-    @SceneChangeDetection()
+    @SceneChangeDetection({ redraw: RedrawType.MINOR })
     stroke: string | undefined = Shape.defaultStyles.stroke;
 
-    @SceneChangeDetection()
+    @SceneChangeDetection({ redraw: RedrawType.MINOR })
     strokeWidth: number = Shape.defaultStyles.strokeWidth;
 
     // An offset value to align to the pixel grid.
@@ -128,25 +128,28 @@ export abstract class Shape extends Node {
         return Math.floor(start) + alignment;
     }
 
-    @SceneChangeDetection()
+    @SceneChangeDetection({ redraw: RedrawType.MINOR })
     lineDash: number[] | undefined = Shape.defaultStyles.lineDash;
 
-    @SceneChangeDetection()
+    @SceneChangeDetection({ redraw: RedrawType.MINOR })
     lineDashOffset: number = Shape.defaultStyles.lineDashOffset;
 
-    @SceneChangeDetection()
+    @SceneChangeDetection({ redraw: RedrawType.MINOR })
     lineCap: ShapeLineCap = Shape.defaultStyles.lineCap;
 
-    @SceneChangeDetection()
+    @SceneChangeDetection({ redraw: RedrawType.MINOR })
     lineJoin: ShapeLineJoin = Shape.defaultStyles.lineJoin;
 
-    @SceneChangeDetection({ transform: (v: number) => Math.min(1, Math.max(0, v)) })
+    @SceneChangeDetection({
+        redraw: RedrawType.MINOR,
+        transform: (v: number) => Math.min(1, Math.max(0, v)),
+    })
     opacity: number = Shape.defaultStyles.opacity;
 
-    @SceneChangeDetection()
+    @SceneChangeDetection({ redraw: RedrawType.MINOR })
     fillShadow: DropShadow | undefined = Shape.defaultStyles.fillShadow;
 
-    @SceneChangeDetection()
+    @SceneChangeDetection({ redraw: RedrawType.MINOR })
     strokeShadow: DropShadow | undefined = Shape.defaultStyles.strokeShadow;
 
     protected fillStroke(ctx: CanvasRenderingContext2D) {

--- a/charts-packages/ag-charts-community/src/scene/shape/shape.ts
+++ b/charts-packages/ag-charts-community/src/scene/shape/shape.ts
@@ -1,4 +1,4 @@
-import { Node, RedrawType } from "../node";
+import { Node, RedrawType, SceneChangeDetection } from "../node";
 import { chainObjects } from "../../util/object";
 import { DropShadow } from "../dropShadow";
 
@@ -90,38 +90,14 @@ export abstract class Shape extends Node {
         }
     }
 
-    protected _fillOpacity: number = 1;
-    set fillOpacity(value: number) {
-        if (this._fillOpacity !== value) {
-            this._fillOpacity = value;
-            this.markDirty(RedrawType.MINOR);
-        }
-    }
-    get fillOpacity(): number {
-        return this._fillOpacity;
-    }
+    @SceneChangeDetection()
+    fillOpacity: number = 1;
 
-    protected _strokeOpacity: number = 1;
-    set strokeOpacity(value: number) {
-        if (this._strokeOpacity !== value) {
-            this._strokeOpacity = value;
-            this.markDirty(RedrawType.MINOR);
-        }
-    }
-    get strokeOpacity(): number {
-        return this._strokeOpacity;
-    }
+    @SceneChangeDetection()
+    strokeOpacity: number = 1;
 
-    protected _fill: string | undefined = Shape.defaultStyles.fill;
-    set fill(value: string | undefined) {
-        if (this._fill !== value) {
-            this._fill = value;
-            this.markDirty(RedrawType.MINOR);
-        }
-    }
-    get fill(): string | undefined {
-        return this._fill;
-    }
+    @SceneChangeDetection()
+    fill: string | undefined = Shape.defaultStyles.fill;
 
     /**
      * Note that `strokeStyle = null` means invisible stroke,
@@ -133,27 +109,11 @@ export abstract class Shape extends Node {
      * The preferred way of making the stroke invisible is setting the `lineWidth` to zero,
      * unless specific looks that is achieved by having an invisible stroke is desired.
      */
-    protected _stroke: string | undefined = Shape.defaultStyles.stroke;
-    set stroke(value: string | undefined) {
-        if (this._stroke !== value) {
-            this._stroke = value;
-            this.markDirty(RedrawType.MINOR);
-        }
-    }
-    get stroke(): string | undefined {
-        return this._stroke;
-    }
+    @SceneChangeDetection()
+    stroke: string | undefined = Shape.defaultStyles.stroke;
 
-    protected _strokeWidth: number = Shape.defaultStyles.strokeWidth;
-    set strokeWidth(value: number) {
-        if (this._strokeWidth !== value) {
-            this._strokeWidth = value;
-            this.markDirty(RedrawType.MINOR);
-        }
-    }
-    get strokeWidth(): number {
-        return this._strokeWidth;
-    }
+    @SceneChangeDetection()
+    strokeWidth: number = Shape.defaultStyles.strokeWidth;
 
     // An offset value to align to the pixel grid.
     get alignment(): number {
@@ -168,116 +128,26 @@ export abstract class Shape extends Node {
         return Math.floor(start) + alignment;
     }
 
-    protected _lineDash: number[] | undefined = Shape.defaultStyles.lineDash;
-    set lineDash(value: number[] | undefined) {
-        const oldValue = this._lineDash;
+    @SceneChangeDetection()
+    lineDash: number[] | undefined = Shape.defaultStyles.lineDash;
 
-        if (oldValue !== value) {
-            if (oldValue && value && oldValue.length === value.length) {
-                let identical = true;
-                const n = value.length;
-                for (let i = 0; i < n; i++) {
-                    if (oldValue[i] !== value[i]) {
-                        identical = false;
-                        break;
-                    }
-                }
-                if (identical) {
-                    return;
-                }
-            }
-            this._lineDash = value;
-            this.markDirty(RedrawType.MINOR);
-        }
-    }
-    get lineDash(): number[] | undefined {
-        return this._lineDash;
-    }
+    @SceneChangeDetection()
+    lineDashOffset: number = Shape.defaultStyles.lineDashOffset;
 
-    protected _lineDashOffset: number = Shape.defaultStyles.lineDashOffset;
-    set lineDashOffset(value: number) {
-        if (this._lineDashOffset !== value) {
-            this._lineDashOffset = value;
-            this.markDirty(RedrawType.MINOR);
-        }
-    }
-    get lineDashOffset(): number {
-        return this._lineDashOffset;
-    }
+    @SceneChangeDetection()
+    lineCap: ShapeLineCap = Shape.defaultStyles.lineCap;
 
-    protected _lineCap: ShapeLineCap = Shape.defaultStyles.lineCap;
-    set lineCap(value: ShapeLineCap) {
-        if (this._lineCap !== value) {
-            this._lineCap = value;
-            this.markDirty(RedrawType.MINOR);
-        }
-    }
-    get lineCap(): ShapeLineCap {
-        return this._lineCap;
-    }
+    @SceneChangeDetection()
+    lineJoin: ShapeLineJoin = Shape.defaultStyles.lineJoin;
 
-    protected _lineJoin: ShapeLineJoin = Shape.defaultStyles.lineJoin;
-    set lineJoin(value: ShapeLineJoin) {
-        if (this._lineJoin !== value) {
-            this._lineJoin = value;
-            this.markDirty(RedrawType.MINOR);
-        }
-    }
-    get lineJoin(): ShapeLineJoin {
-        return this._lineJoin;
-    }
+    @SceneChangeDetection({ transform: (v) => Math.min(1, Math.max(0, v)) })
+    opacity: number = Shape.defaultStyles.opacity;
 
-    protected _opacity: number = Shape.defaultStyles.opacity;
-    set opacity(value: number) {
-        value = Math.min(1, Math.max(0, value));
-        if (this._opacity !== value) {
-            this._opacity = value;
-            this.markDirty(RedrawType.MINOR);
-        }
-    }
-    get opacity(): number {
-        return this._opacity;
-    }
+    @SceneChangeDetection()
+    fillShadow: DropShadow | undefined = Shape.defaultStyles.fillShadow;
 
-    private readonly onShadowChange = () => {
-        this.markDirty(RedrawType.MINOR);
-    }
-
-    protected _fillShadow: DropShadow | undefined = Shape.defaultStyles.fillShadow;
-    set fillShadow(value: DropShadow | undefined) {
-        const oldValue = this._fillShadow;
-        if (oldValue !== value) {
-            if (oldValue) {
-                oldValue.removeEventListener('change', this.onShadowChange);
-            }
-            if (value) {
-                value.addEventListener('change', this.onShadowChange);
-            }
-            this._fillShadow = value;
-            this.markDirty(RedrawType.MINOR);
-        }
-    }
-    get fillShadow(): DropShadow | undefined {
-        return this._fillShadow;
-    }
-
-    protected _strokeShadow: DropShadow | undefined = Shape.defaultStyles.strokeShadow;
-    set strokeShadow(value: DropShadow | undefined) {
-        const oldValue = this._strokeShadow;
-        if (oldValue !== value) {
-            if (oldValue) {
-                oldValue.removeEventListener('change', this.onShadowChange);
-            }
-            if (value) {
-                value.addEventListener('change', this.onShadowChange);
-            }
-            this._strokeShadow = value;
-            this.markDirty(RedrawType.MINOR);
-        }
-    }
-    get strokeShadow(): DropShadow | undefined {
-        return this._strokeShadow;
-    }
+    @SceneChangeDetection()
+    strokeShadow: DropShadow | undefined = Shape.defaultStyles.strokeShadow;
 
     protected fillStroke(ctx: CanvasRenderingContext2D) {
         if (!this.scene) {

--- a/charts-packages/ag-charts-community/src/scene/shape/text.ts
+++ b/charts-packages/ag-charts-community/src/scene/shape/text.ts
@@ -45,12 +45,11 @@ export class Text extends Shape {
     y: number = 0;
 
     private lines: string[] = [];
-    private splitText() {
-        console.log(this);
+    private _splitText() {
         this.lines = this.text.split(/\r?\n/g);
     }
 
-    @SceneChangeDetection({ changeCb: (o) => o.splitText() })
+    @SceneChangeDetection({ changeCb: (o) => o._splitText() })
     text: string = '';
 
     private _dirtyFont: boolean = true;

--- a/charts-packages/ag-charts-community/src/scene/shape/text.ts
+++ b/charts-packages/ag-charts-community/src/scene/shape/text.ts
@@ -38,10 +38,10 @@ export class Text extends Shape {
         textBaseline: 'alphabetic' as CanvasTextBaseline
     });
 
-    @SceneChangeDetection()
+    @SceneChangeDetection({ redraw: RedrawType.MAJOR })
     x: number = 0;
 
-    @SceneChangeDetection()
+    @SceneChangeDetection({ redraw: RedrawType.MAJOR })
     y: number = 0;
 
     private lines: string[] = [];
@@ -49,7 +49,7 @@ export class Text extends Shape {
         this.lines = this.text.split(/\r?\n/g);
     }
 
-    @SceneChangeDetection({ changeCb: (o) => o._splitText() })
+    @SceneChangeDetection({ redraw: RedrawType.MAJOR, changeCb: (o) => o._splitText() })
     text: string = '';
 
     private _dirtyFont: boolean = true;

--- a/charts-packages/ag-charts-community/src/scene/shape/text.ts
+++ b/charts-packages/ag-charts-community/src/scene/shape/text.ts
@@ -2,11 +2,29 @@ import { Shape } from "./shape";
 import { chainObjects } from "../../util/object";
 import { BBox } from "../bbox";
 import { HdpiCanvas } from "../../canvas/hdpiCanvas";
-import { RedrawType } from "../node";
+import { RedrawType, SceneChangeDetection } from "../node";
 
 export type FontStyle = 'normal' | 'italic' | 'oblique';
 export type FontWeight = 'normal' | 'bold' | 'bolder' | 'lighter' | '100' | '200' | '300' | '400' | '500' | '600' | '700' | '800' | '900';
 
+export function SceneFontChangeDetection(opts?: {
+    redraw?: RedrawType,
+    changeCb?: (t: any) => any,
+}) {
+    const { redraw = RedrawType.MAJOR, changeCb: optChangeCb } = opts || {};
+
+    const changeCb = (o: any) => {
+        if (!o._dirtyFont) {
+            o._dirtyFont = true;
+            o.markDirty(redraw);
+        }
+        if (optChangeCb) {
+            optChangeCb(o);
+        }
+    };
+
+    return SceneChangeDetection({ redraw, type: 'font', changeCb });
+}
 export class Text extends Shape {
 
     static className = 'Text';
@@ -20,159 +38,60 @@ export class Text extends Shape {
         textBaseline: 'alphabetic' as CanvasTextBaseline
     });
 
-    private _x: number = 0;
-    set x(value: number) {
-        if (this._x !== value) {
-            this._x = value;
-            this.markDirty(RedrawType.MAJOR);
-        }
-    }
-    get x(): number {
-        return this._x;
-    }
+    @SceneChangeDetection()
+    x: number = 0;
 
-    private _y: number = 0;
-    set y(value: number) {
-        if (this._y !== value) {
-            this._y = value;
-            this.markDirty(RedrawType.MAJOR);
-        }
-    }
-    get y(): number {
-        return this._y;
-    }
+    @SceneChangeDetection()
+    y: number = 0;
 
-    private lineBreakRegex = /\r?\n/g;
     private lines: string[] = [];
-
     private splitText() {
-        this.lines = this._text.split(this.lineBreakRegex);
+        console.log(this);
+        this.lines = this.text.split(/\r?\n/g);
     }
 
-    private _text: string = '';
-    set text(value: string) {
-        const str = String(value); // `value` can be an object here
+    @SceneChangeDetection({ changeCb: (o) => o.splitText() })
+    text: string = '';
 
-        if (this._text !== str) {
-            this._text = str;
-            this.splitText();
-            this.markDirty(RedrawType.MAJOR);
-        }
-    }
-    get text(): string {
-        return this._text;
-    }
-
+    private _dirtyFont: boolean = true;
     private _font?: string;
     get font(): string {
-        if (this.dirtyFont) {
-            this.dirtyFont = false;
+        if (this._dirtyFont) {
+            this._dirtyFont = false;
             this._font = getFont(this.fontSize, this.fontFamily, this.fontStyle, this.fontWeight);
         }
 
         return this._font!;
     }
 
-    private _dirtyFont: boolean = true;
-    set dirtyFont(value: boolean) {
-        if (this._dirtyFont !== value) {
-            this._dirtyFont = value;
-            if (value) {
-                this.markDirty(RedrawType.MAJOR);
-            }
-        }
-    }
-    get dirtyFont(): boolean {
-        return this._dirtyFont;
-    }
+    @SceneFontChangeDetection()
+    fontStyle?: FontStyle;
 
-    private _fontStyle?: FontStyle;
-    set fontStyle(value: FontStyle | undefined) {
-        if (this._fontStyle !== value) {
-            this._fontStyle = value;
-            this.dirtyFont = true;
-        }
-    }
-    get fontStyle(): FontStyle | undefined {
-        return this._fontStyle;
-    }
+    @SceneFontChangeDetection()
+    fontWeight?: FontWeight;
 
-    private _fontWeight?: FontWeight;
-    set fontWeight(value: FontWeight | undefined) {
-        if (this._fontWeight !== value) {
-            this._fontWeight = value;
-            this.dirtyFont = true;
-        }
-    }
-    get fontWeight(): FontWeight | undefined {
-        return this._fontWeight;
-    }
+    @SceneFontChangeDetection()
+    fontSize: number = 10;
 
-    private _fontSize: number = 10;
-    set fontSize(value: number) {
-        if (!isFinite(value)) {
-            value = 10;
-        }
-        if (this._fontSize !== value) {
-            this._fontSize = value;
-            this.dirtyFont = true;
-        }
-    }
-    get fontSize(): number {
-        return this._fontSize;
-    }
+    @SceneFontChangeDetection()
+    fontFamily: string = 'sans-serif';
 
-    private _fontFamily: string = 'sans-serif';
-    set fontFamily(value: string) {
-        if (this._fontFamily !== value) {
-            this._fontFamily = value;
-            this.dirtyFont = true;
-        }
-    }
-    get fontFamily(): string {
-        return this._fontFamily;
-    }
+    @SceneChangeDetection({ redraw: RedrawType.MAJOR })
+    textAlign: CanvasTextAlign = Text.defaultStyles.textAlign;
 
-    private _textAlign: CanvasTextAlign = Text.defaultStyles.textAlign;
-    set textAlign(value: CanvasTextAlign) {
-        if (this._textAlign !== value) {
-            this._textAlign = value;
-            this.markDirty(RedrawType.MAJOR);
-        }
-    }
-    get textAlign(): CanvasTextAlign {
-        return this._textAlign;
-    }
+    @SceneChangeDetection({ redraw: RedrawType.MAJOR })
+    textBaseline: CanvasTextBaseline = Text.defaultStyles.textBaseline;
 
-    private _textBaseline: CanvasTextBaseline = Text.defaultStyles.textBaseline;
-    set textBaseline(value: CanvasTextBaseline) {
-        if (this._textBaseline !== value) {
-            this._textBaseline = value;
-            this.markDirty(RedrawType.MAJOR);
-        }
-    }
-    get textBaseline(): CanvasTextBaseline {
-        return this._textBaseline;
-    }
-
-    private _lineHeight: number = 14;
-    set lineHeight(value: number) {
-        // Multi-line text is complicated because:
-        // - Canvas does not support it natively, so we have to implement it manually
-        // - need to know the height of each line -> need to parse the font shorthand ->
-        //   generally impossible to do because font size may not be in pixels
-        // - so, need to measure the text instead, each line individually -> expensive
-        // - or make the user provide the line height manually for multi-line text
-        // - computeBBox should use the lineHeight for multi-line text but ignore it otherwise
-        // - textBaseline kind of loses its meaning for multi-line text
-        if (this._lineHeight !== value) {
-            this._lineHeight = value;
-            this.markDirty(RedrawType.MAJOR);
-        }
-    }
-    get lineHeight(): number {
-        return this._lineHeight;
-    }
+    // Multi-line text is complicated because:
+    // - Canvas does not support it natively, so we have to implement it manually
+    // - need to know the height of each line -> need to parse the font shorthand ->
+    //   generally impossible to do because font size may not be in pixels
+    // - so, need to measure the text instead, each line individually -> expensive
+    // - or make the user provide the line height manually for multi-line text
+    // - computeBBox should use the lineHeight for multi-line text but ignore it otherwise
+    // - textBaseline kind of loses its meaning for multi-line text
+    @SceneChangeDetection({ redraw: RedrawType.MAJOR })
+    lineHeight: number = 14;
 
     computeBBox(): BBox {
         return HdpiCanvas.has.textMetrics
@@ -233,7 +152,7 @@ export class Text extends Shape {
         return bbox ? bbox.containsPoint(point.x, point.y) : false;
     }
 
-    isPointInStroke(x: number, y: number): boolean {
+    isPointInStroke(_x: number, _y: number): boolean {
         return false;
     }
 


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-6786

Replace repeated change-detection `set`/`get` pattern with a simple field declarataion and an annotation to implement generic (but functionally equivalent) change detection processing.