### PR TITLE
AG-7195 - Fix legend auto-padding retained whilst changing legend position.

### DIFF
--- a/charts-packages/ag-charts-community/src/chart/chart.ts
+++ b/charts-packages/ag-charts-community/src/chart/chart.ts
@@ -920,11 +920,13 @@ export abstract class Chart extends Observable {
     protected legendBBox: BBox = new BBox(0, 0, 0, 0);
 
     protected positionLegend(captionAutoPadding: number) {
-        if (!this.legend.enabled || !this.legend.data.length) {
+        const { legend, legendAutoPadding } = this;
+        legendAutoPadding.clear();
+
+        if (!legend.enabled || !legend.data.length) {
             return;
         }
 
-        const { legend, legendAutoPadding } = this;
         const width = this.width;
         const height = this.height - captionAutoPadding;
         const legendGroup = legend.group;


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-7195

Looks like padding values were accumulating in `legendAutoPadding` as the legend position was changed - made an adjustment to clear these before any legend positioning calculations are performed.