### PR TITLE
AG-5160 - Charts legend docs example updates

### DIFF
--- a/charts-packages/ag-charts-community/src/chart/agChartOptions.ts
+++ b/charts-packages/ag-charts-community/src/chart/agChartOptions.ts
@@ -288,7 +288,7 @@ export interface AgChartLegendMarkerOptions {
 }
 
 export interface AgChartLegendLabelOptions {
-    /** If the label text exceeds the character limit, it will be truncated and an ellipsis will be appended to indicate this. By default, the character limit is 25. */
+    /** If the label text exceeds the character limit, it will be truncated and an ellipsis will be appended to indicate this. */
     characterLimit?: number;
     /** The colour of the text. */
     color?: CssColor;

--- a/community-modules/core/src/ts/interfaces/iAgChartOptions.ts
+++ b/community-modules/core/src/ts/interfaces/iAgChartOptions.ts
@@ -288,7 +288,7 @@ export interface AgChartLegendMarkerOptions {
 }
 
 export interface AgChartLegendLabelOptions {
-    /** If the label text exceeds the character limit, it will be truncated and an ellipsis will be appended to indicate this. By default, the character limit is 25. */
+    /** If the label text exceeds the character limit, it will be truncated and an ellipsis will be appended to indicate this. */
     characterLimit?: number;
     /** The colour of the text. */
     color?: CssColor;

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/doc-interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/doc-interfaces.AUTO.json
@@ -931,7 +931,7 @@
   },
   "AgChartLegendLabelOptions": {
     "characterLimit": {
-      "description": "/** If the label text exceeds the character limit, it will be truncated and an ellipsis will be appended to indicate this. By default, the character limit is 25. */",
+      "description": "/** If the label text exceeds the character limit, it will be truncated and an ellipsis will be appended to indicate this. */",
       "type": { "returnType": "number", "optional": true }
     },
     "color": {

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
@@ -606,7 +606,7 @@
       "formatter?": "(id: string, itemId: any, value: string) => string"
     },
     "docs": {
-      "characterLimit?": "/** If the label text exceeds the character limit, it will be truncated and an ellipsis will be appended to indicate this. By default, the character limit is 25. */",
+      "characterLimit?": "/** If the label text exceeds the character limit, it will be truncated and an ellipsis will be appended to indicate this. */",
       "color?": "/** The colour of the text. */",
       "fontStyle?": "/** The font style to use for the legend. */",
       "fontWeight?": "/** The font weight to use for the legend. */",

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-legend/examples/legend-constraints/index.html
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-legend/examples/legend-constraints/index.html
@@ -26,5 +26,14 @@
                 onchange="updateLegendItemSpacing(event)" />
         </div>
     </div>
+    <div class="toolPanel">
+        <div class="slider">
+            <label for="maxWidthLabel"><strong>item.maxWidth:</strong></label>
+            <span id="maxWidthValue" class="slider-value">100</span>
+            <input type="range" id="maxWidthLabel" min="0" max="100" value="100"
+                oninput="updateLegendItemMaxWidth(event)"
+                onchange="updateLegendItemMaxWidth(event)" />
+        </div>
+    </div>
     <div id="myChart"></div>
 </div>

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-legend/examples/legend-constraints/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-legend/examples/legend-constraints/main.ts
@@ -42,31 +42,40 @@ const options: AgChartOptions = {
   },
 }
 
-var chart = agCharts.AgChart.create(options)
+var chart = agCharts.AgChart.create(options);
 
 function updateLegendItemPaddingX(event: any) {
-  var value = +event.target.value
+  var value = +event.target.value;
 
-  options.legend!.item!.paddingX = value
-  agCharts.AgChart.update(chart, options)
+  options.legend!.item!.paddingX = value;
+  agCharts.AgChart.update(chart, options);
 
-  document.getElementById('xPaddingValue')!.innerHTML = String(value)
+  document.getElementById('xPaddingValue')!.innerHTML = String(value);
 }
 
 function updateLegendItemPaddingY(event: any) {
-  var value = event.target.value
+  var value = event.target.value;
 
-  options.legend!.item!.paddingY = +event.target.value
-  agCharts.AgChart.update(chart, options)
+  options.legend!.item!.paddingY = +event.target.value;
+  agCharts.AgChart.update(chart, options);
 
-  document.getElementById('yPaddingValue')!.innerHTML = String(value)
+  document.getElementById('yPaddingValue')!.innerHTML = String(value);
 }
 
 function updateLegendItemSpacing(event: any) {
-  var value = +event.target.value
+  var value = +event.target.value;
 
-  options.legend!.item!.marker!.padding = value
-  agCharts.AgChart.update(chart, options)
+  options.legend!.item!.marker!.padding = value;
+  agCharts.AgChart.update(chart, options);
 
-  document.getElementById('markerPaddingValue')!.innerHTML = String(value)
+  document.getElementById('markerPaddingValue')!.innerHTML = String(value);
+}
+
+function updateLegendItemMaxWidth(event: any) {
+  var value = +event.target.value;
+
+  options.legend!.item!.maxWidth = value;
+  agCharts.AgChart.update(chart, options);
+
+  document.getElementById('maxWidthValue')!.innerHTML = String(value);
 }

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-legend/index.md
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-legend/index.md
@@ -89,7 +89,9 @@ Please refer to the example below to get a better idea of how the above configs 
 
 ## Fonts
 
-There are a number of configs that affect the `fontSize`, `fontStyle`, `fontWeight`, `fontFamily`, and `color` of the legend item labels:
+There are a number of configs that affect the `fontSize`, `fontStyle`, `fontWeight`, `fontFamily`, and `color` of the legend item labels.
+
+`characterLimit` can also be configured to constrain the length of legend item labels, if the label text exceeds the character limit, it will be truncated and an ellipsis will be appended.
 
 ```js
 legend: {
@@ -99,7 +101,8 @@ legend: {
             fontStyle: 'italic',
             fontWeight: 'bold',
             fontFamily: 'Papyrus',
-            color: 'red'
+            color: 'red',
+            characterLimit: 25
         }
     }
 }

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/doc-interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/doc-interfaces.AUTO.json
@@ -11304,7 +11304,7 @@
   },
   "AgChartLegendLabelOptions": {
     "characterLimit": {
-      "description": "/** If the label text exceeds the character limit, it will be truncated and an ellipsis will be appended to indicate this. By default, the character limit is 25. */",
+      "description": "/** If the label text exceeds the character limit, it will be truncated and an ellipsis will be appended to indicate this. */",
       "type": { "returnType": "number", "optional": true }
     },
     "color": {

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/interfaces.AUTO.json
@@ -6495,7 +6495,7 @@
       "formatter?": "(id: string, itemId: any, value: string) => string"
     },
     "docs": {
-      "characterLimit?": "/** If the label text exceeds the character limit, it will be truncated and an ellipsis will be appended to indicate this. By default, the character limit is 25. */",
+      "characterLimit?": "/** If the label text exceeds the character limit, it will be truncated and an ellipsis will be appended to indicate this. */",
       "color?": "/** The colour of the text. */",
       "fontStyle?": "/** The font style to use for the legend. */",
       "fontWeight?": "/** The font weight to use for the legend. */",


### PR DESCRIPTION
This PR is for https://ag-grid.atlassian.net/browse/AG-5160.

The charts legend constraints example has been updated to include the new `maxWidth` property. The legend docs page has also been updated.
 