### PR TITLE
AG-5738 - Improved tooltip handling

### DIFF
--- a/charts-packages/ag-charts-community/src/chart/chart.ts
+++ b/charts-packages/ag-charts-community/src/chart/chart.ts
@@ -1290,8 +1290,8 @@ export abstract class Chart extends Observable {
             const canvasRect = canvas.element.getBoundingClientRect();
             return {
                 ...meta,
-                pageX: Math.round(canvasRect.left + window.pageXOffset + point.x),
-                pageY: Math.round(canvasRect.top + window.pageYOffset + point.y),
+                pageX: Math.round(canvasRect.left + window.scrollX + point.x),
+                pageY: Math.round(canvasRect.top + window.scrollY + point.y),
                 offsetX: Math.round(canvasRect.left + point.y),
                 offsetY: Math.round(canvasRect.top + point.y),
             };

--- a/charts-packages/ag-charts-community/src/chart/chart.ts
+++ b/charts-packages/ag-charts-community/src/chart/chart.ts
@@ -1,8 +1,7 @@
 import { Scene } from "../scene/scene";
 import { Group } from "../scene/group";
-import { Series, SeriesNodeDatum, SeriesNodeDataContext } from "./series/series";
+import { Series, SeriesNodeDatum, SeriesNodeDataContext, SeriesNodePickMode } from "./series/series";
 import { Padding } from "../util/padding";
-import { Shape } from "../scene/shape/shape";
 import { Node } from "../scene/node";
 import { Rect } from "../scene/shape/rect";
 import { Legend, LegendDatum } from "./legend";
@@ -1026,25 +1025,28 @@ export abstract class Chart extends Observable {
     // x/y are local canvas coordinates in CSS pixels, not actual pixels
     private pickSeriesNode(x: number, y: number): {
         series: Series<any>,
-        node: Node
+        datum: SeriesNodeDatum,
     } | undefined {
-        if (!(this.seriesRect && this.seriesRect.containsPoint(x, y))) {
-            return undefined;
-        }
+        const { tooltip: { tracking } } = this;
 
         const start = performance.now();
 
-        let result: {series: Series<any>,node: Node} | undefined = undefined;
+        // Disable 'nearest match' options if tooltip.tracking is enabled.
+        const pickModes = tracking ? undefined : [SeriesNodePickMode.EXACT_SHAPE_MATCH];
+
+        let result: { series: Series<any>, datum: SeriesNodeDatum, distance: number } | undefined = undefined;
         for (const series of this.series) {
             if (!series.visible || !series.group.visible) {
                 continue;
             }
-            const node = series.pickNode(x, y);
-            if (node) {
-                result = {
-                    series,
-                    node
-                };
+            let { match, distance } = series.pickNode(x, y, pickModes) ?? {};
+            if (!match || distance == null) {
+                continue;
+            }
+            if (!result || result.distance > distance) {
+                result = { series, distance, datum: match };
+            }
+            if (distance === 0) {
                 break;
             }
         }
@@ -1059,58 +1061,8 @@ export abstract class Chart extends Observable {
 
     lastPick?: {
         datum: SeriesNodeDatum;
-        node?: Shape; // We may not always have an associated node, for example
-        // when line series are rendered without markers.
         event?: MouseEvent;
     };
-
-    // Provided x/y are in canvas coordinates.
-    private pickClosestSeriesNodeDatum(x: number, y: number): SeriesNodeDatum | undefined {
-        if (!this.seriesRect || !this.seriesRect.containsPoint(x, y)) {
-            return undefined;
-        }
-
-        let minDistance = Infinity;
-        let closestDatum: SeriesNodeDatum | undefined;
-
-        const { series: allSeries, nodeData: nodeDataMap } = this;
-        for (const series of allSeries) {
-            if (!series.visible || !series.group.visible) {
-                continue;
-            }
-
-            // Ignore off-screen points when finding the closest series node datum in tracking mode.
-            const { xAxis, yAxis } = series;
-            const hitPoint = series.group.transformPoint(x, y);
-
-            const contexts = nodeDataMap.get(series) ?? [];
-            for (const context of contexts) {
-                for (const datum of context.nodeData) {
-                    const { point } = datum;
-                    if (!point) {
-                        continue;
-                    }
-        
-                    const { x, y } = point;
-                    const isInRange = xAxis?.inRange(x) && yAxis?.inRange(y);
-        
-                    if (!isInRange) {
-                        continue;
-                    }
-        
-                    // No need to use Math.sqrt() since x < y implies Math.sqrt(x) < Math.sqrt(y) for
-                    // values > 1 
-                    const distance = (hitPoint.x - x) ** 2 + (hitPoint.y - y) ** 2;
-                    if (distance < minDistance) {
-                        minDistance = distance;
-                        closestDatum = datum;
-                    }
-                }
-            }
-        }
-
-        return closestDatum;
-    }
 
     protected onMouseMove(event: MouseEvent): void {
         this.handleLegendMouseMove(event);
@@ -1135,63 +1087,36 @@ export abstract class Chart extends Observable {
         this.handleTooltip(this.lastTooltipMeta!);
     });
     protected handleTooltip(meta: TooltipMeta) {
-        const { lastPick, tooltip: { tracking: tooltipTracking } } = this;
+        const { lastPick, tooltip: { tracking } } = this;
         const { offsetX, offsetY } = meta;
+
+        const disableTooltip = () => {
+            if (lastPick) {
+                // Cursor moved from a non-marker node to empty space.
+                this.changeHighlightDatum();
+                this.tooltip.toggle(false);
+            }
+        };
+
+        if (!(this.seriesRect && this.seriesRect.containsPoint(offsetX, offsetY))) {
+            disableTooltip();
+            return;
+        }
+
         const pick = this.pickSeriesNode(offsetX, offsetY);
-        let nodeDatum: SeriesNodeDatum | undefined;
 
-        if (pick && pick.node instanceof Shape) {
-            const { node } = pick;
-            nodeDatum = node.datum as SeriesNodeDatum;
-            if (lastPick && lastPick.datum === nodeDatum) {
-                lastPick.node = node;
-                lastPick.event = meta.event;
-            }
-            // Marker nodes will have the `point` info in their datums.
-            // Highlight if not a marker node or, if not in the tracking mode, highlight markers too.
-            if ((!node.datum.point || !tooltipTracking)) {
-                if (!lastPick // cursor moved from empty space to a node
-                    || lastPick.node !== node) { // cursor moved from one node to another
-                        this.onSeriesDatumPick(meta, node.datum, node);
-                } else if (pick.series.tooltip.enabled) { // cursor moved within the same node
-                    this.tooltip.show(meta);
-                }
-                // A non-marker node (takes precedence over marker nodes) was highlighted.
-                // Or we are not in the tracking mode.
-                // Either way, we are done at this point.
-                return;
-            }
+        if (!pick) {
+            disableTooltip();
+            return;
         }
 
-        let hideTooltip = false;
-        // In tracking mode a tooltip is shown for the closest rendered datum.
-        // This makes it easier to show tooltips when markers are small and/or plentiful
-        // and also gives the ability to show tooltips even when the series were configured
-        // to not render markers.
-        if (tooltipTracking) {
-            const closestDatum = this.pickClosestSeriesNodeDatum(offsetX, offsetY);
-            if (closestDatum && closestDatum.point) {
-                const { x, y } = closestDatum.point;
-                const { canvas } = this.scene;
-                const point = closestDatum.series.group.inverseTransformPoint(x, y);
-                const canvasRect = canvas.element.getBoundingClientRect();
-                this.onSeriesDatumPick({
-                    ...meta,
-                    pageX: Math.round(canvasRect.left + window.pageXOffset + point.x),
-                    pageY: Math.round(canvasRect.top + window.pageYOffset + point.y),
-                    offsetX: Math.round(canvasRect.left + point.y),
-                    offsetY: Math.round(canvasRect.top + point.y),
-                }, closestDatum, nodeDatum === closestDatum && pick ? pick.node as Shape : undefined);
-            } else {
-                hideTooltip = true;
-            }
+        if (!lastPick || lastPick.datum !== pick.datum) {
+            this.onSeriesDatumPick(meta, pick.datum);
+            return;
         }
 
-        if (lastPick && (hideTooltip || !tooltipTracking)) {
-            // Cursor moved from a non-marker node to empty space.
-            this.changeHighlightDatum();
-            this.tooltip.toggle(false);
-        }
+        lastPick.event = meta.event;
+        this.tooltip.show(this.mergeTooltipDatum(meta, pick.datum));
     }
 
     protected onMouseDown(_event: MouseEvent) {
@@ -1336,7 +1261,7 @@ export abstract class Chart extends Observable {
         }
     }
 
-    private onSeriesDatumPick(meta: TooltipMeta, datum: SeriesNodeDatum, node?: Shape) {
+    private onSeriesDatumPick(meta: TooltipMeta, datum: SeriesNodeDatum) {
         const { lastPick } = this;
         if (lastPick) {
             if (lastPick.datum === datum) { return; }
@@ -1344,20 +1269,40 @@ export abstract class Chart extends Observable {
 
         this.changeHighlightDatum({
             datum,
-            node,
             event: meta.event,
         });
 
-        const html = datum.series.tooltip.enabled && datum.series.getTooltipHtml(datum);
+        if (datum) {
+            meta = this.mergeTooltipDatum(meta, datum);
+        }
 
+        const html = datum.series.tooltip.enabled && datum.series.getTooltipHtml(datum);
         if (html) {
             this.tooltip.show(meta, html);
         }
     }
 
+    private mergeTooltipDatum(meta: TooltipMeta, datum: SeriesNodeDatum): TooltipMeta {
+        if (datum.point) {
+            const { x, y } = datum.point;
+            const { canvas } = this.scene;
+            const point = datum.series.group.inverseTransformPoint(x, y);
+            const canvasRect = canvas.element.getBoundingClientRect();
+            return {
+                ...meta,
+                pageX: Math.round(canvasRect.left + window.pageXOffset + point.x),
+                pageY: Math.round(canvasRect.top + window.pageYOffset + point.y),
+                offsetX: Math.round(canvasRect.left + point.y),
+                offsetY: Math.round(canvasRect.top + point.y),
+            };
+        }
+
+        return meta;
+}
+
     highlightedDatum?: SeriesNodeDatum;
 
-    changeHighlightDatum(newPick?: { datum: SeriesNodeDatum, node?: Shape, event?: MouseEvent}) {
+    changeHighlightDatum(newPick?: { datum: SeriesNodeDatum, event?: MouseEvent}) {
         const seriesToUpdate: Set<Series> = new Set<Series>();
         const { datum: { series: newSeries = undefined } = {}, datum = undefined } = newPick || {};
         const { lastPick: { datum: { series: lastSeries = undefined } = {} } = {} } = this;

--- a/charts-packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
@@ -18,6 +18,7 @@ import { Scale } from '../../../scale/scale';
 import { sanitizeHtml } from '../../../util/sanitize';
 import { isNumber } from '../../../util/value';
 import { clamper, ContinuousScale } from '../../../scale/continuousScale';
+import { SeriesNodePickMode } from '../series';
 
 export interface BarSeriesNodeClickEvent extends TypedEvent {
     readonly type: 'nodeClick';
@@ -135,7 +136,13 @@ export class BarSeries extends CartesianSeries<SeriesNodeDataContext<BarNodeDatu
     formatter?: (params: BarSeriesFormatterParams) => BarSeriesFormat = undefined;
 
     constructor() {
-        super({ pickGroupIncludes: ['datumNodes'], pathsPerSeries: 0 });
+        super({
+            pickGroupIncludes: ['datumNodes'],
+            pickModes: [
+                SeriesNodePickMode.EXACT_SHAPE_MATCH,
+            ],
+            pathsPerSeries: 0,
+        });
 
         this.label.enabled = false;
     }

--- a/charts-packages/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
@@ -1,4 +1,4 @@
-import { Series, SeriesNodeDataContext } from '../series';
+import { Series, SeriesNodeDataContext, SeriesNodeDatum, SeriesNodePickMode } from '../series';
 import { ChartAxis, ChartAxisDirection } from '../../chartAxis';
 import { SeriesMarker, SeriesMarkerFormatterParams } from '../seriesMarker';
 import { isContinuous, isDiscrete } from '../../../util/value';
@@ -9,6 +9,7 @@ import { Group } from '../../../scene/group';
 import { Text } from '../../../scene/shape/text';
 import { Node } from '../../../scene/node';
 import { RedrawType, SceneChangeDetection } from '../../../scene/changeDetectable';
+import { CategoryAxis } from '../../axis/categoryAxis';
 
 type NodeDataSelection<N extends Node, ContextType extends SeriesNodeDataContext> = Selection<
     N,
@@ -60,8 +61,9 @@ export abstract class CartesianSeries<
      */
     protected readonly seriesItemEnabled = new Map<string, boolean>();
 
-    protected constructor(opts: Partial<SeriesOpts> = {}) {
-        super({ seriesGroupUsesLayer: false });
+    protected constructor(
+        opts: Partial<SeriesOpts> & { pickModes?: SeriesNodePickMode[] } = {}) {
+        super({ seriesGroupUsesLayer: false, pickModes: opts.pickModes });
 
         const {
             pickGroupIncludes = ['datumNodes'] as PickGroupInclude[],
@@ -279,28 +281,118 @@ export abstract class CartesianSeries<
         this.highlightSelection = this.updateHighlightSelectionItem({ item, highlightSelection });
     }
 
-    pickNode(x: number, y: number): Node | undefined {
-        let result = super.pickNode(x, y);
+    protected pickNodeExactShape(x: number, y: number): Node | undefined {
+        let result = super.pickNodeExactShape(x, y);
 
-        if (!result) {
-            const { opts: { pickGroupIncludes } } = this;
-            const markerGroupIncluded = pickGroupIncludes.includes('markers');
+        if (result) {
+            return result;
+        }
 
-            for (const { pickGroup, markerGroup } of this.subGroups) {
-                result = pickGroup.pickNode(x, y);
+        const { opts: { pickGroupIncludes } } = this;
+        const markerGroupIncluded = pickGroupIncludes.includes('markers');
 
-                if (!result && markerGroupIncluded) {
-                    result = markerGroup?.pickNode(x, y);
-                }
+        for (const { pickGroup, markerGroup } of this.subGroups) {
+            result = pickGroup.pickNode(x, y);
 
-                if (result) {
-                    break;
+            if (!result && markerGroupIncluded) {
+                result = markerGroup?.pickNode(x, y);
+            }
+
+            if (result) {
+                return result;
+            }
+        }
+    }
+
+    protected pickNodeClosestDatum(x: number, y: number): { datum: SeriesNodeDatum, distance: number } | undefined {
+        const { xAxis, yAxis, group, contextNodeData } = this;
+        const hitPoint = group.transformPoint(x, y);
+
+        let minDistance = Infinity;
+        let closestDatum: SeriesNodeDatum | undefined;
+
+        for (const context of contextNodeData) {
+            for (const datum of context.nodeData) {
+                const { point: { x = NaN, y = NaN } = {} } = datum;
+                const isInRange = xAxis?.inRange(x) && yAxis?.inRange(y);
+                if (!isInRange) { continue; }
+    
+                // No need to use Math.sqrt() since x < y implies Math.sqrt(x) < Math.sqrt(y) for
+                // values > 1 
+                const distance = (hitPoint.x - x) ** 2 + (hitPoint.y - y) ** 2;
+                if (distance < minDistance) {
+                    minDistance = distance;
+                    closestDatum = datum;
                 }
             }
         }
 
-        return result;
+        if (closestDatum) {
+            return { datum: closestDatum, distance: Math.sqrt(minDistance) };
+        }
     }
+
+    protected pickNodeMainAxisFirst(
+        x: number,
+        y: number,
+        requireCategoryAxis: boolean,
+    ): { datum: SeriesNodeDatum, distance: number } | undefined {
+        const { xAxis, yAxis, group, contextNodeData } = this;
+        
+        // Prefer to start search with any available category axis.
+        const directions = [ xAxis, yAxis ]
+            .filter((a): a is CategoryAxis => a instanceof CategoryAxis)
+            .map(a => a.direction);
+        if (requireCategoryAxis && directions.length === 0) {
+            return;
+        }
+
+        // Default to X-axis unless we found a suitable category axis.
+        const [ primaryDirection = ChartAxisDirection.X ] = directions;
+
+        const hitPoint = group.transformPoint(x, y);
+        const hitPointCoords = primaryDirection === ChartAxisDirection.X ?
+            [hitPoint.x, hitPoint.y] : 
+            [hitPoint.y, hitPoint.x];
+
+        let minDistance = [Infinity, Infinity];
+        let closestDatum: SeriesNodeDatum | undefined = undefined;
+
+        for (const context of contextNodeData) {
+            for (const datum of context.nodeData) {
+                const { point: { x = NaN, y = NaN } = {} } = datum;
+                const isInRange = xAxis?.inRange(x) && yAxis?.inRange(y);
+                if (!isInRange) { continue; }
+
+                const point = primaryDirection === ChartAxisDirection.X ?
+                    [x, y] : 
+                    [y, x];
+
+                // Compare distances from most significant dimension to least.
+                let newMinDistance = true;
+                for (let i = 0; i < point.length; i++) {
+                    const dist = Math.abs(point[i] - hitPointCoords[i]);
+                    if (dist > minDistance[i]) {
+                        newMinDistance = false;
+                        break;
+                    }
+                    if (dist < minDistance[i]) {
+                        minDistance[i] = dist;
+                        minDistance.fill(Infinity, i + 1, minDistance.length);
+                    }
+                }
+
+                if (newMinDistance) {
+                    closestDatum = datum;
+                }
+            }
+        }
+
+        if (closestDatum) {
+            return { datum: closestDatum, distance: Math.sqrt(minDistance[0] ** 2 + minDistance[1] ** 2) };
+        }
+    }
+
 
     toggleSeriesItem(itemId: string, enabled: boolean): void {
         if (this.seriesItemEnabled.size > 0) {

--- a/charts-packages/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
@@ -1,4 +1,4 @@
-import { Series, SeriesNodeDataContext, SeriesNodeDatum, SeriesNodePickMode } from '../series';
+import { Series, SeriesNodeDataContext, SeriesNodeDatum, SeriesNodePickMode, SeriesNodePickMatch } from '../series';
 import { ChartAxis, ChartAxisDirection } from '../../chartAxis';
 import { SeriesMarker, SeriesMarkerFormatterParams } from '../seriesMarker';
 import { isContinuous, isDiscrete } from '../../../util/value';
@@ -281,7 +281,7 @@ export abstract class CartesianSeries<
         this.highlightSelection = this.updateHighlightSelectionItem({ item, highlightSelection });
     }
 
-    protected pickNodeExactShape(x: number, y: number): Node | undefined {
+    protected pickNodeExactShape(x: number, y: number): SeriesNodePickMatch | undefined {
         let result = super.pickNodeExactShape(x, y);
 
         if (result) {
@@ -292,19 +292,19 @@ export abstract class CartesianSeries<
         const markerGroupIncluded = pickGroupIncludes.includes('markers');
 
         for (const { pickGroup, markerGroup } of this.subGroups) {
-            result = pickGroup.pickNode(x, y);
+            let match = pickGroup.pickNode(x, y);
 
-            if (!result && markerGroupIncluded) {
-                result = markerGroup?.pickNode(x, y);
+            if (!match && markerGroupIncluded) {
+                match = markerGroup?.pickNode(x, y);
             }
 
-            if (result) {
-                return result;
+            if (match) {
+                return { datum: match.datum, distance: 0 };
             }
         }
     }
 
-    protected pickNodeClosestDatum(x: number, y: number): { datum: SeriesNodeDatum, distance: number } | undefined {
+    protected pickNodeClosestDatum(x: number, y: number): SeriesNodePickMatch | undefined {
         const { xAxis, yAxis, group, contextNodeData } = this;
         const hitPoint = group.transformPoint(x, y);
 

--- a/charts-packages/ag-charts-community/src/chart/series/cartesian/histogramSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/cartesian/histogramSeries.ts
@@ -9,6 +9,7 @@ import {
     SeriesTooltip,
     Series,
     SeriesNodeDataContext,
+    SeriesNodePickMode,
 } from '../series';
 import { Label } from '../../label';
 import { PointerEvents } from '../../../scene/node';
@@ -138,7 +139,7 @@ export class HistogramSeries extends CartesianSeries<SeriesNodeDataContext<Histo
     lineDashOffset: number = 0;
 
     constructor() {
-        super();
+        super({ pickModes: [ SeriesNodePickMode.EXACT_SHAPE_MATCH ] });
 
         this.label.enabled = false;
     }

--- a/charts-packages/ag-charts-community/src/chart/series/cartesian/scatterSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/cartesian/scatterSeries.ts
@@ -1,6 +1,6 @@
 import { Selection } from '../../../scene/selection';
 import { Group } from '../../../scene/group';
-import { SeriesNodeDatum, CartesianTooltipRendererParams, SeriesTooltip, SeriesNodeDataContext } from '../series';
+import { SeriesNodeDatum, CartesianTooltipRendererParams, SeriesTooltip, SeriesNodeDataContext, SeriesNodePickMode } from '../series';
 import { extent } from '../../../util/array';
 import { LegendDatum } from '../../legend';
 import { LinearScale } from '../../../scale/linearScale';
@@ -133,7 +133,15 @@ export class ScatterSeries extends CartesianSeries<SeriesNodeDataContext<Scatter
     readonly tooltip: ScatterSeriesTooltip = new ScatterSeriesTooltip();
 
     constructor() {
-        super({ pickGroupIncludes: ['markers'], pathsPerSeries: 0, features: ['markers'] });
+        super({
+            pickGroupIncludes: ['markers'],
+            pickModes: [
+                SeriesNodePickMode.NEAREST_BY_MAIN_CATEGORY_AXIS_FIRST,
+                SeriesNodePickMode.NEAREST_NODE,
+            ],
+            pathsPerSeries: 0,
+            features: ['markers'],
+        });
 
         const { label } = this;
 

--- a/charts-packages/ag-charts-community/src/chart/series/hierarchy/hierarchySeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/hierarchy/hierarchySeries.ts
@@ -1,6 +1,10 @@
 import { HierarchyChart } from "../../hierarchyChart";
-import { Series, SeriesNodeDatum, SeriesNodeDataContext } from "../series";
+import { Series, SeriesNodeDatum, SeriesNodeDataContext, SeriesNodePickMode } from "../series";
 
 export abstract class HierarchySeries<S extends SeriesNodeDatum> extends Series<SeriesNodeDataContext<S>> {
     chart?: HierarchyChart;
+
+    constructor() {
+        super({ pickModes: [ SeriesNodePickMode.EXACT_SHAPE_MATCH ] });
+    }
 }

--- a/charts-packages/ag-charts-community/src/chart/series/polar/polarSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/polar/polarSeries.ts
@@ -1,4 +1,4 @@
-import { Series, SeriesNodeDatum, SeriesNodeDataContext } from "../series";
+import { Series, SeriesNodeDatum, SeriesNodeDataContext, SeriesNodePickMode } from "../series";
 import { ChartAxisDirection } from "../../chartAxis";
 import { SeriesMarker, SeriesMarkerFormatterParams } from "../seriesMarker";
 import { RedrawType, SceneChangeDetection } from '../../../scene/changeDetectable';
@@ -24,6 +24,10 @@ export abstract class PolarSeries<S extends SeriesNodeDatum> extends Series<Seri
      * and is not supposed to be set by the user.
      */
     radius: number = 0;
+
+    constructor() {
+        super({ pickModes: [ SeriesNodePickMode.EXACT_SHAPE_MATCH ] });
+    }
 }
 
 export class PolarSeriesMarker extends SeriesMarker {

--- a/charts-packages/ag-charts-community/src/chart/series/series.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/series.ts
@@ -9,6 +9,7 @@ import { isNumber } from '../../util/value';
 import { TimeAxis } from '../axis/timeAxis';
 import { Node } from '../../scene/node';
 import { Deprecated } from '../../util/validation';
+import { CategoryAxis } from '../axis/categoryAxis';
 
 /**
  * Processed series datum used in node selections,
@@ -28,6 +29,18 @@ export interface SeriesNodeDatum {
         readonly x: number;
         readonly y: number;
     };
+}
+
+/** Modes of matching user interactions to rendered nodes (e.g. hover or click) */
+export enum SeriesNodePickMode {
+    /** Pick matches based upon pick coordinates being inside a matching shape/marker. */
+    EXACT_SHAPE_MATCH,
+    /** Pick matches by nearest category/X-axis value, then distance within that category/X-value. */
+    NEAREST_BY_MAIN_AXIS_FIRST,
+    /** Pick matches by nearest category value, then distance within that category. */
+    NEAREST_BY_MAIN_CATEGORY_AXIS_FIRST,
+    /** Pick matches based upon distance to ideal position */
+    NEAREST_NODE,
 }
 
 export interface TooltipRendererParams {
@@ -158,10 +171,14 @@ export abstract class Series<C extends SeriesNodeDataContext = SeriesNodeDataCon
     }
 
     showInLegend = true;
+    pickModes: SeriesNodePickMode[];
 
     cursor = 'default';
 
-    constructor({ seriesGroupUsesLayer = true } = {}) {
+    constructor({
+        seriesGroupUsesLayer = true,
+        pickModes = [SeriesNodePickMode.NEAREST_BY_MAIN_AXIS_FIRST],
+    } = {}) {
         super();
 
         const { group } = this;
@@ -181,6 +198,7 @@ export abstract class Series<C extends SeriesNodeDataContext = SeriesNodeDataCon
                 optimiseDirtyTracking: true,
             })
         );
+        this.pickModes = pickModes;
     }
 
     set grouped(g: boolean) {
@@ -325,8 +343,77 @@ export abstract class Series<C extends SeriesNodeDataContext = SeriesNodeDataCon
 
     abstract getTooltipHtml(seriesDatum: any): string;
 
-    pickNode(x: number, y: number): Node | undefined {
+    pickNode(
+        x: number,
+        y: number,
+        limitPickModes?: SeriesNodePickMode[],
+    ): { pickMode: SeriesNodePickMode, match: SeriesNodeDatum, distance: number } | undefined {
+        const { pickModes, visible, group, xAxis, yAxis } = this;
+
+        if (!visible || !group.visible) {
+            return;
+        }
+
+        for (const pickMode of pickModes) {
+            if (limitPickModes && limitPickModes.includes(pickMode)) {
+                continue;
+            }
+
+            let match: Node | SeriesNodeDatum | undefined = undefined;
+            let distance = Infinity;
+
+            switch (pickMode) {
+                case SeriesNodePickMode.EXACT_SHAPE_MATCH:
+                    match = this.pickNodeExactShape(x, y);
+                    distance = 0;
+                    break;
+
+                case SeriesNodePickMode.NEAREST_BY_MAIN_AXIS_FIRST:
+                case SeriesNodePickMode.NEAREST_BY_MAIN_CATEGORY_AXIS_FIRST:
+                    const result1 = this.pickNodeMainAxisFirst(
+                        x,
+                        y,
+                        pickMode === SeriesNodePickMode.NEAREST_BY_MAIN_CATEGORY_AXIS_FIRST,
+                    );
+                    if (result1) {
+                        match = result1.datum;
+                        distance = result1.distance;
+                    }
+                    break;
+
+                case SeriesNodePickMode.NEAREST_NODE:
+                    const result2 = this.pickNodeClosestDatum(x, y);
+                    if (result2) {
+                        match = result2.datum;
+                        distance = result2.distance;
+                    }
+                    break;
+            }
+
+            if (match) {
+                return { pickMode, match: match instanceof Node ? match.datum : match, distance };
+            }
+        }
+    }
+
+    protected pickNodeExactShape(x: number, y: number): Node | undefined {
         return this.pickGroup.pickNode(x, y);
+    }
+
+    protected pickNodeClosestDatum(_x: number, _y: number): { datum: SeriesNodeDatum, distance: number } | undefined {
+        // Override point for sub-classes - but if this is invoked, the sub-class specified it wants
+        // to use this feature.
+        throw new Error('AG Charts - Series.pickNodeClosestDatum() not implemented');
+    }
+
+    protected pickNodeMainAxisFirst(
+        _x: number,
+        _y: number,
+        _requireCategoryAxis: boolean
+    ): { datum: SeriesNodeDatum, distance: number } | undefined {
+        // Override point for sub-classes - but if this is invoked, the sub-class specified it wants
+        // to use this feature.
+        throw new Error('AG Charts - Series.pickNodeMainAxisFirst() not implemented');
     }
 
     fireNodeClickEvent(_event: MouseEvent, _datum: C['nodeData'][number]): void {


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-5738

As per [this analysis](https://ag-grid.atlassian.net/browse/AG-5738?focusedCommentId=43170), changes tooltip / node selection on hover to:
- For scatter series with number axes - pick closest datum.
- For scatter series with one or more category axes - pick closest X/Y category and then closest datum on that category.
- For bar/column series - pick only on hover-over a bar/column.
- For everything else - pick closest by X-axis value, then by Y-axis (when multiple series are present).

Bonus:
- Reworks the tooltip handling code to improve readability and simplify.