### PR TITLE
AG-6133 - Improve axes rendering when no series enabled

### DIFF
--- a/charts-packages/ag-charts-community/src/axis.ts
+++ b/charts-packages/ag-charts-community/src/axis.ts
@@ -206,10 +206,11 @@ export class Axis<S extends Scale<D, number>, D = any> {
     readonly axisGroup = new Group({ name: `${this.id}-axis`, layer: true, zIndex: 50 });
     readonly crossLineGroup: Group = new Group({ name: `${this.id}-CrossLines` });
 
-    private readonly tickLineGroup = this.axisGroup.appendChild(new Group());
-    private readonly titleGroup = this.axisGroup.appendChild(new Group());
-    private tickLineGroupSelection = Selection.select(this.tickLineGroup).selectAll<Group>();
-    private lineNode = this.tickLineGroup.appendChild(new Line());
+    private readonly lineGroup = this.axisGroup.appendChild(new Group({ name: `${this.id}-Line` }));
+    private readonly tickGroup = this.axisGroup.appendChild(new Group({ name: `${this.id}-Tick` }));
+    private readonly titleGroup = this.axisGroup.appendChild(new Group({ name: `${this.id}-Title` }));
+    private tickLineGroupSelection = Selection.select(this.tickGroup).selectAll<Group>();
+    private lineNode = this.lineGroup.appendChild(new Line());
 
     readonly gridlineGroup = new Group({ name: `${this.id}-gridline`, layer: true, zIndex: 0 });
     private gridlineGroupSelection = Selection.select(this.gridlineGroup).selectAll<Group>();
@@ -396,7 +397,7 @@ export class Axis<S extends Scale<D, number>, D = any> {
             this._title = value;
 
             // position title so that it doesn't briefly get rendered in the top left hand corner of the canvas before update is called.
-            this.positionTitle();
+            this.updateTitle({ ticks: this.ticks || this.scale.ticks!(this.calculatedTickCount) });
         }
     }
     get title(): Caption | undefined {
@@ -458,16 +459,6 @@ export class Axis<S extends Scale<D, number>, D = any> {
 
     /**
      * Creates/removes/updates the scene graph nodes that constitute the axis.
-     * Supposed to be called _manually_ after changing _any_ of the axis properties.
-     * This allows to bulk set axis properties before updating the nodes.
-     * The node changes made by this method are rendered on the next animation frame.
-     * We could schedule this method call automatically on the next animation frame
-     * when any of the axis properties change (the way we do when properties of scene graph's
-     * nodes change), but this will mean that we first wait for the next animation
-     * frame to make changes to the nodes of the axis, then wait for another animation
-     * frame to render those changes. It's nice to have everything update automatically,
-     * but this extra level of async indirection will not just introduce an unwanted delay,
-     * it will also make it harder to reason about the program.
      */
     update() {
         const {
@@ -478,16 +469,13 @@ export class Axis<S extends Scale<D, number>, D = any> {
             gridLength,
             tick,
             label,
-            gridStyle,
             requestedRange,
             translation,
         } = this;
-        const requestedRangeMin = Math.min(requestedRange[0], requestedRange[1]);
-        const requestedRangeMax = Math.max(requestedRange[0], requestedRange[1]);
+        const requestedRangeMin = Math.min(...requestedRange);
+        const requestedRangeMax = Math.max(...requestedRange);
         const rotation = toRadians(this.rotation);
-        const labelRotation = label.rotation ? normalizeAngle360(toRadians(label.rotation)) : 0;
         const parallelLabels = label.parallel;
-        let labelAutoRotation = 0;
 
         const translationX = Math.floor(translation.x);
         const translationY = Math.floor(translation.y);
@@ -504,7 +492,7 @@ export class Axis<S extends Scale<D, number>, D = any> {
         gridlineGroup.translationY = translationY;
         gridlineGroup.rotation = rotation;
 
-        const halfBandwidth = (scale.bandwidth || 0) / 2;
+        this.updateLine();
 
         // The side of the axis line to position the labels on.
         // -1 = left (default)
@@ -520,14 +508,79 @@ export class Axis<S extends Scale<D, number>, D = any> {
         // -1 = flip
         //  1 = don't flip (default)
         const parallelFlipRotation = normalizeAngle360(rotation);
-        const parallelFlipFlag =
-            !labelRotation && parallelFlipRotation >= 0 && parallelFlipRotation <= Math.PI ? -1 : 1;
-
         const regularFlipRotation = normalizeAngle360(rotation - Math.PI / 2);
-        // Flip if the axis rotation angle is in the top hemisphere.
-        const regularFlipFlag = !labelRotation && regularFlipRotation >= 0 && regularFlipRotation <= Math.PI ? -1 : 1;
+        const halfBandwidth = (scale.bandwidth || 0) / 2;
 
         const ticks = this.ticks || scale.ticks!(this.calculatedTickCount);
+        const tickLineGroupSelection = this.updateTicks({ ticks });
+        const labelBboxes = this.updateLabels({
+            parallelFlipRotation,
+            regularFlipRotation,
+            sideFlag,
+            tickLineGroupSelection,
+            ticks,
+        });
+        const gridlineGroupSelection = this.updateGridLines({
+            gridLength,
+            ticks,
+            halfBandwidth,
+            labelBboxes,
+            sideFlag,
+        });
+
+        this.tickLineGroupSelection = tickLineGroupSelection;
+        this.gridlineGroupSelection = gridlineGroupSelection;
+
+        let anyTickVisible = false;
+        const translationYFn = (_: unknown, datum: any) => Math.round(scale.convert(datum) + halfBandwidth);
+        const visibleFn = (node: Group) => {
+            const min = Math.floor(requestedRangeMin);
+            const max = Math.ceil(requestedRangeMax);
+            const visible = min !== max && node.translationY >= min && node.translationY <= max;
+            anyTickVisible = visible || anyTickVisible;
+            return visible;
+        };
+
+        tickLineGroupSelection.attrFn('translationY', translationYFn).attrFn('visible', visibleFn);
+        gridlineGroupSelection.attrFn('translationY', translationYFn).attrFn('visible', visibleFn);
+
+        this.tickGroup.visible = anyTickVisible;
+        this.gridlineGroup.visible = anyTickVisible;
+
+        if (!anyTickVisible) {
+            this.crossLines?.forEach((crossLine) => {
+                crossLine.update(anyTickVisible);
+            });
+            this.updateTitle({ ticks });
+            return;
+        }
+
+        tickLineGroupSelection
+            .selectByTag<Line>(Tags.Tick)
+            .each((line, _, index) => {
+                line.strokeWidth = tick.width;
+                line.stroke = tick.color;
+                line.visible = labelBboxes.has(index);
+            })
+            .attr('x1', sideFlag * tick.size)
+            .attr('x2', 0)
+            .attr('y1', 0)
+            .attr('y2', 0);
+
+        this.updateTitle({ ticks });
+
+        this.crossLines?.forEach((crossLine) => {
+            crossLine.sideFlag = -sideFlag as -1 | 1;
+            crossLine.direction = rotation === -Math.PI / 2 ? ChartAxisDirection.X : ChartAxisDirection.Y;
+            crossLine.label.parallel =
+                crossLine.label.parallel !== undefined ? crossLine.label.parallel : parallelLabels;
+            crossLine.parallelFlipRotation = parallelFlipRotation;
+            crossLine.regularFlipRotation = regularFlipRotation;
+            crossLine.update(anyTickVisible);
+        });
+    }
+
+    private updateTicks({ ticks }: { ticks: any[] }) {
         const updateAxis = this.tickLineGroupSelection.setData(ticks);
         updateAxis.exit.remove();
 
@@ -536,7 +589,23 @@ export class Axis<S extends Scale<D, number>, D = any> {
         enterAxis.append(Line).each((node) => (node.tag = Tags.Tick));
         enterAxis.append(Text);
 
-        const tickLineGroupSelection = updateAxis.merge(enterAxis);
+        return updateAxis.merge(enterAxis);
+    }
+
+    private updateGridLines({
+        gridLength,
+        ticks,
+        labelBboxes,
+        halfBandwidth,
+        sideFlag,
+    }: {
+        gridLength: number;
+        ticks: any[];
+        labelBboxes: Map<number, BBox | null>;
+        halfBandwidth: number;
+        sideFlag: -1 | 1;
+    }) {
+        const { gridStyle, scale, tick } = this;
 
         const updateGridlines = this.gridlineGroupSelection.setData(gridLength ? ticks : []);
         updateGridlines.exit.remove();
@@ -552,31 +621,75 @@ export class Axis<S extends Scale<D, number>, D = any> {
             gridlineGroupSelection = updateGridlines.merge(enterGridline);
         }
 
-        let anyVisible = false;
-        const translationYFn = (_: unknown, datum: any) => Math.round(scale.convert(datum) + halfBandwidth);
-        const visibleFn = (node: Group) => {
-            const min = Math.floor(requestedRangeMin);
-            const max = Math.ceil(requestedRangeMax);
-            const visible = min !== max && node.translationY >= min && node.translationY <= max;
-            anyVisible = visible || anyVisible;
-            return visible;
-        };
+        if (gridLength && gridStyle.length) {
+            const styleCount = gridStyle.length;
+            let gridLines: Selection<Shape, Group, D, D>;
 
-        tickLineGroupSelection.attrFn('translationY', translationYFn).attrFn('visible', visibleFn);
-        gridlineGroupSelection.attrFn('translationY', translationYFn).attrFn('visible', visibleFn);
+            if (this.radialGrid) {
+                const angularGridLength = normalizeAngle360Inclusive(toRadians(gridLength));
 
-        this.axisGroup.visible = anyVisible;
-        this.gridlineGroup.visible = anyVisible;
-        if (!anyVisible) {
-            this.tickLineGroupSelection = tickLineGroupSelection;
-            this.gridlineGroupSelection = gridlineGroupSelection;
+                gridLines = gridlineGroupSelection.selectByTag<Arc>(Tags.GridLine).each((arc, datum, index) => {
+                    const radius = Math.round(scale.convert(datum) + halfBandwidth);
 
-            this.crossLines?.forEach((crossLine) => {
-                crossLine.update(anyVisible);
+                    arc.centerX = 0;
+                    arc.centerY = scale.range[0] - radius;
+                    arc.endAngle = angularGridLength;
+                    arc.radiusX = radius;
+                    arc.radiusY = radius;
+                    arc.visible = labelBboxes.has(index);
+                });
+            } else {
+                gridLines = gridlineGroupSelection.selectByTag<Line>(Tags.GridLine).each((line, _, index) => {
+                    line.x1 = 0;
+                    line.x2 = -sideFlag * gridLength;
+                    line.y1 = 0;
+                    line.y2 = 0;
+                    line.visible = Math.abs(line.parent!.translationY - scale.range[0]) > 1 && labelBboxes.has(index);
+                });
+            }
+
+            gridLines.each((gridLine, _, index) => {
+                const style = gridStyle[index % styleCount];
+
+                gridLine.stroke = style.stroke;
+                gridLine.strokeWidth = tick.width;
+                gridLine.lineDash = style.lineDash;
+                gridLine.fill = undefined;
             });
-
-            return;
         }
+
+        return gridlineGroupSelection;
+    }
+
+    private updateLabels({
+        ticks,
+        tickLineGroupSelection,
+        sideFlag,
+        parallelFlipRotation,
+        regularFlipRotation,
+    }: {
+        ticks: any[];
+        tickLineGroupSelection: Selection<Group, any>;
+        sideFlag: -1 | 1;
+        parallelFlipRotation: number;
+        regularFlipRotation: number;
+    }) {
+        const {
+            label,
+            label: { parallel: parallelLabels },
+            scale,
+            tick,
+            requestedRange,
+        } = this;
+        const requestedRangeMin = Math.min(...requestedRange);
+        const requestedRangeMax = Math.max(...requestedRange);
+        let labelAutoRotation = 0;
+
+        const labelRotation = label.rotation ? normalizeAngle360(toRadians(label.rotation)) : 0;
+        const parallelFlipFlag =
+            !labelRotation && parallelFlipRotation >= 0 && parallelFlipRotation <= Math.PI ? -1 : 1;
+        // Flip if the axis rotation angle is in the top hemisphere.
+        const regularFlipFlag = !labelRotation && regularFlipRotation >= 0 && regularFlipRotation <= Math.PI ? -1 : 1;
 
         // `ticks instanceof NumericTicks` doesn't work here, so we feature detect.
         this.fractionDigits = (ticks as any).fractionDigits >= 0 ? (ticks as any).fractionDigits : 0;
@@ -728,94 +841,32 @@ export class Axis<S extends Scale<D, number>, D = any> {
             });
         }
 
-        tickLineGroupSelection
-            .selectByTag<Line>(Tags.Tick)
-            .each((line, _, index) => {
-                line.strokeWidth = tick.width;
-                line.stroke = tick.color;
-                line.visible = labelBboxes.has(index);
-            })
-            .attr('x1', sideFlag * tick.size)
-            .attr('x2', 0)
-            .attr('y1', 0)
-            .attr('y2', 0);
+        return labelBboxes;
+    }
 
-        if (gridLength && gridStyle.length) {
-            const styleCount = gridStyle.length;
-            let gridLines: Selection<Shape, Group, D, D>;
-
-            if (this.radialGrid) {
-                const angularGridLength = normalizeAngle360Inclusive(toRadians(gridLength));
-
-                gridLines = gridlineGroupSelection.selectByTag<Arc>(Tags.GridLine).each((arc, datum, index) => {
-                    const radius = Math.round(scale.convert(datum) + halfBandwidth);
-
-                    arc.centerX = 0;
-                    arc.centerY = scale.range[0] - radius;
-                    arc.endAngle = angularGridLength;
-                    arc.radiusX = radius;
-                    arc.radiusY = radius;
-                    arc.visible = labelBboxes.has(index);
-                });
-            } else {
-                gridLines = gridlineGroupSelection.selectByTag<Line>(Tags.GridLine).each((line, _, index) => {
-                    line.x1 = 0;
-                    line.x2 = -sideFlag * gridLength;
-                    line.y1 = 0;
-                    line.y2 = 0;
-                    line.visible = Math.abs(line.parent!.translationY - scale.range[0]) > 1 && labelBboxes.has(index);
-                });
-            }
-
-            gridLines.each((gridLine, _, index) => {
-                const style = gridStyle[index % styleCount];
-
-                gridLine.stroke = style.stroke;
-                gridLine.strokeWidth = tick.width;
-                gridLine.lineDash = style.lineDash;
-                gridLine.fill = undefined;
-            });
-        }
-
-        this.tickLineGroupSelection = tickLineGroupSelection;
-        this.gridlineGroupSelection = gridlineGroupSelection;
-
+    private updateLine() {
         // Render axis line.
-        const lineNode = this.lineNode;
+        const { lineNode, requestedRange } = this;
+
         lineNode.x1 = 0;
         lineNode.x2 = 0;
         lineNode.y1 = requestedRange[0];
         lineNode.y2 = requestedRange[1];
         lineNode.strokeWidth = this.line.width;
         lineNode.stroke = this.line.color;
-        lineNode.visible = ticks.length > 0;
-
-        this.positionTitle();
-
-        this.crossLines?.forEach((crossLine) => {
-            crossLine.sideFlag = -sideFlag as -1 | 1;
-            crossLine.direction = rotation === -Math.PI / 2 ? ChartAxisDirection.X : ChartAxisDirection.Y;
-            crossLine.label.parallel =
-                crossLine.label.parallel !== undefined ? crossLine.label.parallel : parallelLabels;
-            crossLine.parallelFlipRotation = parallelFlipRotation;
-            crossLine.regularFlipRotation = regularFlipRotation;
-            crossLine.update(anyVisible);
-        });
+        lineNode.visible = true;
     }
 
-    private positionTitle(): void {
-        const { title, lineNode } = this;
+    private updateTitle({ ticks }: { ticks: any[] }): void {
+        const { label, rotation, title, lineNode, requestedRange, tickGroup, lineGroup } = this;
 
         if (!title) {
             return;
         }
 
         let titleVisible = false;
-
         if (title.enabled && lineNode.visible) {
             titleVisible = true;
-
-            const { label, rotation, requestedRange } = this;
 
             const sideFlag = label.mirrored ? 1 : -1;
             const parallelFlipRotation = normalizeAngle360(rotation);
@@ -827,8 +878,12 @@ export class Axis<S extends Scale<D, number>, D = any> {
             titleNode.rotation = (titleRotationFlag * sideFlag * Math.PI) / 2;
             titleNode.x = Math.floor((titleRotationFlag * sideFlag * (requestedRange[0] + requestedRange[1])) / 2);
 
-            const bbox = this.tickLineGroup.computeBBox();
-            const bboxYDimension = rotation === 0 ? bbox.width : bbox.height;
+            const lineBBox = lineGroup.computeBBox();
+            let bboxYDimension = rotation === 0 ? lineBBox.width : lineBBox.height;
+            if (ticks?.length > 0) {
+                const tickBBox = tickGroup.computeBBox();
+                bboxYDimension += rotation === 0 ? tickBBox.width : tickBBox.height;
+            }
             if (sideFlag === -1) {
                 titleNode.y = Math.floor(titleRotationFlag * (-padding - bboxYDimension));
             } else {

--- a/charts-packages/ag-charts-community/src/axis.ts
+++ b/charts-packages/ag-charts-community/src/axis.ts
@@ -209,7 +209,7 @@ export class Axis<S extends Scale<D, number>, D = any> {
     private readonly lineGroup = this.axisGroup.appendChild(new Group({ name: `${this.id}-Line` }));
     private readonly tickGroup = this.axisGroup.appendChild(new Group({ name: `${this.id}-Tick` }));
     private readonly titleGroup = this.axisGroup.appendChild(new Group({ name: `${this.id}-Title` }));
-    private tickLineGroupSelection = Selection.select(this.tickGroup).selectAll<Group>();
+    private tickGroupSelection = Selection.select(this.tickGroup).selectAll<Group>();
     private lineNode = this.lineGroup.appendChild(new Line());
 
     readonly gridlineGroup = new Group({ name: `${this.id}-gridline`, layer: true, zIndex: 0 });
@@ -512,12 +512,12 @@ export class Axis<S extends Scale<D, number>, D = any> {
         const halfBandwidth = (scale.bandwidth || 0) / 2;
 
         const ticks = this.ticks || scale.ticks!(this.calculatedTickCount);
-        const tickLineGroupSelection = this.updateTicks({ ticks });
+        const tickGroupSelection = this.updateTicks({ ticks });
         const labelBboxes = this.updateLabels({
             parallelFlipRotation,
             regularFlipRotation,
             sideFlag,
-            tickLineGroupSelection,
+            tickLineGroupSelection: tickGroupSelection,
             ticks,
         });
         const gridlineGroupSelection = this.updateGridLines({
@@ -528,7 +528,7 @@ export class Axis<S extends Scale<D, number>, D = any> {
             sideFlag,
         });
 
-        this.tickLineGroupSelection = tickLineGroupSelection;
+        this.tickGroupSelection = tickGroupSelection;
         this.gridlineGroupSelection = gridlineGroupSelection;
 
         let anyTickVisible = false;
@@ -541,7 +541,7 @@ export class Axis<S extends Scale<D, number>, D = any> {
             return visible;
         };
 
-        tickLineGroupSelection.attrFn('translationY', translationYFn).attrFn('visible', visibleFn);
+        tickGroupSelection.attrFn('translationY', translationYFn).attrFn('visible', visibleFn);
         gridlineGroupSelection.attrFn('translationY', translationYFn).attrFn('visible', visibleFn);
 
         this.tickGroup.visible = anyTickVisible;
@@ -555,7 +555,7 @@ export class Axis<S extends Scale<D, number>, D = any> {
             return;
         }
 
-        tickLineGroupSelection
+        tickGroupSelection
             .selectByTag<Line>(Tags.Tick)
             .each((line, _, index) => {
                 line.strokeWidth = tick.width;
@@ -581,7 +581,7 @@ export class Axis<S extends Scale<D, number>, D = any> {
     }
 
     private updateTicks({ ticks }: { ticks: any[] }) {
-        const updateAxis = this.tickLineGroupSelection.setData(ticks);
+        const updateAxis = this.tickGroupSelection.setData(ticks);
         updateAxis.exit.remove();
 
         const enterAxis = updateAxis.enter.append(Group);

--- a/charts-packages/ag-charts-community/src/axis.ts
+++ b/charts-packages/ag-charts-community/src/axis.ts
@@ -882,7 +882,10 @@ export class Axis<S extends Scale<D, number>, D = any> {
             let bboxYDimension = rotation === 0 ? lineBBox.width : lineBBox.height;
             if (ticks?.length > 0) {
                 const tickBBox = tickGroup.computeBBox();
-                bboxYDimension += rotation === 0 ? tickBBox.width : tickBBox.height;
+                const tickWidth = rotation === 0 ? tickBBox.width : tickBBox.height;
+                if (Math.abs(tickWidth) < Infinity) {
+                    bboxYDimension += tickWidth;
+                }
             }
             if (sideFlag === -1) {
                 titleNode.y = Math.floor(titleRotationFlag * (-padding - bboxYDimension));

--- a/charts-packages/ag-charts-community/src/chart/axis/categoryAxis.ts
+++ b/charts-packages/ag-charts-community/src/chart/axis/categoryAxis.ts
@@ -8,6 +8,8 @@ export class CategoryAxis extends ChartAxis<BandScale<string | object>> {
 
     constructor() {
         super(new BandScale<string>());
+
+        this.includeInvisibleDomains = true;
     }
 
     set paddingInner(value: number) {

--- a/charts-packages/ag-charts-community/src/chart/axis/groupedCategoryAxis.ts
+++ b/charts-packages/ag-charts-community/src/chart/axis/groupedCategoryAxis.ts
@@ -31,6 +31,7 @@ export class GroupedCategoryAxis extends ChartAxis<BandScale<string | number>> {
 
     constructor() {
         super(new BandScale<string | number>());
+        this.includeInvisibleDomains = true;
 
         const { axisGroup, gridlineGroup, tickScale, scale } = this;
 

--- a/charts-packages/ag-charts-community/src/chart/axis/numberAxis.ts
+++ b/charts-packages/ag-charts-community/src/chart/axis/numberAxis.ts
@@ -41,7 +41,7 @@ export class NumberAxis extends ChartAxis {
         return this._nice;
     }
 
-    public setDomain(domain: number[], primaryTickCount?: number) {
+    private setDomain(domain: number[], primaryTickCount?: number) {
         const { scale, min, max } = this;
 
         if (domain.length > 2) {

--- a/charts-packages/ag-charts-community/src/chart/axis/numberAxis.ts
+++ b/charts-packages/ag-charts-community/src/chart/axis/numberAxis.ts
@@ -45,7 +45,7 @@ export class NumberAxis extends ChartAxis {
         const { scale, min, max } = this;
 
         if (domain.length > 2) {
-            domain = extent(domain, isContinuous, Number) || [0, 1];
+            domain = extent(domain, isContinuous, Number) || [];
         }
 
         domain = [isNaN(min) ? domain[0] : min, isNaN(max) ? domain[1] : max];

--- a/charts-packages/ag-charts-community/src/chart/cartesianChart.ts
+++ b/charts-packages/ag-charts-community/src/chart/cartesianChart.ts
@@ -240,7 +240,7 @@ export class CartesianChart extends Chart {
         const newAxisWidths: Partial<Record<ChartAxisPosition, number>> = {};
 
         let clipSeries = false;
-        let primaryTickCount: number | undefined;
+        let primaryTickCounts: Partial<Record<ChartAxisDirection, number>> = {};
 
         const crossLinePadding: Partial<Record<ChartAxisPosition, number>> = {};
 
@@ -333,7 +333,10 @@ export class CartesianChart extends Chart {
                 clipSeries = true;
             }
 
-            primaryTickCount = axis.calculateDomain({ primaryTickCount }).primaryTickCount;
+            let primaryTickCount = primaryTickCounts[axis.direction];
+            ({ primaryTickCount } = axis.calculateDomain({ primaryTickCount }));
+            primaryTickCounts[axis.direction] = primaryTickCount;
+
             axis.update();
 
             let axisThickness = 0;

--- a/charts-packages/ag-charts-community/src/chart/cartesianChart.ts
+++ b/charts-packages/ag-charts-community/src/chart/cartesianChart.ts
@@ -197,6 +197,9 @@ export class CartesianChart extends Chart {
         };
         const ceilValues = <T extends Record<string, number | undefined>>(records: T) => {
             return Object.entries(records).reduce((out, [key, value]) => {
+                if (value && Math.abs(value) === Infinity) {
+                    value = 0;
+                }
                 out[key] = value != null ? Math.ceil(value) : value;
                 return out;
             }, {} as any);

--- a/charts-packages/ag-charts-community/src/chart/chartAxis.ts
+++ b/charts-packages/ag-charts-community/src/chart/chartAxis.ts
@@ -36,6 +36,7 @@ export class ChartAxis<S extends Scale<any, number> = Scale<any, number>> extend
     direction: ChartAxisDirection = ChartAxisDirection.Y;
     boundSeries: Series[] = [];
     linkedTo?: ChartAxis;
+    includeInvisibleDomains: boolean = false;
 
     get type(): string {
         return (this.constructor as any).type || '';
@@ -149,7 +150,7 @@ export class ChartAxis<S extends Scale<any, number> = Scale<any, number>> extend
     }
 
     calculateDomain({ primaryTickCount }: { primaryTickCount?: number }) {
-        const { direction, boundSeries } = this;
+        const { direction, boundSeries, includeInvisibleDomains } = this;
 
         if (boundSeries.length === 0) {
             console.warn('AG Charts - chart series not initialised; check series and axes configuration.');
@@ -160,7 +161,7 @@ export class ChartAxis<S extends Scale<any, number> = Scale<any, number>> extend
         } else {
             const domains: any[][] = [];
             boundSeries
-                .filter((s) => s.visible)
+                .filter((s) => includeInvisibleDomains || s.visible)
                 .forEach((series) => {
                     domains.push(series.getDomain(direction));
                 });

--- a/charts-packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
@@ -351,22 +351,6 @@ export class AreaSeries extends CartesianSeries<AreaSeriesNodeDataContext> {
         return true;
     }
 
-    findLargestMinMax(totals: { min: number; max: number }[]): { min: number; max: number } {
-        let min = 0;
-        let max = 0;
-
-        for (const total of totals) {
-            if (total.min < min) {
-                min = total.min;
-            }
-            if (total.max > max) {
-                max = total.max;
-            }
-        }
-
-        return { min, max };
-    }
-
     getDomain(direction: ChartAxisDirection): any[] {
         if (direction === ChartAxisDirection.X) {
             return this.xDomain;

--- a/charts-packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
@@ -242,13 +242,10 @@ export class BarSeries extends CartesianSeries<SeriesNodeDataContext<BarNodeDatu
         return this._yKeys;
     }
 
-    protected _visibles: boolean[][];
+    protected _visibles: boolean[];
     set visibles(visibles: boolean[] | boolean[][]) {
-        if (is2dArray(visibles)) {
-            this._visibles = visibles;
-        } else {
-            this._visibles = this.grouped ? visibles.map((k) => [k]) : [visibles];
-        }
+        const flattenFn = (r: boolean[], n: boolean | boolean[]) => r.concat(...(Array.isArray(n) ? n : [n]));
+        this._visibles = (visibles as any).reduce(flattenFn, []);
 
         this.processSeriesItemEnabled();
     }
@@ -259,9 +256,9 @@ export class BarSeries extends CartesianSeries<SeriesNodeDataContext<BarNodeDatu
     private processSeriesItemEnabled() {
         const { seriesItemEnabled, _visibles: visibles = [] } = this;
         seriesItemEnabled.clear();
-        this._yKeys.forEach((stack, stackIdx) => {
-            const stackVisibles = visibles[stackIdx];
-            stack.forEach((yKey, idx) => seriesItemEnabled.set(yKey, stackVisibles?.[idx] ?? true));
+        let visiblesIdx = 0;
+        this._yKeys.forEach((stack) => {
+            stack.forEach((yKey) => seriesItemEnabled.set(yKey, visibles?.[visiblesIdx++] ?? true));
         });
     }
 

--- a/charts-packages/ag-charts-community/src/chart/series/series.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/series.ts
@@ -449,6 +449,17 @@ export abstract class Series<C extends SeriesNodeDataContext = SeriesNodeDataCon
             return [0, 1];
         }
 
+        if (min === Infinity && max === -Infinity) {
+            // There's no data in the domain.
+            return [];
+        }
+        if (min === Infinity) {
+            min = 0;
+        }
+        if (max === -Infinity) {
+            max = 0;
+        }
+
         if (min === max) {
             // domain has zero length, there is only a single valid value in data
 
@@ -465,7 +476,7 @@ export abstract class Series<C extends SeriesNodeDataContext = SeriesNodeDataCon
         }
 
         if (!(isNumber(min) && isNumber(max))) {
-            return [0, 1];
+            return [];
         }
 
         return [min, max];

--- a/charts-packages/ag-charts-community/src/util/array.ts
+++ b/charts-packages/ag-charts-community/src/util/array.ts
@@ -62,15 +62,15 @@ export function extent<T, K>(
  * finds the min and max using a process appropriate for stacked values. Ie,
  * summing up the positive and negative numbers, and returning the totals of each
  */
-export function findMinMax(values: number[]): { min: number; max: number } {
-    let min = 0;
-    let max = 0;
+export function findMinMax(values: number[]): { min?: number; max?: number } {
+    let min: number | undefined = undefined;
+    let max: number | undefined = undefined;
 
     for (const value of values) {
         if (value < 0) {
-            min += value;
+            min = (min ?? 0) - value;
         } else {
-            max += value;
+            max = (max ?? 0) + value;
         }
     }
 

--- a/charts-packages/ag-charts-community/src/util/array.ts
+++ b/charts-packages/ag-charts-community/src/util/array.ts
@@ -68,7 +68,7 @@ export function findMinMax(values: number[]): { min?: number; max?: number } {
 
     for (const value of values) {
         if (value < 0) {
-            min = (min ?? 0) - value;
+            min = (min ?? 0) + value;
         } else {
             max = (max ?? 0) + value;
         }


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-6133

Adjusted rendering of axes to be more consistent when no series is displayed:
- Axis lines + titles now always render.
- Category axes + ticks always render (unchanged).
- If  axis `min`, `max` or `domain` properties are specified, axis ticks and labels are always rendered.

Bonus fixes:
- Starting with `visible: true` now renders consistently with disabling all series from the legend.
- `Axis.update()` is now decomposed into a few different methods to reduce its complexity.
- Fixes `TimeAxis.domain` handling (specified domain was ignored previously).

Still TODO:
- Add test coverage for all cases above to `axisExamples.test.ts`.

Demo Plunker: https://plnkr.co/edit/kiO6RztUm4MAiSFD?open=main.js

<img width="1669" alt="Screenshot 2022-07-25 at 12 29 24" src="https://user-images.githubusercontent.com/17544187/180767785-dee0fda4-9b8e-4708-a060-46778a7c314a.png">
