### PR TITLE
AG-6225 - Clear Sparklines canvas using the element width and height …

### DIFF
--- a/enterprise-modules/sparklines/src/canvas/hdpiCanvas.ts
+++ b/enterprise-modules/sparklines/src/canvas/hdpiCanvas.ts
@@ -55,7 +55,7 @@ export class HdpiCanvas {
 
     clear() {
         this.context.save();
-        this.context.resetTransform();
+        this.context.setTransform(1, 0, 0, 1, 0, 0);
         this.context.clearRect(0, 0, this.element.width, this.element.height);
         this.context.restore();
     }

--- a/enterprise-modules/sparklines/src/canvas/hdpiCanvas.ts
+++ b/enterprise-modules/sparklines/src/canvas/hdpiCanvas.ts
@@ -53,6 +53,13 @@ export class HdpiCanvas {
         Object.freeze(this);
     }
 
+    clear() {
+        this.context.save();
+        this.context.resetTransform();
+        this.context.clearRect(0, 0, this.element.width, this.element.height);
+        this.context.restore();
+    }
+
     toImage(): HTMLImageElement {
         const img = this.document.createElement('img');
         img.src = this.getDataURL();

--- a/enterprise-modules/sparklines/src/scene/scene.ts
+++ b/enterprise-modules/sparklines/src/scene/scene.ts
@@ -149,7 +149,7 @@ export class Scene {
     }
 
     readonly render = () => {
-        const { ctx, root, pendingSize } = this;
+        const { canvas, ctx, root, pendingSize } = this;
 
         this.animationFrameId = 0;
 
@@ -164,7 +164,7 @@ export class Scene {
         }
 
         // start with a blank canvas, clear previous drawing
-        ctx.clearRect(0, 0, this.width, this.height);
+        canvas.clear();
 
         if (root) {
             ctx.save();


### PR DESCRIPTION
This PR is for https://ag-grid.atlassian.net/browse/AG-6225.

Couldn't reproduce the issue but have added a clear function which will completely wipe the canvas before redrawing