### PR TITLE
AG-7123 - Fix legend formatter definition

### DIFF
--- a/charts-packages/ag-charts-community/src/chart/agChartOptions.ts
+++ b/charts-packages/ag-charts-community/src/chart/agChartOptions.ts
@@ -301,6 +301,12 @@ export interface AgChartLegendMarkerOptions {
     strokeWidth?: PixelSize;
 }
 
+export interface AgChartLegendLabelFormatterParams {
+    id: string;
+    itemId: any;
+    value: string;
+}
+
 export interface AgChartLegendLabelOptions {
     /** If the label text exceeds the maximum length, it will be truncated and an ellipsis will be appended to indicate this. */
     maxLength?: number;
@@ -315,7 +321,7 @@ export interface AgChartLegendLabelOptions {
     /** The font family to use for the legend. */
     fontFamily?: FontFamily;
     /** Function used to render legend labels. Where `id` is a series ID, `itemId` is component ID within a series, such as a field name or an item index. */
-    formatter?: (id: string, itemId: any, value: string) => string;
+    formatter?: (params: AgChartLegendLabelFormatterParams) => string;
 }
 
 export interface AgChartLegendItemOptions {

--- a/charts-packages/ag-charts-community/src/chart/legend.ts
+++ b/charts-packages/ag-charts-community/src/chart/legend.ts
@@ -256,7 +256,7 @@ export class Legend {
 
         itemSelection.each((markerLabel, datum) => {
             // TODO: measure only when one of these properties or data change (in a separate routine)
-            let text = datum.label.text;
+            let text = datum.label.text ?? '<unknown>';
             markerLabel.markerSize = markerSize;
             markerLabel.spacing = markerPadding;
             markerLabel.fontStyle = fontStyle;

--- a/community-modules/core/src/ts/interfaces/iAgChartOptions.ts
+++ b/community-modules/core/src/ts/interfaces/iAgChartOptions.ts
@@ -315,7 +315,7 @@ export interface AgChartLegendLabelOptions {
     /** The font family to use for the legend. */
     fontFamily?: FontFamily;
     /** Function used to render legend labels. Where `id` is a series ID, `itemId` is component ID within a series, such as a field name or an item index. */
-    formatter?: (id: string, itemId: any, value: string) => string;
+    formatter?: (params: { id: string, itemId: any, value: string }) => string;
 }
 
 export interface AgChartLegendItemOptions {

--- a/community-modules/core/src/ts/interfaces/iAgChartOptions.ts
+++ b/community-modules/core/src/ts/interfaces/iAgChartOptions.ts
@@ -301,6 +301,12 @@ export interface AgChartLegendMarkerOptions {
     strokeWidth?: PixelSize;
 }
 
+export interface AgChartLegendLabelFormatterParams {
+    id: string;
+    itemId: any;
+    value: string;
+}
+
 export interface AgChartLegendLabelOptions {
     /** If the label text exceeds the maximum length, it will be truncated and an ellipsis will be appended to indicate this. */
     maxLength?: number;
@@ -315,7 +321,7 @@ export interface AgChartLegendLabelOptions {
     /** The font family to use for the legend. */
     fontFamily?: FontFamily;
     /** Function used to render legend labels. Where `id` is a series ID, `itemId` is component ID within a series, such as a field name or an item index. */
-    formatter?: (params: { id: string, itemId: any, value: string }) => string;
+    formatter?: (params: AgChartLegendLabelFormatterParams) => string;
 }
 
 export interface AgChartLegendItemOptions {

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/doc-interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/doc-interfaces.AUTO.json
@@ -1004,6 +1004,11 @@
       "type": { "returnType": "PixelSize", "optional": true }
     }
   },
+  "AgChartLegendLabelFormatterParams": {
+    "id": { "type": { "returnType": "string", "optional": false } },
+    "itemId": { "type": { "returnType": "any", "optional": false } },
+    "value": { "type": { "returnType": "string", "optional": false } }
+  },
   "AgChartLegendLabelOptions": {
     "maxLength": {
       "description": "/** If the label text exceeds the maximum length, it will be truncated and an ellipsis will be appended to indicate this. */",
@@ -1032,7 +1037,7 @@
     "formatter": {
       "description": "/** Function used to render legend labels. Where `id` is a series ID, `itemId` is component ID within a series, such as a field name or an item index. */",
       "type": {
-        "arguments": { "id": "string", "itemId": "any", "value": "string" },
+        "arguments": { "params": "AgChartLegendLabelFormatterParams" },
         "returnType": "string",
         "optional": true
       }

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
@@ -644,6 +644,10 @@
       "strokeWidth?": "/** The width in pixels of the stroke for markers in the legend. */"
     }
   },
+  "AgChartLegendLabelFormatterParams": {
+    "meta": {},
+    "type": { "id": "string", "itemId": "any", "value": "string" }
+  },
   "AgChartLegendLabelOptions": {
     "meta": {},
     "type": {
@@ -653,7 +657,7 @@
       "fontWeight?": "FontWeight",
       "fontSize?": "FontSize",
       "fontFamily?": "FontFamily",
-      "formatter?": "(id: string, itemId: any, value: string) => string"
+      "formatter?": "(params: AgChartLegendLabelFormatterParams) => string"
     },
     "docs": {
       "maxLength?": "/** If the label text exceeds the maximum length, it will be truncated and an ellipsis will be appended to indicate this. */",

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-formatters/examples/legend-item-formatter/index.html
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-formatters/examples/legend-item-formatter/index.html
@@ -1,0 +1,1 @@
+<div id="myChart" style="height: 100%;"></div>

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-formatters/examples/legend-item-formatter/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-formatters/examples/legend-item-formatter/main.ts
@@ -1,0 +1,66 @@
+import * as agCharts from "ag-charts-community"
+import { AgChartOptions, AgChartLegendLabelFormatterParams } from "ag-charts-community"
+
+function formatter({ value }: AgChartLegendLabelFormatterParams) {
+  switch (value) {
+    case 'car':
+      value += ' 🚗';
+      break;
+    case 'motorbike':
+      value += ' 🏍';
+      break;
+    case 'bicycle':
+      value += ' 🚴‍♀️';
+      break;
+    case 'train':
+      value += ' 🚄';
+      break;
+    case 'bus':
+      value += ' 🚌';
+      break;
+  }
+
+  return value[0].toUpperCase() + value.substring(1);
+}
+
+const options: AgChartOptions = {
+  container: document.getElementById("myChart"),
+  title: {
+    text: "Modes of transport to the office",
+  },
+  data: [
+    {
+      type: "car",
+      count: 150,
+    },
+    {
+      type: "motorbike",
+      count: 12,
+    },
+    {
+      type: "bicycle",
+      count: 36,
+    },
+    {
+      type: "train",
+      count: 87,
+    },
+    {
+      type: "bus",
+      count: 23,
+    },
+  ],
+  series: [
+    {
+      type: "pie",
+      angleKey: "count",
+      labelKey: "type",
+    },
+  ],
+  legend: {
+    enabled: true,
+    item: { label: { formatter } },
+  },
+}
+
+agCharts.AgChart.create(options)

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-formatters/index.md
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-formatters/index.md
@@ -2,13 +2,13 @@
 title: "Formatters"
 ---
 
-Formatters allow individual series items and markers to be customised based on the data they represent.
+Formatters allow individual item customisation based on the data they represent.
 
-When it comes to formatters, all series can be divided into two categories:
-- _series with markers_, such as `line`, `scatter` and `area`, where each data point is represented by a marker that can be of any shape
-- _series without markers_, such as `bar` and `pie`, where each data point is represented by a series item with a fixed shape, for example a rectangle or a pie sector
+Please use the [API reference](/charts-api/) to learn more about the formatters, the inputs they receive and the attributes they allow to customize.
 
-## Marker formatter example
+## Marker Formatter
+
+Applies to _series with markers_, such as `line`, `scatter` and `area`, where each data point is represented by a marker that can be of any shape.
 
 If we take a stacked area series where we want the markers of the second sub-series to be larger than default size, we could use the following formatter function:
 
@@ -37,24 +37,41 @@ series: [
 
 <chart-example title='Marker Formatter' name='marker-formatter' type='generated'></chart-example>
 
-## Series item formatter example
+## Series Item Formatter
+
+Applies to _series without markers_, such as `bar` and `pie`, where each data point is represented by a series item with a fixed shape, for example a rectangle or a pie sector
 
 If we have a list of values by country presented via bar series and want the bar for a particular country to stand out, we could use the following formatter function:
 
 ```js
-type: 'column',
-xKey: 'country',
-yKey: 'gdp',
-formatter: params => ({
-    fill: params.datum[params.xKey] === 'UK' ? 'red' : params.fill
-    // we can also use `params.datum.country`, but the formatter
-    // would have to be updated whenever the `xKey` is changed
-})
+function formatter({ datum, fill }) {
+    return {
+        fill: params.datum[params.xKey] === 'UK'
+              ? params.highlighted
+                ? 'lime'
+                : 'red'
+              : params.fill,
+    };
+}
+
+series: [
+    {
+        type: 'column',
+        xKey: 'country',
+        yKey: 'gdp',
+        formatter,
+    },
+]
 ```
 
 <chart-example title='Series Formatter' name='series-formatter' type='generated'></chart-example>
 
-Please use the [API reference](/charts-api/) to learn more about the marker and series formatters, the inputs they receive and the attributes they allow to customize.
+## Legend Item Label Formatter
+
+Applies to all series types. This formatter allows adjustment of the text label used for the legend
+item corresponding to a series
+
+<chart-example title='Legend Item Label Formatter' name='legend-item-formatter' type='generated'></chart-example>
 
 ## Next Up
 

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/doc-interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/doc-interfaces.AUTO.json
@@ -12079,6 +12079,11 @@
       "type": { "returnType": "PixelSize", "optional": true }
     }
   },
+  "AgChartLegendLabelFormatterParams": {
+    "id": { "type": { "returnType": "string", "optional": false } },
+    "itemId": { "type": { "returnType": "any", "optional": false } },
+    "value": { "type": { "returnType": "string", "optional": false } }
+  },
   "AgChartLegendLabelOptions": {
     "maxLength": {
       "description": "/** If the label text exceeds the maximum length, it will be truncated and an ellipsis will be appended to indicate this. */",
@@ -12107,9 +12112,7 @@
     "formatter": {
       "description": "/** Function used to render legend labels. Where `id` is a series ID, `itemId` is component ID within a series, such as a field name or an item index. */",
       "type": {
-        "arguments": {
-          "params": "{ id: string; itemId: any; value: string; }"
-        },
+        "arguments": { "params": "AgChartLegendLabelFormatterParams" },
         "returnType": "string",
         "optional": true
       }

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/doc-interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/doc-interfaces.AUTO.json
@@ -12107,7 +12107,9 @@
     "formatter": {
       "description": "/** Function used to render legend labels. Where `id` is a series ID, `itemId` is component ID within a series, such as a field name or an item index. */",
       "type": {
-        "arguments": { "id": "string", "itemId": "any", "value": "string" },
+        "arguments": {
+          "params": "{ id: string; itemId: any; value: string; }"
+        },
         "returnType": "string",
         "optional": true
       }

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/interfaces.AUTO.json
@@ -6906,6 +6906,10 @@
       "strokeWidth?": "/** The width in pixels of the stroke for markers in the legend. */"
     }
   },
+  "AgChartLegendLabelFormatterParams": {
+    "meta": {},
+    "type": { "id": "string", "itemId": "any", "value": "string" }
+  },
   "AgChartLegendLabelOptions": {
     "meta": {},
     "type": {
@@ -6915,7 +6919,7 @@
       "fontWeight?": "FontWeight",
       "fontSize?": "FontSize",
       "fontFamily?": "FontFamily",
-      "formatter?": "(params: { id: string; itemId: any; value: string; }) => string"
+      "formatter?": "(params: AgChartLegendLabelFormatterParams) => string"
     },
     "docs": {
       "maxLength?": "/** If the label text exceeds the maximum length, it will be truncated and an ellipsis will be appended to indicate this. */",

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/interfaces.AUTO.json
@@ -6915,7 +6915,7 @@
       "fontWeight?": "FontWeight",
       "fontSize?": "FontSize",
       "fontFamily?": "FontFamily",
-      "formatter?": "(id: string, itemId: any, value: string) => string"
+      "formatter?": "(params: { id: string; itemId: any; value: string; }) => string"
     },
     "docs": {
       "maxLength?": "/** If the label text exceeds the maximum length, it will be truncated and an ellipsis will be appended to indicate this. */",


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-7123

Improves the documentation around `legend.item.formatter`, including correcting parameter definitions to align with reality.