### PR TITLE
Improved documentation for gridOptions and framework bindings

### DIFF
--- a/grid-packages/ag-grid-docs/documentation/doc-pages/grid-interface/_index-angular.md
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/grid-interface/_index-angular.md
@@ -64,6 +64,9 @@
 |
 | The `gridOptions` object is a 'one stop shop' for the entire interface into the grid and can be used instead of or in addition to the normal framework bindings.
 |
+| If an option is passed via the `gridOptions` and the normal framework bindings, the one from the framework binding will overwrite the setting in the `gridOptions`.
+| With this approach you can have a global `gridOptions` object that you pass to all your grids while still being able to override specific options on each individual grid.
+|
 | The example below shows the different types of items available on `gridOptions`.
 |
 | ```js

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/grid-interface/_index-react.md
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/grid-interface/_index-react.md
@@ -97,6 +97,9 @@
 | The `gridOptions` object is a 'one stop shop' for the entire interface into the grid, commonly used if using plain JavaScript.
 | Grid options can however be used instead of, or in addition to, normal framework bindings.
 |
+| If an option is passed via the `gridOptions` and the normal framework bindings, the one from the framework binding will overwrite the setting in the `gridOptions`.
+| With this approach you can have a global `gridOptions` object that you pass to all your grids while still being able to override specific options on each individual grid.
+|
 | The example below shows the different types of items available on `gridOptions`.
 |
 | ```js

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/grid-interface/_index-vue.md
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/grid-interface/_index-vue.md
@@ -67,6 +67,9 @@
 | The `gridOptions` object is a 'one stop shop' for the entire interface into the grid, commonly used if using plain JavaScript.
 | Grid options can however be used instead of, or in addition to, normal framework binding.
 |
+| If an option is passed via the `gridOptions` and the normal framework bindings, the one from the framework binding will overwrite the setting in the `gridOptions`.
+| With this approach you can have a global `gridOptions` object that you pass to all your grids while still being able to override specific options on each individual grid.
+|
 | The example below shows the different types of items available on `gridOptions`.
 |
 | ```js


### PR DESCRIPTION
Currently it's not very clear what happens if you specify an option on the gridOptions and with a framework binding
https://www.ag-grid.com/angular-data-grid/grid-interface/#grid-options-1

I took a look at the source code and it looks like (and I can also confirm this from my testing) that the values from the framework bindings will override the settings made in gridOptions
https://github.com/ag-grid/ag-grid/blob/latest/grid-packages/ag-grid-angular/projects/ag-grid-angular/src/lib/ag-grid-angular.component.ts#L204
