### PR TITLE
AG-7054 - Fix disabled stack bar series hides all series

### DIFF
--- a/charts-packages/ag-charts-community/src/chart/cartesianChart.ts
+++ b/charts-packages/ag-charts-community/src/chart/cartesianChart.ts
@@ -81,13 +81,10 @@ export class CartesianChart extends Chart {
 
         const { seriesRect } = this.updateAxes(shrinkRect);
 
-        this.createNodeData();
-
         this.seriesRect = seriesRect;
         this.series.forEach((series) => {
             series.group.translationX = Math.floor(seriesRect.x);
             series.group.translationY = Math.floor(seriesRect.y);
-            series.update(); // this has to happen after the `updateAxes` call
         });
 
         const { seriesRoot } = this;

--- a/charts-packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
@@ -392,7 +392,7 @@ export class BarSeries extends CartesianSeries<SeriesNodeDataContext<BarNodeDatu
         const yAbsTotal = this.yData.map((group) =>
             group.map((stack) =>
                 stack.reduce((acc, stack) => {
-                    acc += Math.abs(stack);
+                    acc += isNaN(stack) ? 0 : Math.abs(stack);
                     return acc;
                 }, 0)
             )
@@ -579,6 +579,9 @@ export class BarSeries extends CartesianSeries<SeriesNodeDataContext<BarNodeDatu
                     // Bars outside of visible range are not rendered, so we create node data
                     // only for the visible subset of user data.
                     if (!xAxis.inRange(barX, barWidth)) {
+                        continue;
+                    }
+                    if (isNaN(currY)) {
                         continue;
                     }
 

--- a/charts-packages/ag-charts-community/src/util/array.ts
+++ b/charts-packages/ag-charts-community/src/util/array.ts
@@ -69,7 +69,7 @@ export function findMinMax(values: number[]): { min?: number; max?: number } {
     for (const value of values) {
         if (value < 0) {
             min = (min ?? 0) + value;
-        } else {
+        } else if (value >= 0) {
             max = (max ?? 0) + value;
         }
     }


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-7054

Fixes `NaN` in the `BarSeries.processData()`  causing all stacked-series `y` calculations to also resolve to `NaN`.

Looks like this was probably a result of the change here: https://github.com/ag-grid/ag-grid/pull/5396/files#diff-84e11554c8f4be20782e7971d008d090fa7cbf2b8d2329863f0c386903961b9fR377

Bonus:
- Found some redundant calls triggering series data reprocessing in the `Chart.performLayout()` code - removed these since we're typically already doing this at the next stage in `Chart.performUpdate()` processing.