### PR TITLE
AG-6820 - Further Chart rendering optimisations

### DIFF
--- a/charts-packages/ag-charts-community/src/axis.ts
+++ b/charts-packages/ag-charts-community/src/axis.ts
@@ -283,7 +283,7 @@ export class Axis<S extends Scale<D, number>, D = any> {
         this.updateRange();
     }
     get range(): number[] {
-        return this.requestedRange.slice();
+        return this.requestedRange;
     }
 
     protected _visibleRange: number[] = [0, 1];

--- a/charts-packages/ag-charts-community/src/chart/chart.ts
+++ b/charts-packages/ag-charts-community/src/chart/chart.ts
@@ -996,10 +996,8 @@ export abstract class Chart extends Observable {
             return undefined;
         }
 
-        const allSeries = this.series;
         let node: Node | undefined = undefined;
-        for (let i = allSeries.length - 1; i >= 0; i--) {
-            const series = allSeries[i];
+        for (const series of this.series) {
             if (!series.visible || !series.group.visible) {
                 continue;
             }
@@ -1026,8 +1024,6 @@ export abstract class Chart extends Observable {
             return undefined;
         }
 
-        const allSeries = this.series;
-
         type Point = { x: number, y: number };
 
         function getDistance(p1: Point, p2: Point): number {
@@ -1039,13 +1035,12 @@ export abstract class Chart extends Observable {
         let minDistance = Infinity;
         let closestDatum: SeriesNodeDatum | undefined;
 
-        for (let i = allSeries.length - 1; i >= 0; i--) {
-            const series = allSeries[i];
+        for (const series of this.series) {
             if (!series.visible || !series.group.visible) {
                 continue;
             }
             const hitPoint = series.group.transformPoint(x, y);
-            series.getNodeData().forEach(datum => {
+            for (const datum of series.getNodeData()) {
                 if (!datum.point) {
                     return;
                 }
@@ -1063,7 +1058,7 @@ export abstract class Chart extends Observable {
                     minDistance = distance;
                     closestDatum = datum;
                 }
-            });
+            }
         }
 
         return closestDatum;

--- a/charts-packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
@@ -23,7 +23,7 @@ import { Text } from "../../../scene/shape/text";
 import { Label } from "../../label";
 import { sanitizeHtml } from "../../../util/sanitize";
 import { FontStyle, FontWeight } from "../../../scene/shape/text";
-import { isContinuous, isDiscrete, isNumber } from "../../../util/value";
+import { isContinuous, isNumber } from "../../../util/value";
 import { clamper, ContinuousScale } from "../../../scale/continuousScale";
 import { doOnce } from "../../../util/function";
 import { Node } from '../../../scene/node';

--- a/charts-packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
@@ -413,6 +413,7 @@ export class AreaSeries extends CartesianSeries {
 
     update(): void {
         this.updateSelections();
+        this.updateHighlightSelection();
         this.updateNodes();
     }
 
@@ -425,7 +426,6 @@ export class AreaSeries extends CartesianSeries {
         this.createSelectionData();
         this.updateSeriesGroups();
 
-        this.highlightMarkerSelection = this.updateMarkerSelection(this.highlightMarkerSelection, this.allMarkerSelectionData);
         this.seriesGroups.forEach(((seriesGroup, idx) => {
             const { markerSelection } = seriesGroup;
             this.updateFillSelection(idx);
@@ -433,6 +433,18 @@ export class AreaSeries extends CartesianSeries {
             seriesGroup.markerSelection = this.updateMarkerSelection(markerSelection, this.markerSelectionData[idx]);
             this.updateLabelSelection(idx);
         }))
+    }
+
+    updateHighlightSelection() {
+        const {
+            chart: {
+                highlightedDatum: { datum = undefined, series = undefined } = {},
+                highlightedDatum = undefined,
+            } = {},
+        } = this;
+
+        const highlightData = series === this && highlightedDatum && datum ? [highlightedDatum as MarkerSelectionDatum] : [];
+        this.highlightMarkerSelection = this.updateMarkerSelection(this.highlightMarkerSelection, highlightData);
     }
 
     updateNodes() {
@@ -664,11 +676,11 @@ export class AreaSeries extends CartesianSeries {
 
             const fill = new Path();
             fill.tag = AreaSeriesTag.Fill;
-            pickGroup.appendChild(fill);
+            group.appendChild(fill);
 
             const stroke = new Path();
             stroke.tag = AreaSeriesTag.Stroke;
-            pickGroup.appendChild(stroke);
+            group.appendChild(stroke);
 
             seriesGroups.push({
                 group,

--- a/charts-packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
@@ -721,13 +721,14 @@ export class AreaSeries extends CartesianSeries {
         const path = fill.path;
         path.clear({ trackChanges: true });
 
-        points.forEach(({ x, y }, i) => {
-            if (i > 0) {
-                path.lineTo(x, y);
+        let i = 0;
+        for (const p of points) {
+            if (i++ > 0) {
+                path.lineTo(p.x, p.y);
             } else {
-                path.moveTo(x, y);
+                path.moveTo(p.x, p.y);
             }
-        });
+        }
 
         path.closePath();
         fill.checkPathDirty();
@@ -765,16 +766,17 @@ export class AreaSeries extends CartesianSeries {
         const path = stroke.path
         path.clear({ trackChanges: true });
 
-        points.forEach(({x, y}, i) => {
-            if (yValues[i] === undefined) {
+        let i = 0;
+        for (const p of points) {
+            if (yValues[i++] === undefined) {
                 moveTo = true;
             } else if (moveTo) {
-                path.moveTo(x, y);
+                path.moveTo(p.x, p.y);
                 moveTo = false;
             } else {
-                path.lineTo(x, y);
+                path.lineTo(p.x, p.y);
             }
-        });
+        }
         stroke.checkPathDirty();
     }
 

--- a/charts-packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
@@ -683,6 +683,7 @@ export class BarSeries extends CartesianSeries {
 
     update(): void {
         this.updateSelections();
+        this.updateHighlightSelection();
         this.updateNodes();
     }
 
@@ -695,12 +696,23 @@ export class BarSeries extends CartesianSeries {
         this.createNodeData();
         this.updateSeriesGroups();
 
-        this.highlightRectSelection = this.updateRectSelection(this.highlightRectSelection, this.allNodeData);
         this.seriesGroups.forEach((groupSeries, idx) => {
             const { labelSelection, rectSelection } = groupSeries;
             groupSeries.rectSelection = this.updateRectSelection(rectSelection, this.nodeData[idx]);
             groupSeries.labelSelection = this.updateLabelSelection(labelSelection, this.nodeData[idx]);
         });
+    }
+
+    updateHighlightSelection() {
+        const {
+            chart: {
+                highlightedDatum: { datum = undefined, series = undefined } = {},
+                highlightedDatum = undefined,
+            } = {},
+        } = this;
+
+        const highlightData = series === this && highlightedDatum && datum ? [highlightedDatum as BarNodeDatum] : [];
+        this.highlightRectSelection = this.updateRectSelection(this.highlightRectSelection, highlightData);
     }
 
     private updateSeriesGroups() {

--- a/charts-packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
@@ -773,7 +773,7 @@ export class BarSeries extends CartesianSeries {
 
         const {
             fills, strokes, fillOpacity, strokeOpacity, shadow, formatter,
-            xKey, flipXY, yKeys,
+            xKey, flipXY,
             chart: { highlightedDatum },
             highlightStyle: {
                 fill: deprecatedFill,

--- a/charts-packages/ag-charts-community/src/chart/series/cartesian/histogramSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/cartesian/histogramSeries.ts
@@ -319,6 +319,7 @@ export class HistogramSeries extends CartesianSeries {
 
     update(): void {
         this.updateSelections();
+        this.updateHighlightSelection();
         this.updateNodes();
     }
 
@@ -330,7 +331,7 @@ export class HistogramSeries extends CartesianSeries {
 
         const nodeData = this.createNodeData();
 
-        this.updateRectSelection(nodeData);
+        this.rectSelection = this.updateRectSelection(this.rectSelection, nodeData);
         this.updateTextSelection(nodeData);
     }
 
@@ -412,9 +413,10 @@ export class HistogramSeries extends CartesianSeries {
         return nodeData;
     }
 
-    private updateRectSelection(nodeData: HistogramNodeDatum[]): void {
-        const { rectSelection, highlightSelection } = this;
-
+    private updateRectSelection(
+        rectSelection: Selection<Rect, Group, HistogramNodeDatum, any>,
+        nodeData: HistogramNodeDatum[],
+    ): Selection<Rect, Group, HistogramNodeDatum, any> {
         const update = (selection: typeof rectSelection) => {
             const updateRects = selection.setData(nodeData);
             updateRects.exit.remove();
@@ -427,8 +429,19 @@ export class HistogramSeries extends CartesianSeries {
             return updateRects.merge(enterRects);
         };
 
-        this.rectSelection = update(rectSelection);
-        this.highlightSelection = update(highlightSelection);
+        return update(rectSelection);
+    }
+
+    private updateHighlightSelection(): void {
+        const {
+            chart: {
+                highlightedDatum: { datum = undefined, series = undefined } = {},
+                highlightedDatum = undefined,
+            } = {},
+        } = this;
+
+        const highlightData = series === this && highlightedDatum && datum ? [highlightedDatum as HistogramNodeDatum] : [];
+        this.highlightSelection = this.updateRectSelection(this.highlightSelection, highlightData);
     }
 
     private updateRectNodes(): void {

--- a/charts-packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
@@ -72,9 +72,8 @@ export class LineSeries extends CartesianSeries {
 
     private lineNode = new Path();
 
-    // We use groups for this selection even though each group only contains a marker ATM
-    // because in the future we might want to add label support as well.
-    private nodeSelection: Selection<Group, Group, LineNodeDatum, any> = Selection.select(this.seriesGroup).selectAll<Group>();
+    private markerSelection: Selection<Marker, Group, LineNodeDatum, any> = Selection.select(this.seriesGroup).selectAll<Marker>();
+    private textSelection: Selection<Text, Group, LineNodeDatum, any> = Selection.select(this.seriesGroup).selectAll<Text>();
     private highlightSelection: Selection<Marker, Group, LineNodeDatum, any> = Selection.select(this.highlightGroup).selectAll<Marker>();
     private nodeData: LineNodeDatum[] = [];
 
@@ -299,14 +298,17 @@ export class LineSeries extends CartesianSeries {
         const nodeData = shape && enabled ? this.nodeData : [];
         const MarkerShape = getMarker(shape);
 
-        const { nodeSelection, highlightSelection } = this;
+        const { markerSelection, textSelection } = this;
 
-        const updateSelection = nodeSelection.setData(nodeData);
-        updateSelection.exit.remove();
-        const enterSelection = updateSelection.enter.append(Group);
-        enterSelection.append(MarkerShape);
-        enterSelection.append(Text);
-        this.nodeSelection = updateSelection.merge(enterSelection);
+        const updateMarkerSelection = markerSelection.setData(nodeData);
+        updateMarkerSelection.exit.remove();
+        const enterMarkerSelection = updateMarkerSelection.enter.append(MarkerShape);
+        this.markerSelection = updateMarkerSelection.merge(enterMarkerSelection);
+
+        const updateTextSelection = textSelection.setData(nodeData);
+        updateTextSelection.exit.remove();
+        const enterTextSelection = updateTextSelection.enter.append(Text);
+        this.textSelection = updateTextSelection.merge(enterTextSelection);
     }
 
     private updateHighlightSelection() {
@@ -406,7 +408,7 @@ export class LineSeries extends CartesianSeries {
             node.visible = node.size > 0;
         };
 
-        this.nodeSelection.selectByClass(MarkerShape)
+        this.markerSelection
             .each((node, datum) => updateMarkerFn(node, datum, false));
         this.highlightSelection
             .each((node, datum) => {
@@ -442,10 +444,7 @@ export class LineSeries extends CartesianSeries {
             }
         };
 
-        this.nodeSelection.selectByClass(Text)
-            .each(updateTextFn);
-        this.highlightSelection.selectByClass(Text)
-            .each(updateTextFn);
+        this.textSelection.each(updateTextFn);
     }
 
     getNodeData(): readonly LineNodeDatum[] {

--- a/charts-packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
@@ -188,6 +188,7 @@ export class LineSeries extends CartesianSeries {
 
     update(): void {
         this.updateSelections();
+        this.updateHighlightSelection();
         this.updateNodes();
     }
 
@@ -306,13 +307,23 @@ export class LineSeries extends CartesianSeries {
         enterSelection.append(MarkerShape);
         enterSelection.append(Text);
         this.nodeSelection = updateSelection.merge(enterSelection);
-    
-        const updateHighlightSelection = highlightSelection.setData(nodeData);
+    }
+
+    private updateHighlightSelection() {
+        const {
+            marker: { shape, enabled },
+            chart: { highlightedDatum: { datum = undefined, series = undefined } = {}, highlightedDatum = undefined } = {},
+            highlightSelection,
+        } = this;
+        const highlightData = shape && enabled && series === this && highlightedDatum && datum ? [highlightedDatum as LineNodeDatum] : [];
+        const MarkerShape = getMarker(shape);
+
+        const updateHighlightSelection = highlightSelection.setData(highlightData);
         updateHighlightSelection.exit.remove();
         const enterHighlightSelection = updateHighlightSelection.enter.append(MarkerShape);
         this.highlightSelection = updateHighlightSelection.merge(enterHighlightSelection);
     }
-
+    
     private updateNodes() {
         this.group.visible = this.visible;
         this.seriesGroup.visible = this.visible;

--- a/charts-packages/ag-charts-community/src/chart/series/cartesian/scatterSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/cartesian/scatterSeries.ts
@@ -63,7 +63,7 @@ export class ScatterSeries extends CartesianSeries {
     private sizeScale = new LinearScale();
 
     private nodeData: ScatterNodeDatum[] = [];
-    private markerSelection: Selection<Marker, Group, ScatterNodeDatum, any> = Selection.select(this.pickGroup).selectAll<Marker>();
+    private markerSelection: Selection<Marker, Group, ScatterNodeDatum, any> = Selection.select(this.seriesGroup).selectAll<Marker>();
     private highlightSelection: Selection<Marker, Group, ScatterNodeDatum, any> = Selection.select(this.highlightGroup).selectAll<Marker>();
     private labelSelection: Selection<Text, Group, PlacedLabel, any> = Selection.select(this.seriesGroup).selectAll<Text>();
 

--- a/charts-packages/ag-charts-community/src/chart/series/cartesian/scatterSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/cartesian/scatterSeries.ts
@@ -262,6 +262,7 @@ export class ScatterSeries extends CartesianSeries {
 
     update(): void {
         this.updateSelections();
+        this.updateMarkerSelection(true);
         this.updateNodes();
     }
 
@@ -272,7 +273,7 @@ export class ScatterSeries extends CartesianSeries {
         this.nodeDataRefresh = false;
 
         this.createNodeData();
-        this.updateMarkerSelection();
+        this.updateMarkerSelection(false);
         this.updateLabelSelection();
     }
 
@@ -295,19 +296,33 @@ export class ScatterSeries extends CartesianSeries {
         this.labelSelection = updateLabels.merge(enterLabels);
     }
 
-    private updateMarkerSelection(): void {
-        const { markerSelection, highlightSelection } = this;
+    private updateMarkerSelection(highlight: boolean): void {
+        const {
+            nodeData,
+            markerSelection,
+            marker: { enabled },
+            highlightSelection,
+            chart: {
+                highlightedDatum: { datum = undefined, series = undefined } = {},
+                highlightedDatum = undefined,
+            } = {},
+        } = this;
         const MarkerShape = getMarker(this.marker.shape);
 
-        const update = (selection: typeof markerSelection) => {
-            const updateMarkers = selection.setData(this.nodeData);
+        const update = (selection: typeof markerSelection, data: ScatterNodeDatum[]) => {
+            const updateMarkers = selection.setData(data);
             updateMarkers.exit.remove();
             const enterMarkers = updateMarkers.enter.append(MarkerShape);
             return updateMarkers.merge(enterMarkers);
         };
 
-        this.markerSelection = update(markerSelection);
-        this.highlightSelection = update(highlightSelection);
+        if (highlight) {
+            const highlightData = enabled && series === this && highlightedDatum && datum ? [highlightedDatum as ScatterNodeDatum] : [];
+            this.highlightSelection = update(highlightSelection, highlightData);
+        } else {
+            const data = enabled ? nodeData : [];
+            this.markerSelection = update(markerSelection, data);
+        }
     }
 
     private updateLabelNodes() {
@@ -386,7 +401,7 @@ export class ScatterSeries extends CartesianSeries {
             node.translationX = datum.point.x;
             node.translationY = datum.point.y;
             node.zIndex = isDatumHighlighted ? Series.highlightedZIndex : index;
-            node.visible = marker.enabled && node.size > 0;
+            node.visible = node.size > 0;
         });
 
         this.markerSelection

--- a/charts-packages/ag-charts-community/src/scene/node.ts
+++ b/charts-packages/ag-charts-community/src/scene/node.ts
@@ -185,33 +185,22 @@ export abstract class Node { // Don't confuse with `window.Node`.
         if (Node.isNode(nodes)) {
             nodes = [nodes];
         }
-        // The function takes an array rather than having open-ended
-        // arguments like `...nodes: Node[]` because the latter is
-        // transpiled to a function where the `arguments` object
-        // is copied to a temporary array inside a loop.
-        // So an array is created either way. And if we already have
-        // an array of nodes we want to add, we have to use the prohibitively
-        // expensive spread operator to pass it to the function,
-        // and, on top of that, the copy of the `arguments` is still made.
-        const n = nodes.length;
 
-        for (let i = 0; i < n; i++) {
-            const node = nodes[i];
-
+        for (const node of nodes) {
             if (node.parent) {
                 throw new Error(`${node} already belongs to another parent: ${node.parent}.`);
             }
             if (node.scene) {
-                throw new Error(`${node} already belongs a scene: ${node.scene}.`);
+                throw new Error(`${node} already belongs to a scene: ${node.scene}.`);
             }
             if (this.childSet[node.id]) {
                 // Cast to `any` to avoid `Property 'name' does not exist on type 'Function'`.
                 throw new Error(`Duplicate ${(node.constructor as any).name} node: ${node}`);
             }
-
+    
             this._children.push(node);
             this.childSet[node.id] = true;
-
+    
             node._parent = this;
             node._setScene(this.scene);
         }
@@ -220,24 +209,7 @@ export abstract class Node { // Don't confuse with `window.Node`.
     }
 
     appendChild<T extends Node>(node: T): T {
-        if (node.parent) {
-            throw new Error(`${node} already belongs to another parent: ${node.parent}.`);
-        }
-        if (node.scene) {
-            throw new Error(`${node} already belongs to a scene: ${node.scene}.`);
-        }
-        if (this.childSet[node.id]) {
-            // Cast to `any` to avoid `Property 'name' does not exist on type 'Function'`.
-            throw new Error(`Duplicate ${(node.constructor as any).name} node: ${node}`);
-        }
-
-        this._children.push(node);
-        this.childSet[node.id] = true;
-
-        node._parent = this;
-        node._setScene(this.scene);
-
-        this.markDirty(this, RedrawType.MAJOR);
+        this.append(node);
 
         return node;
     }
@@ -251,7 +223,7 @@ export abstract class Node { // Don't confuse with `window.Node`.
                 delete this.childSet[node.id];
                 node._parent = undefined;
                 node._setScene();
-                this.markDirty(this, RedrawType.MAJOR);
+                this.markDirty(node, RedrawType.MAJOR);
 
                 return node;
             }
@@ -287,7 +259,7 @@ export abstract class Node { // Don't confuse with `window.Node`.
                     + `but is not in its list of children.`);
             }
 
-            this.markDirty(this, RedrawType.MAJOR);
+            this.markDirty(node, RedrawType.MAJOR);
         } else {
             this.append(node);
         }

--- a/charts-packages/ag-charts-community/src/scene/node.ts
+++ b/charts-packages/ag-charts-community/src/scene/node.ts
@@ -54,7 +54,7 @@ export function SceneChangeDetection(opts?: {
             // steps, as these setters are called a LOT during update cycles.        
             const setterJs = `
                 ${debug ? 'var setCount = 0;' : ''}
-                function set${key}(value) {
+                function set_${key}(value) {
                     const oldValue = this.${privateKey};
                     ${convertor ? 'value = convertor(value);' : ''}
                     if (value !== oldValue) {
@@ -67,13 +67,13 @@ export function SceneChangeDetection(opts?: {
                         ${changeCb ? 'changeCb(this);' : ''}
                     }
                 };
-                set${key};
+                set_${key};
             `;
             const getterJs = `
-                function get${key}() {
+                function get_${key}() {
                     return this.${privateKey};
                 };
-                get${key};
+                get_${key};
             `;
             Object.defineProperty(target, key, {
                 set: eval(setterJs),

--- a/charts-packages/ag-charts-community/src/scene/scene.ts
+++ b/charts-packages/ag-charts-community/src/scene/scene.ts
@@ -44,7 +44,7 @@ export class Scene {
     ) {
         const {
             document = window.document,
-            mode = (window as any).agChartsSceneRenderModel || 'composite',
+            mode = (window as any).agChartsSceneRenderModel || 'adv-composite',
             width,
             height,
         } = opts;
@@ -316,8 +316,6 @@ export class Scene {
     }
 
     buildTree(node: Node): { name?: string, node?: any, dirty?: string } {
-        const childrenDirtyTree = node.children.map(c => this.buildDirtyTree(c))
-            .filter(c => c.paths.length > 0);
         const name = (node instanceof Group ? node.name : null) ?? node.id;
 
         return {
@@ -326,7 +324,11 @@ export class Scene {
             dirty: RedrawType[node.dirty],
             ...node.children.map((c) => this.buildTree(c))
                 .reduce((result, childTree) => {
-                    result[childTree.name || '<unknown>'] = childTree;
+                    let { name, node } = childTree;
+                    if (!node.visible || node.opacity <= 0) {
+                        name = `* ${name}`;
+                    }
+                    result[name ?? '<unknown>'] = childTree;
                     return result;
                 }, {} as Record<string, {}>),
         };


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-6820

Improves:
- Up-to halves the number of series scene nodes by reducing the highlight series node count to 0/1.
- Memory churn in some cases (unnecessary `.slice()` use and destructuring in some tight / high-volume loops).
- `LineSeries` and `AreaSeries` datum highlight performance by ~40ms and 5ms respectively, with 150K data-points.
