### PR TITLE
AG-6924 - Fix Chart update cases

### DIFF
--- a/charts-packages/ag-charts-community/src/chart/cartesianChart.ts
+++ b/charts-packages/ag-charts-community/src/chart/cartesianChart.ts
@@ -300,7 +300,12 @@ export class CartesianChart extends Chart {
             axis.calculateTickCount();
 
             if (axis.direction === ChartAxisDirection.X) {
-                axis.visibleRange = [navigator.min, navigator.max];
+                let { min, max, enabled } = navigator;
+                if (enabled) {
+                    axis.visibleRange = [min, max];
+                } else {
+                    axis.visibleRange = [0, 1];
+                }
             }
             if (!clipSeries && (axis.visibleRange[0] > 0 || axis.visibleRange[1] < 1)) {
                 clipSeries = true;

--- a/charts-packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
@@ -555,6 +555,10 @@ export class AreaSeries extends CartesianSeries<AreaSeriesNodeDataContext> {
         return contexts;
     }
 
+    protected isPathOrSelectionDirty(): boolean {
+        return this.marker.isDirty();
+    }
+
     protected updatePaths(opts: {
         seriesHighlighted?: boolean;
         contextData: AreaSeriesNodeDataContext;
@@ -653,13 +657,18 @@ export class AreaSeries extends CartesianSeries<AreaSeriesNodeDataContext> {
         nodeData: MarkerSelectionDatum[];
         datumSelection: Selection<Marker, Group, MarkerSelectionDatum, any>;
     }) {
-        const { nodeData, datumSelection } = opts;
+        let { nodeData, datumSelection } = opts;
         const {
             marker: { enabled, shape },
         } = this;
         const data = enabled && nodeData ? nodeData : [];
 
         const MarkerShape = getMarker(shape);
+
+        if (this.marker.isDirty()) {
+            datumSelection = datumSelection.setData([]);
+            datumSelection.exit.remove();
+        }
 
         const updateSelection = datumSelection.setData(data);
         updateSelection.exit.remove();
@@ -735,6 +744,10 @@ export class AreaSeries extends CartesianSeries<AreaSeriesNodeDataContext> {
             node.visible =
                 node.size > 0 && !!seriesItemEnabled.get(datum.yKey) && !isNaN(datum.point.x) && !isNaN(datum.point.y);
         });
+
+        if (!isDatumHighlighted) {
+            this.marker.markClean();
+        }
     }
 
     protected updateLabelSelection(opts: {

--- a/charts-packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
@@ -253,6 +253,10 @@ export class LineSeries extends CartesianSeries<LineContext> {
         return [{ itemId: yKey, nodeData, labelData: nodeData }];
     }
 
+    protected isPathOrSelectionDirty(): boolean {
+        return this.marker.isDirty();
+    }
+
     protected updatePaths(opts: { seriesHighlighted?: boolean; contextData: LineContext; paths: Path[] }): void {
         const {
             contextData: { nodeData },
@@ -298,6 +302,11 @@ export class LineSeries extends CartesianSeries<LineContext> {
         } = this;
         nodeData = shape && enabled ? nodeData : [];
         const MarkerShape = getMarker(shape);
+
+        if (this.marker.isDirty()) {
+            datumSelection = datumSelection.setData([]);
+            datumSelection.exit.remove();
+        }
 
         const updateDatumSelection = datumSelection.setData(nodeData);
         updateDatumSelection.exit.remove();
@@ -361,6 +370,10 @@ export class LineSeries extends CartesianSeries<LineContext> {
             node.translationY = datum.point.y;
             node.visible = node.size > 0;
         });
+
+        if (!isDatumHighlighted) {
+            this.marker.markClean();
+        }
     }
 
     protected updateLabelSelection(opts: {

--- a/charts-packages/ag-charts-community/src/chart/series/cartesian/scatterSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/cartesian/scatterSeries.ts
@@ -253,15 +253,24 @@ export class ScatterSeries extends CartesianSeries<SeriesNodeDataContext<Scatter
         return [{ itemId: this.yKey, nodeData, labelData: nodeData }];
     }
 
+    protected isPathOrSelectionDirty(): boolean {
+        return this.marker.isDirty();
+    }
+
     protected updateDatumSelection(opts: {
         nodeData: ScatterNodeDatum[];
         datumSelection: Selection<Marker, Group, ScatterNodeDatum, any>;
     }): Selection<Marker, Group, ScatterNodeDatum, any> {
-        const { nodeData, datumSelection } = opts;
+        let { nodeData, datumSelection } = opts;
         const {
             marker: { enabled, shape },
         } = this;
         const MarkerShape = getMarker(shape);
+
+        if (this.marker.isDirty()) {
+            datumSelection = datumSelection.setData([]);
+            datumSelection.exit.remove();
+        }
 
         const data = enabled ? nodeData : [];
         const updateDatums = datumSelection.setData(data);
@@ -339,6 +348,10 @@ export class ScatterSeries extends CartesianSeries<SeriesNodeDataContext<Scatter
             node.translationY = datum.point.y;
             node.visible = node.size > 0;
         });
+
+        if (!isDatumHighlighted) {
+            this.marker.markClean();
+        }
     }
 
     protected updateLabelSelection(opts: {

--- a/charts-packages/ag-charts-community/src/chart/series/polar/polarSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/polar/polarSeries.ts
@@ -1,7 +1,7 @@
 import { Series, SeriesNodeDatum, SeriesNodeDataContext } from "../series";
 import { ChartAxisDirection } from "../../chartAxis";
 import { SeriesMarker, SeriesMarkerFormatterParams } from "../seriesMarker";
-
+import { RedrawType, SceneChangeDetection } from '../../../scene/changeDetectable';
 export abstract class PolarSeries<S extends SeriesNodeDatum> extends Series<SeriesNodeDataContext<S>> {
 
     directionKeys = {
@@ -27,6 +27,7 @@ export abstract class PolarSeries<S extends SeriesNodeDatum> extends Series<Seri
 }
 
 export class PolarSeriesMarker extends SeriesMarker {
+    @SceneChangeDetection({ redraw: RedrawType.MAJOR })
     formatter?: (params: PolarSeriesMarkerFormatterParams) => {
         fill?: string,
         stroke?: string,

--- a/charts-packages/ag-charts-community/src/chart/series/seriesMarker.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/seriesMarker.ts
@@ -1,17 +1,21 @@
 import { Marker } from "../marker/marker";
 import { Circle } from "../marker/circle";
+import { ChangeDetectable, SceneChangeDetection, RedrawType } from "../../scene/changeDetectable";
 
-export class SeriesMarker {
+export class SeriesMarker extends ChangeDetectable {
 
+    @SceneChangeDetection({ redraw: RedrawType.MAJOR })
     enabled = true;
 
     /**
      * One of the predefined marker names, or a marker constructor function (for user-defined markers).
      * A series will create one marker instance per data point.
      */
-    shape: string | (new () => Marker) = Circle;
+     @SceneChangeDetection({ redraw: RedrawType.MAJOR })
+     shape: string | (new () => Marker) = Circle;
 
-    size = 6;
+     @SceneChangeDetection({ redraw: RedrawType.MAJOR })
+     size = 6;
 
     /**
      * In case a series has the `sizeKey` set, the `sizeKey` values along with the `size` and `maxSize` configs
@@ -19,18 +23,25 @@ export class SeriesMarker {
      * within the `[size, maxSize]` range, where the largest values will correspond to the `maxSize`
      * and the lowest to the `size`.
      */
+    @SceneChangeDetection({ redraw: RedrawType.MAJOR })
     maxSize = 30;
 
+    @SceneChangeDetection({ redraw: RedrawType.MAJOR })
     domain?: [number, number] = undefined;
 
+    @SceneChangeDetection({ redraw: RedrawType.MAJOR })
     fill?: string = undefined;
 
+    @SceneChangeDetection({ redraw: RedrawType.MAJOR })
     stroke?: string = undefined;
 
+    @SceneChangeDetection({ redraw: RedrawType.MAJOR })
     strokeWidth?: number = 1;
 
+    @SceneChangeDetection({ redraw: RedrawType.MAJOR })
     fillOpacity?: number = undefined;
 
+    @SceneChangeDetection({ redraw: RedrawType.MAJOR })
     strokeOpacity?: number = undefined;
 }
 

--- a/charts-packages/ag-charts-community/src/scene/changeDetectable.ts
+++ b/charts-packages/ag-charts-community/src/scene/changeDetectable.ts
@@ -18,8 +18,9 @@ export function SceneChangeDetection(opts?: {
     type?: 'normal' | 'transform' | 'path' | 'font',
     convertor?: (o: any) => any,
     changeCb?: (o: any) => any,
+    checkDirtyOnAssignment?: boolean,
 }) {
-    const { redraw = RedrawType.TRIVIAL, type = 'normal', changeCb, convertor } = opts || {};
+    const { redraw = RedrawType.TRIVIAL, type = 'normal', changeCb, convertor, checkDirtyOnAssignment = false } = opts || {};
     
     const debug = windowValue('agChartsSceneChangeDetectionDebug') != null;
 
@@ -44,6 +45,7 @@ export function SceneChangeDetection(opts?: {
                         ${type === 'font' ? `if (!this._dirtyFont) { this._dirtyFont = true; this.markDirty(this, redraw); }` : ''}
                         ${changeCb ? 'changeCb(this);' : ''}
                     }
+                    ${checkDirtyOnAssignment ? `if (value != null && value._dirty > ${RedrawType.NONE}) { this.markDirty(value, value._dirty); }` : ''}
                 };
                 set_${key};
             `;

--- a/charts-packages/ag-charts-community/src/scene/changeDetectable.ts
+++ b/charts-packages/ag-charts-community/src/scene/changeDetectable.ts
@@ -1,0 +1,84 @@
+import { windowValue } from "../util/window";
+
+export enum RedrawType {
+    NONE, // No change in rendering.
+
+    // Canvas doesn't need clearing, an incremental re-rerender is sufficient.
+    TRIVIAL, // Non-positional change in rendering.
+
+    // Group needs clearing, a semi-incremental re-render is sufficient.
+    MINOR, // Small change in rendering, potentially affecting other elements in the same group.
+
+    // Canvas needs to be cleared for these redraw types.
+    MAJOR, // Significant change in rendering.
+}
+
+export function SceneChangeDetection(opts?: {
+    redraw?: RedrawType,
+    type?: 'normal' | 'transform' | 'path' | 'font',
+    convertor?: (o: any) => any,
+    changeCb?: (o: any) => any,
+}) {
+    const { redraw = RedrawType.TRIVIAL, type = 'normal', changeCb, convertor } = opts || {};
+    
+    const debug = windowValue('agChartsSceneChangeDetectionDebug') != null;
+
+    return function (target: any, key: string) {
+        // `target` is either a constructor (static member) or prototype (instance member)
+        const privateKey = `__${key}`;
+
+        if (!target[key]) {
+            // Remove all conditional logic from runtime - generate a setter with the exact necessary
+            // steps, as these setters are called a LOT during update cycles.        
+            const setterJs = `
+                ${debug ? 'var setCount = 0;' : ''}
+                function set_${key}(value) {
+                    const oldValue = this.${privateKey};
+                    ${convertor ? 'value = convertor(value);' : ''}
+                    if (value !== oldValue) {
+                        this.${privateKey} = value;
+                        ${debug ? `console.log({ t: this, property: '${key}', oldValue, value, stack: new Error().stack });` : ''}
+                        ${type === 'normal' ? 'this.markDirty(this, ' + redraw + ');' : ''}
+                        ${type === 'transform' ? 'this.markDirtyTransform(' + redraw + ');' : ''}
+                        ${type === 'path' ? `if (!this._dirtyPath) { this._dirtyPath = true; this.markDirty(this, redraw); }` : ''}
+                        ${type === 'font' ? `if (!this._dirtyFont) { this._dirtyFont = true; this.markDirty(this, redraw); }` : ''}
+                        ${changeCb ? 'changeCb(this);' : ''}
+                    }
+                };
+                set_${key};
+            `;
+            const getterJs = `
+                function get_${key}() {
+                    return this.${privateKey};
+                };
+                get_${key};
+            `;
+            Object.defineProperty(target, key, {
+                set: eval(setterJs),
+                get: eval(getterJs),
+                enumerable: true,
+                configurable: false,
+            });
+        }
+    }
+}
+
+export abstract class ChangeDetectable {
+    protected _dirty: RedrawType = RedrawType.MAJOR;
+
+    protected markDirty(_source: any, type = RedrawType.TRIVIAL) {
+        if (this._dirty > type) {
+            return;
+        }
+
+        this._dirty = type;
+    }
+
+    markClean(opts?: {force?: boolean, recursive?: boolean}) {
+        this._dirty = RedrawType.NONE;
+    }
+
+    isDirty(): boolean {
+        return this._dirty > RedrawType.NONE;
+    }
+}

--- a/charts-packages/ag-charts-community/src/scene/dropShadow.ts
+++ b/charts-packages/ag-charts-community/src/scene/dropShadow.ts
@@ -1,7 +1,14 @@
-export class DropShadow {
+import { ChangeDetectable, SceneChangeDetection, RedrawType } from './changeDetectable';
+
+export class DropShadow extends ChangeDetectable {
+    @SceneChangeDetection({ redraw: RedrawType.MAJOR })
     enabled = true;
+    @SceneChangeDetection({ redraw: RedrawType.MAJOR })
     color = 'rgba(0, 0, 0, 0.5)';
+    @SceneChangeDetection({ redraw: RedrawType.MAJOR })
     xOffset = 0;
+    @SceneChangeDetection({ redraw: RedrawType.MAJOR })
     yOffset = 0;
+    @SceneChangeDetection({ redraw: RedrawType.MAJOR })
     blur = 5;
 }

--- a/charts-packages/ag-charts-community/src/scene/shape/line.ts
+++ b/charts-packages/ag-charts-community/src/scene/shape/line.ts
@@ -76,6 +76,8 @@ export class Line extends Shape {
 
         this.fillStroke(ctx);
 
+        this.fillShadow?.markClean();
+        this.strokeShadow?.markClean();
         super.render(renderCtx);
     }
 }

--- a/charts-packages/ag-charts-community/src/scene/shape/path.ts
+++ b/charts-packages/ag-charts-community/src/scene/shape/path.ts
@@ -52,7 +52,9 @@ export class Path extends Shape {
             return;
         }
 
-        this.dirtyPath = this.path.isDirty();
+        this.dirtyPath = this.path.isDirty() ||
+            (this.fillShadow?.isDirty() ?? false) ||
+            (this.strokeShadow?.isDirty() ?? false);
     }
 
     /**
@@ -126,6 +128,8 @@ export class Path extends Shape {
             this.fillStroke(ctx);
         }
 
+        this.fillShadow?.markClean();
+        this.strokeShadow?.markClean();
         super.render(renderCtx);
     }
 }

--- a/charts-packages/ag-charts-community/src/scene/shape/shape.ts
+++ b/charts-packages/ag-charts-community/src/scene/shape/shape.ts
@@ -146,10 +146,10 @@ export abstract class Shape extends Node {
     })
     opacity: number = Shape.defaultStyles.opacity;
 
-    @SceneChangeDetection({ redraw: RedrawType.MINOR })
+    @SceneChangeDetection({ redraw: RedrawType.MINOR, checkDirtyOnAssignment: true })
     fillShadow: DropShadow | undefined = Shape.defaultStyles.fillShadow;
 
-    @SceneChangeDetection({ redraw: RedrawType.MINOR })
+    @SceneChangeDetection({ redraw: RedrawType.MINOR, checkDirtyOnAssignment: true })
     strokeShadow: DropShadow | undefined = Shape.defaultStyles.strokeShadow;
 
     protected fillStroke(ctx: CanvasFillStrokeStyles & CanvasCompositing & CanvasShadowStyles & CanvasPathDrawingStyles & CanvasDrawPath) {

--- a/charts-packages/ag-charts-community/src/util/json.test.ts
+++ b/charts-packages/ag-charts-community/src/util/json.test.ts
@@ -87,6 +87,18 @@ describe('json module', () => {
                 expect(diff).toBeNull();
             });
 
+            it('should correctly diff mismatching arrays', () => {
+                const source = {
+                    foo: [1, 2, 3, 4],
+                };
+                const target = {
+                    foo: [9, 8, 7, 6],
+                };
+
+                const diff = jsonDiff(source, target);
+                expect(diff).toEqual(target);
+            });
+
             it('should correctly diff function changes in arrays', () => {
                 const source = {
                     foo: [{ fn: () => 'hello-world!'}],

--- a/charts-packages/ag-charts-community/src/util/json.ts
+++ b/charts-packages/ag-charts-community/src/util/json.ts
@@ -58,6 +58,18 @@ export function jsonDiff<T extends any>(source: T, target: T, opts?: { stringify
         return null;
     }
 
+    if (targetType === 'primitive') {
+        if (sourceType !== 'primitive') {
+            return { ...target };
+        }
+
+        if (source !== target) {
+            return target;
+        }
+
+        return null;
+    }
+
     const lhs = source || {} as any;
     const rhs = target || {} as any;
 


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-6924

Fixes some edge-cases in option update change detection:
- `Series.lineDash` changes now correctly detected during factory json-diff phase.
- `Series.fillShadow` and `Series.strokeShadow` changes now correctly get detected as scene changes.
- `Series.marker` changes now correct detected and refreshed during scene selection update phase.

There maybe other cases, but we should be able to handle them following the patterns established here after we find them in testing.