### PR TITLE
AG-6932 - Add distinct marker layers

### DIFF
--- a/charts-packages/ag-charts-community/src/chart/agChartV2.ts
+++ b/charts-packages/ag-charts-community/src/chart/agChartV2.ts
@@ -117,12 +117,12 @@ export abstract class AgChart {
 }
 
 export abstract class AgChartV2 {
-    static DEBUG = windowValue('agChartsDebug') ?? false;
+    static DEBUG = () => windowValue('agChartsDebug') ?? false;
     
     static create<T extends ChartType>(userOptions: ChartOptionType<T>): T {
         debug('user options', userOptions);
         const mixinOpts: any = {};
-        if (AgChartV2.DEBUG) {
+        if (AgChartV2.DEBUG()) {
             mixinOpts['debug'] = true;
         }
 
@@ -144,7 +144,7 @@ export abstract class AgChartV2 {
     static update<T extends ChartType>(chart: Chart, userOptions: ChartOptionType<T>): void {
         debug('user options', userOptions);
         const mixinOpts: any = {};
-        if (AgChartV2.DEBUG) {
+        if (AgChartV2.DEBUG()) {
             mixinOpts['debug'] = true;
         }
 
@@ -174,7 +174,7 @@ export abstract class AgChartV2 {
 }
 
 function debug(message?: any, ...optionalParams: any[]): void {
-    if (AgChartV2.DEBUG) {
+    if (AgChartV2.DEBUG()) {
         console.log(message, ...optionalParams);
     }
 }

--- a/charts-packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
@@ -137,7 +137,7 @@ export class AreaSeries extends CartesianSeries<AreaSeriesNodeDataContext> {
     lineDashOffset: number = 0;
 
     constructor() {
-        super({ pathsPerSeries: 2, pickGroupIncludes: ['datumNodes'] });
+        super({ pathsPerSeries: 2, pickGroupIncludes: ['markers'], features: ['markers'] });
 
         const { marker, label } = this;
 
@@ -653,11 +653,11 @@ export class AreaSeries extends CartesianSeries<AreaSeriesNodeDataContext> {
         }
     }
 
-    protected updateDatumSelection(opts: {
+    protected updateMarkerSelection(opts: {
         nodeData: MarkerSelectionDatum[];
-        datumSelection: Selection<Marker, Group, MarkerSelectionDatum, any>;
+        markerSelection: Selection<Marker, Group, MarkerSelectionDatum, any>;
     }) {
-        let { nodeData, datumSelection } = opts;
+        let { nodeData, markerSelection } = opts;
         const {
             marker: { enabled, shape },
         } = this;
@@ -666,23 +666,23 @@ export class AreaSeries extends CartesianSeries<AreaSeriesNodeDataContext> {
         const MarkerShape = getMarker(shape);
 
         if (this.marker.isDirty()) {
-            datumSelection = datumSelection.setData([]);
-            datumSelection.exit.remove();
+            markerSelection = markerSelection.setData([]);
+            markerSelection.exit.remove();
         }
 
-        const updateSelection = datumSelection.setData(data);
-        updateSelection.exit.remove();
-        const enterMarkers = updateSelection.enter.append(MarkerShape).each((marker) => {
+        const updateMarkerSelection = markerSelection.setData(data);
+        updateMarkerSelection.exit.remove();
+        const enterMarkers = updateMarkerSelection.enter.append(MarkerShape).each((marker) => {
             marker.tag = AreaSeriesTag.Marker;
         });
-        return updateSelection.merge(enterMarkers);
+        return updateMarkerSelection.merge(enterMarkers);
     }
 
-    protected updateDatumNodes(opts: {
-        datumSelection: Selection<Marker, Group, MarkerSelectionDatum, any>;
+    protected updateMarkerNodes(opts: {
+        markerSelection: Selection<Marker, Group, MarkerSelectionDatum, any>;
         isHighlight: boolean;
     }) {
-        const { datumSelection, isHighlight: isDatumHighlighted } = opts;
+        const { markerSelection, isHighlight: isDatumHighlighted } = opts;
         const {
             xKey,
             marker,
@@ -705,7 +705,7 @@ export class AreaSeries extends CartesianSeries<AreaSeriesNodeDataContext> {
         const { size, formatter } = marker;
         const markerStrokeWidth = marker.strokeWidth !== undefined ? marker.strokeWidth : this.strokeWidth;
 
-        datumSelection.each((node, datum) => {
+        markerSelection.each((node, datum) => {
             const yKeyIndex = yKeys.indexOf(datum.yKey);
             const fill =
                 isDatumHighlighted && highlightedFill !== undefined

--- a/charts-packages/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
@@ -27,14 +27,18 @@ interface SubGroup<C extends SeriesNodeDataContext, SceneNodeType extends Node> 
     paths: Path[];
     group: Group;
     pickGroup: Group;
+    markerGroup?: Group;
     datumSelection: NodeDataSelection<SceneNodeType, C>;
     labelSelection: LabelDataSelection<Text, C>;
+    markerSelection?: NodeDataSelection<Marker, C>;
 }
 
-type PickGroupInclude = 'mainPath' | 'datumNodes';
+type PickGroupInclude = 'mainPath' | 'datumNodes' | 'markers';
+type SeriesFeature = 'markers';
 interface SeriesOpts {
     pickGroupIncludes: PickGroupInclude[];
     pathsPerSeries: number;
+    features: SeriesFeature[];
 }
 
 export abstract class CartesianSeries<
@@ -59,8 +63,12 @@ export abstract class CartesianSeries<
     protected constructor(opts: Partial<SeriesOpts> = {}) {
         super({ seriesGroupUsesLayer: false });
 
-        const { pickGroupIncludes = ['datumNodes'] as PickGroupInclude[], pathsPerSeries = 1 } = opts;
-        this.opts = { pickGroupIncludes, pathsPerSeries };
+        const {
+            pickGroupIncludes = ['datumNodes'] as PickGroupInclude[],
+            pathsPerSeries = 1,
+            features = [],
+        } = opts;
+        this.opts = { pickGroupIncludes, pathsPerSeries, features };
     }
 
     directionKeys: { [key in ChartAxisDirection]?: string[] } = {
@@ -139,13 +147,16 @@ export abstract class CartesianSeries<
         }
 
         this.subGroups.forEach((subGroup, seriesIdx) => {
-            const { datumSelection, labelSelection, paths } = subGroup;
+            const { datumSelection, labelSelection, markerSelection, paths } = subGroup;
             const contextData = this.contextNodeData[seriesIdx];
             const { nodeData, labelData, itemId } = contextData;
 
             this.updatePaths({ seriesHighlighted, itemId, contextData, paths, seriesIdx });
             subGroup.datumSelection = this.updateDatumSelection({ nodeData, datumSelection, seriesIdx });
             subGroup.labelSelection = this.updateLabelSelection({ labelData, labelSelection, seriesIdx });
+            if (markerSelection) {
+                subGroup.markerSelection = this.updateMarkerSelection({ nodeData, markerSelection, seriesIdx })
+            }
         });
     }
 
@@ -153,14 +164,20 @@ export abstract class CartesianSeries<
         const {
             contextNodeData,
             subGroups,
-            opts: { pickGroupIncludes, pathsPerSeries },
+            opts: { pickGroupIncludes, pathsPerSeries, features },
         } = this;
         if (contextNodeData.length === subGroups.length) {
             return;
         }
 
         if (contextNodeData.length < subGroups.length) {
-            subGroups.splice(contextNodeData.length).forEach((group) => this.seriesGroup.removeChild(group.group));
+            subGroups.splice(contextNodeData.length)
+                .forEach(({group, markerGroup}) => {
+                    this.seriesGroup.removeChild(group);
+                    if (markerGroup) {
+                        this.seriesGroup.removeChild(markerGroup);
+                    }
+                });
         }
 
         while (contextNodeData.length > subGroups.length) {
@@ -169,49 +186,81 @@ export abstract class CartesianSeries<
                 layer: true,
                 zIndex: Series.SERIES_LAYER_ZINDEX,
             });
-            this.seriesGroup.appendChild(group);
+            const markerGroup = features.includes('markers') ? 
+                new Group({
+                    name: `${this.id}-series-sub${this.subGroupId++}-markers`,
+                    layer: true,
+                    zIndex: Series.SERIES_MARKER_LAYER_ZINDEX,
+                }) :
+                undefined;
             const pickGroup = new Group();
 
-            const paths: Path[] = [];
             const pathParentGroup = pickGroupIncludes.includes('mainPath') ? pickGroup : group;
+            const datumParentGroup = pickGroupIncludes.includes('datumNodes') ? pickGroup : group;
+
+            this.seriesGroup.appendChild(group);
+            if (markerGroup) {
+                this.seriesGroup.appendChild(markerGroup);
+            }
+
+            const paths: Path[] = [];
             for (let index = 0; index < pathsPerSeries; index++) {
                 paths[index] = new Path();
                 pathParentGroup.appendChild(paths[index]);
             }
             group.appendChild(pickGroup);
 
-            const datumParentGroup = pickGroupIncludes.includes('datumNodes') ? pickGroup : group;
             subGroups.push({
                 paths,
                 group,
                 pickGroup,
+                markerGroup,
                 labelSelection: Selection.select(group).selectAll<Text>(),
                 datumSelection: Selection.select(datumParentGroup).selectAll<N>(),
+                markerSelection: markerGroup ? Selection.select(markerGroup).selectAll<Marker>() : undefined,
             });
         }
     }
 
     protected updateNodes(seriesHighlighted?: boolean) {
-        const { highlightSelection, contextNodeData } = this;
+        const { highlightSelection, contextNodeData, seriesItemEnabled, opts: { features } } = this;
+        const markersEnabled = features.includes('markers');
 
-        const visible = this.visible && this.contextNodeData.length > 0;
+        const anySeriesItemEnabled = seriesItemEnabled.size === 0 || [...seriesItemEnabled.values()].some(v => v === true);
+        const visible = this.visible && this.contextNodeData.length > 0 && anySeriesItemEnabled;
         this.group.visible = visible;
         this.seriesGroup.visible = visible;
         this.highlightGroup.visible = visible && !!seriesHighlighted;
         this.seriesGroup.opacity = this.getOpacity();
 
-        this.updateDatumNodes({ datumSelection: highlightSelection, isHighlight: true, seriesIdx: -1 });
+        if (markersEnabled) {
+            this.updateMarkerNodes({ markerSelection: (highlightSelection as any), isHighlight: true, seriesIdx: -1 });
+        } else {
+            this.updateDatumNodes({ datumSelection: highlightSelection, isHighlight: true, seriesIdx: -1 });
+        }
 
         this.subGroups.forEach((subGroup, seriesIdx) => {
-            const { group, datumSelection, labelSelection, paths } = subGroup;
+            const { group, markerGroup, datumSelection, labelSelection, markerSelection, paths } = subGroup;
             const { itemId } = contextNodeData[seriesIdx];
             group.opacity = this.getOpacity({ itemId });
             group.zIndex = this.getZIndex({ itemId });
             group.visible = visible && (this.seriesItemEnabled.get(itemId) ?? true);
+            if (markerGroup) {
+                markerGroup.opacity = group.opacity;
+                markerGroup.zIndex = group.zIndex + (Series.SERIES_MARKER_LAYER_ZINDEX - Series.SERIES_LAYER_ZINDEX);
+                markerGroup.visible = group.visible;
+            }
+
+            if (!group.visible) {
+                return;
+            }
 
             this.updatePathNodes({ seriesHighlighted, itemId, paths, seriesIdx });
-            this.updateDatumNodes({ datumSelection: datumSelection, isHighlight: false, seriesIdx });
-            this.updateLabelNodes({ labelSelection: labelSelection, seriesIdx });
+            this.updateDatumNodes({ datumSelection, isHighlight: false, seriesIdx });
+            this.updateLabelNodes({ labelSelection, seriesIdx });
+            if (markersEnabled && markerSelection) {
+                this.updateMarkerNodes({ markerSelection, isHighlight: false, seriesIdx });
+            }
         });
     }
 
@@ -230,8 +279,15 @@ export abstract class CartesianSeries<
         let result = super.pickNode(x, y);
 
         if (!result) {
-            for (const { pickGroup } of this.subGroups) {
+            const { opts: { pickGroupIncludes } } = this;
+            const markerGroupIncluded = pickGroupIncludes.includes('markers');
+
+            for (const { pickGroup, markerGroup } of this.subGroups) {
                 result = pickGroup.pickNode(x, y);
+
+                if (!result && markerGroupIncluded) {
+                    result = markerGroup?.pickNode(x, y);
+                }
 
                 if (result) {
                     break;
@@ -280,22 +336,51 @@ export abstract class CartesianSeries<
         item?: C['nodeData'][number];
         highlightSelection: NodeDataSelection<N, C>;
     }): NodeDataSelection<N, C> {
-        const { item, highlightSelection: datumSelection } = opts;
+        const { opts: { features } } = this;
+        const markersEnabled = features.includes('markers');
+
+        const { item, highlightSelection } = opts;
         const nodeData = item ? [item] : [];
 
-        return this.updateDatumSelection({ nodeData, datumSelection, seriesIdx: -1 });
+        if (markersEnabled) {
+            const markerSelection = highlightSelection as any;
+            return this.updateMarkerSelection({ nodeData, markerSelection, seriesIdx: -1 }) as any;
+        } else {
+            return this.updateDatumSelection({ nodeData, datumSelection: highlightSelection, seriesIdx: -1 });
+        }
     }
 
-    protected abstract updateDatumSelection(opts: {
+    protected updateDatumSelection(opts: {
         nodeData: C['nodeData'];
         datumSelection: NodeDataSelection<N, C>;
         seriesIdx: number;
-    }): NodeDataSelection<N, C>;
-    protected abstract updateDatumNodes(opts: {
+    }): NodeDataSelection<N, C> {
+        // Override point for sub-classes.
+        return opts.datumSelection;
+    }
+    protected updateDatumNodes(opts: {
         datumSelection: NodeDataSelection<N, C>;
         isHighlight: boolean;
         seriesIdx: number;
-    }): void;
+    }): void {
+        // Override point for sub-classes.
+    }
+
+    protected updateMarkerSelection(opts: {
+        nodeData: C['nodeData'];
+        markerSelection: NodeDataSelection<Marker, C>;
+        seriesIdx: number;
+    }): NodeDataSelection<Marker, C> {
+        // Override point for sub-classes.
+        return opts.markerSelection;
+    }
+    protected updateMarkerNodes(opts: {
+        markerSelection: NodeDataSelection<Marker, C>;
+        isHighlight: boolean;
+        seriesIdx: number;
+    }): void {
+        // Override point for sub-classes.
+    }
 
     protected abstract updateLabelSelection(opts: {
         labelData: C['labelData'];

--- a/charts-packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
@@ -82,7 +82,7 @@ export class LineSeries extends CartesianSeries<LineContext> {
     tooltip: LineSeriesTooltip = new LineSeriesTooltip();
 
     constructor() {
-        super({ pickGroupIncludes: ['datumNodes'] });
+        super({ pickGroupIncludes: ['markers'], features: ['markers'] });
 
         const { marker, label } = this;
 
@@ -292,11 +292,11 @@ export class LineSeries extends CartesianSeries<LineContext> {
         lineNode.lineDashOffset = this.lineDashOffset;
     }
 
-    protected updateDatumSelection(opts: {
+    protected updateMarkerSelection(opts: {
         nodeData: LineNodeDatum[];
-        datumSelection: Selection<Marker, Group, LineNodeDatum, any>;
+        markerSelection: Selection<Marker, Group, LineNodeDatum, any>;
     }): Selection<Marker, Group, LineNodeDatum, any> {
-        let { nodeData, datumSelection } = opts;
+        let { nodeData, markerSelection } = opts;
         const {
             marker: { shape, enabled },
         } = this;
@@ -304,21 +304,21 @@ export class LineSeries extends CartesianSeries<LineContext> {
         const MarkerShape = getMarker(shape);
 
         if (this.marker.isDirty()) {
-            datumSelection = datumSelection.setData([]);
-            datumSelection.exit.remove();
+            markerSelection = markerSelection.setData([]);
+            markerSelection.exit.remove();
         }
 
-        const updateDatumSelection = datumSelection.setData(nodeData);
-        updateDatumSelection.exit.remove();
-        const enterDatumSelection = updateDatumSelection.enter.append(MarkerShape);
-        return updateDatumSelection.merge(enterDatumSelection);
+        const updateMarkerSelection = markerSelection.setData(nodeData);
+        updateMarkerSelection.exit.remove();
+        const enterDatumSelection = updateMarkerSelection.enter.append(MarkerShape);
+        return updateMarkerSelection.merge(enterDatumSelection);
     }
 
-    protected updateDatumNodes(opts: {
-        datumSelection: Selection<Marker, Group, LineNodeDatum, any>;
+    protected updateMarkerNodes(opts: {
+        markerSelection: Selection<Marker, Group, LineNodeDatum, any>;
         isHighlight: boolean;
     }) {
-        const { datumSelection, isHighlight: isDatumHighlighted } = opts;
+        const { markerSelection, isHighlight: isDatumHighlighted } = opts;
         const {
             marker,
             xKey,
@@ -338,7 +338,7 @@ export class LineSeries extends CartesianSeries<LineContext> {
         const { size, formatter } = marker;
         const markerStrokeWidth = marker.strokeWidth !== undefined ? marker.strokeWidth : this.strokeWidth;
 
-        datumSelection.each((node, datum) => {
+        markerSelection.each((node, datum) => {
             const fill = isDatumHighlighted && highlightedFill !== undefined ? highlightedFill : marker.fill;
             const stroke =
                 isDatumHighlighted && highlightedStroke !== undefined ? highlightedStroke : marker.stroke || lineStroke;

--- a/charts-packages/ag-charts-community/src/chart/series/cartesian/scatterSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/cartesian/scatterSeries.ts
@@ -127,7 +127,7 @@ export class ScatterSeries extends CartesianSeries<SeriesNodeDataContext<Scatter
     readonly tooltip: ScatterSeriesTooltip = new ScatterSeriesTooltip();
 
     constructor() {
-        super({ pickGroupIncludes: ['datumNodes'], pathsPerSeries: 0 });
+        super({ pickGroupIncludes: ['markers'], pathsPerSeries: 0, features: ['markers'] });
 
         const { label } = this;
 
@@ -257,33 +257,33 @@ export class ScatterSeries extends CartesianSeries<SeriesNodeDataContext<Scatter
         return this.marker.isDirty();
     }
 
-    protected updateDatumSelection(opts: {
+    protected updateMarkerSelection(opts: {
         nodeData: ScatterNodeDatum[];
-        datumSelection: Selection<Marker, Group, ScatterNodeDatum, any>;
+        markerSelection: Selection<Marker, Group, ScatterNodeDatum, any>;
     }): Selection<Marker, Group, ScatterNodeDatum, any> {
-        let { nodeData, datumSelection } = opts;
+        let { nodeData, markerSelection } = opts;
         const {
             marker: { enabled, shape },
         } = this;
         const MarkerShape = getMarker(shape);
 
         if (this.marker.isDirty()) {
-            datumSelection = datumSelection.setData([]);
-            datumSelection.exit.remove();
+            markerSelection = markerSelection.setData([]);
+            markerSelection.exit.remove();
         }
 
         const data = enabled ? nodeData : [];
-        const updateDatums = datumSelection.setData(data);
-        updateDatums.exit.remove();
-        const enterDatums = updateDatums.enter.append(MarkerShape);
-        return updateDatums.merge(enterDatums);
+        const updateMarkers = markerSelection.setData(data);
+        updateMarkers.exit.remove();
+        const enterMarkers = updateMarkers.enter.append(MarkerShape);
+        return updateMarkers.merge(enterMarkers);
     }
 
-    protected updateDatumNodes(opts: {
-        datumSelection: Selection<Marker, Group, ScatterNodeDatum, any>;
+    protected updateMarkerNodes(opts: {
+        markerSelection: Selection<Marker, Group, ScatterNodeDatum, any>;
         isHighlight: boolean;
     }): void {
-        const { datumSelection, isHighlight: isDatumHighlighted } = opts;
+        const { markerSelection, isHighlight: isDatumHighlighted } = opts;
         const {
             marker,
             xKey,
@@ -294,7 +294,6 @@ export class ScatterSeries extends CartesianSeries<SeriesNodeDataContext<Scatter
             fill: seriesFill,
             stroke: seriesStroke,
             sizeScale,
-            sizeData,
             highlightStyle: {
                 fill: deprecatedFill,
                 stroke: deprecatedStroke,
@@ -311,7 +310,7 @@ export class ScatterSeries extends CartesianSeries<SeriesNodeDataContext<Scatter
 
         sizeScale.range = [marker.size, marker.maxSize];
 
-        datumSelection.each((node, datum) => {
+        markerSelection.each((node, datum) => {
             const fill =
                 isDatumHighlighted && highlightedFill !== undefined ? highlightedFill : marker.fill || seriesFill;
             const stroke =

--- a/charts-packages/ag-charts-community/src/chart/series/series.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/series.ts
@@ -96,6 +96,7 @@ export type SeriesNodeDataContext<S = SeriesNodeDatum, L = S> = {
 export abstract class Series<C extends SeriesNodeDataContext = SeriesNodeDataContext> extends Observable {
     protected static readonly highlightedZIndex = 1000000000000;
     protected static readonly SERIES_LAYER_ZINDEX = 100;
+    protected static readonly SERIES_MARKER_LAYER_ZINDEX = 110;
     protected static readonly SERIES_HIGHLIGHT_LAYER_ZINDEX = 150;
 
     readonly id = createId(this);

--- a/charts-packages/ag-charts-community/src/scene/node.ts
+++ b/charts-packages/ag-charts-community/src/scene/node.ts
@@ -500,7 +500,7 @@ export abstract class Node extends ChangeDetectable { // Don't confuse with `win
     protected dirtyZIndex: boolean = false;
 
     @SceneChangeDetection({
-        redraw: RedrawType.MINOR,
+        redraw: RedrawType.TRIVIAL,
         changeCb: (o) => {
             if (o.parent) {
                 o.parent.dirtyZIndex = true;


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-6932

Fixes z-ordering issues with markers overlapping series paths / datum (line/area, bar/column/histogram respectively) by moving markers to their own layers with z-index set to render them always in-front of the main series rendering.

Bonus:
- Fixes some recent performance regressions introduced by:
  - #5302 due to z-index changes not being considered a lightweight rendering change (was forcing re-render of entire series on z-index change, rather than just layers being reordered).
  - Also attempts to short-circuit node-data refresh and node update if the series (or it's sub-series) aren't visible.
- Fixes dynamic pickup of `window.agChartsDebug` flag to assist with debugging.

Before:
![Screenshot 2022-06-28 at 12 38 18](https://user-images.githubusercontent.com/17544187/176422974-3bdd763b-c7f4-4483-b4d2-c42fa18dc526.png)

After:
![Screenshot 2022-06-29 at 12 09 54](https://user-images.githubusercontent.com/17544187/176423001-9b09a38d-ca61-48e3-9e8d-e56893c87b01.png)

