### PR TITLE
Invalid aria prop `aria-description` on <div> tag.

### DIFF
--- a/community-modules/core/.eslintrc
+++ b/community-modules/core/.eslintrc
@@ -14,6 +14,7 @@
     "ie11"
   ],
   "rules": {
+    "jsx-a11y/aria-props": 0,
     "ie11/no-collection-args": [
       "error"
     ],

--- a/enterprise-modules/all-modules/.eslintrc
+++ b/enterprise-modules/all-modules/.eslintrc
@@ -13,6 +13,7 @@
     "ie11"
   ],
   "rules": {
+    "jsx-a11y/aria-props": 0,
     "ie11/no-collection-args": [
       "error"
     ],


### PR DESCRIPTION
Invalid aria prop `aria-description` on <div> tag.

It's not ignored by **eslint**, and it's giving error,

![image](https://user-images.githubusercontent.com/55147176/174423703-a04c3b2e-30c3-4170-8867-25b5f71e8557.png)



