### PR TITLE
AG-6902 - Fix Chart legend hover not updating series opacity.

### DIFF
--- a/charts-packages/ag-charts-community/src/scene/group.ts
+++ b/charts-packages/ag-charts-community/src/scene/group.ts
@@ -203,6 +203,8 @@ export class Group extends Node {
                 stats.nodesSkipped += this.nodeCount.count;
             }
 
+            super.markClean({ recursive: false });
+
             // Nothing to do.
             return;
         }
@@ -332,6 +334,8 @@ export class Group extends Node {
                 stats.layersSkipped++;
                 stats.nodesSkipped += this.nodeCount.count;
             }
+
+            super.markClean({ recursive: false });
 
             // Nothing to do.
             return;

--- a/charts-packages/ag-charts-community/src/scene/node.ts
+++ b/charts-packages/ag-charts-community/src/scene/node.ts
@@ -59,7 +59,7 @@ export function SceneChangeDetection(opts?: {
                     ${convertor ? 'value = convertor(value);' : ''}
                     if (value !== oldValue) {
                         this.${privateKey} = value;
-                        ${debug ? `if (window.agChartsSceneChangeDetectionDebug) console.log({ t: this, property: '${key}', oldValue, value, stack: new Error().stack });` : ''}
+                        ${debug ? `console.log({ t: this, property: '${key}', oldValue, value, stack: new Error().stack });` : ''}
                         ${type === 'normal' ? 'this.markDirty(this, ' + redraw + ');' : ''}
                         ${type === 'transform' ? 'this.markDirtyTransform(' + redraw + ');' : ''}
                         ${type === 'path' ? `if (!this._dirtyPath) { this._dirtyPath = true; this.markDirty(this, redraw); }` : ''}

--- a/charts-packages/ag-charts-community/src/scene/scene.ts
+++ b/charts-packages/ag-charts-community/src/scene/scene.ts
@@ -257,7 +257,7 @@ export class Scene {
 
         if (root && canvasCleared) {
             if (this.debug.consoleLog) {
-                console.log({ redrawType: RedrawType[root.dirty], canvasCleared, tree: this.buildTree(root) });
+                console.log('before', { redrawType: RedrawType[root.dirty], canvasCleared, tree: this.buildTree(root) });
             }
 
             if (root.visible) {
@@ -326,7 +326,10 @@ export class Scene {
             ctx.restore();
         }
 
-    }
+        if (root && this.debug.consoleLog) {
+            console.log('after', { redrawType: RedrawType[root.dirty], canvasCleared, tree: this.buildTree(root) });
+        }
+}
 
     buildTree(node: Node): { name?: string, node?: any, dirty?: string } {
         const name = (node instanceof Group ? node.name : null) ?? node.id;


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-6902

Fixes edge-case of changing hover between legend items. The root cause was that the `Group.dirty` flag was not being cleared in the `Group.dirty === RedrawType.TRIVIAL` case, which meant subsequent dirty processing didn't percolate `TRIVIAL` updates up the tree.