### PR TITLE
AG-6708 - Fix no data time axis range

### DIFF
--- a/charts-packages/ag-charts-community/src/chart/series/series.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/series.ts
@@ -350,9 +350,10 @@ export abstract class Series<C extends SeriesNodeDataContext = SeriesNodeDataCon
 
     readonly highlightStyle = new HighlightStyle();
 
-    protected fixNumericExtent(extent?: [number | Date, number | Date], axis?: ChartAxis): [number, number] {
-        if (!extent) {
-            return [0, 1];
+    protected fixNumericExtent(extent?: [number | Date, number | Date], axis?: ChartAxis): number[] {
+        if (extent === undefined) {
+            // Don't return a range, there is no range.
+            return [];
         }
 
         let [min, max] = extent;

--- a/charts-packages/ag-charts-community/src/scale/continuousScale.ts
+++ b/charts-packages/ag-charts-community/src/scale/continuousScale.ts
@@ -56,7 +56,7 @@ export abstract class ContinuousScale implements Scale<any, any> {
 
     protected _domain: any[] = [0, 1];
     protected setDomain(values: any[]) {
-        this._domain = Array.prototype.map.call(values, (v: any) => +v);
+        this._domain = values.map((v) => +v);
         if (this._clamp !== identity) {
             this._clamp = this.clamper(this.domain);
         }
@@ -74,7 +74,7 @@ export abstract class ContinuousScale implements Scale<any, any> {
 
     protected _range: any[] = [0, 1];
     set range(values: any[]) {
-        this._range = Array.prototype.slice.call(values);
+        this._range = values.slice();
         this.rescale();
     }
     get range(): any[] {

--- a/charts-packages/ag-charts-community/src/scale/timeScale.ts
+++ b/charts-packages/ag-charts-community/src/scale/timeScale.ts
@@ -121,7 +121,7 @@ export class TimeScale extends ContinuousScale {
 
     protected _domain: Date[] = [new Date(2000, 0, 1), new Date(2000, 0, 2)];
     set domain(values: Date[]) {
-        super.setDomain(Array.prototype.map.call(values, (t: any) => t instanceof Date ? +t : +new Date(+t)));
+        super.setDomain(values.map((t: any) => t instanceof Date ? +t : +new Date(+t)));
     }
     get domain(): Date[] {
         return super.getDomain().map((t: any) => new Date(t));

--- a/charts-packages/ag-charts-community/src/util/numberFormat.ts
+++ b/charts-packages/ag-charts-community/src/util/numberFormat.ts
@@ -449,13 +449,13 @@ export interface FormatLocale {
 export function formatLocale(locale: FormatLocaleOptions): FormatLocale {
     const group = locale.grouping === undefined || locale.thousands === undefined
         ? identity
-        : formatGroup(Array.prototype.map.call(locale.grouping, Number) as number[], String(locale.thousands));
+        : formatGroup(locale.grouping.map(Number) as number[], String(locale.thousands));
     const currencyPrefix = locale.currency === undefined ? '' : String(locale.currency[0]);
     const currencySuffix = locale.currency === undefined ? '' : String(locale.currency[1]);
     const decimal = locale.decimal === undefined ? '.' : String(locale.decimal);
     const numerals = locale.numerals === undefined
         ? identity
-        : formatNumerals(Array.prototype.map.call(locale.numerals, String) as string[]);
+        : formatNumerals(locale.numerals.map(String) as string[]);
     const percent = locale.percent === undefined ? '%' : String(locale.percent);
     const minus = locale.minus === undefined ? '\u2212' : String(locale.minus);
     const nan = locale.nan === undefined ? 'NaN' : String(locale.nan);


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-6708

Fixes `TimeAxis` domain detection when there are no data points.

Before (https://plnkr.co/edit/GoGbXTUjclhDu3oe?open=main.js):
<img width="686" alt="Screenshot 2022-07-12 at 11 29 59" src="https://user-images.githubusercontent.com/17544187/178470356-9c15e3fc-c6c6-4316-84af-fce4e495d7ca.png">

After (https://plnkr.co/edit/vkbStfixLc0Tp3WR?open=main.js):
![Screenshot 2022-07-12 at 11 30 09](https://user-images.githubusercontent.com/17544187/178470383-df68b262-4204-4c2f-9c6d-69afd7e9fd58.png)

Verified that switching to `line`, `scatter`, `area` and `column` all work correctly with zero data points too.

Bonus:
- Improved readability of some uses of `Array.prototype`.