### PR TITLE
AG-6939 - Fix chart deprecations warnings.

### DIFF
--- a/charts-packages/ag-charts-community/src/chart/agChartOptions.ts
+++ b/charts-packages/ag-charts-community/src/chart/agChartOptions.ts
@@ -667,10 +667,14 @@ export interface AgSeriesMarker {
     maxSize?: PixelSize;
     /** The colour to use for marker fills. If this is not specified, the markers will take their fill from the series. */
     fill?: CssColor;
+    /** Opacity of the marker fills. */
+    fillOpacity?: Opacity;
     /** The colour to use for marker strokes. If this is not specified, the markers will take their stroke from the series. */
     stroke?: CssColor;
     /** The width in pixels of the marker stroke. If this is not specified, the markers will take their stroke width from the series. */
     strokeWidth?: PixelSize;
+    /** Opacity of the marker strokes. */
+    strokeOpacity?: Opacity;
 }
 
 export interface AgSeriesMarkerFormatterParams {

--- a/charts-packages/ag-charts-community/src/chart/mapping/__snapshots__/prepare.test.ts.snap
+++ b/charts-packages/ag-charts-community/src/chart/mapping/__snapshots__/prepare.test.ts.snap
@@ -1771,8 +1771,6 @@ Object {
   "series": Array [
     Object {
       "cursor": "default",
-      "fill": "#f3622d",
-      "fillOpacity": 0.7,
       "highlightStyle": Object {
         "item": Object {
           "fill": "yellow",
@@ -1794,19 +1792,18 @@ Object {
       "marker": Object {
         "enabled": true,
         "fill": "#f3622d",
+        "fillOpacity": 0.7,
         "formatter": [Function],
         "maxSize": 100,
         "shape": "circle",
         "size": 5,
         "stroke": "#aa4520",
+        "strokeOpacity": 0.7,
         "strokeWidth": 0,
       },
       "showInLegend": true,
       "sizeKey": "magnitude",
       "sizeName": "Magnitude",
-      "stroke": "#f3622d",
-      "strokeOpacity": 1,
-      "strokeWidth": 2,
       "title": undefined,
       "tooltip": Object {
         "enabled": true,
@@ -3451,8 +3448,6 @@ Object {
   "series": Array [
     Object {
       "cursor": "default",
-      "fill": "#f3622d",
-      "fillOpacity": 0.85,
       "highlightStyle": Object {
         "item": Object {
           "fill": "yellow",
@@ -3474,19 +3469,18 @@ Object {
       "marker": Object {
         "enabled": true,
         "fill": "#cc5b58",
+        "fillOpacity": 0.85,
         "formatter": undefined,
         "maxSize": 30,
         "shape": "circle",
         "size": 0,
         "stroke": "#aa4520",
+        "strokeOpacity": 0.85,
         "strokeWidth": 1,
       },
       "showInLegend": true,
       "sizeKey": "size",
       "sizeName": "Commits",
-      "stroke": "#f3622d",
-      "strokeOpacity": 1,
-      "strokeWidth": 2,
       "title": "Punch Card",
       "tooltip": Object {
         "enabled": true,
@@ -3691,8 +3685,6 @@ Object {
   "series": Array [
     Object {
       "cursor": "default",
-      "fill": "#f3622d",
-      "fillOpacity": 0.5,
       "highlightStyle": Object {
         "item": Object {
           "fill": "yellow",
@@ -3714,19 +3706,18 @@ Object {
       "marker": Object {
         "enabled": true,
         "fill": "#f3622d",
+        "fillOpacity": 0.5,
         "formatter": undefined,
         "maxSize": 100,
         "shape": "circle",
         "size": 5,
         "stroke": "#aa4520",
+        "strokeOpacity": 0.5,
         "strokeWidth": 1,
       },
       "showInLegend": true,
       "sizeKey": "population",
       "sizeName": "Population",
-      "stroke": "#f3622d",
-      "strokeOpacity": 1,
-      "strokeWidth": 2,
       "title": "Most populous cities",
       "tooltip": Object {
         "enabled": true,
@@ -4491,11 +4482,11 @@ Object {
       "highlightStyle": Object {
         "item": Object {
           "fill": "yellow",
+          "strokeWidth": 1,
         },
         "series": Object {
           "dimOpacity": 1,
         },
-        "strokeWidth": 1,
       },
       "label": Object {
         "color": "rgb(70, 70, 70)",
@@ -4587,7 +4578,9 @@ Object {
       "column": Object {
         "series": Object {
           "highlightStyle": Object {
-            "strokeWidth": 1,
+            "item": Object {
+              "strokeWidth": 1,
+            },
           },
           "strokeWidth": 0,
         },
@@ -8860,8 +8853,6 @@ Object {
   "series": Array [
     Object {
       "cursor": "default",
-      "fill": "#f3622d",
-      "fillOpacity": 0.5,
       "highlightStyle": Object {
         "item": Object {
           "fill": "yellow",
@@ -8883,19 +8874,18 @@ Object {
       "marker": Object {
         "enabled": true,
         "fill": "#002D72",
+        "fillOpacity": 1,
         "formatter": undefined,
         "maxSize": 30,
         "shape": "circle",
         "size": 12,
         "stroke": "#aa4520",
+        "strokeOpacity": 1,
         "strokeWidth": 1,
       },
       "showInLegend": true,
       "sizeKey": undefined,
       "sizeName": "Size",
-      "stroke": "#f3622d",
-      "strokeOpacity": 0,
-      "strokeWidth": 2,
       "title": undefined,
       "tooltip": Object {
         "enabled": true,

--- a/charts-packages/ag-charts-community/src/chart/mapping/prepare.ts
+++ b/charts-packages/ag-charts-community/src/chart/mapping/prepare.ts
@@ -221,8 +221,11 @@ function calculateSeriesPalette<T extends SeriesOptionsTypes>(context: Preparati
             paletteOptions.stroke = takeColours(context, strokes, 1)[0];
             break;
         case 'scatter':
-            paletteOptions.fill = takeColours(context, fills, 1)[0];
-            // fall-through - only fills varies for `scatter`.
+            paletteOptions.marker = {
+                stroke: takeColours(context, strokes, 1)[0],
+                fill: takeColours(context, fills, 1)[0],
+            };
+            break;
         case 'line':
             paletteOptions.stroke = takeColours(context, fills, 1)[0];
             paletteOptions.marker = {

--- a/charts-packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
@@ -690,6 +690,8 @@ export class AreaSeries extends CartesianSeries<AreaSeriesNodeDataContext> {
             yKeys,
             fills,
             strokes,
+            fillOpacity,
+            strokeOpacity,
             highlightStyle: {
                 fill: deprecatedFill,
                 stroke: deprecatedStroke,
@@ -737,6 +739,8 @@ export class AreaSeries extends CartesianSeries<AreaSeriesNodeDataContext> {
             node.fill = (format && format.fill) || fill;
             node.stroke = (format && format.stroke) || stroke;
             node.strokeWidth = format && format.strokeWidth !== undefined ? format.strokeWidth : strokeWidth;
+            node.fillOpacity = marker.fillOpacity ?? fillOpacity ?? 1;
+            node.strokeOpacity = marker.strokeOpacity ?? strokeOpacity ?? 1;
             node.size = format && format.size !== undefined ? format.size : size;
 
             node.translationX = datum.point.x;
@@ -908,8 +912,8 @@ export class AreaSeries extends CartesianSeries<AreaSeriesNodeDataContext> {
                         shape: marker.shape,
                         fill: marker.fill || fills[index % fills.length],
                         stroke: marker.stroke || strokes[index % strokes.length],
-                        fillOpacity,
-                        strokeOpacity,
+                        fillOpacity: marker.fillOpacity ?? fillOpacity,
+                        strokeOpacity: marker.strokeOpacity ?? strokeOpacity,
                     },
                 });
             });

--- a/charts-packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
@@ -324,6 +324,7 @@ export class LineSeries extends CartesianSeries<LineContext> {
             xKey,
             yKey,
             stroke: lineStroke,
+            strokeOpacity,
             highlightStyle: {
                 fill: deprecatedFill,
                 stroke: deprecatedStroke,
@@ -364,6 +365,8 @@ export class LineSeries extends CartesianSeries<LineContext> {
             node.fill = (format && format.fill) || fill;
             node.stroke = (format && format.stroke) || stroke;
             node.strokeWidth = format && format.strokeWidth !== undefined ? format.strokeWidth : strokeWidth;
+            node.fillOpacity = marker.fillOpacity ?? 1;
+            node.strokeOpacity = marker.strokeOpacity ?? strokeOpacity ?? 1;
             node.size = format && format.size !== undefined ? format.size : size;
 
             node.translationX = datum.point.x;
@@ -514,8 +517,8 @@ export class LineSeries extends CartesianSeries<LineContext> {
                     shape: marker.shape,
                     fill: marker.fill || 'rgba(0, 0, 0, 0)',
                     stroke: marker.stroke || stroke || 'rgba(0, 0, 0, 0)',
-                    fillOpacity: 1,
-                    strokeOpacity,
+                    fillOpacity: marker.fillOpacity ?? 1,
+                    strokeOpacity: marker.strokeOpacity ?? strokeOpacity ?? 1,
                 },
             });
         }

--- a/charts-packages/ag-charts-community/src/chart/series/cartesian/scatterSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/cartesian/scatterSeries.ts
@@ -69,30 +69,30 @@ export class ScatterSeries extends CartesianSeries<SeriesNodeDataContext<Scatter
     /**
      * @deprecated Use {@link marker.fill} instead.
      */
-     @Deprecated('Use marker.fill instead.')
+     @Deprecated('Use marker.fill instead.', { default: '#c16068' })
      fill: string | undefined = '#c16068';
 
     /**
      * @deprecated Use {@link marker.stroke} instead.
      */
-     @Deprecated('Use marker.stroke instead.')
+     @Deprecated('Use marker.stroke instead.', { default: '#874349' })
      stroke: string | undefined = '#874349';
 
     /**
      * @deprecated Use {@link marker.strokeWidth} instead.
      */
-     @Deprecated('Use marker.strokeWidth instead.')
+     @Deprecated('Use marker.strokeWidth instead.', { default: 2 })
     strokeWidth: number = 2;
     /**
      * @deprecated Use {@link marker.fillOpacity} instead.
      */
-     @Deprecated('Use marker.fillOpacity instead.')
+     @Deprecated('Use marker.fillOpacity instead.', { default: 1 })
     fillOpacity: number = 1;
 
     /**
      * @deprecated Use {@link marker.strokeOpacity} instead.
      */
-     @Deprecated('Use marker.strokeOpacity instead.')
+     @Deprecated('Use marker.strokeOpacity instead.', { default: 1 })
     strokeOpacity: number = 1;
 
     title?: string = undefined;

--- a/charts-packages/ag-charts-community/src/chart/series/cartesian/scatterSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/cartesian/scatterSeries.ts
@@ -141,8 +141,6 @@ export class ScatterSeries extends CartesianSeries<SeriesNodeDataContext<Scatter
     }
 
     setColors(fills: string[], strokes: string[]) {
-        this.fill = fills[0];
-        this.stroke = strokes[0];
         this.marker.fill = fills[0];
         this.marker.stroke = strokes[0];
     }

--- a/charts-packages/ag-charts-community/src/chart/themes/chartTheme.ts
+++ b/charts-packages/ag-charts-community/src/chart/themes/chartTheme.ts
@@ -311,11 +311,11 @@ export class ChartTheme {
                 yName: '',
                 sizeName: 'Size',
                 labelName: 'Label',
-                strokeWidth: 2,
-                fillOpacity: 1,
-                strokeOpacity: 1,
-                    marker: {
-                    ...ChartTheme.getCartesianSeriesMarkerDefaults()
+                marker: {
+                    ...ChartTheme.getCartesianSeriesMarkerDefaults(),
+                    strokeWidth: 1,
+                    fillOpacity: 1,
+                    strokeOpacity: 1,
                 },
                 label: {
                     enabled: false,
@@ -345,7 +345,7 @@ export class ChartTheme {
                     yOffset: 3,
                     blur: 5
                 },
-                    marker: {
+                marker: {
                     ...ChartTheme.getCartesianSeriesMarkerDefaults(),
                     enabled: false
                 },

--- a/charts-packages/ag-charts-community/src/util/validation.ts
+++ b/charts-packages/ag-charts-community/src/util/validation.ts
@@ -44,8 +44,9 @@ const FONT_WEIGHTS = ['normal', 'bold', 'bolder', 'lighter', '100', '200', '300'
 export const OPT_FONT_STYLE = (v: any) => v === undefined || v === 'normal' || v === 'italic' || v === 'oblique';
 export const OPT_FONT_WEIGHT = (v: any) => v === undefined || FONT_WEIGHTS.includes(v);
 
-export function Deprecated(message?: string) {
-    let logged = true;
+export function Deprecated(message?: string, opts?: { default: any }) {
+    let logged = false;
+    const { default: def = undefined} = opts ?? {};
 
     return function (target: any, key: any) {
         // `target` is either a constructor (static member) or prototype (instance member)
@@ -53,7 +54,7 @@ export function Deprecated(message?: string) {
 
         if (!target[key]) {
             const setter = function(v: any) {
-                if (!logged) {
+                if (v !== def && !logged) {
                     const msg = [
                         `AG Charts - Property [${target.constructor?.name ?? target.className}.${key}] is deprecated.`,
                         message,

--- a/community-modules/core/src/ts/interfaces/iAgChartOptions.ts
+++ b/community-modules/core/src/ts/interfaces/iAgChartOptions.ts
@@ -667,10 +667,14 @@ export interface AgSeriesMarker {
     maxSize?: PixelSize;
     /** The colour to use for marker fills. If this is not specified, the markers will take their fill from the series. */
     fill?: CssColor;
+    /** Opacity of the marker fills. */
+    fillOpacity?: Opacity;
     /** The colour to use for marker strokes. If this is not specified, the markers will take their stroke from the series. */
     stroke?: CssColor;
     /** The width in pixels of the marker stroke. If this is not specified, the markers will take their stroke width from the series. */
     strokeWidth?: PixelSize;
+    /** Opacity of the marker strokes. */
+    strokeOpacity?: Opacity;
 }
 
 export interface AgSeriesMarkerFormatterParams {

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/doc-interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/doc-interfaces.AUTO.json
@@ -1642,6 +1642,10 @@
       "description": "/** The colour to use for marker fills. If this is not specified, the markers will take their fill from the series. */",
       "type": { "returnType": "CssColor", "optional": true }
     },
+    "fillOpacity": {
+      "description": "/** Opacity of the marker fills. */",
+      "type": { "returnType": "Opacity", "optional": true }
+    },
     "stroke": {
       "description": "/** The colour to use for marker strokes. If this is not specified, the markers will take their stroke from the series. */",
       "type": { "returnType": "CssColor", "optional": true }
@@ -1649,6 +1653,10 @@
     "strokeWidth": {
       "description": "/** The width in pixels of the marker stroke. If this is not specified, the markers will take their stroke width from the series. */",
       "type": { "returnType": "PixelSize", "optional": true }
+    },
+    "strokeOpacity": {
+      "description": "/** Opacity of the marker strokes. */",
+      "type": { "returnType": "Opacity", "optional": true }
     }
   },
   "AgSeriesMarkerFormatterParams": {
@@ -1704,6 +1712,10 @@
       "description": "/** The colour to use for marker fills. If this is not specified, the markers will take their fill from the series. */",
       "type": { "returnType": "CssColor", "optional": true }
     },
+    "fillOpacity": {
+      "description": "/** Opacity of the marker fills. */",
+      "type": { "returnType": "Opacity", "optional": true }
+    },
     "stroke": {
       "description": "/** The colour to use for marker strokes. If this is not specified, the markers will take their stroke from the series. */",
       "type": { "returnType": "CssColor", "optional": true }
@@ -1711,6 +1723,10 @@
     "strokeWidth": {
       "description": "/** The width in pixels of the marker stroke. If this is not specified, the markers will take their stroke width from the series. */",
       "type": { "returnType": "PixelSize", "optional": true }
+    },
+    "strokeOpacity": {
+      "description": "/** Opacity of the marker strokes. */",
+      "type": { "returnType": "Opacity", "optional": true }
     }
   },
   "AgAreaSeriesMarker": {
@@ -1741,6 +1757,10 @@
       "description": "/** The colour to use for marker fills. If this is not specified, the markers will take their fill from the series. */",
       "type": { "returnType": "CssColor", "optional": true }
     },
+    "fillOpacity": {
+      "description": "/** Opacity of the marker fills. */",
+      "type": { "returnType": "Opacity", "optional": true }
+    },
     "stroke": {
       "description": "/** The colour to use for marker strokes. If this is not specified, the markers will take their stroke from the series. */",
       "type": { "returnType": "CssColor", "optional": true }
@@ -1748,6 +1768,10 @@
     "strokeWidth": {
       "description": "/** The width in pixels of the marker stroke. If this is not specified, the markers will take their stroke width from the series. */",
       "type": { "returnType": "PixelSize", "optional": true }
+    },
+    "strokeOpacity": {
+      "description": "/** Opacity of the marker strokes. */",
+      "type": { "returnType": "Opacity", "optional": true }
     }
   },
   "AgSeriesTooltip": {

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
@@ -1131,8 +1131,10 @@
       "size?": "PixelSize",
       "maxSize?": "PixelSize",
       "fill?": "CssColor",
+      "fillOpacity?": "Opacity",
       "stroke?": "CssColor",
-      "strokeWidth?": "PixelSize"
+      "strokeWidth?": "PixelSize",
+      "strokeOpacity?": "Opacity"
     },
     "docs": {
       "enabled?": "/** Whether or not to show markers. */",
@@ -1140,8 +1142,10 @@
       "size?": "/** The size in pixels of the markers. */",
       "maxSize?": "/** For series where the size of the marker is determined by the data, this determines the largest size a marker can be in pixels. */",
       "fill?": "/** The colour to use for marker fills. If this is not specified, the markers will take their fill from the series. */",
+      "fillOpacity?": "/** Opacity of the marker fills. */",
       "stroke?": "/** The colour to use for marker strokes. If this is not specified, the markers will take their stroke from the series. */",
-      "strokeWidth?": "/** The width in pixels of the marker stroke. If this is not specified, the markers will take their stroke width from the series. */"
+      "strokeWidth?": "/** The width in pixels of the marker stroke. If this is not specified, the markers will take their stroke width from the series. */",
+      "strokeOpacity?": "/** Opacity of the marker strokes. */"
     }
   },
   "AgSeriesMarkerFormatterParams": {
@@ -1190,8 +1194,10 @@
       "size?": "PixelSize",
       "maxSize?": "PixelSize",
       "fill?": "CssColor",
+      "fillOpacity?": "Opacity",
       "stroke?": "CssColor",
-      "strokeWidth?": "PixelSize"
+      "strokeWidth?": "PixelSize",
+      "strokeOpacity?": "Opacity"
     },
     "docs": {
       "formatter?": "/** Function used to return formatting for individual markers, based on the supplied information. If the current marker is highlighted, the `highlighted` property will be set to `true`; make sure to check this if you want to differentiate between the highlighted and un-highlighted states. */",
@@ -1200,8 +1206,10 @@
       "size?": "/** The size in pixels of the markers. */",
       "maxSize?": "/** For series where the size of the marker is determined by the data, this determines the largest size a marker can be in pixels. */",
       "fill?": "/** The colour to use for marker fills. If this is not specified, the markers will take their fill from the series. */",
+      "fillOpacity?": "/** Opacity of the marker fills. */",
       "stroke?": "/** The colour to use for marker strokes. If this is not specified, the markers will take their stroke from the series. */",
-      "strokeWidth?": "/** The width in pixels of the marker stroke. If this is not specified, the markers will take their stroke width from the series. */"
+      "strokeWidth?": "/** The width in pixels of the marker stroke. If this is not specified, the markers will take their stroke width from the series. */",
+      "strokeOpacity?": "/** Opacity of the marker strokes. */"
     }
   },
   "AgAreaSeriesMarker": {
@@ -1213,8 +1221,10 @@
       "size?": "PixelSize",
       "maxSize?": "PixelSize",
       "fill?": "CssColor",
+      "fillOpacity?": "Opacity",
       "stroke?": "CssColor",
-      "strokeWidth?": "PixelSize"
+      "strokeWidth?": "PixelSize",
+      "strokeOpacity?": "Opacity"
     },
     "docs": {
       "formatter?": "/** Function used to return formatting for individual markers, based on the supplied information. If the current marker is highlighted, the `highlighted` property will be set to `true`; make sure to check this if you want to differentiate between the highlighted and un-highlighted states. */",
@@ -1223,8 +1233,10 @@
       "size?": "/** The size in pixels of the markers. */",
       "maxSize?": "/** For series where the size of the marker is determined by the data, this determines the largest size a marker can be in pixels. */",
       "fill?": "/** The colour to use for marker fills. If this is not specified, the markers will take their fill from the series. */",
+      "fillOpacity?": "/** Opacity of the marker fills. */",
       "stroke?": "/** The colour to use for marker strokes. If this is not specified, the markers will take their stroke from the series. */",
-      "strokeWidth?": "/** The width in pixels of the marker stroke. If this is not specified, the markers will take their stroke width from the series. */"
+      "strokeWidth?": "/** The width in pixels of the marker stroke. If this is not specified, the markers will take their stroke width from the series. */",
+      "strokeOpacity?": "/** Opacity of the marker strokes. */"
     }
   },
   "AgSeriesTooltip": {

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-overview/examples/bubble-with-categories/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-overview/examples/bubble-with-categories/main.ts
@@ -27,8 +27,9 @@ const options: AgChartOptions = {
         size: 0,
         maxSize: 30,
         fill: '#cc5b58',
+        fillOpacity: 0.85,
+        strokeOpacity: 0.85,
       },
-      fillOpacity: 0.85,
     },
   ],
   axes: [

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-overview/examples/bubble-with-negative-values/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-overview/examples/bubble-with-negative-values/main.ts
@@ -28,8 +28,9 @@ const options: AgChartOptions = {
       marker: {
         size: 5,
         maxSize: 100,
+        fillOpacity: 0.5,
+        strokeOpacity: 0.5,
       },
-      fillOpacity: 0.5,
     },
   ],
   axes: [

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-overview/examples/grouped-column/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-overview/examples/grouped-column/main.ts
@@ -12,7 +12,9 @@ const options: AgChartOptions = {
         series: {
           strokeWidth: 0,
           highlightStyle: {
-            strokeWidth: 1,
+            item: {
+              strokeWidth: 1,
+            },
           },
         },
       },

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-overview/examples/per-marker-customisation/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-overview/examples/per-marker-customisation/main.ts
@@ -75,8 +75,9 @@ const options: AgChartOptions = {
           }
         },
         strokeWidth: 0,
+        fillOpacity: 0.7,
+        strokeOpacity: 0.7,
       },
-      fillOpacity: 0.7,
     },
   ],
   axes: [

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-overview/examples/simple-bubble/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-overview/examples/simple-bubble/main.ts
@@ -29,8 +29,9 @@ const options: AgChartOptions = {
         maxSize: 100,
         fill: '#41874b',
         stroke: '#41874b',
+        fillOpacity: 0.5,
+        strokeOpacity: 0.5,
       },
-      fillOpacity: 0.5,
     },
   ],
   axes: [

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-overview/examples/simple-scatter/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-overview/examples/simple-scatter/main.ts
@@ -18,9 +18,9 @@ const options: AgChartOptions = {
       type: 'scatter',
       xKey: 'weight',
       yKey: 'height',
-      fillOpacity: 0.5,
-      strokeOpacity: 0,
       marker: {
+        fillOpacity: 0.5,
+        strokeOpacity: 0,
         size: 12,
         fill: '#002D72',
       },

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/doc-interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/doc-interfaces.AUTO.json
@@ -3179,11 +3179,11 @@
       "type": { "returnType": "boolean", "optional": true }
     },
     "serverSideSortOnServer": {
-      "description": "/** When enabled, the grid will always request the server to provide the sort results.\n * Default: `1` */",
+      "description": "/** When enabled, the grid will always request the server to provide the sort results.\n * Default: `false` */",
       "type": { "returnType": "boolean", "optional": true }
     },
     "serverSideFilterOnServer": {
-      "description": "/** When enabled, the grid will always request the server to provide the filter results.\n * Default: `1` */",
+      "description": "/** When enabled, the grid will always request the server to provide the filter results.\n * Default: `false` */",
       "type": { "returnType": "boolean", "optional": true }
     },
     "serverSideSortingAlwaysResets": {
@@ -12702,6 +12702,10 @@
       "description": "/** The colour to use for marker fills. If this is not specified, the markers will take their fill from the series. */",
       "type": { "returnType": "CssColor", "optional": true }
     },
+    "fillOpacity": {
+      "description": "/** Opacity of the marker fills. */",
+      "type": { "returnType": "Opacity", "optional": true }
+    },
     "stroke": {
       "description": "/** The colour to use for marker strokes. If this is not specified, the markers will take their stroke from the series. */",
       "type": { "returnType": "CssColor", "optional": true }
@@ -12709,6 +12713,10 @@
     "strokeWidth": {
       "description": "/** The width in pixels of the marker stroke. If this is not specified, the markers will take their stroke width from the series. */",
       "type": { "returnType": "PixelSize", "optional": true }
+    },
+    "strokeOpacity": {
+      "description": "/** Opacity of the marker strokes. */",
+      "type": { "returnType": "Opacity", "optional": true }
     }
   },
   "AgSeriesMarkerFormatterParams": {
@@ -12764,6 +12772,10 @@
       "description": "/** The colour to use for marker fills. If this is not specified, the markers will take their fill from the series. */",
       "type": { "returnType": "CssColor", "optional": true }
     },
+    "fillOpacity": {
+      "description": "/** Opacity of the marker fills. */",
+      "type": { "returnType": "Opacity", "optional": true }
+    },
     "stroke": {
       "description": "/** The colour to use for marker strokes. If this is not specified, the markers will take their stroke from the series. */",
       "type": { "returnType": "CssColor", "optional": true }
@@ -12771,6 +12783,10 @@
     "strokeWidth": {
       "description": "/** The width in pixels of the marker stroke. If this is not specified, the markers will take their stroke width from the series. */",
       "type": { "returnType": "PixelSize", "optional": true }
+    },
+    "strokeOpacity": {
+      "description": "/** Opacity of the marker strokes. */",
+      "type": { "returnType": "Opacity", "optional": true }
     }
   },
   "AgAreaSeriesMarker": {
@@ -12801,6 +12817,10 @@
       "description": "/** The colour to use for marker fills. If this is not specified, the markers will take their fill from the series. */",
       "type": { "returnType": "CssColor", "optional": true }
     },
+    "fillOpacity": {
+      "description": "/** Opacity of the marker fills. */",
+      "type": { "returnType": "Opacity", "optional": true }
+    },
     "stroke": {
       "description": "/** The colour to use for marker strokes. If this is not specified, the markers will take their stroke from the series. */",
       "type": { "returnType": "CssColor", "optional": true }
@@ -12808,6 +12828,10 @@
     "strokeWidth": {
       "description": "/** The width in pixels of the marker stroke. If this is not specified, the markers will take their stroke width from the series. */",
       "type": { "returnType": "PixelSize", "optional": true }
+    },
+    "strokeOpacity": {
+      "description": "/** Opacity of the marker strokes. */",
+      "type": { "returnType": "Opacity", "optional": true }
     }
   },
   "AgSeriesTooltip": {
@@ -23500,11 +23524,11 @@
       "type": { "returnType": "boolean", "optional": true }
     },
     "serverSideSortOnServer": {
-      "description": "/** When enabled, the grid will always request the server to provide the sort results.\n * Default: `1` */",
+      "description": "/** When enabled, the grid will always request the server to provide the sort results.\n * Default: `false` */",
       "type": { "returnType": "boolean", "optional": true }
     },
     "serverSideFilterOnServer": {
-      "description": "/** When enabled, the grid will always request the server to provide the filter results.\n * Default: `1` */",
+      "description": "/** When enabled, the grid will always request the server to provide the filter results.\n * Default: `false` */",
       "type": { "returnType": "boolean", "optional": true }
     },
     "serverSideSortingAlwaysResets": {
@@ -26265,11 +26289,11 @@
       "type": { "returnType": "boolean", "optional": true }
     },
     "serverSideSortOnServer": {
-      "description": "/** When enabled, the grid will always request the server to provide the sort results.\n * Default: `1` */",
+      "description": "/** When enabled, the grid will always request the server to provide the sort results.\n * Default: `false` */",
       "type": { "returnType": "boolean", "optional": true }
     },
     "serverSideFilterOnServer": {
-      "description": "/** When enabled, the grid will always request the server to provide the filter results.\n * Default: `1` */",
+      "description": "/** When enabled, the grid will always request the server to provide the filter results.\n * Default: `false` */",
       "type": { "returnType": "boolean", "optional": true }
     },
     "serverSideSortingAlwaysResets": {
@@ -29040,11 +29064,11 @@
       "type": { "returnType": "boolean", "optional": true }
     },
     "serverSideSortOnServer": {
-      "description": "/** When enabled, the grid will always request the server to provide the sort results.\n * Default: `1` */",
+      "description": "/** When enabled, the grid will always request the server to provide the sort results.\n * Default: `false` */",
       "type": { "returnType": "boolean", "optional": true }
     },
     "serverSideFilterOnServer": {
-      "description": "/** When enabled, the grid will always request the server to provide the filter results.\n * Default: `1` */",
+      "description": "/** When enabled, the grid will always request the server to provide the filter results.\n * Default: `false` */",
       "type": { "returnType": "boolean", "optional": true }
     },
     "serverSideSortingAlwaysResets": {

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/grid-options.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/grid-options.AUTO.json
@@ -808,11 +808,11 @@
     "type": { "returnType": "boolean" }
   },
   "serverSideSortOnServer": {
-    "description": "/** When enabled, the grid will always request the server to provide the sort results.\n * Default: `1` */",
+    "description": "/** When enabled, the grid will always request the server to provide the sort results.\n * Default: `false` */",
     "type": { "returnType": "boolean" }
   },
   "serverSideFilterOnServer": {
-    "description": "/** When enabled, the grid will always request the server to provide the filter results.\n * Default: `1` */",
+    "description": "/** When enabled, the grid will always request the server to provide the filter results.\n * Default: `false` */",
     "type": { "returnType": "boolean" }
   },
   "serverSideSortingAlwaysResets": {

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/interfaces.AUTO.json
@@ -2064,8 +2064,8 @@
       "serverSideDatasource?": "/** Provide the `serverSideDatasource` for server side row model. */",
       "serverSideSortAllLevels?": "/** When enabled, always refreshes top level groups regardless of which column was sorted. This property only applies when there is Row Grouping & sorting is handled on the server. Default: `false` */",
       "serverSideFilterAllLevels?": "/** When enabled, always refreshes top level groups regardless of which column was filtered. This property only applies when there is Row Grouping & filtering is handled on the server. Default: `false` */",
-      "serverSideSortOnServer?": "/** When enabled, the grid will always request the server to provide the sort results.\n * Default: `1` */",
-      "serverSideFilterOnServer?": "/** When enabled, the grid will always request the server to provide the filter results.\n * Default: `1` */",
+      "serverSideSortOnServer?": "/** When enabled, the grid will always request the server to provide the sort results.\n * Default: `false` */",
+      "serverSideFilterOnServer?": "/** When enabled, the grid will always request the server to provide the filter results.\n * Default: `false` */",
       "serverSideSortingAlwaysResets?": "/** @deprecated This property has been deprecated. Use `serverSideSortAllLevels` instead.\n */",
       "serverSideFilteringAlwaysResets?": "/** @deprecated This property has been deprecated. Use `serverSideFilterAllLevels` instead.\n */",
       "suppressEnterpriseResetOnNewColumns?": "/** @deprecated */",
@@ -7383,8 +7383,10 @@
       "size?": "PixelSize",
       "maxSize?": "PixelSize",
       "fill?": "CssColor",
+      "fillOpacity?": "Opacity",
       "stroke?": "CssColor",
-      "strokeWidth?": "PixelSize"
+      "strokeWidth?": "PixelSize",
+      "strokeOpacity?": "Opacity"
     },
     "docs": {
       "enabled?": "/** Whether or not to show markers. */",
@@ -7392,8 +7394,10 @@
       "size?": "/** The size in pixels of the markers. */",
       "maxSize?": "/** For series where the size of the marker is determined by the data, this determines the largest size a marker can be in pixels. */",
       "fill?": "/** The colour to use for marker fills. If this is not specified, the markers will take their fill from the series. */",
+      "fillOpacity?": "/** Opacity of the marker fills. */",
       "stroke?": "/** The colour to use for marker strokes. If this is not specified, the markers will take their stroke from the series. */",
-      "strokeWidth?": "/** The width in pixels of the marker stroke. If this is not specified, the markers will take their stroke width from the series. */"
+      "strokeWidth?": "/** The width in pixels of the marker stroke. If this is not specified, the markers will take their stroke width from the series. */",
+      "strokeOpacity?": "/** Opacity of the marker strokes. */"
     }
   },
   "AgSeriesMarkerFormatterParams": {
@@ -7442,8 +7446,10 @@
       "size?": "PixelSize",
       "maxSize?": "PixelSize",
       "fill?": "CssColor",
+      "fillOpacity?": "Opacity",
       "stroke?": "CssColor",
-      "strokeWidth?": "PixelSize"
+      "strokeWidth?": "PixelSize",
+      "strokeOpacity?": "Opacity"
     },
     "docs": {
       "formatter?": "/** Function used to return formatting for individual markers, based on the supplied information. If the current marker is highlighted, the `highlighted` property will be set to `true`; make sure to check this if you want to differentiate between the highlighted and un-highlighted states. */",
@@ -7452,8 +7458,10 @@
       "size?": "/** The size in pixels of the markers. */",
       "maxSize?": "/** For series where the size of the marker is determined by the data, this determines the largest size a marker can be in pixels. */",
       "fill?": "/** The colour to use for marker fills. If this is not specified, the markers will take their fill from the series. */",
+      "fillOpacity?": "/** Opacity of the marker fills. */",
       "stroke?": "/** The colour to use for marker strokes. If this is not specified, the markers will take their stroke from the series. */",
-      "strokeWidth?": "/** The width in pixels of the marker stroke. If this is not specified, the markers will take their stroke width from the series. */"
+      "strokeWidth?": "/** The width in pixels of the marker stroke. If this is not specified, the markers will take their stroke width from the series. */",
+      "strokeOpacity?": "/** Opacity of the marker strokes. */"
     }
   },
   "AgAreaSeriesMarker": {
@@ -7465,8 +7473,10 @@
       "size?": "PixelSize",
       "maxSize?": "PixelSize",
       "fill?": "CssColor",
+      "fillOpacity?": "Opacity",
       "stroke?": "CssColor",
-      "strokeWidth?": "PixelSize"
+      "strokeWidth?": "PixelSize",
+      "strokeOpacity?": "Opacity"
     },
     "docs": {
       "formatter?": "/** Function used to return formatting for individual markers, based on the supplied information. If the current marker is highlighted, the `highlighted` property will be set to `true`; make sure to check this if you want to differentiate between the highlighted and un-highlighted states. */",
@@ -7475,8 +7485,10 @@
       "size?": "/** The size in pixels of the markers. */",
       "maxSize?": "/** For series where the size of the marker is determined by the data, this determines the largest size a marker can be in pixels. */",
       "fill?": "/** The colour to use for marker fills. If this is not specified, the markers will take their fill from the series. */",
+      "fillOpacity?": "/** Opacity of the marker fills. */",
       "stroke?": "/** The colour to use for marker strokes. If this is not specified, the markers will take their stroke from the series. */",
-      "strokeWidth?": "/** The width in pixels of the marker stroke. If this is not specified, the markers will take their stroke width from the series. */"
+      "strokeWidth?": "/** The width in pixels of the marker stroke. If this is not specified, the markers will take their stroke width from the series. */",
+      "strokeOpacity?": "/** Opacity of the marker strokes. */"
     }
   },
   "AgSeriesTooltip": {
@@ -13522,8 +13534,8 @@
       "serverSideDatasource?": "/** Provide the `serverSideDatasource` for server side row model. */",
       "serverSideSortAllLevels?": "/** When enabled, always refreshes top level groups regardless of which column was sorted. This property only applies when there is Row Grouping & sorting is handled on the server. Default: `false` */",
       "serverSideFilterAllLevels?": "/** When enabled, always refreshes top level groups regardless of which column was filtered. This property only applies when there is Row Grouping & filtering is handled on the server. Default: `false` */",
-      "serverSideSortOnServer?": "/** When enabled, the grid will always request the server to provide the sort results.\n * Default: `1` */",
-      "serverSideFilterOnServer?": "/** When enabled, the grid will always request the server to provide the filter results.\n * Default: `1` */",
+      "serverSideSortOnServer?": "/** When enabled, the grid will always request the server to provide the sort results.\n * Default: `false` */",
+      "serverSideFilterOnServer?": "/** When enabled, the grid will always request the server to provide the filter results.\n * Default: `false` */",
       "serverSideSortingAlwaysResets?": "/** @deprecated This property has been deprecated. Use `serverSideSortAllLevels` instead.\n */",
       "serverSideFilteringAlwaysResets?": "/** @deprecated This property has been deprecated. Use `serverSideFilterAllLevels` instead.\n */",
       "suppressEnterpriseResetOnNewColumns?": "/** @deprecated */",
@@ -14292,8 +14304,8 @@
       "serverSideDatasource?": "/** Provide the `serverSideDatasource` for server side row model. */",
       "serverSideSortAllLevels?": "/** When enabled, always refreshes top level groups regardless of which column was sorted. This property only applies when there is Row Grouping & sorting is handled on the server. Default: `false` */",
       "serverSideFilterAllLevels?": "/** When enabled, always refreshes top level groups regardless of which column was filtered. This property only applies when there is Row Grouping & filtering is handled on the server. Default: `false` */",
-      "serverSideSortOnServer?": "/** When enabled, the grid will always request the server to provide the sort results.\n * Default: `1` */",
-      "serverSideFilterOnServer?": "/** When enabled, the grid will always request the server to provide the filter results.\n * Default: `1` */",
+      "serverSideSortOnServer?": "/** When enabled, the grid will always request the server to provide the sort results.\n * Default: `false` */",
+      "serverSideFilterOnServer?": "/** When enabled, the grid will always request the server to provide the filter results.\n * Default: `false` */",
       "serverSideSortingAlwaysResets?": "/** @deprecated This property has been deprecated. Use `serverSideSortAllLevels` instead.\n */",
       "serverSideFilteringAlwaysResets?": "/** @deprecated This property has been deprecated. Use `serverSideFilterAllLevels` instead.\n */",
       "suppressEnterpriseResetOnNewColumns?": "/** @deprecated */",
@@ -15066,8 +15078,8 @@
       "serverSideDatasource?": "/** Provide the `serverSideDatasource` for server side row model. */",
       "serverSideSortAllLevels?": "/** When enabled, always refreshes top level groups regardless of which column was sorted. This property only applies when there is Row Grouping & sorting is handled on the server. Default: `false` */",
       "serverSideFilterAllLevels?": "/** When enabled, always refreshes top level groups regardless of which column was filtered. This property only applies when there is Row Grouping & filtering is handled on the server. Default: `false` */",
-      "serverSideSortOnServer?": "/** When enabled, the grid will always request the server to provide the sort results.\n * Default: `1` */",
-      "serverSideFilterOnServer?": "/** When enabled, the grid will always request the server to provide the filter results.\n * Default: `1` */",
+      "serverSideSortOnServer?": "/** When enabled, the grid will always request the server to provide the sort results.\n * Default: `false` */",
+      "serverSideFilterOnServer?": "/** When enabled, the grid will always request the server to provide the filter results.\n * Default: `false` */",
       "serverSideSortingAlwaysResets?": "/** @deprecated This property has been deprecated. Use `serverSideSortAllLevels` instead.\n */",
       "serverSideFilteringAlwaysResets?": "/** @deprecated This property has been deprecated. Use `serverSideFilterAllLevels` instead.\n */",
       "suppressEnterpriseResetOnNewColumns?": "/** @deprecated */",

--- a/grid-packages/ag-grid-docs/documentation/src/components/charts-api-explorer/Editors.tsx
+++ b/grid-packages/ag-grid-docs/documentation/src/components/charts-api-explorer/Editors.tsx
@@ -20,6 +20,7 @@ type AliasTypeProps<T> = {
     breakIndex?: number,
     min?: T,
     max?: T,
+    step?: T,
     unit?: string,
 };
 
@@ -47,6 +48,7 @@ const FONT_SIZE_EDITOR_PROPS: AliasTypeProps<FontSize> = {
 };
 
 const OPACITY_PROPS: AliasTypeProps<Opacity> = {
+    step: 0.1,
     min: 0,
     max: 1,
 };
@@ -190,13 +192,13 @@ export const getPrimitiveEditor = ({ meta, desc }: JsonModelProperty, key: strin
     return { editor, editorProps: { ...meta, ...editorProps } };
 };
 
-const setStepEditorProp = (editorProps: Record<string, any>, { min, max }: JsonModelProperty['meta']) => {
-    if (min == null || max == null) {
+const setStepEditorProp = (editorProps: Record<string, any>, { min, max, step }: JsonModelProperty['meta']) => {
+    if (min == null || max == null || step != null) {
         return;
     }
-    if (max - min <= 1) {
+    if ((max - min) <= 1) {
         editorProps.step = 0.05;
-    } else if (max - min <= 10) {
+    } else if ((max - min) <= 10) {
         editorProps.step = 0.1;
     }
 };


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-6939

Re-enabled @Deprecated() checks in Charts, and fixes many examples using deprecated properties.

Additionally reinstates `Marker.{fill,stroke}Opacity` which is needed by `ScatterSeries`, and now also works correctly for `LineSeries` and `AreaSeries`.