### PR TITLE
AG-7201 - Fix PieSeries label rendering zindex.

### DIFF
--- a/charts-packages/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
@@ -74,7 +74,7 @@ export abstract class CartesianSeries<
     protected readonly seriesItemEnabled = new Map<string, boolean>();
 
     protected constructor(opts: Partial<SeriesOpts> & { pickModes?: SeriesNodePickMode[] } = {}) {
-        super({ seriesGroupUsesLayer: true, pickModes: opts.pickModes });
+        super({ useSeriesGroupLayer: true, pickModes: opts.pickModes });
 
         const {
             pickGroupIncludes = ['datumNodes'] as PickGroupInclude[],
@@ -89,7 +89,7 @@ export abstract class CartesianSeries<
     destroy() {
         super.destroy();
 
-        this._contextNodeData.splice(0, this._contextNodeData.length); 
+        this._contextNodeData.splice(0, this._contextNodeData.length);
         this.subGroups.splice(0, this.subGroups.length);
     }
 
@@ -310,26 +310,26 @@ export abstract class CartesianSeries<
                     pickGroup,
                 } = subGroup;
                 const { itemId } = contextNodeData[seriesIdx];
-    
+
                 const subGroupVisible = visible && (seriesItemEnabled.get(itemId) ?? true);
                 const subGroupOpacity = this.getOpacity({ itemId });
                 group.opacity = subGroupOpacity;
                 group.visible = subGroupVisible;
                 pickGroup.visible = subGroupVisible;
                 labelGroup.visible = subGroupVisible;
-    
+
                 if (markerGroup) {
                     markerGroup.opacity = subGroupOpacity;
                     markerGroup.zIndex = group.zIndex >= Layers.SERIES_LAYER_ZINDEX ? group.zIndex : group.zIndex + 1;
                     markerGroup.visible = subGroupVisible;
                 }
-    
+
                 for (const path of paths) {
                     if (path.parent !== group) {
                         path.opacity = subGroupOpacity;
                         path.visible = subGroupVisible;
                     }
-                }    
+                }
 
                 if (!group.visible) {
                     return;

--- a/charts-packages/ag-charts-community/src/chart/series/polar/pieSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/polar/pieSeries.ts
@@ -415,6 +415,7 @@ export class PieSeries extends PolarSeries<PieNodeDatum> {
         this.group.visible = isVisible;
         this.seriesGroup.visible = isVisible;
         this.highlightGroup.visible = isVisible && this.chart?.highlightedDatum?.series === this;
+        this.labelGroup!.visible = isVisible;
 
         this.seriesGroup.opacity = this.getOpacity();
 

--- a/charts-packages/ag-charts-community/src/chart/series/polar/polarSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/polar/polarSeries.ts
@@ -25,8 +25,8 @@ export abstract class PolarSeries<S extends SeriesNodeDatum> extends Series<Seri
      */
     radius: number = 0;
 
-    constructor() {
-        super({ pickModes: [SeriesNodePickMode.EXACT_SHAPE_MATCH] });
+    constructor({ useLabelLayer = false }) {
+        super({ useLabelLayer, pickModes: [SeriesNodePickMode.EXACT_SHAPE_MATCH] });
     }
 
     getLabelData(): PointLabelDatum[] {

--- a/charts-packages/ag-charts-community/src/chart/series/series.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/series.ts
@@ -136,6 +136,9 @@ export abstract class Series<C extends SeriesNodeDataContext = SeriesNodeDataCon
     readonly highlightNode: Group;
     readonly highlightLabel: Group;
 
+    // Lazily initialised labelGroup for label presentation.
+    readonly labelGroup?: Group;
+
     // The group node that contains all the nodes that can be "picked" (react to hover, tap, click).
     readonly pickGroup: Group;
 
@@ -177,14 +180,18 @@ export abstract class Series<C extends SeriesNodeDataContext = SeriesNodeDataCon
 
     cursor = 'default';
 
-    constructor({ seriesGroupUsesLayer = true, pickModes = [SeriesNodePickMode.NEAREST_BY_MAIN_AXIS_FIRST] } = {}) {
+    constructor({
+        useSeriesGroupLayer = true,
+        useLabelLayer = false,
+        pickModes = [SeriesNodePickMode.NEAREST_BY_MAIN_AXIS_FIRST],
+    } = {}) {
         super();
 
         const { group } = this;
         this.seriesGroup = group.appendChild(
             new Group({
                 name: `${this.id}-series`,
-                layer: seriesGroupUsesLayer,
+                layer: useSeriesGroupLayer,
                 zIndex: Layers.SERIES_LAYER_ZINDEX,
             })
         );
@@ -205,6 +212,16 @@ export abstract class Series<C extends SeriesNodeDataContext = SeriesNodeDataCon
         this.highlightLabel.zIndex = 10;
 
         this.pickModes = pickModes;
+
+        if (useLabelLayer) {
+            this.labelGroup = group.appendChild(
+                new Group({
+                    name: `${this.id}-series-labels`,
+                    layer: true,
+                    zIndex: Layers.SERIES_LABEL_ZINDEX,
+                })
+            );
+        }
     }
 
     destroy(): void {


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-7201

Moves `PieSeries` labels into their own layer so that they can always appear above series highlights.

![Screenshot 2022-08-26 at 16 22 50](https://user-images.githubusercontent.com/17544187/186939698-3bb6f102-b49e-4814-86f4-5500ce8102d5.png)
