### PR TITLE
Fix broken typings for agGridColumn

### DIFF
--- a/community-modules/react/src/shared/agGridColumn.ts
+++ b/community-modules/react/src/shared/agGridColumn.ts
@@ -10,10 +10,6 @@ export interface AgGridColumnGroupProps extends ColGroupDef {
 }
 
 export class AgGridColumn extends Component<AgGridColumnProps | AgGridColumnGroupProps, {}> {
-    constructor(public props: any) {
-        super(props);
-    }
-
     render() {
         return null;
     }


### PR DESCRIPTION
Hello, current AgGridColumn types are broken.

<img width="909" alt="image" src="https://user-images.githubusercontent.com/6780529/173152486-c894affc-94c9-42a6-831d-12a2c57b8f54.png">

I removed redundant code in order to make the typings work again.