### PR TITLE
Ag 5105/cross lines

### DIFF
--- a/charts-packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
@@ -22,7 +22,7 @@ import { interpolate } from '../../../util/string';
 import { Text, FontStyle, FontWeight } from '../../../scene/shape/text';
 import { Label } from '../../label';
 import { sanitizeHtml } from '../../../util/sanitize';
-import { isContinuous, isNumber } from '../../../util/value';
+import { checkDatum, isContinuous, isNumber } from '../../../util/value';
 import { clamper, ContinuousScale } from '../../../scale/continuousScale';
 import { doOnce } from '../../../util/function';
 
@@ -252,7 +252,7 @@ export class AreaSeries extends CartesianSeries<AreaSeriesNodeDataContext> {
                 continue;
             }
 
-            const xDatum = this.checkDatum(datum[xKey], isContinuousX);
+            const xDatum = checkDatum(datum[xKey], isContinuousX);
             if (isContinuousX && xDatum === undefined) {
                 continue;
             } else {
@@ -275,7 +275,7 @@ export class AreaSeries extends CartesianSeries<AreaSeriesNodeDataContext> {
                 if (!seriesItemEnabled.get(yKey)) {
                     seriesYs.push(0);
                 } else {
-                    const yDatum = this.checkDatum(value, isContinuousY);
+                    const yDatum = checkDatum(value, isContinuousY);
                     seriesYs.push(yDatum);
                 }
             });

--- a/charts-packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
@@ -22,7 +22,7 @@ import { equal } from '../../../util/equal';
 import { TypedEvent } from '../../../util/observable';
 import { Scale } from '../../../scale/scale';
 import { sanitizeHtml } from '../../../util/sanitize';
-import { isNumber } from '../../../util/value';
+import { checkDatum, isNumber } from '../../../util/value';
 import { clamper, ContinuousScale } from '../../../scale/continuousScale';
 
 export interface BarSeriesNodeClickEvent extends TypedEvent {
@@ -355,7 +355,7 @@ export class BarSeries extends CartesianSeries<SeriesNodeDataContext<BarNodeDatu
                 console.warn(`The key '${xKey}' was not found in the data: `, datum);
             }
 
-            const x = this.checkDatum(datum[xKey], isContinuousX);
+            const x = checkDatum(datum[xKey], isContinuousX);
 
             if (isContinuousX) {
                 setSmallestXInterval(x, prevX);
@@ -374,7 +374,7 @@ export class BarSeries extends CartesianSeries<SeriesNodeDataContext<BarNodeDatu
                         console.warn(`The key '${yKey}' was not found in the data: `, datum);
                     }
 
-                    const yDatum = this.checkDatum(datum[yKey], isContinuousY);
+                    const yDatum = checkDatum(datum[yKey], isContinuousY);
 
                     if (!seriesItemEnabled.get(yKey) || yDatum === undefined) {
                         return 0;

--- a/charts-packages/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
@@ -90,25 +90,6 @@ export abstract class CartesianSeries<
     }
 
     /**
-     * Note: we are passing `isContinuousScale` into this method because it will
-     *       typically be called inside a loop and this check only needs to happen once.
-     * @param value A domain value to be plotted along an axis.
-     * @param isContinuousScale Typically this will be the value of `xAxis.scale instanceof ContinuousScale` or `yAxis.scale instanceof ContinuousScale`.
-     * @returns `value`, if the value is valid for its axis/scale, or `undefined`.
-     */
-    protected checkDatum<T>(value: T, isContinuousScale: boolean): T | string | undefined {
-        if (isContinuousScale && isContinuous(value)) {
-            return value;
-        } else if (!isContinuousScale) {
-            if (!isDiscrete(value)) {
-                return String(value);
-            }
-            return value;
-        }
-        return undefined;
-    }
-
-    /**
      * Note: we are passing the xAxis and yAxis because the calling code is supposed to make sure
      *       that series has both of them defined, and also to avoid one level of indirection,
      *       e.g. `this.xAxis!.inRange(x)`, both of which are suboptimal in tight loops where this method is used.

--- a/charts-packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
@@ -15,7 +15,7 @@ import { TooltipRendererResult, toTooltipHtml } from '../../chart';
 import { interpolate } from '../../../util/string';
 import { Label } from '../../label';
 import { sanitizeHtml } from '../../../util/sanitize';
-import { isContinuous } from '../../../util/value';
+import { checkDatum, isContinuous } from '../../../util/value';
 import { Marker } from '../../marker/marker';
 
 interface LineNodeDatum extends SeriesNodeDatum {
@@ -144,7 +144,7 @@ export class LineSeries extends CartesianSeries<LineContext> {
             const x = datum[xKey];
             const y = datum[yKey];
 
-            const xDatum = this.checkDatum(x, isContinuousX);
+            const xDatum = checkDatum(x, isContinuousX);
 
             if (isContinuousX && xDatum === undefined) {
                 continue;
@@ -152,7 +152,7 @@ export class LineSeries extends CartesianSeries<LineContext> {
                 xData.push(xDatum);
             }
 
-            const yDatum = this.checkDatum(y, isContinuousY);
+            const yDatum = checkDatum(y, isContinuousY);
             yData.push(yDatum);
         }
 

--- a/charts-packages/ag-charts-community/src/chart/series/cartesian/scatterSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/cartesian/scatterSeries.ts
@@ -22,7 +22,7 @@ import { Text } from '../../../scene/shape/text';
 import { HdpiCanvas } from '../../../canvas/hdpiCanvas';
 import { Marker } from '../../marker/marker';
 import { MeasuredLabel } from '../../../util/labelPlacement';
-import { isContinuous } from '../../../util/value';
+import { checkDatum, isContinuous } from '../../../util/value';
 import { Deprecated } from '../../../util/validation';
 
 interface ScatterNodeDatum extends SeriesNodeDatum {
@@ -170,9 +170,7 @@ export class ScatterSeries extends CartesianSeries<SeriesNodeDataContext<Scatter
         const isContinuousY = yScale instanceof ContinuousScale;
 
         this.validData = data.filter(
-            (d) =>
-                this.checkDatum(d[xKey], isContinuousX) !== undefined &&
-                this.checkDatum(d[yKey], isContinuousY) !== undefined
+            (d) => checkDatum(d[xKey], isContinuousX) !== undefined && checkDatum(d[yKey], isContinuousY) !== undefined
         );
         this.xData = this.validData.map((d) => d[xKey]);
         this.yData = this.validData.map((d) => d[yKey]);

--- a/charts-packages/ag-charts-community/src/chart/themes/chartTheme.ts
+++ b/charts-packages/ag-charts-community/src/chart/themes/chartTheme.ts
@@ -97,11 +97,11 @@ export class ChartTheme {
                 },
             ],
             crossLines: {
-                enabled: true,
+                enabled: false,
                 fill: 'rgb(187,221,232)',
                 stroke: 'rgb(70,162,192)',
                 label: {
-                    enabled: true,
+                    enabled: false,
                     fontStyle: undefined,
                     fontWeight: undefined,
                     fontSize: 12,

--- a/charts-packages/ag-charts-community/src/util/value.ts
+++ b/charts-packages/ag-charts-community/src/util/value.ts
@@ -34,3 +34,15 @@ export function isDiscrete(value: any): boolean {
 export function isContinuous(value: any): boolean {
     return isNumeric(value) || isDate(value);
 }
+
+export function checkDatum<T>(value: T, isContinuousScale: boolean): T | string | undefined {
+    if (isContinuousScale && isContinuous(value)) {
+        return value;
+    } else if (!isContinuousScale) {
+        if (!isDiscrete(value)) {
+            return String(value);
+        }
+        return value;
+    }
+    return undefined;
+}

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-axes/index.md
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-axes/index.md
@@ -428,7 +428,7 @@ crossLines: [
     type: 'range',
     range: ['apple', 'orange'],
     label: {
-      text: 'Peak',
+      text: 'Price Peak',
       position: 'top',
       fontSize: 14,
       // other cross line label options...


### PR DESCRIPTION
- Validate the values supplied to cross lines 
- Only clamp values for range cross lines
- Do not display line for clamped range boundaries
- Do not display line cross lines outside of the axis domain
- Make crossLine invisible if update results in no path data
- Update crossLine docs
- Set the default enabled values for cross lines and cross line label to false in chartTheme