### PR TITLE
Enable `noUnused*` TSConfig rules for Charts.

### DIFF
--- a/charts-packages/ag-charts-community/src/chart/agChart.test.ts
+++ b/charts-packages/ag-charts-community/src/chart/agChart.test.ts
@@ -4,7 +4,7 @@ import { LegendPosition } from "./legend";
 import { AreaSeries } from "./series/cartesian/areaSeries";
 import { BarSeries } from "./series/cartesian/barSeries";
 import { LineSeries } from "./series/cartesian/lineSeries";
-import { ChartAxis, ChartAxisPosition } from "./chartAxis";
+import { ChartAxisPosition } from "./chartAxis";
 import { NumberAxis } from "./axis/numberAxis";
 import { ChartTheme } from "./themes/chartTheme";
 import { AgChartV2 } from "./agChartV2";
@@ -29,24 +29,6 @@ const revenueProfitData = [{
     revenue: 185000,
     profit: 50000,
     foobar: 23500
-}];
-
-const data2 = [{
-    month: 'Mar',
-    apples: 2,
-    oranges: 3
-}, {
-    month: 'May',
-    apples: 4,
-    oranges: 5
-}, {
-    month: 'Jun',
-    apples: 6,
-    oranges: 7
-}, {
-    month: 'Jul',
-    apples: 8,
-    oranges: 9
 }];
 
 describe('update', () => {

--- a/charts-packages/ag-charts-community/src/chart/test/utils.ts
+++ b/charts-packages/ag-charts-community/src/chart/test/utils.ts
@@ -58,7 +58,8 @@ export function loadExampleOptions(name: string, evalFn = 'options'): any {
 
     let evalExpr = `${dataFileContent.join('\n')} \n ${exampleFileLines.join('\n')}; ${evalFn};`;
     try {
-        require('../../main');
+        // @ts-ignore - used in the eval() call.
+        const agCharts = require('../../main');
         return eval(evalExpr);
     } catch (error) {
         console.error(`AG Charts - unable to read example data for [${name}]; error: ${error.message}`);

--- a/charts-packages/ag-charts-community/src/chart/test/utils.ts
+++ b/charts-packages/ag-charts-community/src/chart/test/utils.ts
@@ -58,7 +58,7 @@ export function loadExampleOptions(name: string, evalFn = 'options'): any {
 
     let evalExpr = `${dataFileContent.join('\n')} \n ${exampleFileLines.join('\n')}; ${evalFn};`;
     try {
-        const agCharts = require('../../main');
+        require('../../main');
         return eval(evalExpr);
     } catch (error) {
         console.error(`AG Charts - unable to read example data for [${name}]; error: ${error.message}`);

--- a/charts-packages/ag-charts-community/src/interpolate/color.test.ts
+++ b/charts-packages/ag-charts-community/src/interpolate/color.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, it } from "@jest/globals";
+import { expect, test } from "@jest/globals";
 import { Color } from "../util/color";
 import color from "./color";
 

--- a/charts-packages/ag-charts-community/src/scale/bandScale.test.ts
+++ b/charts-packages/ag-charts-community/src/scale/bandScale.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, it } from "@jest/globals";
+import { expect, test } from "@jest/globals";
 import { BandScale } from "./bandScale";
 
 test('initial state', () => {

--- a/charts-packages/ag-charts-community/src/scale/linearScale.test.ts
+++ b/charts-packages/ag-charts-community/src/scale/linearScale.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, it } from "@jest/globals";
+import { expect, test } from "@jest/globals";
 import { LinearScale } from "./linearScale";
 
 test('domain', () => {

--- a/charts-packages/ag-charts-community/src/scale/logScale.test.ts
+++ b/charts-packages/ag-charts-community/src/scale/logScale.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, it } from "@jest/globals";
+import { expect, test } from "@jest/globals";
 import { NumericTicks } from "../util/ticks";
 import { LogScale } from "./logScale";
 

--- a/charts-packages/ag-charts-community/src/scale/ordinalScale.test.ts
+++ b/charts-packages/ag-charts-community/src/scale/ordinalScale.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, it } from "@jest/globals";
+import { expect, test } from "@jest/globals";
 import { OrdinalScale } from "./ordinalScale";
 
 test('initial state', () => {

--- a/charts-packages/ag-charts-community/src/scene/matrix.test.ts
+++ b/charts-packages/ag-charts-community/src/scene/matrix.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, it } from "@jest/globals";
+import { expect, test } from "@jest/globals";
 import { Matrix } from "./matrix";
 
 test('multiply', () => {

--- a/charts-packages/ag-charts-community/src/scene/node.test.ts
+++ b/charts-packages/ag-charts-community/src/scene/node.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, it } from "@jest/globals";
+import { expect, test } from "@jest/globals";
 import { Rect } from "./shape/rect";
 import { Group } from "./group";
 

--- a/charts-packages/ag-charts-community/src/scene/path.test.ts
+++ b/charts-packages/ag-charts-community/src/scene/path.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, it } from "@jest/globals";
+import { expect, test } from "@jest/globals";
 import { Path2D } from "./path2D";
 
 test('parseSvgPath', () => {

--- a/charts-packages/ag-charts-community/src/util/color.test.ts
+++ b/charts-packages/ag-charts-community/src/util/color.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, it } from "@jest/globals";
+import { expect, test } from "@jest/globals";
 import { Color } from "./color";
 
 test('constructor', () => {

--- a/charts-packages/ag-charts-community/src/util/number.test.ts
+++ b/charts-packages/ag-charts-community/src/util/number.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, it } from "@jest/globals";
+import { expect, test } from "@jest/globals";
 import { toFixed, toReadableNumber } from "./number";
 
 test('toFixed', () => {

--- a/charts-packages/ag-charts-community/src/util/numberFormat.test.ts
+++ b/charts-packages/ag-charts-community/src/util/numberFormat.test.ts
@@ -1,7 +1,6 @@
-import { describe, expect, test, it } from "@jest/globals";
+import { describe, expect, test } from "@jest/globals";
 import { format, formatDecimalParts, formatPrefix } from "./numberFormat";
 import { LinearScale } from "../scale/linearScale";
-import { NumericTicks } from "./ticks";
 
 describe('formatDecimalParts', () => {
     test('1.23', () => {

--- a/charts-packages/ag-charts-community/src/util/object.test.ts
+++ b/charts-packages/ag-charts-community/src/util/object.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, it } from "@jest/globals";
+import { expect, test } from "@jest/globals";
 import { getValue } from './object';
 
 test('getValue', () => {

--- a/charts-packages/ag-charts-community/src/util/secondaryAxisTicks.test.ts
+++ b/charts-packages/ag-charts-community/src/util/secondaryAxisTicks.test.ts
@@ -1,8 +1,8 @@
 import { expect, test } from "@jest/globals";
-import { calculateNiceSecondaryAxis, getTicks } from "./secondaryAxisTicks";
+import { calculateNiceSecondaryAxis } from "./secondaryAxisTicks";
 
 function ticks(a: number, b: number, count: number): number[] {
-    let [domain, ticks] = calculateNiceSecondaryAxis([a, b], count);
+    let [, ticks] = calculateNiceSecondaryAxis([a, b], count);
     return ticks;
 }
 

--- a/charts-packages/ag-charts-community/src/util/string.test.ts
+++ b/charts-packages/ag-charts-community/src/util/string.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, it } from "@jest/globals";
+import { describe, expect, it } from "@jest/globals";
 import { interpolate } from "./string";
 import { locale } from "./time/format/defaultLocale";
 

--- a/charts-packages/ag-charts-community/src/util/ticks.test.ts
+++ b/charts-packages/ag-charts-community/src/util/ticks.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, it } from "@jest/globals";
+import { expect, test } from "@jest/globals";
 import getTicks, { NumericTicks } from "./ticks";
 
 function compareTicks(ticks: NumericTicks, array: number[]) {

--- a/charts-packages/ag-charts-community/src/util/time/format/locale.test.ts
+++ b/charts-packages/ag-charts-community/src/util/time/format/locale.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, it } from "@jest/globals";
+import { expect, test } from "@jest/globals";
 import formatLocale, { formatRe, pad, requote, TimeLocaleDefinition } from "./locale";
 
 const defaultLocaleDefinition: TimeLocaleDefinition = {

--- a/charts-packages/ag-charts-community/src/util/time/minute.test.ts
+++ b/charts-packages/ag-charts-community/src/util/time/minute.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, it } from "@jest/globals";
+import { expect, test } from "@jest/globals";
 import minute from "./minute";
 
 test('minute.every', () => {

--- a/charts-packages/ag-charts-community/src/util/time/week.test.ts
+++ b/charts-packages/ag-charts-community/src/util/time/week.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, it } from "@jest/globals";
+import { expect, test } from "@jest/globals";
 import { sunday } from "./week";
 import { durationMinute } from "./duration";
 

--- a/charts-packages/ag-charts-community/src/util/value.test.ts
+++ b/charts-packages/ag-charts-community/src/util/value.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, it } from "@jest/globals";
+import { expect, test } from "@jest/globals";
 import { isNumber, isContinuous, isStringObject, isNumberObject } from "./value";
 
 test('isNumber', () => {

--- a/charts-packages/ag-charts-community/tsconfig.cjs.es5.json
+++ b/charts-packages/ag-charts-community/tsconfig.cjs.es5.json
@@ -7,7 +7,9 @@
             "@ag-*": [
                 "node_modules/@ag-*/dist/cjs/es5/main"
             ]
-        }
+        },
+        "noUnusedParameters": true,
+        "noUnusedLocals": true,
     },
     "include": [
         "src/**/*"

--- a/charts-packages/ag-charts-community/tsconfig.cjs.es6.json
+++ b/charts-packages/ag-charts-community/tsconfig.cjs.es6.json
@@ -7,7 +7,9 @@
             "@ag-*": [
                 "node_modules/@ag-*/dist/cjs/es6/main"
             ]
-        }
+        },
+        "noUnusedParameters": true,
+        "noUnusedLocals": true,
     },
     "include": [
         "src/**/*"

--- a/charts-packages/ag-charts-community/tsconfig.esm.es5.json
+++ b/charts-packages/ag-charts-community/tsconfig.esm.es5.json
@@ -7,8 +7,10 @@
       "@ag-*": [
         "node_modules/@ag-*/dist/esm/es5/main"
       ]
-    }
-  },
+    },
+    "noUnusedParameters": true,
+    "noUnusedLocals": true,
+},
   "include": [
     "src/**/*"
   ],

--- a/charts-packages/ag-charts-community/tsconfig.esm.es6.json
+++ b/charts-packages/ag-charts-community/tsconfig.esm.es6.json
@@ -7,7 +7,9 @@
       "@ag-*": [
         "node_modules/@ag-*/dist/esm/es6/main"
       ]
-    }
+    },
+    "noUnusedParameters": true,
+    "noUnusedLocals": true,
   },
   "include": [
     "src/**/*"

--- a/charts-packages/ag-charts-community/tsconfig.test.json
+++ b/charts-packages/ag-charts-community/tsconfig.test.json
@@ -2,7 +2,9 @@
   "extends": "../../module-build/tsconfig.test.json",
   "compilerOptions": {
     "outDir": "dist-test",
-    "rootDir": "src/ts"
+    "rootDir": "src/ts",
+    "noUnusedParameters": true,
+    "noUnusedLocals": true,
   },
   "include": [
     "**/*.test.ts",


### PR DESCRIPTION
Enabled stricter `tsconfig.json` compiler options, to highlight low-hanging SonarCloud issues more proactively.

Bonus:
- Fixes all current violations of these new rules.