### PR TITLE
AG-6957 - Fix cross filtering scatter chart

### DIFF
--- a/charts-packages/ag-charts-community/src/chart/agChartOptions.ts
+++ b/charts-packages/ag-charts-community/src/chart/agChartOptions.ts
@@ -762,12 +762,16 @@ export interface AgScatterSeriesTooltip extends AgSeriesTooltip {
 
 export interface AgScatterSeriesLabelOptions extends AgChartLabelOptions {}
 
+export interface AgScatterSeriesMarker extends AgCartesianSeriesMarker {
+    /** If sizeKey is used, explicitly specifies the extent of the domain of it's values. */
+    domain?: [number, number];
+}
 /** Configuration for scatter/bubble series. */
 export interface AgScatterSeriesOptions extends AgBaseSeriesOptions {
     /** Configuration for the treemap series.  */
     type?: 'scatter';
     /** Configuration for the markers used in the series.  */
-    marker?: AgCartesianSeriesMarker;
+    marker?: AgScatterSeriesMarker;
     /** Configuration for the labels shown on top of data points.  */
     label?: AgScatterSeriesLabelOptions;
     /** The key to use to retrieve x-values from the data.  */

--- a/community-modules/core/src/ts/interfaces/iAgChartOptions.ts
+++ b/community-modules/core/src/ts/interfaces/iAgChartOptions.ts
@@ -762,12 +762,16 @@ export interface AgScatterSeriesTooltip extends AgSeriesTooltip {
 
 export interface AgScatterSeriesLabelOptions extends AgChartLabelOptions {}
 
+export interface AgScatterSeriesMarker extends AgCartesianSeriesMarker {
+    /** If sizeKey is used, explicitly specifies the extent of the domain of it's values. */
+    domain?: [number, number];
+}
 /** Configuration for scatter/bubble series. */
 export interface AgScatterSeriesOptions extends AgBaseSeriesOptions {
     /** Configuration for the treemap series.  */
     type?: 'scatter';
     /** Configuration for the markers used in the series.  */
-    marker?: AgCartesianSeriesMarker;
+    marker?: AgScatterSeriesMarker;
     /** Configuration for the labels shown on top of data points.  */
     label?: AgScatterSeriesLabelOptions;
     /** The key to use to retrieve x-values from the data.  */

--- a/enterprise-modules/charts/src/charts/chartComp/chartProxies/cartesian/scatterChartProxy.ts
+++ b/enterprise-modules/charts/src/charts/chartComp/chartProxies/cartesian/scatterChartProxy.ts
@@ -1,4 +1,4 @@
-import { AgCartesianAxisOptions, AgScatterSeriesOptions, ChartAxisPosition } from "ag-charts-community";
+import { AgCartesianAxisOptions, AgScatterSeriesMarker, AgScatterSeriesOptions, ChartAxisPosition } from "ag-charts-community";
 import { ChartProxyParams, FieldDefinition, UpdateChartParams } from "../chartProxy";
 import { CartesianChartProxy } from "./cartesianChartProxy";
 import { deepMerge } from "../../utils/object";
@@ -63,11 +63,101 @@ export class ScatterChartProxy extends CartesianChartProxy {
             }
         ));
 
-        return this.crossFiltering ? this.extractCrossFilterSeries(series) : series;
+        return this.crossFiltering ? this.extractCrossFilterSeries(series, params) : series;
     }
 
-    private extractCrossFilterSeries(series: AgScatterSeriesOptions[]): AgScatterSeriesOptions[] {
-        return []; //TODO
+    private extractCrossFilterSeries(
+        series: AgScatterSeriesOptions[],
+        params: UpdateChartParams,
+    ): AgScatterSeriesOptions[] {
+        const { data } = params;
+        const { chartTheme: { palette } } = this;
+
+        const filteredOutKey = (key: string) => `${key}-filtered-out`;
+
+        const calcMarkerDomain = (data: any, sizeKey?: string) => {
+            const markerDomain: [number, number] = [Infinity, -Infinity];
+            if (sizeKey != null) {
+                for (const datum of data) {
+                    const value = datum[sizeKey] ?? datum[filteredOutKey(sizeKey)];
+                    if (value < markerDomain[0]) {
+                        markerDomain[0] = value;
+                    }
+                    if (value > markerDomain[1]) {
+                        markerDomain[1] = value;
+                    }
+                }
+            }
+            if (markerDomain[0] <= markerDomain[1]) {
+                return markerDomain;
+            }
+            return undefined;
+        };
+
+        const updatePrimarySeries = (series: AgScatterSeriesOptions, idx: number): AgScatterSeriesOptions => {
+            const { sizeKey } = series;
+            const fill = palette.fills[idx];
+            const stroke = palette.strokes[idx];
+
+            let markerDomain = calcMarkerDomain(data, sizeKey);
+            const marker: AgScatterSeriesMarker = {
+                ...series.marker,
+                fill,
+                stroke,
+                domain: markerDomain,
+            };
+
+            return {
+                ...series,
+                marker,
+                highlightStyle: { item: { fill: 'yellow' } },
+                listeners: {
+                    ...series.listeners,
+                    nodeClick: this.crossFilterCallback
+                },
+            };
+        }
+
+        const updateFilteredOutSeries = (series: AgScatterSeriesOptions): AgScatterSeriesOptions => {
+            let { sizeKey, yKey, xKey } = series;
+            if (sizeKey != null) {
+                sizeKey = filteredOutKey(sizeKey);
+            }
+
+            return {
+                ...series,
+                yKey: filteredOutKey(yKey!),
+                xKey: filteredOutKey(xKey!),
+                marker: {
+                    ...series.marker,
+                    fillOpacity: 0.3,
+                    strokeOpacity: 0.3,
+                },
+                sizeKey,
+                showInLegend: false,
+                listeners: {
+                    ...series.listeners,
+                    nodeClick: (e: any) => {
+                        const value = e.datum[e.series.xKey!];
+
+                        // Need to remove the `-filtered-out` suffixes from the event so that
+                        // upstream processing maps the event correctly onto grid column ids.
+                        const filterableEvent = {
+                            ...e,
+                            xKey,
+                            datum: { ...e.datum, [xKey!]: value },
+                        };
+                        this.crossFilterCallback(filterableEvent);
+                    }
+                },
+            };
+        };
+
+        const updatedSeries = series.map(updatePrimarySeries);
+        return [
+            ...updatedSeries,
+            ...updatedSeries.map(updateFilteredOutSeries),
+        ];
     }
 
     private getSeriesDefinitions(fields: FieldDefinition[], paired: boolean): (SeriesDefinition | null)[] {

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/doc-interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/doc-interfaces.AUTO.json
@@ -1950,6 +1950,55 @@
       "type": { "returnType": "CssColor", "optional": true }
     }
   },
+  "AgScatterSeriesMarker": {
+    "domain": {
+      "description": "/** If sizeKey is used, explicitly specifies the extent of the domain of it's values. */",
+      "type": { "returnType": "[number, number]", "optional": true }
+    },
+    "formatter": {
+      "description": "/** Function used to return formatting for individual markers, based on the supplied information. If the current marker is highlighted, the `highlighted` property will be set to `true`; make sure to check this if you want to differentiate between the highlighted and un-highlighted states. */",
+      "type": {
+        "returnType": "AgCartesianSeriesMarkerFormatter",
+        "optional": true
+      }
+    },
+    "enabled": {
+      "description": "/** Whether or not to show markers. */",
+      "type": { "returnType": "boolean", "optional": true }
+    },
+    "shape": {
+      "description": "/** The shape to use for the markers. You can also supply a custom marker by providing a `Marker` subclass. */",
+      "type": { "returnType": "MarkerShape", "optional": true }
+    },
+    "size": {
+      "description": "/** The size in pixels of the markers. */",
+      "type": { "returnType": "PixelSize", "optional": true }
+    },
+    "maxSize": {
+      "description": "/** For series where the size of the marker is determined by the data, this determines the largest size a marker can be in pixels. */",
+      "type": { "returnType": "PixelSize", "optional": true }
+    },
+    "fill": {
+      "description": "/** The colour to use for marker fills. If this is not specified, the markers will take their fill from the series. */",
+      "type": { "returnType": "CssColor", "optional": true }
+    },
+    "fillOpacity": {
+      "description": "/** Opacity of the marker fills. */",
+      "type": { "returnType": "Opacity", "optional": true }
+    },
+    "stroke": {
+      "description": "/** The colour to use for marker strokes. If this is not specified, the markers will take their stroke from the series. */",
+      "type": { "returnType": "CssColor", "optional": true }
+    },
+    "strokeWidth": {
+      "description": "/** The width in pixels of the marker stroke. If this is not specified, the markers will take their stroke width from the series. */",
+      "type": { "returnType": "PixelSize", "optional": true }
+    },
+    "strokeOpacity": {
+      "description": "/** Opacity of the marker strokes. */",
+      "type": { "returnType": "Opacity", "optional": true }
+    }
+  },
   "AgScatterSeriesOptions": {
     "type": {
       "description": "/** Configuration for the treemap series. */",
@@ -1957,7 +2006,7 @@
     },
     "marker": {
       "description": "/** Configuration for the markers used in the series. */",
-      "type": { "returnType": "AgCartesianSeriesMarker", "optional": true }
+      "type": { "returnType": "AgScatterSeriesMarker", "optional": true }
     },
     "label": {
       "description": "/** Configuration for the labels shown on top of data points. */",

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
@@ -1354,11 +1354,40 @@
       "color?": "/** The colour to use for the labels. */"
     }
   },
+  "AgScatterSeriesMarker": {
+    "meta": {},
+    "type": {
+      "domain?": "[number, number]",
+      "formatter?": "AgCartesianSeriesMarkerFormatter",
+      "enabled?": "boolean",
+      "shape?": "MarkerShape",
+      "size?": "PixelSize",
+      "maxSize?": "PixelSize",
+      "fill?": "CssColor",
+      "fillOpacity?": "Opacity",
+      "stroke?": "CssColor",
+      "strokeWidth?": "PixelSize",
+      "strokeOpacity?": "Opacity"
+    },
+    "docs": {
+      "domain?": "/** If sizeKey is used, explicitly specifies the extent of the domain of it's values. */",
+      "formatter?": "/** Function used to return formatting for individual markers, based on the supplied information. If the current marker is highlighted, the `highlighted` property will be set to `true`; make sure to check this if you want to differentiate between the highlighted and un-highlighted states. */",
+      "enabled?": "/** Whether or not to show markers. */",
+      "shape?": "/** The shape to use for the markers. You can also supply a custom marker by providing a `Marker` subclass. */",
+      "size?": "/** The size in pixels of the markers. */",
+      "maxSize?": "/** For series where the size of the marker is determined by the data, this determines the largest size a marker can be in pixels. */",
+      "fill?": "/** The colour to use for marker fills. If this is not specified, the markers will take their fill from the series. */",
+      "fillOpacity?": "/** Opacity of the marker fills. */",
+      "stroke?": "/** The colour to use for marker strokes. If this is not specified, the markers will take their stroke from the series. */",
+      "strokeWidth?": "/** The width in pixels of the marker stroke. If this is not specified, the markers will take their stroke width from the series. */",
+      "strokeOpacity?": "/** Opacity of the marker strokes. */"
+    }
+  },
   "AgScatterSeriesOptions": {
     "meta": { "doc": "/** Configuration for scatter/bubble series. */" },
     "type": {
       "type?": "'scatter'",
-      "marker?": "AgCartesianSeriesMarker",
+      "marker?": "AgScatterSeriesMarker",
       "label?": "AgScatterSeriesLabelOptions",
       "xKey?": "string",
       "yKey?": "string",

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/doc-interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/doc-interfaces.AUTO.json
@@ -13015,6 +13015,55 @@
       "type": { "returnType": "CssColor", "optional": true }
     }
   },
+  "AgScatterSeriesMarker": {
+    "domain": {
+      "description": "/** If sizeKey is used, explicitly specifies the extent of the domain of it's values. */",
+      "type": { "returnType": "[number, number]", "optional": true }
+    },
+    "formatter": {
+      "description": "/** Function used to return formatting for individual markers, based on the supplied information. If the current marker is highlighted, the `highlighted` property will be set to `true`; make sure to check this if you want to differentiate between the highlighted and un-highlighted states. */",
+      "type": {
+        "returnType": "AgCartesianSeriesMarkerFormatter",
+        "optional": true
+      }
+    },
+    "enabled": {
+      "description": "/** Whether or not to show markers. */",
+      "type": { "returnType": "boolean", "optional": true }
+    },
+    "shape": {
+      "description": "/** The shape to use for the markers. You can also supply a custom marker by providing a `Marker` subclass. */",
+      "type": { "returnType": "MarkerShape", "optional": true }
+    },
+    "size": {
+      "description": "/** The size in pixels of the markers. */",
+      "type": { "returnType": "PixelSize", "optional": true }
+    },
+    "maxSize": {
+      "description": "/** For series where the size of the marker is determined by the data, this determines the largest size a marker can be in pixels. */",
+      "type": { "returnType": "PixelSize", "optional": true }
+    },
+    "fill": {
+      "description": "/** The colour to use for marker fills. If this is not specified, the markers will take their fill from the series. */",
+      "type": { "returnType": "CssColor", "optional": true }
+    },
+    "fillOpacity": {
+      "description": "/** Opacity of the marker fills. */",
+      "type": { "returnType": "Opacity", "optional": true }
+    },
+    "stroke": {
+      "description": "/** The colour to use for marker strokes. If this is not specified, the markers will take their stroke from the series. */",
+      "type": { "returnType": "CssColor", "optional": true }
+    },
+    "strokeWidth": {
+      "description": "/** The width in pixels of the marker stroke. If this is not specified, the markers will take their stroke width from the series. */",
+      "type": { "returnType": "PixelSize", "optional": true }
+    },
+    "strokeOpacity": {
+      "description": "/** Opacity of the marker strokes. */",
+      "type": { "returnType": "Opacity", "optional": true }
+    }
+  },
   "AgScatterSeriesOptions": {
     "type": {
       "description": "/** Configuration for the treemap series. */",
@@ -13022,7 +13071,7 @@
     },
     "marker": {
       "description": "/** Configuration for the markers used in the series. */",
-      "type": { "returnType": "AgCartesianSeriesMarker", "optional": true }
+      "type": { "returnType": "AgScatterSeriesMarker", "optional": true }
     },
     "label": {
       "description": "/** Configuration for the labels shown on top of data points. */",

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/interfaces.AUTO.json
@@ -7606,11 +7606,40 @@
       "color?": "/** The colour to use for the labels. */"
     }
   },
+  "AgScatterSeriesMarker": {
+    "meta": {},
+    "type": {
+      "domain?": "[number, number]",
+      "formatter?": "AgCartesianSeriesMarkerFormatter",
+      "enabled?": "boolean",
+      "shape?": "MarkerShape",
+      "size?": "PixelSize",
+      "maxSize?": "PixelSize",
+      "fill?": "CssColor",
+      "fillOpacity?": "Opacity",
+      "stroke?": "CssColor",
+      "strokeWidth?": "PixelSize",
+      "strokeOpacity?": "Opacity"
+    },
+    "docs": {
+      "domain?": "/** If sizeKey is used, explicitly specifies the extent of the domain of it's values. */",
+      "formatter?": "/** Function used to return formatting for individual markers, based on the supplied information. If the current marker is highlighted, the `highlighted` property will be set to `true`; make sure to check this if you want to differentiate between the highlighted and un-highlighted states. */",
+      "enabled?": "/** Whether or not to show markers. */",
+      "shape?": "/** The shape to use for the markers. You can also supply a custom marker by providing a `Marker` subclass. */",
+      "size?": "/** The size in pixels of the markers. */",
+      "maxSize?": "/** For series where the size of the marker is determined by the data, this determines the largest size a marker can be in pixels. */",
+      "fill?": "/** The colour to use for marker fills. If this is not specified, the markers will take their fill from the series. */",
+      "fillOpacity?": "/** Opacity of the marker fills. */",
+      "stroke?": "/** The colour to use for marker strokes. If this is not specified, the markers will take their stroke from the series. */",
+      "strokeWidth?": "/** The width in pixels of the marker stroke. If this is not specified, the markers will take their stroke width from the series. */",
+      "strokeOpacity?": "/** Opacity of the marker strokes. */"
+    }
+  },
   "AgScatterSeriesOptions": {
     "meta": { "doc": "/** Configuration for scatter/bubble series. */" },
     "type": {
       "type?": "'scatter'",
-      "marker?": "AgCartesianSeriesMarker",
+      "marker?": "AgScatterSeriesMarker",
       "label?": "AgScatterSeriesLabelOptions",
       "xKey?": "string",
       "yKey?": "string",

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/integrated-charts-api-cross-filter-chart/index.md
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/integrated-charts-api-cross-filter-chart/index.md
@@ -73,10 +73,9 @@ The following examples show the different chart types that support cross-filteri
 
 <grid-example title='Sales Dashboard 2' name='sales-dashboard2' type='generated' options='{ "exampleHeight": 1000, "enterprise":  true,  "modules": ["clientside", "menu", "charts", "setfilter", "multifilter", "filterpanel", "columnpanel"] }'></grid-example>
 
-[//]: # (### Example: Most Populous Cities)
+### Example: Most Populous Cities
 
-[//]: # ()
-[//]: # (<grid-example title='Most Populous Cities' name='most-populous-cities' type='generated' options='{ "exampleHeight": 1000, "enterprise":  true,  "modules": ["clientside", "menu", "charts", "setfilter", "multifilter", "filterpanel", "columnpanel"] }'></grid-example>)
+<grid-example title='Most Populous Cities' name='most-populous-cities' type='generated' options='{ "exampleHeight": 1000, "enterprise":  true,  "modules": ["clientside", "menu", "charts", "setfilter", "multifilter", "filterpanel", "columnpanel"] }'></grid-example>
 
 ## Next Up
 


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-6957

Attempt to re-enable the 'Most Populous Cities' cross-filtering example, which was removed in `28.0.0` due to scatter-chart support being unimplemented.

Changes:
- Adds support for specifying scatter-series marker range to the options interface contract.
- Adds support for cross-filtering back to `scatterChartProxy.ts`.
- Re-enables the  'Most Populous Cities' cross-filtering example.