### PR TITLE
Only prevent default on cancelable touch events

### DIFF
--- a/community-modules/core/src/ts/widgets/touchListener.ts
+++ b/community-modules/core/src/ts/widgets/touchListener.ts
@@ -135,7 +135,7 @@ export class TouchListener implements IEventEmitter {
         }
 
         // stops the tap from also been processed as a mouse click
-        if (this.preventMouseClick) {
+        if (this.preventMouseClick && touchEvent.cancelable) {
             touchEvent.preventDefault();
         }
 


### PR DESCRIPTION
Causes the error:

    IgnoredEventCancel: intervention: Ignored attempt to cancel a touchend event with cancelable=false

Internal ticket:
https://ag-grid.zendesk.com/hc/en-us/requests/23283