### PR TITLE
AG-6933 - Fix PieSeries.visible option support.

### DIFF
--- a/charts-packages/ag-charts-community/src/chart/polarChart.ts
+++ b/charts-packages/ag-charts-community/src/chart/polarChart.ts
@@ -72,7 +72,6 @@ export class PolarChart extends Chart {
                 series.centerX = centerX;
                 series.centerY = centerY;
                 series.radius = radius;
-                series.update();
             }
         });
     }

--- a/charts-packages/ag-charts-community/src/chart/series/polar/pieSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/polar/pieSeries.ts
@@ -155,7 +155,7 @@ export class PieSeries extends PolarSeries<PieNodeDatum> {
 
     set data(input: any[] | undefined) {
         this._data = input;
-        this.seriesItemEnabled = input?.map(() => true) || [];
+        this.processSeriesItemEnabled();
     }
     get data() {
         return this._data;
@@ -221,6 +221,15 @@ export class PieSeries extends PolarSeries<PieNodeDatum> {
     shadow?: DropShadow = undefined;
 
     readonly highlightStyle = new PieHighlightStyle();
+
+    visibleChanged() {
+        this.processSeriesItemEnabled();
+    }
+
+    private processSeriesItemEnabled() {
+        const { data, visible } = this;
+        this.seriesItemEnabled = data?.map(() => visible) || [];
+    }
 
     setColors(fills: string[], strokes: string[]) {
         this.fills = fills;
@@ -404,7 +413,7 @@ export class PieSeries extends PolarSeries<PieNodeDatum> {
             return;
         }
 
-        const isVisible = this.visible && this.seriesItemEnabled.indexOf(true) >= 0;
+        const isVisible = this.seriesItemEnabled.indexOf(true) >= 0;
         this.group.visible = isVisible;
         this.seriesGroup.visible = isVisible;
         this.highlightGroup.visible = isVisible && this.chart?.highlightedDatum?.series === this;
@@ -630,5 +639,6 @@ export class PieSeries extends PolarSeries<PieNodeDatum> {
 
     toggleSeriesItem(itemId: number, enabled: boolean): void {
         this.seriesItemEnabled[itemId] = enabled;
+        this.nodeDataRefresh = true;
     }
 }

--- a/charts-packages/ag-charts-community/src/chart/series/series.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/series.ts
@@ -142,7 +142,15 @@ export abstract class Series<C extends SeriesNodeDataContext = SeriesNodeDataCon
         return this._data;
     }
 
-    visible = true;
+    protected _visible = true;
+    set visible(value: boolean) {
+        this._visible = value;
+        this.visibleChanged();
+    }
+    get visible() {
+        return this._visible;
+    }
+
     showInLegend = true;
 
     cursor = 'default';
@@ -213,6 +221,10 @@ export abstract class Series<C extends SeriesNodeDataContext = SeriesNodeDataCon
     // Indicate that something external changed and we should recalculate nodeData.
     markNodeDataDirty() {
         this.nodeDataRefresh = true;
+    }
+
+    visibleChanged() {
+        // Override point for this.visible change post-processing.
     }
 
     // Produce data joins and update selection's nodes using node data.


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-6933

Improves `PieSeries.visible` support, to match with how the cartesian series works (chart rendered with series removed, legend items deselected).