### PR TITLE
AG-5740 - Add more consistent series.visible handling.

### DIFF
--- a/charts-packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
@@ -164,14 +164,27 @@ export class AreaSeries extends CartesianSeries<AreaSeriesNodeDataContext> {
             this._yKeys = values;
             this.yData = [];
 
-            const { seriesItemEnabled } = this;
-            seriesItemEnabled.clear();
-            values.forEach((key) => seriesItemEnabled.set(key, true));
+            this.processSeriesItemEnabled();
         }
     }
 
     get yKeys(): string[] {
         return this._yKeys;
+    }
+
+    protected _visibles: boolean[];
+    set visibles(visibles: boolean[]) {
+        this._visibles = visibles;
+        this.processSeriesItemEnabled();
+    }
+    get visibles() {
+        return this._visibles;
+    }
+
+    private processSeriesItemEnabled() {
+        const { seriesItemEnabled, _visibles: visibles = [] } = this;
+        seriesItemEnabled.clear();
+        this._yKeys.forEach((key, idx) => seriesItemEnabled.set(key, visibles[idx] ?? true));
     }
 
     setColors(fills: string[], strokes: string[]) {

--- a/charts-packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
@@ -220,11 +220,7 @@ export class BarSeries extends CartesianSeries<SeriesNodeDataContext<BarNodeDatu
             });
             this.yData = [];
 
-            const { seriesItemEnabled } = this;
-            seriesItemEnabled.clear();
-            yKeys.forEach((stack) => {
-                stack.forEach((yKey) => seriesItemEnabled.set(yKey, true));
-            });
+            this.processSeriesItemEnabled();
 
             const { groupScale } = this;
             groupScale.domain = visibleStacks;
@@ -234,6 +230,29 @@ export class BarSeries extends CartesianSeries<SeriesNodeDataContext<BarNodeDatu
     }
     get yKeys(): string[][] {
         return this._yKeys;
+    }
+    
+    protected _visibles: boolean[][];
+    set visibles(visibles: boolean[] | boolean[][]) {
+        if (is2dArray(visibles)) {
+            this._visibles = visibles;
+        } else {
+            this._visibles = this.grouped ? visibles.map((k) => [k]) : [visibles];
+        }
+
+        this.processSeriesItemEnabled();
+    }
+    get visibles() {
+        return this._visibles;
+    }
+
+    private processSeriesItemEnabled() {
+        const { seriesItemEnabled, _visibles: visibles = [] } = this;
+        seriesItemEnabled.clear();
+        this._yKeys.forEach((stack, stackIdx) => {
+            const stackVisibles = visibles[stackIdx];
+            stack.forEach((yKey, idx) => seriesItemEnabled.set(yKey, stackVisibles?.[idx] ?? true));
+        });
     }
 
     protected _grouped: boolean = false;


### PR DESCRIPTION
Attempts to make `visible: false` behave more consistently across series. After this change, setting `visible: false` means that series will appear as if they have been toggled disabled from the legend.