### PR TITLE
AG-6671 - Fix sparklines item highlighting

### DIFF
--- a/enterprise-modules/sparklines/src/sparkline/sparkline.ts
+++ b/enterprise-modules/sparklines/src/sparkline/sparkline.ts
@@ -561,8 +561,6 @@ export abstract class Sparkline extends Observable {
             if (distance <= minDistance) {
                 minDistance = distance;
                 closestDatum = datum;
-            } else {
-                return closestDatum;
             }
         }
 


### PR DESCRIPTION
Don't break out of the loop early when finding closest node during highlighting as this approach breaks in the case where the provided sparkline data is not ordered