### PR TITLE
AG-6815 - Rework chart axis layout calculations

### DIFF
--- a/charts-packages/ag-charts-community/src/axis.ts
+++ b/charts-packages/ag-charts-community/src/axis.ts
@@ -6,7 +6,6 @@ import { Text, FontStyle, FontWeight } from "./scene/shape/text";
 import { Arc } from "./scene/shape/arc";
 import { Shape } from "./scene/shape/shape";
 import { BBox } from "./scene/bbox";
-import { Matrix } from "./scene/matrix";
 import { Caption } from "./caption";
 import { createId } from "./util/id";
 import { normalizeAngle360, normalizeAngle360Inclusive, toRadians } from "./util/angle";
@@ -176,11 +175,13 @@ export class Axis<S extends Scale<D, number>, D = any> {
     ticks: any[];
 
     readonly axisGroup = new Group({ name: `${this.id}-axis`, layer: true, zIndex: 50 });
-    private axisGroupSelection: Selection<Group, Group, D, D>;
-    private lineNode = new Line();
+    private readonly tickLineGroup = this.axisGroup.appendChild(new Group());
+    private readonly titleGroup = this.axisGroup.appendChild(new Group());
+    private tickLineGroupSelection = Selection.select(this.tickLineGroup).selectAll<Group>();
+    private lineNode = this.tickLineGroup.appendChild(new Line());
 
     readonly gridlineGroup = new Group({ name: `${this.id}-gridline`, layer: true, zIndex: 0 });
-    private gridlineGroupSelection: Selection<Group, Group, D, D>;
+    private gridlineGroupSelection = Selection.select(this.gridlineGroup).selectAll<Group>();
 
     readonly line: {
         /**
@@ -235,11 +236,6 @@ export class Axis<S extends Scale<D, number>, D = any> {
 
     constructor(scale: S) {
         this.scale = scale;
-
-        this.axisGroupSelection = Selection.select(this.axisGroup).selectAll<Group>();
-        this.axisGroup.append(this.lineNode);
-
-        this.gridlineGroupSelection = Selection.select(this.gridlineGroup).selectAll<Group>();
 
         this.label.onFormatChange = this.onLabelFormatChange.bind(this);
     }
@@ -329,12 +325,12 @@ export class Axis<S extends Scale<D, number>, D = any> {
         const oldTitle = this._title;
         if (oldTitle !== value) {
             if (oldTitle) {
-                this.axisGroup.removeChild(oldTitle.node);
+                this.titleGroup.removeChild(oldTitle.node);
             }
 
             if (value) {
                 value.node.rotation = -Math.PI / 2;
-                this.axisGroup.appendChild(value.node);
+                this.titleGroup.appendChild(value.node);
             }
 
             this._title = value;
@@ -447,7 +443,7 @@ export class Axis<S extends Scale<D, number>, D = any> {
         const regularFlipFlag = !labelRotation && regularFlipRotation >= 0 && regularFlipRotation <= Math.PI ? -1 : 1;
 
         const ticks = this.ticks || scale.ticks!(this.calculatedTickCount);
-        const updateAxis = this.axisGroupSelection.setData(ticks);
+        const updateAxis = this.tickLineGroupSelection.setData(ticks);
         updateAxis.exit.remove();
 
         const enterAxis = updateAxis.enter.append(Group);
@@ -455,7 +451,7 @@ export class Axis<S extends Scale<D, number>, D = any> {
         enterAxis.append(Line).each(node => node.tag = Tags.Tick);
         enterAxis.append(Text);
 
-        const axisGroupSelection = updateAxis.merge(enterAxis);
+        const tickLineGroupSelection = updateAxis.merge(enterAxis);
 
         const updateGridlines = this.gridlineGroupSelection.setData(this.gridLength ? ticks : []);
         updateGridlines.exit.remove();
@@ -481,7 +477,7 @@ export class Axis<S extends Scale<D, number>, D = any> {
             return visible;
         };
 
-        axisGroupSelection
+        tickLineGroupSelection
             .attrFn('translationY', translationYFn)
             .attrFn('visible', visibleFn);
         gridlineGroupSelection
@@ -491,7 +487,7 @@ export class Axis<S extends Scale<D, number>, D = any> {
         this.axisGroup.visible = anyVisible;
         this.gridlineGroup.visible = anyVisible;
         if (!anyVisible) {
-            this.axisGroupSelection = axisGroupSelection;
+            this.tickLineGroupSelection = tickLineGroupSelection;
             this.gridlineGroupSelection = gridlineGroupSelection;
             return;
         }
@@ -506,7 +502,7 @@ export class Axis<S extends Scale<D, number>, D = any> {
         let halfFirstLabelLength = false;
         let halfLastLabelLength = false;
         const availableRange = requestedRangeMax - requestedRangeMin;
-        const labelSelection = axisGroupSelection.selectByClass(Text)
+        const labelSelection = tickLineGroupSelection.selectByClass(Text)
             .each((node, datum, index) => {
                 node.fontStyle = label.fontStyle;
                 node.fontWeight = label.fontWeight;
@@ -623,7 +619,7 @@ export class Axis<S extends Scale<D, number>, D = any> {
             });
         }
 
-        axisGroupSelection.selectByTag<Line>(Tags.Tick)
+        tickLineGroupSelection.selectByTag<Line>(Tags.Tick)
             .each((line, _, index) => {
                 line.strokeWidth = tick.width;
                 line.stroke = tick.color;
@@ -673,7 +669,7 @@ export class Axis<S extends Scale<D, number>, D = any> {
             });
         }
 
-        this.axisGroupSelection = axisGroupSelection;
+        this.tickLineGroupSelection = tickLineGroupSelection;
         this.gridlineGroupSelection = gridlineGroupSelection;
 
         // Render axis line.
@@ -707,17 +703,16 @@ export class Axis<S extends Scale<D, number>, D = any> {
             const parallelFlipRotation = normalizeAngle360(rotation);
             const padding = title.padding.bottom;
             const titleNode = title.node;
-            const bbox = this.computeBBox({ excludeTitle: true });
+            const bbox = this.tickLineGroup.computeBBox();
             const titleRotationFlag = sideFlag === -1 && parallelFlipRotation > Math.PI && parallelFlipRotation < Math.PI * 2 ? -1 : 1;
 
             titleNode.rotation = titleRotationFlag * sideFlag * Math.PI / 2;
-            // titleNode.x = titleRotationFlag * sideFlag * (lineNode.y1 + lineNode.y2) / 2; // TODO: remove?
-            titleNode.x = titleRotationFlag * sideFlag * (requestedRange[0] + requestedRange[1]) / 2;
+            titleNode.x = Math.floor(titleRotationFlag * sideFlag * (requestedRange[0] + requestedRange[1]) / 2);
 
             if (sideFlag === -1) {
-                titleNode.y = titleRotationFlag * (-padding - bbox.width + Math.max(bbox.x + bbox.width, 0));
+                titleNode.y = Math.floor(titleRotationFlag * (-padding - bbox.height));
             } else {
-                titleNode.y = -padding - bbox.width - Math.min(bbox.x, 0);
+                titleNode.y = Math.floor(-padding - bbox.width);
             }
             titleNode.textBaseline = titleRotationFlag === 1 ? 'bottom' : 'top';
         }
@@ -754,68 +749,7 @@ export class Axis<S extends Scale<D, number>, D = any> {
 
     thickness: number = 0;
 
-    computeBBox(options?: { excludeTitle: boolean }): BBox {
-        const { title, lineNode } = this;
-        const labels = this.axisGroupSelection.selectByClass(Text);
-
-        let left = Infinity;
-        let right = -Infinity;
-        let top = Infinity;
-        let bottom = -Infinity;
-
-        labels.each(label => {
-            // The label itself is rotated, but not translated, the group that
-            // contains it is. So to capture the group transform in the label bbox
-            // calculation we combine the transform matrices of the label and the group.
-            // Depending on the timing of the `axis.computeBBox()` method call, we may
-            // not have the group's and the label's transform matrices updated yet (because
-            // the transform matrix is not recalculated whenever a node's transform attributes
-            // change, instead it's marked for recalculation on the next frame by setting
-            // the node's `dirtyTransform` flag to `true`), so we force them to update
-            // right here by calling `computeTransformMatrix`.
-            label.computeTransformMatrix();
-            const matrix = Matrix.flyweight(label.matrix);
-            const group = label.parent!;
-            group.computeTransformMatrix();
-            matrix.preMultiplySelf(group.matrix);
-            const labelBBox = label.computeBBox();
-
-            if (labelBBox) {
-                const bbox = matrix.transformBBox(labelBBox);
-
-                left = Math.min(left, bbox.x);
-                right = Math.max(right, bbox.x + bbox.width);
-                top = Math.min(top, bbox.y);
-                bottom = Math.max(bottom, bbox.y + bbox.height);
-            }
-        });
-
-        if (title && title.enabled && lineNode.visible && (!options || !options.excludeTitle)) {
-            const label = title.node;
-            label.computeTransformMatrix();
-            const matrix = Matrix.flyweight(label.matrix);
-            const labelBBox = label.computeBBox();
-
-            if (labelBBox) {
-                const bbox = matrix.transformBBox(labelBBox);
-
-                left = Math.min(left, bbox.x);
-                right = Math.max(right, bbox.x + bbox.width);
-                top = Math.min(top, bbox.y);
-                bottom = Math.max(bottom, bbox.y + bbox.height);
-            }
-        }
-
-        left = Math.min(left, 0);
-        right = Math.max(right, 0);
-        top = Math.min(top, lineNode.y1, lineNode.y2);
-        bottom = Math.max(bottom, lineNode.y1, lineNode.y2);
-
-        return new BBox(
-            left,
-            top,
-            right - left,
-            bottom - top
-        );
+    computeBBox(): BBox {
+        return this.axisGroup.computeBBox();
     }
 }

--- a/charts-packages/ag-charts-community/src/chart/axis/groupedCategoryAxis.ts
+++ b/charts-packages/ag-charts-community/src/chart/axis/groupedCategoryAxis.ts
@@ -4,11 +4,12 @@ import { Line } from "../../scene/shape/line";
 import { normalizeAngle360, toRadians } from "../../util/angle";
 import { Text } from "../../scene/shape/text";
 import { BBox } from "../../scene/bbox";
-import { Matrix } from "../../scene/matrix";
 import { BandScale } from "../../scale/bandScale";
 import { ticksToTree, TreeLayout, treeLayout } from "../../layout/tree";
 import { AxisLabel } from "../../axis";
-import { ChartAxis } from "../chartAxis";
+import { ChartAxis, ChartAxisDirection } from "../chartAxis";
+import { extent } from "../../util/array";
+import { isContinuous } from "../../util/value";
 
 class GroupedCategoryAxisLabel extends AxisLabel {
     grid: boolean = false;
@@ -163,6 +164,31 @@ export class GroupedCategoryAxis extends ChartAxis<BandScale<string | number>> {
     }
     get gridLength(): number {
         return this._gridLength;
+    }
+
+    calculateDomain({ primaryTickCount }: { primaryTickCount?: number }) {
+        const { direction, boundSeries } = this;
+        const domains: any[][] = [];
+        let isNumericX: boolean | undefined = undefined;
+        boundSeries.filter(s => s.visible).forEach(series => {
+            if (direction === ChartAxisDirection.X) {
+                if (isNumericX === undefined) {
+                    // always add first X domain
+                    const domain = series.getDomain(direction);
+                    domains.push(domain);
+                    isNumericX = typeof domain[0] === 'number';
+                } else if (isNumericX) {
+                    // only add further X domains if the axis is numeric
+                    domains.push(series.getDomain(direction));
+                }
+            } else {
+                domains.push(series.getDomain(direction));
+            }
+        });
+        const domain = new Array<any>().concat(...domains);
+        this.domain = extent(domain, isContinuous) || domain;
+
+        return { primaryTickCount };
     }
 
     /**
@@ -427,46 +453,5 @@ export class GroupedCategoryAxis extends ChartAxis<BandScale<string | number>> {
                     line.fill = undefined;
                 });
         }
-    }
-
-    computeBBox(options?: { excludeTitle: boolean }): BBox {
-        const includeTitle = !options || !options.excludeTitle;
-        let left = Infinity;
-        let right = -Infinity;
-        let top = Infinity;
-        let bottom = -Infinity;
-
-        this.labelSelection.each((label, _, index) => {
-            // The label itself is rotated, but not translated, the group that
-            // contains it is. So to capture the group transform in the label bbox
-            // calculation we combine the transform matrices of the label and the group.
-            // Depending on the timing of the `axis.computeBBox()` method call, we may
-            // not have the group's and the label's transform matrices updated yet (because
-            // the transform matrix is not recalculated whenever a node's transform attributes
-            // change, instead it's marked for recalculation on the next frame by setting
-            // the node's `dirtyTransform` flag to `true`), so we force them to update
-            // right here by calling `computeTransformMatrix`.
-            if (index > 0 || includeTitle) { // first node is the root (title)
-                label.computeTransformMatrix();
-                const matrix = Matrix.flyweight(label.matrix);
-                const labelBBox = label.computeBBox();
-
-                if (labelBBox) {
-                    const bbox = matrix.transformBBox(labelBBox);
-
-                    left = Math.min(left, bbox.x);
-                    right = Math.max(right, bbox.x + bbox.width);
-                    top = Math.min(top, bbox.y);
-                    bottom = Math.max(bottom, bbox.y + bbox.height);
-                }
-            }
-        });
-
-        return new BBox(
-            left,
-            top,
-            Math.max(right - left, this.longestSeparatorLength),
-            bottom - top
-        );
     }
 }

--- a/charts-packages/ag-charts-community/src/chart/axis/numberAxis.ts
+++ b/charts-packages/ag-charts-community/src/chart/axis/numberAxis.ts
@@ -114,4 +114,14 @@ export class NumberAxis extends ChartAxis {
             return String(datum);
         }
     }
+
+    protected updateDomain(domain: any[], isYAxis: boolean, primaryTickCount?: number) {
+        if (isYAxis) {
+            // the `primaryTickCount` is used to align the secondary axis tick count with the primary
+            this.setDomain(domain, primaryTickCount);
+            return primaryTickCount ?? this.scale.ticks!(this.calculatedTickCount).length;
+        }
+
+        return super.updateDomain(domain, isYAxis, primaryTickCount);
+    }
 }

--- a/charts-packages/ag-charts-community/src/chart/cartesianChart.ts
+++ b/charts-packages/ag-charts-community/src/chart/cartesianChart.ts
@@ -5,7 +5,7 @@ import { ChartAxisPosition, ChartAxisDirection } from "./chartAxis";
 import { BBox } from "../scene/bbox";
 import { ClipRect } from "../scene/clipRect";
 import { Navigator } from "./navigator/navigator";
-import { NumberAxis } from "./axis/numberAxis";
+import { ChartAxis } from "./chartAxis";
 
 export class CartesianChart extends Chart {
     static className = 'CartesianChart';
@@ -29,11 +29,11 @@ export class CartesianChart extends Chart {
     readonly navigator = new Navigator(this);
 
     performLayout(): void {
-        this.scene.root!!.visible = true;
+        this.scene.root!.visible = true;
 
         const { width, height, axes, legend, navigator } = this;
 
-        const shrinkRect = new BBox(0, 0, width, height);
+        let shrinkRect = new BBox(0, 0, width, height);
 
         this.positionCaptions();
         this.positionLegend();
@@ -74,126 +74,33 @@ export class CartesianChart extends Chart {
         shrinkRect.height -= padding.top + captionAutoPadding + padding.bottom;
 
         if (navigator.enabled) {
-            shrinkRect.height -= navigator.height + navigator.margin;
+            const navigatorTotalHeight = navigator.height + navigator.margin;
+            navigator.x = shrinkRect.x;
+            navigator.y = shrinkRect.y + shrinkRect.height + navigator.margin;
+            navigator.width = shrinkRect.width;
+            shrinkRect.height -= navigatorTotalHeight;
         }
 
-        // Set the number of ticks for continuous axes based on the available range
-        // before updating the axis domain via `this.updateAxes()` as the tick count has an effect on the calculated `nice` domain extent
-        axes.forEach(axis => {
-            let availableRange = 0;
-            switch (axis.position) {
-                case ChartAxisPosition.Top:
-                case ChartAxisPosition.Bottom:
-                    availableRange = shrinkRect.width;
-                    break;
-                case ChartAxisPosition.Left:
-                case ChartAxisPosition.Right:
-                    availableRange = shrinkRect.height;
-                    break;
-            }
-            axis.calculateTickCount(availableRange);
-        });
-
-        this.updateAxes();
-
-        let bottomAxesHeight = 0;
-        const axisPositionVisited: { [key in ChartAxisPosition]: boolean } = {
-            top: false,
-            right: false,
-            bottom: false,
-            left: false,
-            angle: false,
-            radius: false
-        }
-
-        axes.forEach(axis => {
-            axis.axisGroup.visible = true;
-            axis.gridlineGroup.visible = true;
-            let axisThickness = Math.floor(axis.thickness || axis.computeBBox().width);
-
-            // for multiple axes in the same direction and position, apply padding at the top of each inner axis (i.e. between axes).
-            const axisPadding = axis.title && axis.title.padding.top || 15;
-
-            if (axisPositionVisited[axis.position]) {
-                axisThickness += axisPadding;
-            }
-
-            switch (axis.position) {
-                case ChartAxisPosition.Top:
-                    axisPositionVisited[ChartAxisPosition.Top] = true;
-                    shrinkRect.y += axisThickness;
-                    shrinkRect.height -= axisThickness;
-                    axis.translation.y = Math.floor(shrinkRect.y + 1);
-                    axis.label.mirrored = true;
-                    break;
-                case ChartAxisPosition.Right:
-                    axisPositionVisited[ChartAxisPosition.Right] = true;
-                    shrinkRect.width -= axisThickness;
-                    axis.translation.x = Math.max(Math.floor(shrinkRect.x), Math.floor(shrinkRect.x + shrinkRect.width));
-                    axis.label.mirrored = true;
-                    break;
-                case ChartAxisPosition.Bottom:
-                    axisPositionVisited[ChartAxisPosition.Bottom] = true;
-                    shrinkRect.height -= axisThickness;
-                    bottomAxesHeight += axisThickness;
-                    axis.translation.y = Math.max(Math.floor(shrinkRect.y), Math.floor(shrinkRect.y + shrinkRect.height + 1));
-                    break;
-                case ChartAxisPosition.Left:
-                    axisPositionVisited[ChartAxisPosition.Left] = true;
-                    shrinkRect.x += axisThickness;
-                    shrinkRect.width -= axisThickness;
-                    axis.translation.x = Math.floor(shrinkRect.x);
-                    break;
-            }
-        });
+        const { seriesRect } = this.updateAxes(shrinkRect);
 
         // width and height should not be negative
-        shrinkRect.width = Math.max(0, shrinkRect.width);
-        shrinkRect.height = Math.max(0, shrinkRect.height);
-
-        axes.forEach(axis => {
-            switch (axis.position) {
-                case ChartAxisPosition.Top:
-                case ChartAxisPosition.Bottom:
-                    axis.translation.x = Math.floor(shrinkRect.x);
-                    axis.range = [0, shrinkRect.width];
-                    axis.gridLength = shrinkRect.height;
-                    break;
-                case ChartAxisPosition.Left:
-                case ChartAxisPosition.Right:
-                    axis.translation.y = Math.floor(shrinkRect.y);
-                    if (axis instanceof CategoryAxis || axis instanceof GroupedCategoryAxis) {
-                        axis.range = [0, shrinkRect.height];
-                    } else {
-                        axis.range = [shrinkRect.height, 0];
-                    }
-                    axis.gridLength = shrinkRect.width;
-                    break;
-            }
-        });
+        seriesRect.width = Math.max(0, seriesRect.width);
+        seriesRect.height = Math.max(0, seriesRect.height);
 
         this.createNodeData();
 
-        this.seriesRect = shrinkRect;
+        this.seriesRect = seriesRect;
         this.series.forEach(series => {
-            series.group.translationX = Math.floor(shrinkRect.x);
-            series.group.translationY = Math.floor(shrinkRect.y);
+            series.group.translationX = Math.floor(seriesRect.x);
+            series.group.translationY = Math.floor(seriesRect.y);
             series.update(); // this has to happen after the `updateAxes` call
         });
 
         const { seriesRoot } = this;
-        seriesRoot.x = shrinkRect.x;
-        seriesRoot.y = shrinkRect.y;
-        seriesRoot.width = shrinkRect.width;
-        seriesRoot.height = shrinkRect.height;
-
-        if (navigator.enabled) {
-            navigator.x = shrinkRect.x;
-            navigator.y = shrinkRect.y + shrinkRect.height + bottomAxesHeight + navigator.margin;
-            navigator.width = shrinkRect.width;
-        }
-
-        this.axes.forEach(axis => axis.update());
+        seriesRoot.x = seriesRect.x;
+        seriesRoot.y = seriesRect.y;
+        seriesRoot.width = seriesRect.width;
+        seriesRoot.height = seriesRect.height;
     }
 
     private _onTouchStart: any;
@@ -288,50 +195,161 @@ export class CartesianChart extends Chart {
         });
     }
 
-    updateAxes() {
-        const { navigator } = this;
-        let clipSeries = false;
-        let primaryTickCount: number;
+    updateAxes(inputShrinkRect: BBox) {
+        const axisWidths: Partial<Record<ChartAxisPosition, number>> = {
+            [ChartAxisPosition.Top]: 0,
+            [ChartAxisPosition.Bottom]: 0,
+            [ChartAxisPosition.Left]: 0,
+            [ChartAxisPosition.Right]: 0,
+        };
 
-        this.axes.forEach(axis => {
-            const { direction, boundSeries } = axis;
-
-            if (boundSeries.length === 0 && this._series.length > 0) {
-                console.warn('AG Charts - chart series not initialised; check series and axes configuration.');
-            }
-
-            if (axis.linkedTo) {
-                axis.domain = axis.linkedTo.domain;
-            } else {
-                const domains: any[][] = [];
-                boundSeries.filter(s => s.visible).forEach(series => {
-                    domains.push(series.getDomain(direction));
+        const stableWidths = <T extends typeof axisWidths>(other: T) => {
+            return Object.entries(axisWidths)
+                .every(([p, w]) => {
+                    const otherW = (other as any)[p];
+                    if (w || otherW) {
+                        return w === otherW;
+                    }
+                    return true;
                 });
+        };
 
-                const domain = new Array<any>().concat(...domains);
+        // Iteratively try to resolve axis widths - since X axis width affects Y axis range,
+        // and vice-versa, we need to iteratively try and find a fit for the axes and their
+        // ticks/labels.
+        let lastPass: typeof axisWidths = {};
+        let clipSeries = false;
+        let seriesRect: BBox = inputShrinkRect.clone();
+        let count = 0;
+        do {
+            Object.assign(axisWidths, lastPass);
 
-                const isYAxis = axis.direction === 'y';
+            const result = this.updateAxesPass(axisWidths, inputShrinkRect.clone());
+            lastPass = result.axisWidths;
+            clipSeries = result.clipSeries;
+            seriesRect = result.seriesRect;
 
-                if (axis instanceof NumberAxis && isYAxis) {
-                    // the `primaryTickCount` is used to align the secondary axis tick count with the primary
-                    axis.setDomain(domain, primaryTickCount);
-                    primaryTickCount = primaryTickCount || axis.scale.ticks!(axis.calculatedTickCount).length;
-                } else {
-                    axis.domain = domain;
-                }
+            if (count++ > 10) {
+                throw new Error('AG Charts - unable to find stable axis layout.');
             }
+        } while (!stableWidths(lastPass));
+
+        this.seriesRoot.enabled = clipSeries;
+
+        return { seriesRect };
+    }
+
+
+    private updateAxesPass(
+        axisWidths: Partial<Record<ChartAxisPosition, number>>,
+        shrinkRect: BBox,
+    ) {
+        const { navigator, axes } = this;
+        const visited: Partial<Record<ChartAxisPosition, number>> = {};
+        const newAxisWidths: Partial<Record<ChartAxisPosition, number>> = {};
+
+        let clipSeries = false;
+        let primaryTickCount: number | undefined;
+
+        const buildSeriesRect = () => {
+            let seriesRect = shrinkRect.clone();
+            const { top, bottom, left, right } = axisWidths;
+            seriesRect.x += left ?? 0;
+            seriesRect.y += top ?? 0;
+            seriesRect.width -= (left ?? 0) + (right ?? 0);
+            seriesRect.height -= (top ?? 0) + (bottom ?? 0);
+            return seriesRect;
+        }
+        const seriesRect = buildSeriesRect();
+
+        // Set the number of ticks for continuous axes based on the available range
+        // before updating the axis domain via `this.updateAxes()` as the tick count has an effect on the calculated `nice` domain extent
+        axes.forEach(axis => {
+            const { position, direction } = axis;
+            visited[position] = (visited[position] ?? 0) + 1;
+
+            // for multiple axes in the same direction and position, apply padding at the top of each inner axis (i.e. between axes).
+            const axisPadding = axis.title && axis.title.padding.top || 15;
+
+            const axisLeftRightRange = (axis: ChartAxis<any>) => {
+                if (axis instanceof CategoryAxis || axis instanceof GroupedCategoryAxis) {
+                    return [0, seriesRect.height];
+                }
+                return [seriesRect.height, 0];
+            };
+
+            axis.label.mirrored = ['top', 'right'].includes(position);
+
+            const axisOffset = newAxisWidths[position] ?? 0;
+            switch (position) {
+                case ChartAxisPosition.Top:
+                    axis.range = [0, seriesRect.width];
+                    axis.gridLength = seriesRect.height;
+                    break;
+                case ChartAxisPosition.Right:
+                    axis.range = axisLeftRightRange(axis);
+                    axis.gridLength = seriesRect.width;
+                    break;
+                case ChartAxisPosition.Bottom:
+                    axis.range = [0, seriesRect.width];
+                    axis.gridLength = seriesRect.height;
+                    break;
+                case ChartAxisPosition.Left:
+                    axis.range = axisLeftRightRange(axis);
+                    axis.gridLength = seriesRect.width;
+                    break;
+            }
+
+            axis.calculateTickCount();
 
             if (axis.direction === ChartAxisDirection.X) {
                 axis.visibleRange = [navigator.min, navigator.max];
             }
-
             if (!clipSeries && (axis.visibleRange[0] > 0 || axis.visibleRange[1] < 1)) {
                 clipSeries = true;
             }
-
+    
+            primaryTickCount = axis.calculateDomain({ primaryTickCount }).primaryTickCount;
             axis.update();
+            
+            let axisThickness = 0;
+            if (axis.thickness) {
+                axisThickness = axis.thickness;
+            } else {
+                const bbox = axis.computeBBox();
+                axisThickness = direction === ChartAxisDirection.X ? bbox.height : bbox.width;
+            }
+
+            const visitCount = (visited[position] ?? 0);
+            if (visitCount > 1) {
+                axisThickness += axisPadding;
+            }
+
+            switch (position) {
+                case ChartAxisPosition.Top:
+                    axis.translation.x = Math.floor(shrinkRect.x + (axisWidths.left ?? 0));
+                    axis.translation.y = Math.floor(shrinkRect.y + 1 + axisOffset + axisThickness);
+                    break;
+                case ChartAxisPosition.Right:
+                    const safeX = Math.max(shrinkRect.x, shrinkRect.x + shrinkRect.width);
+                    axis.translation.x = Math.floor(safeX - axisThickness - axisOffset);
+                    axis.translation.y = Math.floor(shrinkRect.y + (axisWidths.top ?? 0));
+                    break;
+                case ChartAxisPosition.Bottom:
+                    const safeY = Math.max(shrinkRect.y, shrinkRect.y + shrinkRect.height + 1);
+                    axis.translation.x = Math.floor(shrinkRect.x + (axisWidths.left ?? 0));
+                    axis.translation.y = Math.floor(safeY - axisThickness - axisOffset);
+                    break;
+                case ChartAxisPosition.Left:
+                    axis.translation.x = Math.floor(shrinkRect.x + axisOffset + axisThickness);
+                    axis.translation.y = Math.floor(shrinkRect.y + (axisWidths.top ?? 0));
+                    break;
+            }
+            axis.update();
+
+            newAxisWidths[position] = (newAxisWidths[position] ?? 0) + axisThickness;
         });
 
-        this.seriesRoot.enabled = clipSeries;
+        return { clipSeries, seriesRect, axisWidths: newAxisWidths };
     }
 }

--- a/charts-packages/ag-charts-community/src/chart/chartAxis.ts
+++ b/charts-packages/ag-charts-community/src/chart/chartAxis.ts
@@ -59,8 +59,11 @@ export class ChartAxis<S extends Scale<any, number> = Scale<any, number>> extend
     /**
      * For continuous axes, if tick count has not been specified, set the number of ticks based on the available range
      */
-    calculateTickCount(availableRange: number): void {
+    calculateTickCount(): void {
         if (!this.useCalculatedTickCount()) { return; }
+
+        const [min, max] = this.range;
+        const availableRange = Math.abs(max - min);
 
         // Approximate number of pixels to allocate for each tick.
         const optimalRangePx = 600;
@@ -104,5 +107,33 @@ export class ChartAxis<S extends Scale<any, number> = Scale<any, number>> extend
     }
     get position(): ChartAxisPosition {
         return this._position;
+    }
+
+    calculateDomain({ primaryTickCount }: { primaryTickCount?: number }) {
+        const { direction, boundSeries } = this;
+
+        if (boundSeries.length === 0) {
+            console.warn('AG Charts - chart series not initialised; check series and axes configuration.');
+        }
+
+        if (this.linkedTo) {
+            this.domain = this.linkedTo.domain;
+        } else {
+            const domains: any[][] = [];
+            boundSeries.filter(s => s.visible).forEach(series => {
+                domains.push(series.getDomain(direction));
+            });
+
+            const domain = new Array<any>().concat(...domains);
+            const isYAxis = this.direction === 'y';
+            primaryTickCount = this.updateDomain(domain, isYAxis, primaryTickCount);
+        }
+
+        return { primaryTickCount };
+    }
+
+    protected updateDomain(domain: any[], isYAxis: boolean, primaryTickCount?: number) {
+        this.domain = domain;
+        return primaryTickCount;
     }
 }

--- a/charts-packages/ag-charts-community/src/chart/groupedCategoryChart.ts
+++ b/charts-packages/ag-charts-community/src/chart/groupedCategoryChart.ts
@@ -1,39 +1,10 @@
 import { CartesianChart } from "./cartesianChart";
-import { extent } from "../util/array";
 import { GroupedCategoryAxis } from "./axis/groupedCategoryAxis";
-import { ChartAxis, ChartAxisDirection } from "./chartAxis";
-import { isContinuous } from "../util/value";
+import { ChartAxis } from "./chartAxis";
 
 export type GroupedCategoryChartAxis = GroupedCategoryAxis | ChartAxis;
 
 export class GroupedCategoryChart extends CartesianChart {
     static className = 'GroupedCategoryChart';
     static type = 'groupedCategory' as const;
-
-    updateAxes() {
-        this.axes.forEach(axis => {
-            const { direction, boundSeries } = axis;
-            const domains: any[][] = [];
-            let isNumericX: boolean | undefined = undefined;
-            boundSeries.filter(s => s.visible).forEach(series => {
-                if (direction === ChartAxisDirection.X) {
-                    if (isNumericX === undefined) {
-                        // always add first X domain
-                        const domain = series.getDomain(direction);
-                        domains.push(domain);
-                        isNumericX = typeof domain[0] === 'number';
-                    } else if (isNumericX) {
-                        // only add further X domains if the axis is numeric
-                        domains.push(series.getDomain(direction));
-                    }
-                } else {
-                    domains.push(series.getDomain(direction));
-                }
-            });
-            const domain = new Array<any>().concat(...domains);
-            axis.domain = extent(domain, isContinuous) || domain;
-
-            axis.update();
-        });
-    }
 }

--- a/charts-packages/ag-charts-community/src/scene/bbox.ts
+++ b/charts-packages/ag-charts-community/src/scene/bbox.ts
@@ -22,6 +22,11 @@ export class BBox {
         this.height = height;
     }
 
+    clone() {
+        const { x, y, width, height } = this;
+        return new BBox(x, y, width, height);
+    }
+
     isValid(): boolean {
         return isFinite(this.x) && isFinite(this.y) && isFinite(this.width) && isFinite(this.height);
     }


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-6815

Reworks the Chart Axis layout calculations to:
- Be more explicit about taking an iterative approach to finding a solution.
- Use more than a fixed number of iterations (2 previously, possibly), especially in light of recent additions such as auto-hiding of labels/ticks depending on available space.
- Push more responsibility back into the `Axis` class hierarchy to help simplify `CartesianChart.performLayout()`.
- Detangle the mess of dependencies in layout calculations (previously 4-5x loops over axis, now just one).
- Remove redundant code duplication (e.g. `Axis.computeBBox()` rather than delegating to `Group.computeBBox()`).

See also:
https://ag-grid.atlassian.net/browse/AG-6878
https://ag-grid.atlassian.net/browse/AG-6783