### PR TITLE
AG-7062 - Add series highlight label handling.

### DIFF
--- a/charts-packages/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
@@ -270,8 +270,10 @@ export abstract class CartesianSeries<
 
         let labelItem: C['labelData'][number] | undefined;
         if (this.label.enabled && item != null) {
+            const { itemId = undefined } = item;
+
             for (const { labelData } of contextNodeData) {
-                labelItem = labelData.find((ld) => ld.datum === item.datum);
+                labelItem = labelData.find((ld) => ld.datum === item.datum && ld.itemId === itemId);
 
                 if (labelItem != null) {
                     break;

--- a/charts-packages/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
@@ -48,9 +48,9 @@ export abstract class CartesianSeries<
 > extends Series<C> {
     private contextNodeData: C[];
 
-    private highlightSelection: NodeDataSelection<N, C> = Selection.select(this.highlightNodes).selectAll<N>();
+    private highlightSelection: NodeDataSelection<N, C> = Selection.select(this.highlightNode).selectAll<N>();
     private highlightLabelSelection: LabelDataSelection<Text, C> = Selection.select(
-        this.highlightLabels
+        this.highlightLabel
     ).selectAll<Text>();
 
     private subGroups: SubGroup<C, any>[] = [];

--- a/charts-packages/ag-charts-community/src/chart/series/series.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/series.ts
@@ -136,6 +136,8 @@ export abstract class Series<C extends SeriesNodeDataContext = SeriesNodeDataCon
     // for large-scale data-sets, where the only thing that routinely varies is the currently
     // highlighted node.
     readonly highlightGroup: Group;
+    readonly highlightNodes: Group;
+    readonly highlightLabels: Group;
 
     // The group node that contains all the nodes that can be "picked" (react to hover, tap, click).
     readonly pickGroup: Group;
@@ -190,6 +192,7 @@ export abstract class Series<C extends SeriesNodeDataContext = SeriesNodeDataCon
             })
         );
         this.pickGroup = this.seriesGroup.appendChild(new Group());
+
         this.highlightGroup = group.appendChild(
             new Group({
                 name: `${this.id}-highlight`,
@@ -198,6 +201,11 @@ export abstract class Series<C extends SeriesNodeDataContext = SeriesNodeDataCon
                 optimiseDirtyTracking: true,
             })
         );
+        this.highlightNodes = this.highlightGroup.appendChild(new Group());
+        this.highlightLabels = this.highlightGroup.appendChild(new Group());
+        this.highlightNodes.zIndex = 0;
+        this.highlightLabels.zIndex = 10;
+
         this.pickModes = pickModes;
     }
 

--- a/charts-packages/ag-charts-community/src/chart/series/series.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/series.ts
@@ -136,8 +136,8 @@ export abstract class Series<C extends SeriesNodeDataContext = SeriesNodeDataCon
     // for large-scale data-sets, where the only thing that routinely varies is the currently
     // highlighted node.
     readonly highlightGroup: Group;
-    readonly highlightNodes: Group;
-    readonly highlightLabels: Group;
+    readonly highlightNode: Group;
+    readonly highlightLabel: Group;
 
     // The group node that contains all the nodes that can be "picked" (react to hover, tap, click).
     readonly pickGroup: Group;
@@ -201,10 +201,10 @@ export abstract class Series<C extends SeriesNodeDataContext = SeriesNodeDataCon
                 optimiseDirtyTracking: true,
             })
         );
-        this.highlightNodes = this.highlightGroup.appendChild(new Group());
-        this.highlightLabels = this.highlightGroup.appendChild(new Group());
-        this.highlightNodes.zIndex = 0;
-        this.highlightLabels.zIndex = 10;
+        this.highlightNode = this.highlightGroup.appendChild(new Group());
+        this.highlightLabel = this.highlightGroup.appendChild(new Group());
+        this.highlightNode.zIndex = 0;
+        this.highlightLabel.zIndex = 10;
 
         this.pickModes = pickModes;
     }


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-7062

Attempts to fix series label obstruction by highlighted datum.

Adds a special group for highlighted item labels (in the same layer as the existing highlight, but higher z-index) to render an unobscured label for the highlighted datum. We then follow a similar processing pattern as for highlighted items - i.e. identifying the 0 or 1 highlighted label datum, and then updating the special highlighted item label selection with this.