### PR TITLE
fix typo in DOM virtualisation documentation

### DIFF
--- a/grid-packages/ag-grid-docs/documentation/doc-pages/dom-virtualisation/index.md
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/dom-virtualisation/index.md
@@ -2,7 +2,7 @@
 title: "DOM Virtualisation"
 ---
 
-The grid uses DOM virtualistaion to vastly improve rendering performance.
+The grid uses DOM virtualisation to vastly improve rendering performance.
 
 If you loaded 1,000 records with 20 columns into the browser without using a datagrid (eg using 'table', 'tr' and 'td' tags), then the page would end up with a lot of rendered DOM elements. This would drastically slow down the web page. This results in either a very poor user experience, or simply crashing the browser as the browser runs out of memory.
 


### PR DESCRIPTION
On the [documentation page for DOM virtualisation](https://www.ag-grid.com/javascript-data-grid/dom-virtualisation/) there's a typo, the word 'Virtualisation' is spelt incorrectly:
![ag-grid-dom-virtualisation-typo](https://user-images.githubusercontent.com/32019551/169141749-79fcd3f8-5277-4a6a-a842-b679705c64b9.png)

