### PR TITLE
AG-6791 -Refactor Charts series opacity calculation.

### DIFF
--- a/charts-packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
@@ -608,7 +608,7 @@ export class AreaSeries extends CartesianSeries {
             shape.lineDashOffset = this.lineDashOffset;
             shape.fillShadow = shadow;
             shape.visible = !!seriesItemEnabled.get(datum.itemId);
-            shape.opacity = this.getOpacity(datum);
+            shape.opacity = this.getOpacity();
 
             const { points } = datum;
 
@@ -653,7 +653,7 @@ export class AreaSeries extends CartesianSeries {
 
         this.strokeSelection.each((shape, datum, index) => {
             shape.visible = !!seriesItemEnabled.get(datum.itemId);
-            shape.opacity = this.getOpacity(datum);
+            shape.opacity = this.getOpacity();
             shape.stroke = strokes[index % strokes.length];
             shape.strokeWidth = this.getStrokeWidth(this.strokeWidth, datum);
             shape.strokeOpacity = strokeOpacity;
@@ -752,7 +752,7 @@ export class AreaSeries extends CartesianSeries {
             node.translationX = datum.point.x;
             node.translationY = datum.point.y;
             node.visible = marker.enabled && node.size > 0 && !!seriesItemEnabled.get(datum.yKey) && !isNaN(datum.point.x) && !isNaN(datum.point.y);
-            node.opacity = this.getOpacity(datum);
+            node.opacity = this.getOpacity();
         });
     }
 
@@ -784,7 +784,7 @@ export class AreaSeries extends CartesianSeries {
                 text.y = point.y - 10;
                 text.fill = color;
                 text.visible = true;
-                text.opacity = this.getOpacity(datum);
+                text.opacity = this.getOpacity();
             } else {
                 text.visible = false;
             }

--- a/charts-packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
@@ -759,7 +759,7 @@ export class BarSeries extends CartesianSeries {
             // Prevent stroke from rendering for zero height columns and zero width bars.
             rect.visible = flipXY ? datum.width > 0 : datum.height > 0;
             rect.zIndex = isDatumHighlighted ? Series.highlightedZIndex : index;
-            rect.opacity = this.getOpacity(datum);
+            rect.opacity = this.getOpacity();
         });
     }
 
@@ -782,7 +782,6 @@ export class BarSeries extends CartesianSeries {
         }
 
         const {
-            chart: { highlightedDatum },
             label: { enabled: labelEnabled, fontStyle, fontWeight, fontSize, fontFamily, color }
         } = this;
 
@@ -801,7 +800,7 @@ export class BarSeries extends CartesianSeries {
                 text.y = label.y;
                 text.fill = color;
                 text.visible = true;
-                text.opacity = this.getOpacity(datum);
+                text.opacity = this.getOpacity();
             } else {
                 text.visible = false;
             }

--- a/charts-packages/ag-charts-community/src/chart/series/cartesian/histogramSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/cartesian/histogramSeries.ts
@@ -462,7 +462,7 @@ export class HistogramSeries extends CartesianSeries {
             rect.fillShadow = shadow;
             rect.zIndex = isDatumHighlighted ? Series.highlightedZIndex : index;
             rect.visible = datum.height > 0; // prevent stroke from rendering for zero height columns
-            rect.opacity = this.getOpacity(datum);
+            rect.opacity = this.getOpacity();
         });
     }
 

--- a/charts-packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
@@ -333,12 +333,10 @@ export class LineSeries extends CartesianSeries {
 
         lineNode.stroke = this.stroke;
         lineNode.strokeWidth = this.getStrokeWidth(this.strokeWidth);
-        lineNode.strokeOpacity = this.strokeOpacity;
+        lineNode.strokeOpacity = this.strokeOpacity * (1 / this.getOpacity());
 
         lineNode.lineDash = this.lineDash;
         lineNode.lineDashOffset = this.lineDashOffset;
-
-        lineNode.opacity = 1;
     }
 
     private updateMarkerNodes() {
@@ -365,13 +363,7 @@ export class LineSeries extends CartesianSeries {
         const markerStrokeWidth = marker.strokeWidth !== undefined ? marker.strokeWidth : this.strokeWidth;
         const MarkerShape = getMarker(marker.shape);
 
-        const markerSelection = this.nodeSelection.selectByClass(MarkerShape);
-        const datumOpacity = new Array<number>(markerSelection.size);
-        markerSelection.each((_, datum, idx) => {
-            datumOpacity[idx] = this.getOpacity(datum);
-        });
-        const nodesHaveIdenticalOpacity = datumOpacity.every((v) => v === datumOpacity[0]);
-        this.seriesGroup.opacity = nodesHaveIdenticalOpacity ? datumOpacity[0] : 1;
+        this.seriesGroup.opacity = this.getOpacity();
 
         const updateMarkerFn = (node: Marker, datum: LineNodeDatum, idx: number, isDatumHighlighted: boolean) => {
             const fill = isDatumHighlighted && highlightedFill !== undefined ? highlightedFill : marker.fill;
@@ -405,11 +397,10 @@ export class LineSeries extends CartesianSeries {
 
             node.translationX = datum.point.x;
             node.translationY = datum.point.y;
-            node.opacity = nodesHaveIdenticalOpacity ? 1 : datumOpacity[idx];
             node.visible = marker.enabled && node.size > 0;
         };
 
-        markerSelection
+        this.nodeSelection.selectByClass(MarkerShape)
             .each((node, datum, idx) => updateMarkerFn(node, datum, idx, false));
         this.highlightSelection.selectByClass(MarkerShape)
             .each((node, datum, idx) => {

--- a/charts-packages/ag-charts-community/src/chart/series/cartesian/scatterSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/cartesian/scatterSeries.ts
@@ -378,7 +378,7 @@ export class ScatterSeries extends CartesianSeries {
             node.strokeOpacity = marker.strokeOpacity !== undefined ? marker.strokeOpacity : strokeOpacity;
             node.translationX = datum.point.x;
             node.translationY = datum.point.y;
-            node.opacity = this.getOpacity(datum);
+            node.opacity = this.getOpacity();
             node.zIndex = isDatumHighlighted ? Series.highlightedZIndex : index;
             node.visible = marker.enabled && node.size > 0;
         });

--- a/charts-packages/ag-charts-community/src/chart/series/series.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/series.ts
@@ -194,11 +194,17 @@ export abstract class Series extends Observable {
     // Produce data joins and update selection's nodes using node data.
     abstract update(): void;
 
-    protected getOpacity(datum?: { itemId?: any }): number {
-        const { chart, highlightStyle: { series: { dimOpacity = 1 } } } = this;
-        return !chart || !chart.highlightedDatum ||
-            chart.highlightedDatum.series === this &&
-            (!datum || chart.highlightedDatum.itemId === datum.itemId) ? 1 : dimOpacity;
+    protected getOpacity(): number {
+        const { 
+            chart: { highlightedDatum: { series = undefined } = {} } = {},
+            highlightStyle: { series: { dimOpacity = 1 } },
+         } = this;
+        
+        if (series && series !== this) {
+            return dimOpacity;
+        } else {
+            return 1;
+        }
     }
 
     protected getStrokeWidth(defaultStrokeWidth: number, datum?: { itemId?: any }): number {


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-6791

Refactor per-datum contract for `Series.getOpacity()` to allow simplification/optimisation of where opacity is applied.

This is a follow-up to #5216.