### PR TITLE
AG-6907 - Improve number axis tick calculations.

### DIFF
--- a/charts-packages/ag-charts-community/src/chart/agChartOptions.ts
+++ b/charts-packages/ag-charts-community/src/chart/agChartOptions.ts
@@ -467,7 +467,7 @@ export interface AgAxisLabelOptions {
     /** Format string used when rendering labels for time axes. */
     format?: string;
     /** Function used to render axis labels. If `value` is a number, `fractionDigits` will also be provided, which indicates the number of fractional digits used in the step between ticks; for example, a tick step of `0.0005` would have `fractionDigits` set to `4` */
-    formatter?: (params: AgAxisLabelFormatterParams) => string;
+    formatter?: (params: AgAxisLabelFormatterParams) => string | undefined;
 }
 
 export interface AgAxisGridStyle {

--- a/charts-packages/ag-charts-community/src/chart/chartAxis.ts
+++ b/charts-packages/ag-charts-community/src/chart/chartAxis.ts
@@ -62,15 +62,39 @@ export class ChartAxis<S extends Scale<any, number> = Scale<any, number>> extend
     calculateTickCount(): void {
         if (!this.useCalculatedTickCount()) { return; }
 
-        const [min, max] = this.range;
+        const { tick: { count }, range: [min, max] } = this;
+
+        if (count) {
+            return;
+        }
+
         const availableRange = Math.abs(max - min);
+        const optimalTickInteralPx = this.calculateTickInternalEstimate();
 
         // Approximate number of pixels to allocate for each tick.
         const optimalRangePx = 600;
-        const optimalTickInteralPx = 70;
-        const tickIntervalRatio = Math.pow(Math.log(availableRange) / Math.log(optimalRangePx), 2);
+        const minTickIntervalRatio = 0.75;
+        const tickIntervalRatio = Math.max(Math.pow(Math.log(availableRange) / Math.log(optimalRangePx), 2), minTickIntervalRatio);
         const tickInterval = optimalTickInteralPx * tickIntervalRatio;
-        this._calculatedTickCount = this.tick.count || Math.max(2, Math.floor(availableRange / tickInterval));
+        this._calculatedTickCount = Math.max(2, Math.floor(availableRange / tickInterval));
+    }
+
+    protected calculateTickInternalEstimate() {
+        const { domain, label: { fontSize }, direction } = this;
+
+        const padding = fontSize * 1.5;
+        if (direction === 'y') {
+            return fontSize * 2 + padding;
+        }
+
+        const ticks = this.scale.ticks?.(10) || [domain[0], domain[domain.length - 1]];
+
+        // Dynamic optimal tick interval based upon label scale.
+        const approxMaxLabelCharacters = Math.max(...ticks.map((v) => {
+            return String(v).length;
+        }));
+
+        return approxMaxLabelCharacters * fontSize + padding;
     }
 
     protected _position: ChartAxisPosition = ChartAxisPosition.Left;

--- a/community-modules/core/src/ts/interfaces/iAgChartOptions.ts
+++ b/community-modules/core/src/ts/interfaces/iAgChartOptions.ts
@@ -467,7 +467,7 @@ export interface AgAxisLabelOptions {
     /** Format string used when rendering labels for time axes. */
     format?: string;
     /** Function used to render axis labels. If `value` is a number, `fractionDigits` will also be provided, which indicates the number of fractional digits used in the step between ticks; for example, a tick step of `0.0005` would have `fractionDigits` set to `4` */
-    formatter?: (params: AgAxisLabelFormatterParams) => string;
+    formatter?: (params: AgAxisLabelFormatterParams) => string | undefined;
 }
 
 export interface AgAxisGridStyle {

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/doc-interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/doc-interfaces.AUTO.json
@@ -1250,7 +1250,7 @@
       "description": "/** Function used to render axis labels. If `value` is a number, `fractionDigits` will also be provided, which indicates the number of fractional digits used in the step between ticks; for example, a tick step of `0.0005` would have `fractionDigits` set to `4` */",
       "type": {
         "arguments": { "params": "AgAxisLabelFormatterParams" },
-        "returnType": "string",
+        "returnType": "string | undefined",
         "optional": true
       }
     }

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
@@ -815,7 +815,7 @@
       "autoRotate?": "boolean",
       "autoRotateAngle?": "number",
       "format?": "string",
-      "formatter?": "(params: AgAxisLabelFormatterParams) => string"
+      "formatter?": "(params: AgAxisLabelFormatterParams) => string | undefined"
     },
     "docs": {
       "fontStyle?": "/** The font style to use for the labels. */",

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-overview/examples/grouped-column/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-overview/examples/grouped-column/main.ts
@@ -44,7 +44,8 @@ const options: AgChartOptions = {
       position: "left",
       label: {
         formatter: (params) => {
-          return params.value / 1000 + "M"
+          const formatted = params.value / 1000 + "M";
+          return formatted.indexOf('.') >= 0 ? undefined : formatted;
         },
       },
     },

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/doc-interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/doc-interfaces.AUTO.json
@@ -11719,7 +11719,7 @@
       "description": "/** Function used to render axis labels. If `value` is a number, `fractionDigits` will also be provided, which indicates the number of fractional digits used in the step between ticks; for example, a tick step of `0.0005` would have `fractionDigits` set to `4` */",
       "type": {
         "arguments": { "params": "AgAxisLabelFormatterParams" },
-        "returnType": "string",
+        "returnType": "string | undefined",
         "optional": true
       }
     }

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/interfaces.AUTO.json
@@ -6762,7 +6762,7 @@
       "autoRotate?": "boolean",
       "autoRotateAngle?": "number",
       "format?": "string",
-      "formatter?": "(params: AgAxisLabelFormatterParams) => string"
+      "formatter?": "(params: AgAxisLabelFormatterParams) => string | undefined"
     },
     "docs": {
       "fontStyle?": "/** The font style to use for the labels. */",


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-6907

After #5280 some gallery + other examples had a reduced tick count. The root cause of this seems to be that the `availableRange` taken into account in `ChartAxis.calculateTickCount()` is now more accurate and smaller as it takes other axes into account.

I've taken another swing at improving the `ChartAxis.calculateTickCount()` calculation, specifically for number axes - we now try and estimate the size of the largest label, and use this as the basis (with some padding) for calculating the optimal number of ticks. For `y` axes we assume a single line of text for the label, and apply more generous padding.

Bonus:
- I updated a gallery example to remove labels with decimals using a formatter.
- I then found there was a bug in the axis label-skipping code which meant that we ended up with 9 labels, each with 2 ticks between them, and a gap where a 3rd tick should've been. The reason for this seems to be that the empty label case still has a `BBox` with a non-zero height, triggering the skipping process unnecessarily. This is now fixed.
- I then found that our label formatter typings don't allow for an `undefined` result - this is also fixed.