### PR TITLE
AG-6887 - Series highlight z-order improvements

### DIFF
--- a/charts-packages/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
@@ -203,6 +203,7 @@ export abstract class CartesianSeries<
             const { group, datumSelection, labelSelection, paths } = subGroup;
             const { itemId } = contextNodeData[seriesIdx];
             group.opacity = this.getOpacity({ itemId });
+            group.zIndex = this.getZIndex({ itemId });
             group.visible = visible && (this.seriesItemEnabled.get(itemId) ?? true);
 
             this.updatePathNodes({ seriesHighlighted, itemId, paths, seriesIdx });

--- a/charts-packages/ag-charts-community/src/scene/group.ts
+++ b/charts-packages/ag-charts-community/src/scene/group.ts
@@ -251,8 +251,7 @@ export class Group extends Node {
         clipBBox = clipBBox ? this.matrix.inverse().transformBBox(clipBBox) : undefined;
 
         if (dirtyZIndex) {
-            this.dirtyZIndex = false;
-            children.sort((a, b) => a.zIndex - b.zIndex);
+            this.sortChildren();
             forceRender = true;
         }
 
@@ -380,8 +379,7 @@ export class Group extends Node {
         clipBBox = clipBBox ? this.matrix.inverse().transformBBox(clipBBox) : undefined;
 
         if (dirtyZIndex) {
-            this.dirtyZIndex = false;
-            children.sort((a, b) => a.zIndex - b.zIndex);
+            this.sortChildren();
             forceRender = true;
         }
 
@@ -444,5 +442,18 @@ export class Group extends Node {
                 visibleChildren[child.id] = child;
             }
         }
+    }
+
+    private sortChildren() {
+        this.dirtyZIndex = false;
+        this.children.sort((a, b) => {
+            const result = a.zIndex - b.zIndex;
+            if (result !== 0) {
+                return result;
+            }
+            return a.id < b.id ? -1 : 
+                a.id > b.id ? 1 :
+                0;
+        });
     }
 }

--- a/charts-packages/ag-charts-community/src/scene/group.ts
+++ b/charts-packages/ag-charts-community/src/scene/group.ts
@@ -29,6 +29,12 @@ export class Group extends Node {
         }
     }
 
+    protected zIndexChanged() {
+        if (this.layer) {
+            this._scene?.moveLayer(this.layer, this.zIndex);
+        }
+    }
+
     public constructor(
         protected readonly opts?: {
             readonly layer?: boolean,

--- a/charts-packages/ag-charts-community/src/scene/node.ts
+++ b/charts-packages/ag-charts-community/src/scene/node.ts
@@ -567,6 +567,7 @@ export abstract class Node { // Don't confuse with `window.Node`.
             if (o.parent) {
                 o.parent.dirtyZIndex = true;
             }
+            o.zIndexChanged();
         },
     })
     zIndex: number = 0;
@@ -588,5 +589,9 @@ export abstract class Node { // Don't confuse with `window.Node`.
         }
 
         return { count, visibleCount, dirtyCount };
+    }
+
+    protected zIndexChanged() {
+        // Override point for sub-classes.
     }
 }

--- a/charts-packages/ag-charts-community/src/scene/scene.ts
+++ b/charts-packages/ag-charts-community/src/scene/scene.ts
@@ -136,13 +136,7 @@ export class Scene {
         }
 
         this.layers.push(newLayer);
-        this.layers.sort((a, b) => { 
-            const zDiff = a.zIndex - b.zIndex;
-            if (zDiff !== 0) {
-                return zDiff;
-            }
-            return a.id - b.id;
-        });
+        this.sortLayers();
 
         if (domLayer) {
             const domCanvases= this.layers.map(v => v.canvas)
@@ -171,6 +165,30 @@ export class Scene {
                 console.log({ layers: this.layers });
             }
         }
+    }
+
+    moveLayer(canvas: HdpiCanvas | HdpiOffscreenCanvas, newZIndex: number) {
+        const layer = this.layers.find((l) => l.canvas === canvas);
+
+        if (layer) {
+            layer.zIndex = newZIndex;
+            this.sortLayers();
+            this.markDirty();
+
+            if (this.debug.consoleLog) {
+                console.log({ layers: this.layers });
+            }
+        }
+    }
+
+    private sortLayers() {
+        this.layers.sort((a, b) => { 
+            const zDiff = a.zIndex - b.zIndex;
+            if (zDiff !== 0) {
+                return zDiff;
+            }
+            return a.id - b.id;
+        });
     }
 
     private _dirty = false;


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-6887

Whilst reviewing the z-order changes made for `28.0.0` it became clear there were some easily achievable improvements, which are captured as part of this PR:
- Highlighted series is now temporarily bumped in `zIndex`, so hidden series can be more easily seen when hovering over the series itself or it's legend item.
- Highlighted datum rendering is at a higher `zIndex` than all series, so highlighted datum can be easily seen. (No change in this PR - just stating new `28.0.0` behaviour which has been approved)

Bonus:
- Cleanup Group and Scene `zIndex` processing.