### PR TITLE
AG-7202 - Fix secondary axis ticks when series are toggled via legend

### DIFF
--- a/charts-packages/ag-charts-community/src/axis.ts
+++ b/charts-packages/ag-charts-community/src/axis.ts
@@ -202,7 +202,7 @@ export class Axis<S extends Scale<D, number>, D = any> {
         return this._scale;
     }
 
-    ticks: any[];
+    ticks?: any[];
     protected getTicks() {
         return this.ticks ?? this.scale.ticks!(this.calculatedTickCount);
     }

--- a/charts-packages/ag-charts-community/src/chart/axis/numberAxis.ts
+++ b/charts-packages/ag-charts-community/src/chart/axis/numberAxis.ts
@@ -53,6 +53,12 @@ export class NumberAxis extends ChartAxis {
         if (primaryTickCount) {
             // when `primaryTickCount` is supplied the current axis is a secondary axis which needs to be aligned to
             // the primary by constraining the tick count to the primary axis tick count
+            if (isNaN(domain[0]) || isNaN(domain[1])) {
+                scale.domain = domain;
+                this.ticks = undefined;
+                return;
+            }
+
             const [d, ticks] = calculateNiceSecondaryAxis(domain, primaryTickCount);
             scale.domain = d;
             this.ticks = ticks;
@@ -122,7 +128,7 @@ export class NumberAxis extends ChartAxis {
         if (isYAxis) {
             // the `primaryTickCount` is used to align the secondary axis tick count with the primary
             this.setDomain(domain, primaryTickCount);
-            return primaryTickCount ?? this.scale.ticks!(this.calculatedTickCount).length;
+            return primaryTickCount || this.scale.ticks!(this.calculatedTickCount).length;
         }
 
         return super.updateDomain(domain, isYAxis, primaryTickCount);


### PR DESCRIPTION
PR for https://ag-grid.atlassian.net/browse/AG-7202.

Fixes ticks being set to `NaN` values when the domain is undefined.