### PR TITLE
AG-6820 - Further Chart rendering optimisations for larger data-sets

### DIFF
--- a/charts-packages/ag-charts-community/src/canvas/hdpiCanvas.ts
+++ b/charts-packages/ag-charts-community/src/canvas/hdpiCanvas.ts
@@ -8,6 +8,7 @@ export class HdpiCanvas {
     readonly document: Document;
     readonly element: HTMLCanvasElement;
     readonly context: CanvasRenderingContext2D;
+    readonly imageSource: HTMLCanvasElement;
 
     // The width/height attributes of the Canvas element default to
     // 300/150 according to w3.org.
@@ -21,6 +22,7 @@ export class HdpiCanvas {
     }) {
         this.document = document;
         this.element = document.createElement('canvas');
+        this.imageSource = this.element;
         this.context = this.element.getContext('2d')!;
 
         const { style } = this.element;

--- a/charts-packages/ag-charts-community/src/canvas/hdpiCanvas.ts
+++ b/charts-packages/ag-charts-community/src/canvas/hdpiCanvas.ts
@@ -22,8 +22,8 @@ export class HdpiCanvas {
     }) {
         this.document = document;
         this.element = document.createElement('canvas');
-        this.imageSource = this.element;
         this.context = this.element.getContext('2d')!;
+        this.imageSource = this.context.canvas;
 
         const { style } = this.element;
 

--- a/charts-packages/ag-charts-community/src/canvas/hdpiCanvas.ts
+++ b/charts-packages/ag-charts-community/src/canvas/hdpiCanvas.ts
@@ -94,6 +94,10 @@ export class HdpiCanvas {
         Object.freeze(this);
     }
 
+    snapshot() {
+        // No-op for compatibility with HdpiOffscreenCanvas.
+    }
+
     clear() {
         this.context.save();
         this.context.resetTransform();
@@ -327,7 +331,7 @@ export class HdpiCanvas {
         return size;
     }
 
-    static overrideScale(ctx: CanvasRenderingContext2D, scale: number) {
+    static overrideScale(ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D, scale: number) {
         let depth = 0;
         const overrides = {
             save() {

--- a/charts-packages/ag-charts-community/src/canvas/hdpiOffscreenCanvas.ts
+++ b/charts-packages/ag-charts-community/src/canvas/hdpiOffscreenCanvas.ts
@@ -1,0 +1,97 @@
+import { HdpiCanvas } from "./hdpiCanvas";
+
+/**
+ * Wraps a native OffscreenCanvas and overrides its OffscreenCanvasRenderingContext2D to
+ * provide resolution independent rendering based on `window.devicePixelRatio`.
+ */
+export class HdpiOffscreenCanvas {
+    readonly context: OffscreenCanvasRenderingContext2D;
+    readonly canvas: OffscreenCanvas;
+    imageSource: ImageBitmap;
+
+    enabled: boolean = true;
+    opacity: number = 1;
+
+    static isSupported() {
+        return false;
+        // return OffscreenCanvas != null;
+    }
+
+    // The width/height attributes of the Canvas element default to
+    // 300/150 according to w3.org.
+    constructor({
+        width = 600,
+        height = 300,
+    }) {
+        this.canvas = new OffscreenCanvas(width, height);
+        this.context = this.canvas.getContext('2d')!;
+        this.imageSource = this.canvas.transferToImageBitmap();
+
+        this.setPixelRatio();
+        this.resize(width, height);
+    }
+
+    snapshot() {
+        this.imageSource.close();
+        this.imageSource = this.canvas.transferToImageBitmap();
+    }
+
+    destroy() {
+        this.imageSource.close();
+    }
+
+    clear() {
+        this.context.save();
+        this.context.resetTransform();
+        this.context.clearRect(0, 0, this.width, this.height);
+        this.context.restore();
+    }
+
+    // `NaN` is deliberate here, so that overrides are always applied
+    // and the `resetTransform` inside the `resize` method works in IE11.
+    _pixelRatio: number = NaN;
+    get pixelRatio(): number {
+        return this._pixelRatio;
+    }
+
+    /**
+     * Changes the pixel ratio of the Canvas element to the given value,
+     * or uses the window.devicePixelRatio (default), then resizes the Canvas
+     * element accordingly (default).
+     */
+    setPixelRatio(ratio?: number) {
+        const pixelRatio = ratio || window.devicePixelRatio;
+
+        if (pixelRatio === this.pixelRatio) {
+            return;
+        }
+
+        HdpiCanvas.overrideScale(this.context, pixelRatio);
+
+        this._pixelRatio = pixelRatio;
+        this.resize(this.width, this.height);
+    }
+
+    private _width: number = 0;
+    get width(): number {
+        return this._width;
+    }
+
+    private _height: number = 0;
+    get height(): number {
+        return this._height;
+    }
+
+    resize(width: number, height: number) {
+        if (!(width > 0 && height > 0)) {
+            return;
+        }
+        const { canvas, context, pixelRatio } = this;
+        canvas.width = Math.round(width * pixelRatio);
+        canvas.height = Math.round(height * pixelRatio);
+        context.resetTransform();
+
+        this._width = width;
+        this._height = height;
+    }
+}

--- a/charts-packages/ag-charts-community/src/canvas/hdpiOffscreenCanvas.ts
+++ b/charts-packages/ag-charts-community/src/canvas/hdpiOffscreenCanvas.ts
@@ -13,8 +13,7 @@ export class HdpiOffscreenCanvas {
     opacity: number = 1;
 
     static isSupported() {
-        return false;
-        // return OffscreenCanvas != null;
+        return OffscreenCanvas != null;
     }
 
     // The width/height attributes of the Canvas element default to

--- a/charts-packages/ag-charts-community/src/canvas/hdpiOffscreenCanvas.ts
+++ b/charts-packages/ag-charts-community/src/canvas/hdpiOffscreenCanvas.ts
@@ -13,7 +13,7 @@ export class HdpiOffscreenCanvas {
     opacity: number = 1;
 
     static isSupported() {
-        return OffscreenCanvas != null;
+        return (window as any)['OffscreenCanvas'] != null;
     }
 
     // The width/height attributes of the Canvas element default to

--- a/charts-packages/ag-charts-community/src/chart/chart.ts
+++ b/charts-packages/ag-charts-community/src/chart/chart.ts
@@ -1186,21 +1186,34 @@ export abstract class Chart extends Observable {
 
     private checkLegendClick(event: MouseEvent): boolean {
         const datum = this.legend.getDatumForPoint(event.offsetX, event.offsetY);
-
-        if (datum) {
-            const { id, itemId, enabled } = datum;
-            const series = find(this.series, (s) => s.id === id);
-
-            if (series) {
-                series.toggleSeriesItem(itemId, !enabled);
-                if (enabled) {
-                    this.tooltip.toggle(false);
-                }
-                return true;
-            }
+        if (!datum) {
+            return false;
         }
 
-        return false;
+        const { id, itemId, enabled } = datum;
+        const series = find(this.series, (s) => s.id === id);
+        if (!series) {
+            return false;
+        }
+
+        series.toggleSeriesItem(itemId, !enabled);
+        if (enabled) {
+            this.tooltip.toggle(false);
+        }
+
+        if (enabled && this.highlightedDatum?.series === series) {
+            this.highlightedDatum = undefined;
+        }
+
+        if (!enabled) {
+            this.highlightedDatum = {
+                series,
+                itemId,
+                datum: undefined
+            };
+        }
+
+        return true;
     }
 
     private pointerInsideLegend = false;

--- a/charts-packages/ag-charts-community/src/chart/chart.ts
+++ b/charts-packages/ag-charts-community/src/chart/chart.ts
@@ -517,9 +517,7 @@ export abstract class Chart extends Observable {
             this.performUpdate(count);
         } catch (error) {
             this._lastPerformUpdateError = error;
-            if (this.debug) {
-                console.error(error);
-            }
+            console.error(error);
         }
     });
     public update(type = ChartUpdateType.FULL, opts?: { forceNodeDataRefresh: boolean }) {

--- a/charts-packages/ag-charts-community/src/chart/chart.ts
+++ b/charts-packages/ag-charts-community/src/chart/chart.ts
@@ -512,6 +512,7 @@ export abstract class Chart extends Observable {
 
     private firstRenderComplete = false;
     private firstResizeReceived = false;
+    private seriesToUpdate: Set<Series> = new Set();
     private performUpdateTrigger = debouncedCallback(({ count }) => {
         try {
             this.performUpdate(count);
@@ -520,11 +521,18 @@ export abstract class Chart extends Observable {
             console.error(error);
         }
     });
-    public update(type = ChartUpdateType.FULL, opts?: { forceNodeDataRefresh: boolean }) {
-        const { forceNodeDataRefresh = false } = opts || {};
+    public update(
+        type = ChartUpdateType.FULL, 
+        opts?: { forceNodeDataRefresh?: boolean, seriesToUpdate?: Iterable<Series> }
+    ) {
+        const { forceNodeDataRefresh = false, seriesToUpdate = this.series } = opts || {};
 
         if (forceNodeDataRefresh) {
             this.series.forEach(series => series.markNodeDataDirty());
+        }
+
+        for (const series of seriesToUpdate) {
+            this.seriesToUpdate.add(series);
         }
 
         if (type < this._performUpdateType) {
@@ -553,9 +561,10 @@ export abstract class Chart extends Observable {
 
                 this.performLayout();
             case ChartUpdateType.SERIES_UPDATE:
-                this.series.forEach(series => {
+                this.seriesToUpdate.forEach(series => {
                     series.update();
                 });
+                this.seriesToUpdate.clear();
             case ChartUpdateType.SCENE_RENDER:
                 this.scene.render({ start });
                 this.firstRenderComplete = true;
@@ -1274,22 +1283,27 @@ export abstract class Chart extends Observable {
     highlightedDatum?: SeriesNodeDatum;
 
     changeHighlightDatum(newPick?: { datum: SeriesNodeDatum, node?: Shape, event?: MouseEvent}) {
-        const seriesToUpdate: Set<Series | undefined> = new Set<Series>();
-        const { datum = undefined } = newPick || {};
+        const seriesToUpdate: Set<Series> = new Set<Series>();
+        const { datum: { series: newSeries = undefined } = {}, datum = undefined } = newPick || {};
+        const { lastPick: { datum: { series: lastSeries = undefined } = {} } = {} } = this;
 
-        if (this.lastPick) {
-            seriesToUpdate.add(this.lastPick?.datum?.series);
+        if (lastSeries) {
+            seriesToUpdate.add(lastSeries);
         }
 
-        if (datum) {
-            this.element.style.cursor = datum.series.cursor;
+        if (newSeries) {
+            seriesToUpdate.add(newSeries);
+            this.element.style.cursor = newSeries.cursor;
         }
 
         this.lastPick = newPick;
         this.highlightedDatum = datum;
 
-        seriesToUpdate.add(newPick?.datum?.series);
-
-        this.update(ChartUpdateType.SERIES_UPDATE);
+        let updateAll = newSeries == null || lastSeries == null;
+        if (updateAll) {
+            this.update(ChartUpdateType.SERIES_UPDATE);
+        } else {
+            this.update(ChartUpdateType.SERIES_UPDATE, { seriesToUpdate });
+        }
     }
 }

--- a/charts-packages/ag-charts-community/src/chart/legend.ts
+++ b/charts-packages/ag-charts-community/src/chart/legend.ts
@@ -162,7 +162,7 @@ export class Legend {
     public onMarkerShapeChange() {
         this.itemSelection = this.itemSelection.setData([]);
         this.itemSelection.exit.remove();
-        this.group.markDirty(RedrawType.MINOR);
+        this.group.markDirty(this.group, RedrawType.MINOR);
     }
 
     /**

--- a/charts-packages/ag-charts-community/src/chart/marker/marker.ts
+++ b/charts-packages/ag-charts-community/src/chart/marker/marker.ts
@@ -1,39 +1,16 @@
-import { Path } from "../../scene/shape/path";
+import { Path, ScenePathChangeDetection } from "../../scene/shape/path";
 import { BBox } from "../../scene/bbox";
 
 export abstract class Marker extends Path {
-    protected _x: number = 0;
-    set x(value: number) {
-        if (this._x !== value) {
-            this._x = value;
-            this.dirtyPath = true;
-        }
-    }
-    get x(): number {
-        return this._x;
-    }
 
-    protected _y: number = 0;
-    set y(value: number) {
-        if (this._y !== value) {
-            this._y = value;
-            this.dirtyPath = true;
-        }
-    }
-    get y(): number {
-        return this._y;
-    }
+    @ScenePathChangeDetection()
+    x: number = 0;
 
-    protected _size: number = 12;
-    set size(value: number) {
-        if (this._size !== value) {
-            this._size = Math.abs(value);
-            this.dirtyPath = true;
-        }
-    }
-    get size(): number {
-        return this._size;
-    }
+    @ScenePathChangeDetection()
+    y: number = 0;
+
+    @ScenePathChangeDetection({ convertor: Math.abs })
+    size: number = 12;
 
     computeBBox(): BBox {
         const { x, y, size } = this;

--- a/charts-packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
@@ -764,8 +764,9 @@ export class AreaSeries extends CartesianSeries {
         markerSelection: Selection<Marker, Group, MarkerSelectionDatum, any>,
         data: MarkerSelectionDatum[],
     ): Selection<Marker, Group, MarkerSelectionDatum, any> {
-        const MarkerShape = getMarker(this.marker.shape);
-        data = MarkerShape ? data : [];
+        const { marker: { enabled, shape }} = this;
+        data = shape && enabled ? data : [];
+        const MarkerShape = getMarker(shape);
 
         const updateMarkers = markerSelection.setData(data);
         updateMarkers.exit.remove();
@@ -844,7 +845,7 @@ export class AreaSeries extends CartesianSeries {
 
             node.translationX = datum.point.x;
             node.translationY = datum.point.y;
-            node.visible = marker.enabled && node.size > 0 && !!seriesItemEnabled.get(datum.yKey) && !isNaN(datum.point.x) && !isNaN(datum.point.y);
+            node.visible = node.size > 0 && !!seriesItemEnabled.get(datum.yKey) && !isNaN(datum.point.x) && !isNaN(datum.point.y);
         });
     }
 

--- a/charts-packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
@@ -632,7 +632,9 @@ export class AreaSeries extends CartesianSeries {
                 }
             });
 
-            fillPoints.push(...fillPhantomPoints.slice().reverse());
+            for (let i = fillPhantomPoints.length - 1; i >= 0; i--) {
+                fillPoints.push(fillPhantomPoints[i]);
+            }
         });
 
         this.allMarkerSelectionData = markerSelectionData.reduce((r, n) => r.concat(n), []);

--- a/charts-packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
@@ -292,13 +292,13 @@ export class LineSeries extends CartesianSeries {
     }
 
     private updateNodeSelection() {
-        const { marker } = this;
-        const nodeData = marker.shape ? this.nodeData : [];
-        const MarkerShape = getMarker(marker.shape);
+        const { marker: { shape, enabled } } = this;
+        const nodeData = shape && enabled ? this.nodeData : [];
+        const MarkerShape = getMarker(shape);
 
         const { nodeSelection, highlightSelection } = this;
-        const update = (selection: typeof nodeSelection) => {
-            const updateSelection = selection.setData(nodeData);
+        const update = (selection: typeof nodeSelection, data: typeof nodeData) => {
+            const updateSelection = selection.setData(data);
             updateSelection.exit.remove();
             
             const enterSelection = updateSelection.enter.append(Group);
@@ -307,8 +307,8 @@ export class LineSeries extends CartesianSeries {
             return updateSelection.merge(enterSelection);
         }
 
-        this.nodeSelection = update(nodeSelection);
-        this.highlightSelection = update(highlightSelection);
+        this.nodeSelection = update(nodeSelection, nodeData);
+        this.highlightSelection = update(highlightSelection, nodeData);
     }
 
     private updateNodes() {
@@ -390,7 +390,7 @@ export class LineSeries extends CartesianSeries {
 
             node.translationX = datum.point.x;
             node.translationY = datum.point.y;
-            node.visible = marker.enabled && node.size > 0;
+            node.visible = node.size > 0;
         };
 
         this.nodeSelection.selectByClass(MarkerShape)

--- a/charts-packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
@@ -75,7 +75,7 @@ export class LineSeries extends CartesianSeries {
     // We use groups for this selection even though each group only contains a marker ATM
     // because in the future we might want to add label support as well.
     private nodeSelection: Selection<Group, Group, LineNodeDatum, any> = Selection.select(this.pickGroup).selectAll<Group>();
-    private highlightSelection: Selection<Group, Group, LineNodeDatum, any> = Selection.select(this.highlightGroup).selectAll<Group>();
+    private highlightSelection: Selection<Marker, Group, LineNodeDatum, any> = Selection.select(this.highlightGroup).selectAll<Marker>();
     private nodeData: LineNodeDatum[] = [];
 
     readonly marker = new CartesianSeriesMarker();
@@ -297,18 +297,18 @@ export class LineSeries extends CartesianSeries {
         const MarkerShape = getMarker(shape);
 
         const { nodeSelection, highlightSelection } = this;
-        const update = (selection: typeof nodeSelection, data: typeof nodeData) => {
-            const updateSelection = selection.setData(data);
-            updateSelection.exit.remove();
-            
-            const enterSelection = updateSelection.enter.append(Group);
-            enterSelection.append(MarkerShape);
-            enterSelection.append(Text);
-            return updateSelection.merge(enterSelection);
-        }
 
-        this.nodeSelection = update(nodeSelection, nodeData);
-        this.highlightSelection = update(highlightSelection, nodeData);
+        const updateSelection = nodeSelection.setData(nodeData);
+        updateSelection.exit.remove();
+        const enterSelection = updateSelection.enter.append(Group);
+        enterSelection.append(MarkerShape);
+        enterSelection.append(Text);
+        this.nodeSelection = updateSelection.merge(enterSelection);
+    
+        const updateSelection2 = highlightSelection.setData(nodeData);
+        updateSelection2.exit.remove();
+        const enterSelection2 = updateSelection2.enter.append(MarkerShape);
+        this.highlightSelection = updateSelection2.merge(enterSelection2);
     }
 
     private updateNodes() {
@@ -395,7 +395,7 @@ export class LineSeries extends CartesianSeries {
 
         this.nodeSelection.selectByClass(MarkerShape)
             .each((node, datum) => updateMarkerFn(node, datum, false));
-        this.highlightSelection.selectByClass(MarkerShape)
+        this.highlightSelection
             .each((node, datum) => {
                 const isDatumHighlighted = datum === highlightedDatum;
 

--- a/charts-packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
@@ -74,7 +74,7 @@ export class LineSeries extends CartesianSeries {
 
     // We use groups for this selection even though each group only contains a marker ATM
     // because in the future we might want to add label support as well.
-    private nodeSelection: Selection<Group, Group, LineNodeDatum, any> = Selection.select(this.pickGroup).selectAll<Group>();
+    private nodeSelection: Selection<Group, Group, LineNodeDatum, any> = Selection.select(this.seriesGroup).selectAll<Group>();
     private highlightSelection: Selection<Marker, Group, LineNodeDatum, any> = Selection.select(this.highlightGroup).selectAll<Marker>();
     private nodeData: LineNodeDatum[] = [];
 
@@ -307,10 +307,10 @@ export class LineSeries extends CartesianSeries {
         enterSelection.append(Text);
         this.nodeSelection = updateSelection.merge(enterSelection);
     
-        const updateSelection2 = highlightSelection.setData(nodeData);
-        updateSelection2.exit.remove();
-        const enterSelection2 = updateSelection2.enter.append(MarkerShape);
-        this.highlightSelection = updateSelection2.merge(enterSelection2);
+        const updateHighlightSelection = highlightSelection.setData(nodeData);
+        updateHighlightSelection.exit.remove();
+        const enterHighlightSelection = updateHighlightSelection.enter.append(MarkerShape);
+        this.highlightSelection = updateHighlightSelection.merge(enterHighlightSelection);
     }
 
     private updateNodes() {

--- a/charts-packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
@@ -216,7 +216,7 @@ export class LineSeries extends CartesianSeries {
         const linePath = lineNode.path;
         const nodeData: LineNodeDatum[] = [];
 
-        linePath.clear();
+        linePath.clear({ trackChanges: true });
         let moveTo = true;
         let prevXInRange: undefined | -1 | 0 | 1 = undefined;
         let nextXYDatums: [number, number] | undefined = undefined;
@@ -284,6 +284,8 @@ export class LineSeries extends CartesianSeries {
                     } : undefined
                 });
             }
+
+            lineNode.checkPathDirty();
         }
 
         // Used by marker nodes and for hit-testing even when not using markers

--- a/charts-packages/ag-charts-community/src/chart/series/series.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/series.ts
@@ -110,7 +110,12 @@ export abstract class Series extends Observable {
     // for large-scale data-sets, where the only thing that routinely varies is the currently
     // highlighted node.
     readonly highlightGroup: Group = this.group.appendChild(
-        new Group({ name: `${this.id}-highlight`, layer: true, zIndex: Series.SERIES_HIGHLIGHT_LAYER_ZINDEX }),
+        new Group({
+            name: `${this.id}-highlight`,
+            layer: true,
+            zIndex: Series.SERIES_HIGHLIGHT_LAYER_ZINDEX,
+            optimiseDirtyTracking: true,
+        }),
     );
 
     // The group node that contains all the nodes that can be "picked" (react to hover, tap, click).

--- a/charts-packages/ag-charts-community/src/chart/shapes/rangeSelector.ts
+++ b/charts-packages/ag-charts-community/src/chart/shapes/rangeSelector.ts
@@ -138,7 +138,7 @@ export class RangeSelector extends Group {
             }
         });
 
-        this.markClean(true);
+        this.markClean({ force: true });
         if (stats) stats.nodesRendered++;
     }
 }

--- a/charts-packages/ag-charts-community/src/scene/group.ts
+++ b/charts-packages/ag-charts-community/src/scene/group.ts
@@ -79,7 +79,7 @@ export class Group extends Node {
         }
     }
 
-    markClean(opts: { recursive?: boolean, force?: boolean }) {
+    markClean(opts?: {force?: boolean, recursive?: boolean}) {
         // Ensure we update visibility tracking before blowing away dirty flags.
         this.syncChildVisibility();
 

--- a/charts-packages/ag-charts-community/src/scene/group.ts
+++ b/charts-packages/ag-charts-community/src/scene/group.ts
@@ -4,12 +4,13 @@ import { Matrix } from "./matrix";
 import { HdpiCanvas } from "../canvas/hdpiCanvas";
 import { Scene } from "./scene";
 import { Path2D } from "./path2D";
+import { HdpiOffscreenCanvas } from "../canvas/hdpiOffscreenCanvas";
 
 export class Group extends Node {
 
     static className = 'Group';
 
-    private layer?: HdpiCanvas;
+    private layer?: HdpiCanvas | HdpiOffscreenCanvas;
     private clipPath: Path2D = new Path2D();
     readonly name?: string;
 
@@ -242,6 +243,7 @@ export class Group extends Node {
         if (layer) {
             if (stats) stats.layersRendered++;
             ctx.restore();
+            layer.snapshot();
         }
 
         if (name && consoleLog && stats) {

--- a/charts-packages/ag-charts-community/src/scene/group.ts
+++ b/charts-packages/ag-charts-community/src/scene/group.ts
@@ -10,9 +10,12 @@ export class Group extends Node {
 
     static className = 'Group';
 
-    private layer?: HdpiCanvas | HdpiOffscreenCanvas;
-    private clipPath: Path2D = new Path2D();
+    protected layer?: HdpiCanvas | HdpiOffscreenCanvas;
+    protected clipPath: Path2D = new Path2D();
     readonly name?: string;
+
+    readonly dirtyChildren: Record<string, Node> = {};
+    readonly visibleChildren: Record<string, Node> = {};
 
     @SceneChangeDetection({
         convertor: (v: number) => Math.min(1, Math.max(0, v)),
@@ -27,10 +30,11 @@ export class Group extends Node {
     }
 
     public constructor(
-        private readonly opts?: {
-            layer?: boolean,
-            zIndex?: number,
-            name?: string,
+        protected readonly opts?: {
+            readonly layer?: boolean,
+            readonly zIndex?: number,
+            readonly name?: string,
+            readonly optimiseDirtyTracking?: boolean,
         }
     ) {
         super();
@@ -66,9 +70,21 @@ export class Group extends Node {
         }
     }
 
-    markDirty(type = RedrawType.TRIVIAL) {
+    markDirty(source: Node, type = RedrawType.TRIVIAL) {
         const parentType = type <= RedrawType.MINOR ? RedrawType.TRIVIAL : type;
-        super.markDirty(type, parentType);
+        super.markDirty(source, type, parentType);
+
+        if (source !== this && this.dirtyChildren) {
+            this.dirtyChildren[source.id] = source;
+        }
+    }
+
+    markClean(opts: { recursive?: boolean, force?: boolean }) {
+        for (const key of Object.keys(this.dirtyChildren)) {
+            delete this.dirtyChildren[key];
+        }
+
+        super.markClean(opts);
     }
 
     // We consider a group to be boundless, thus any point belongs to it.
@@ -130,8 +146,17 @@ export class Group extends Node {
     }
 
     render(renderCtx: RenderContext) {
+        if (this.layer && this.opts?.optimiseDirtyTracking) {
+            this.optimisedRender(renderCtx);
+            return;
+        }
+
+        this.basicRender(renderCtx);
+    }
+
+    private basicRender(renderCtx: RenderContext) {
         const { opts: { name = undefined } = {} } = this;
-        const { _debug: { consoleLog = false, onlyLayers = [] } = {} } = this;
+        const { _debug: { consoleLog = false } = {} } = this;
         const { dirty, dirtyZIndex, clipPath, layer, children } = this;
         let { ctx, forceRender, clipBBox, resized, stats } = renderCtx;
 
@@ -156,8 +181,8 @@ export class Group extends Node {
 
             if (layer && stats) {
                 stats.layersSkipped++;
+                stats.nodesSkipped += this.nodeCount.count;
             }
-            if (stats) stats.nodesSkipped += this.nodeCount.count;
 
             // Nothing to do.
             return;
@@ -184,10 +209,6 @@ export class Group extends Node {
                 clipPath.rect(x, y, width, height);
                 clipPath.draw(ctx);
                 ctx.clip();
-            }
-
-            if (onlyLayers.length > 0) {
-                groupVisible = !!name && onlyLayers.indexOf(name) >= 0;
             }
         } else {
             // Only apply opacity if this isn't a distinct layer - opacity will be applied
@@ -245,6 +266,128 @@ export class Group extends Node {
             ctx.restore();
             layer.snapshot();
         }
+
+        if (name && consoleLog && stats) {
+            const counts = this.nodeCount;
+            console.log({ name, result: 'rendered', skipped, renderCtx, counts, group: this });
+        }
+    }
+
+    private optimisedRender(renderCtx: RenderContext) {
+        const { _debug: { consoleLog = false } = {} } = this;
+        const { name, dirty, dirtyZIndex, clipPath, layer, children, dirtyChildren, visibleChildren, visible: groupVisible } = this;
+        let { ctx, clipBBox, resized, stats } = renderCtx;
+
+        if (!layer) {
+            return;
+        }
+
+        const isDirty = dirty >= RedrawType.MINOR || dirtyZIndex || resized;
+        const isChildDirty = isDirty || Object.keys(dirtyChildren).length > 0;
+
+        if (name && consoleLog) {
+            console.log({ name, group: this, isDirty, isChildDirty, renderCtx });
+        }
+
+        // By default there is no need to force redraw a group which has it's own canvas layer
+        // as the layer is independent of any other layer.
+        let forceRender = false;
+
+        if (!isDirty && !isChildDirty) {
+            if (name && consoleLog && stats) {
+                const counts = this.nodeCount;
+                console.log({ name, result: 'skipping', renderCtx, counts, group: this });
+            }
+
+            if (stats) {
+                stats.layersSkipped++;
+                stats.nodesSkipped += this.nodeCount.count;
+            }
+
+            // Nothing to do.
+            return;
+        }
+
+        // Switch context to the canvas layer we use for this group.
+        ctx = layer.context;
+        ctx.save();
+        ctx.setTransform(renderCtx.ctx.getTransform());
+
+        forceRender = true;
+        layer.clear();
+
+        if (clipBBox) {
+            const { width, height, x, y } = clipBBox;
+
+            if (consoleLog) {
+                console.log({ name, clipBBox, ctxTransform: ctx.getTransform(), renderCtx, group: this });
+            }
+
+            clipPath.clear();
+            clipPath.rect(x, y, width, height);
+            clipPath.draw(ctx);
+            ctx.clip();
+        }
+
+        for (const child of Object.values(dirtyChildren)) {
+            if (!child.visible && visibleChildren[child.id]) {
+                delete visibleChildren[child.id];
+            } else if (child.visible && !visibleChildren[child.id]) {
+                visibleChildren[child.id] = child;
+            }
+        }
+
+        // A group can have `scaling`, `rotation`, `translation` properties
+        // that are applied to the canvas context before children are rendered,
+        // so all children can be transformed at once.
+        this.computeTransformMatrix();
+        this.matrix.toContext(ctx);
+        clipBBox = clipBBox ? this.matrix.inverse().transformBBox(clipBBox) : undefined;
+
+        if (dirtyZIndex) {
+            this.dirtyZIndex = false;
+            children.sort((a, b) => a.zIndex - b.zIndex);
+            forceRender = true;
+        }
+
+        // Reduce churn if renderCtx is identical.
+        const renderContextChanged = forceRender !== renderCtx.forceRender ||
+                clipBBox !== renderCtx.clipBBox ||
+                ctx !== renderCtx.ctx;
+        const childRenderContext =  renderContextChanged ?
+            { ...renderCtx, ctx, forceRender, clipBBox } :
+            renderCtx;
+
+        if (consoleLog) {
+            console.log({ name, visibleChildren, dirtyChildren });
+        }
+
+        let skipped = 0;
+        if (groupVisible) {
+            for (const child of Object.values(visibleChildren)) {
+                if (!forceRender && child.dirty === RedrawType.NONE) {
+                    // Skip children that don't need to be redrawn.
+                    if (stats) skipped += child.nodeCount.count;
+                    continue;
+                }
+    
+                ctx.save();
+                child.render(childRenderContext);
+                ctx.restore();
+            }
+        }
+
+        this.markClean({ recursive: false });
+        for (const child of Object.values(dirtyChildren)) {
+            child.markClean();
+            delete dirtyChildren[child.id];
+        }
+
+        if (stats) stats.nodesSkipped += skipped;
+
+        if (stats) stats.layersRendered++;
+        ctx.restore();
+        layer.snapshot();
 
         if (name && consoleLog && stats) {
             const counts = this.nodeCount;

--- a/charts-packages/ag-charts-community/src/scene/matrix.ts
+++ b/charts-packages/ag-charts-community/src/scene/matrix.ts
@@ -264,7 +264,7 @@ export class Matrix {
         return target;
     }
 
-    toContext(ctx: CanvasRenderingContext2D) {
+    toContext(ctx: CanvasTransform) {
         // It's fair to say that matrix multiplications are not cheap.
         // However, updating path definitions on every frame isn't either, so
         // it may be cheaper to just translate paths. It's also fair to

--- a/charts-packages/ag-charts-community/src/scene/node.ts
+++ b/charts-packages/ag-charts-community/src/scene/node.ts
@@ -57,7 +57,7 @@ export function SceneChangeDetection(opts?: {
                     ${convertor ? 'value = convertor(value);' : ''}
                     if (value !== oldValue) {
                         this.${privateKey} = value;
-                        ${debug ? `if (setCount++ % 10 === 0) console.log({ property: '${key}', oldValue, value });` : ''}
+                        ${debug ? `if (setCount++ % 1000 === 0) console.log({ t: this, property: '${key}', oldValue, value, stack: new Error().stack });` : ''}
                         ${type === 'normal' ? 'this.markDirty(' + redraw + ');' : ''}
                         ${type === 'transform' ? 'this.markDirtyTransform(' + redraw + ');' : ''}
                         ${changeCb ? 'changeCb(this);' : ''}

--- a/charts-packages/ag-charts-community/src/scene/node.ts
+++ b/charts-packages/ag-charts-community/src/scene/node.ts
@@ -41,7 +41,7 @@ export function SceneChangeDetection(opts?: {
     changeCb?: (o: any) => any,
 }) {
     const { redraw = RedrawType.TRIVIAL, type = 'normal', changeCb, convertor } = opts || {};
-    const debug = false;
+    const debug = (window as any).agChartsSceneChangeDetectionDebug != null;
 
     return function (target: any, key: string) {
         // `target` is either a constructor (static member) or prototype (instance member)
@@ -57,7 +57,7 @@ export function SceneChangeDetection(opts?: {
                     ${convertor ? 'value = convertor(value);' : ''}
                     if (value !== oldValue) {
                         this.${privateKey} = value;
-                        ${debug ? `if (setCount++ % 1000 === 0) console.log({ t: this, property: '${key}', oldValue, value, stack: new Error().stack });` : ''}
+                        ${debug ? `if (window.agChartsSceneChangeDetectionDebug) console.log({ t: this, property: '${key}', oldValue, value, stack: new Error().stack });` : ''}
                         ${type === 'normal' ? 'this.markDirty(this, ' + redraw + ');' : ''}
                         ${type === 'transform' ? 'this.markDirtyTransform(' + redraw + ');' : ''}
                         ${type === 'path' ? `if (!this._dirtyPath) { this._dirtyPath = true; this.markDirty(this, redraw); }` : ''}
@@ -555,7 +555,9 @@ export abstract class Node { // Don't confuse with `window.Node`.
         return this._dirty;
     }
 
-    markClean({ force = false, recursive = true } = {}) {
+    markClean(opts?: {force?: boolean, recursive?: boolean}) {
+        const { force = false, recursive = true } = opts || {};
+
         if (this._dirty === RedrawType.NONE && !force) {
             return;
         }

--- a/charts-packages/ag-charts-community/src/scene/node.ts
+++ b/charts-packages/ag-charts-community/src/scene/node.ts
@@ -60,6 +60,8 @@ export function SceneChangeDetection(opts?: {
                         ${debug ? `if (setCount++ % 1000 === 0) console.log({ t: this, property: '${key}', oldValue, value, stack: new Error().stack });` : ''}
                         ${type === 'normal' ? 'this.markDirty(' + redraw + ');' : ''}
                         ${type === 'transform' ? 'this.markDirtyTransform(' + redraw + ');' : ''}
+                        ${type === 'path' ? `if (!this._dirtyPath) { this._dirtyPath = true; this.markDirty(this, redraw); }` : ''}
+                        ${type === 'font' ? `if (!this._dirtyFont) { this._dirtyFont = true; this.markDirty(this, redraw); }` : ''}
                         ${changeCb ? 'changeCb(this);' : ''}
                     }
                 };

--- a/charts-packages/ag-charts-community/src/scene/node.ts
+++ b/charts-packages/ag-charts-community/src/scene/node.ts
@@ -22,7 +22,7 @@ export enum RedrawType {
 }
 
 export type RenderContext = {
-    ctx: CanvasRenderingContext2D;
+    ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D;
     forceRender: boolean;
     resized: boolean;
     clipBBox?: BBox;

--- a/charts-packages/ag-charts-community/src/scene/path2D.ts
+++ b/charts-packages/ag-charts-community/src/scene/path2D.ts
@@ -6,8 +6,11 @@ export class Path2D {
     // to minimize the number of allocations.
 
     private xy?: [number, number];
-    readonly commands: string[] = [];
-    readonly params: number[] = [];
+    private previousCommands: string[] = [];
+    private previousParams: number[] = [];
+    private previousClosedPath: boolean = false;
+    commands: string[] = [];
+    params: number[] = [];
 
     private static splitCommandsRe = /(?=[AaCcHhLlMmQqSsTtVvZz])/g;
     private static matchParamsRe = /-?[0-9]*\.?\d+/g;
@@ -15,6 +18,32 @@ export class Path2D {
     private static cubicCommandRe = /[CcSs]/;
     private static xmlDeclaration = '<?xml version="1.0" encoding="UTF-8"?>';
     private static xmlns = 'http://www.w3.org/2000/svg';
+
+    isDirty() {
+        if (this._closedPath !== this.previousClosedPath) {
+            return true;
+        }
+        if (this.previousCommands.length !== this.commands.length) {
+            return true;
+        }
+        if (this.previousParams.length !== this.params.length) {
+            return true;
+        }
+
+        for (let i = 0; i < this.commands.length; i++) {
+            if (this.commands[i] !== this.previousCommands[i]) {
+                return true;
+            }
+        }
+        
+        for (let i = 0; i < this.params.length; i++) {
+            if (this.params[i] !== this.previousParams[i]) {
+                return true;
+            }
+        }
+        
+        return false;
+    }
 
     draw(ctx: CanvasDrawPath & CanvasPath) {
         const commands = this.commands;
@@ -375,9 +404,17 @@ export class Path2D {
         }
     }
 
-    clear() {
-        this.commands.length = 0;
-        this.params.length = 0;
+    clear({ trackChanges } = { trackChanges: false }) {
+        if (trackChanges) {
+            this.previousCommands = this.commands;
+            this.previousParams = this.params;
+            this.previousClosedPath = this._closedPath;
+            this.commands = [];
+            this.params = [];
+        } else {
+            this.commands.length = 0;
+            this.params.length = 0;
+        }
         this.xy = undefined;
         this._closedPath = false;
     }

--- a/charts-packages/ag-charts-community/src/scene/path2D.ts
+++ b/charts-packages/ag-charts-community/src/scene/path2D.ts
@@ -16,15 +16,14 @@ export class Path2D {
     private static xmlDeclaration = '<?xml version="1.0" encoding="UTF-8"?>';
     private static xmlns = 'http://www.w3.org/2000/svg';
 
-    draw(ctx: CanvasRenderingContext2D) {
+    draw(ctx: CanvasDrawPath & CanvasPath) {
         const commands = this.commands;
         const params = this.params;
-        const n = commands.length;
         let j = 0;
 
         ctx.beginPath();
-        for (let i = 0; i < n; i++) {
-            switch (commands[i]) {
+        for (const command of commands) {
+            switch (command) {
                 case 'M':
                     ctx.moveTo(params[j++], params[j++]);
                     break;

--- a/charts-packages/ag-charts-community/src/scene/scene.ts
+++ b/charts-packages/ag-charts-community/src/scene/scene.ts
@@ -299,7 +299,7 @@ export class Scene {
                 `${time(preprocessingStart, end)} (${time(preprocessingStart, start)} + ${time(start, end)})`,
                 this.debug.stats === 'detailed' ? `Layers: ${pct(layersRendered, layersSkipped)}` : null,
                 this.debug.stats === 'detailed' ? `Nodes: ${pct(nodesRendered, nodesSkipped)}` : null,
-            ].filter(v => v != null);
+            ].filter((v): v is string => v != null);
             const lineHeight = 15;
 
             ctx.save();

--- a/charts-packages/ag-charts-community/src/scene/scene.ts
+++ b/charts-packages/ag-charts-community/src/scene/scene.ts
@@ -9,7 +9,6 @@ interface DebugOptions {
     dirtyTree: boolean;
     renderBoundingBoxes: boolean;
     consoleLog: boolean;
-    onlyLayers: string[];
 }
 
 interface SceneOptions {
@@ -52,7 +51,6 @@ export class Scene {
 
         this.opts = { document, mode };
         this.debug.stats = (window as any).agChartsSceneStats ?? false;
-        this.debug.onlyLayers = (window as any).agChartsSceneOnlyLayers ?? [];
         this.debug.dirtyTree = (window as any).agChartsSceneDirtyTree ?? false;
         this.canvas = new HdpiCanvas({ document, width, height });
         this.ctx = this.canvas.context;
@@ -213,7 +211,6 @@ export class Scene {
         stats: false,
         renderBoundingBoxes: false,
         consoleLog: false,
-        onlyLayers: [],
     };
 
     render(opts: { start: number }) {

--- a/charts-packages/ag-charts-community/src/scene/scene.ts
+++ b/charts-packages/ag-charts-community/src/scene/scene.ts
@@ -255,13 +255,13 @@ export class Scene {
         if (mode !== 'dom-composite' && layers.length > 0 && canvasCleared) {
             ctx.save();
             ctx.setTransform(1 / canvas.pixelRatio, 0, 0, 1 / canvas.pixelRatio, 0, 0);
-            layers.forEach((layer) => {
-                if (layer.canvas.enabled) {
-                    ctx.globalAlpha = layer.canvas.opacity;
-                    // Indirect reference to fix typings for tests.
-                    const canvas = layer.canvas.context.canvas;
-                    ctx.drawImage(canvas, 0, 0);
+            layers.forEach(({ canvas: { imageSource, enabled, opacity }}) => {
+                if (!enabled) {
+                    return;
                 }
+
+                ctx.globalAlpha = opacity;
+                ctx.drawImage(imageSource, 0, 0);
             });
             ctx.restore();
         }

--- a/charts-packages/ag-charts-community/src/scene/scene.ts
+++ b/charts-packages/ag-charts-community/src/scene/scene.ts
@@ -5,7 +5,7 @@ import { Group } from "./group";
 import { HdpiOffscreenCanvas } from "../canvas/hdpiOffscreenCanvas";
 
 interface DebugOptions {
-    stats: boolean;
+    stats: false | 'basic' | 'detailed';
     dirtyTree: boolean;
     renderBoundingBoxes: boolean;
     consoleLog: boolean;
@@ -239,7 +239,7 @@ export class Scene {
             forceRender: true,
             resized: !!pendingSize,
         };
-        if (this.debug.stats) {
+        if (this.debug.stats === 'detailed') {
             renderCtx.stats = { layersRendered: 0, layersSkipped: 0, nodesRendered: 0, nodesSkipped: 0 };
         }
 
@@ -297,9 +297,9 @@ export class Scene {
                 renderCtx.stats || {};
             const stats = [
                 `${time(preprocessingStart, end)} (${time(preprocessingStart, start)} + ${time(start, end)})`,
-                `Layers: ${pct(layersRendered, layersSkipped)}`,
-                `Nodes: ${pct(nodesRendered, nodesSkipped)}`
-            ];
+                this.debug.stats === 'detailed' ? `Layers: ${pct(layersRendered, layersSkipped)}` : null,
+                this.debug.stats === 'detailed' ? `Nodes: ${pct(nodesRendered, nodesSkipped)}` : null,
+            ].filter(v => v != null);
             const lineHeight = 15;
 
             ctx.save();

--- a/charts-packages/ag-charts-community/src/scene/shape/path.ts
+++ b/charts-packages/ag-charts-community/src/scene/shape/path.ts
@@ -40,7 +40,7 @@ export class Path extends Shape {
         if (this._dirtyPath !== value) {
             this._dirtyPath = value;
             if (value) {
-                this.markDirty(RedrawType.MAJOR);
+                this.markDirty(this, RedrawType.MAJOR);
             }
         }
     }
@@ -57,7 +57,7 @@ export class Path extends Shape {
         if (this._svgPath !== value) {
             this._svgPath = value;
             this.path.setFromString(value);
-            this.markDirty(RedrawType.MAJOR);
+            this.markDirty(this, RedrawType.MAJOR);
         }
     }
     get svgPath(): string {

--- a/charts-packages/ag-charts-community/src/scene/shape/path.ts
+++ b/charts-packages/ag-charts-community/src/scene/shape/path.ts
@@ -7,17 +7,7 @@ export function ScenePathChangeDetection(opts?: {
     convertor?: (o: any) => any,
     changeCb?: (t: any) => any,
 }) {
-    const { redraw = RedrawType.MAJOR, changeCb: optChangeCb, convertor } = opts || {};
-
-    const changeCb = (o: any) => {
-        if (!o._dirtyPath) {
-            o._dirtyPath = true;
-            o.markDirty(redraw);
-        }
-        if (optChangeCb) {
-            optChangeCb(o);
-        }
-    };
+    const { redraw = RedrawType.MAJOR, changeCb, convertor } = opts || {};
 
     return SceneChangeDetection({ redraw, type: 'path', convertor, changeCb });
 }

--- a/charts-packages/ag-charts-community/src/scene/shape/path.ts
+++ b/charts-packages/ag-charts-community/src/scene/shape/path.ts
@@ -13,7 +13,6 @@ export function ScenePathChangeDetection(opts?: {
 }
 
 export class Path extends Shape {
-
     static className = 'Path';
 
     /**
@@ -46,6 +45,14 @@ export class Path extends Shape {
     }
     get dirtyPath(): boolean {
         return this._dirtyPath;
+    }
+
+    checkPathDirty() {
+        if (this._dirtyPath) {
+            return;
+        }
+
+        this.dirtyPath = this.path.isDirty();
     }
 
     /**

--- a/charts-packages/ag-charts-community/src/scene/shape/path.ts
+++ b/charts-packages/ag-charts-community/src/scene/shape/path.ts
@@ -4,9 +4,10 @@ import { RedrawType, SceneChangeDetection, RenderContext } from "../node";
 
 export function ScenePathChangeDetection(opts?: {
     redraw?: RedrawType,
+    convertor?: (o: any) => any,
     changeCb?: (t: any) => any,
 }) {
-    const { redraw = RedrawType.MAJOR, changeCb: optChangeCb } = opts || {};
+    const { redraw = RedrawType.MAJOR, changeCb: optChangeCb, convertor } = opts || {};
 
     const changeCb = (o: any) => {
         if (!o._dirtyPath) {
@@ -18,7 +19,7 @@ export function ScenePathChangeDetection(opts?: {
         }
     };
 
-    return SceneChangeDetection({ redraw, type: 'path', changeCb });
+    return SceneChangeDetection({ redraw, type: 'path', convertor, changeCb });
 }
 
 export class Path extends Shape {

--- a/charts-packages/ag-charts-community/src/scene/shape/shape.ts
+++ b/charts-packages/ag-charts-community/src/scene/shape/shape.ts
@@ -152,7 +152,7 @@ export abstract class Shape extends Node {
     @SceneChangeDetection({ redraw: RedrawType.MINOR })
     strokeShadow: DropShadow | undefined = Shape.defaultStyles.strokeShadow;
 
-    protected fillStroke(ctx: CanvasRenderingContext2D) {
+    protected fillStroke(ctx: CanvasFillStrokeStyles & CanvasCompositing & CanvasShadowStyles & CanvasPathDrawingStyles & CanvasDrawPath) {
         if (!this.scene) {
             return;
         }

--- a/charts-packages/ag-charts-community/src/scene/shape/text.ts
+++ b/charts-packages/ag-charts-community/src/scene/shape/text.ts
@@ -11,17 +11,7 @@ export function SceneFontChangeDetection(opts?: {
     redraw?: RedrawType,
     changeCb?: (t: any) => any,
 }) {
-    const { redraw = RedrawType.MAJOR, changeCb: optChangeCb } = opts || {};
-
-    const changeCb = (o: any) => {
-        if (!o._dirtyFont) {
-            o._dirtyFont = true;
-            o.markDirty(redraw);
-        }
-        if (optChangeCb) {
-            optChangeCb(o);
-        }
-    };
+    const { redraw = RedrawType.MAJOR, changeCb } = opts || {};
 
     return SceneChangeDetection({ redraw, type: 'font', changeCb });
 }

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/doc-interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/doc-interfaces.AUTO.json
@@ -3683,19 +3683,34 @@
   "RedrawType": {},
   "RenderContext": {},
   "DebugOptions": {
-    "stats": { "type": { "returnType": "boolean", "optional": false } },
+    "stats": {
+      "type": {
+        "returnType": "false | 'basic' | 'detailed'",
+        "optional": false
+      }
+    },
     "dirtyTree": { "type": { "returnType": "boolean", "optional": false } },
     "renderBoundingBoxes": {
       "type": { "returnType": "boolean", "optional": false }
     },
-    "consoleLog": { "type": { "returnType": "boolean", "optional": false } },
-    "onlyLayers": { "type": { "returnType": "string[]", "optional": false } }
+    "consoleLog": { "type": { "returnType": "boolean", "optional": false } }
   },
   "SceneOptions": {
     "document": { "type": { "returnType": "Document", "optional": false } },
     "mode": {
       "type": {
-        "returnType": "'simple' | 'composite' | 'dom-composite'",
+        "returnType": "'simple' | 'composite' | 'dom-composite' | 'adv-composite'",
+        "optional": false
+      }
+    }
+  },
+  "SceneLayer": {
+    "id": { "type": { "returnType": "number", "optional": false } },
+    "name": { "type": { "returnType": "string", "optional": true } },
+    "zIndex": { "type": { "returnType": "number", "optional": false } },
+    "canvas": {
+      "type": {
+        "returnType": "HdpiOffscreenCanvas | HdpiCanvas",
         "optional": false
       }
     }

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
@@ -2785,23 +2785,31 @@
   },
   "RenderContext": {
     "meta": { "isTypeAlias": true },
-    "type": "{ ctx: CanvasRenderingContext2D; forceRender: boolean; resized: boolean; clipBBox?: BBox; stats?: { nodesRendered: number; nodesSkipped: number; layersRendered: number; layersSkipped: number; }; }"
+    "type": "{ ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D; forceRender: boolean; resized: boolean; clipBBox?: BBox; stats?: { nodesRendered: number; nodesSkipped: number; layersRendered: number; layersSkipped: number; }; }"
   },
   "DebugOptions": {
     "meta": {},
     "type": {
-      "stats": "boolean",
+      "stats": "false | 'basic' | 'detailed'",
       "dirtyTree": "boolean",
       "renderBoundingBoxes": "boolean",
-      "consoleLog": "boolean",
-      "onlyLayers": "string[]"
+      "consoleLog": "boolean"
     }
   },
   "SceneOptions": {
     "meta": {},
     "type": {
       "document": "Document",
-      "mode": "'simple' | 'composite' | 'dom-composite'"
+      "mode": "'simple' | 'composite' | 'dom-composite' | 'adv-composite'"
+    }
+  },
+  "SceneLayer": {
+    "meta": {},
+    "type": {
+      "id": "number",
+      "name?": "string",
+      "zIndex": "number",
+      "canvas": "HdpiOffscreenCanvas | HdpiCanvas"
     }
   },
   "ValueFn": {


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-6820

Attempts to address scaling issues with the Charts scene rendering which were identified whilst testing in the O(50K->150K) range. Focuses on line, area and scatter series as the types most likely to see use with very large data-sets:
- Switches to use of `OffscreenCanvas` + `ImageBitmap` APIs and bitmap copying of layers to main canvas for better rendering performance when a large number of points are rendered.
- Adds support to `Group` for an optimised dirty-check path, for groups where the number of visible/dirty elements is typically a low % of the total children. This is important for highlight series, where only one node will be visible / dirty at a time.
- Inlines more `@SceneChangeDetection` cases for better execution performance.
- Introduces path-level dirty detection, enabled in specific cases (Line and area series plots, which are complex single-paths that don't scale well from a change-detection/render perspective).