### PR TITLE
AG-7110 Add localised "Frequency" as default histogram series label

### DIFF
--- a/enterprise-modules/charts/src/charts/chartComp/chartProxies/cartesian/histogramChartProxy.ts
+++ b/enterprise-modules/charts/src/charts/chartComp/chartProxies/cartesian/histogramChartProxy.ts
@@ -26,6 +26,7 @@ export class HistogramChartProxy extends CartesianChartProxy {
             type: this.standaloneChartType,
             xKey: firstField.colId,
             xName: firstField.displayName,
+            yName: this.chartProxyParams.translate("histogramFrequency"),
             areaPlot: false, // only constant width is supported via integrated charts
         }];
     }

--- a/enterprise-modules/charts/src/charts/chartComp/chartProxies/chartProxy.ts
+++ b/enterprise-modules/charts/src/charts/chartComp/chartProxies/chartProxy.ts
@@ -18,6 +18,7 @@ export interface ChartProxyParams {
     chartOptionsToRestore?: AgChartThemeOverrides;
     chartPaletteToRestore?: AgChartThemePalette;
     seriesChartTypes: SeriesChartType[];
+    translate: (toTranslate: string, defaultText?: string) => string;
 }
 
 export interface FieldDefinition {

--- a/enterprise-modules/charts/src/charts/chartComp/gridChartComp.ts
+++ b/enterprise-modules/charts/src/charts/chartComp/gridChartComp.ts
@@ -198,6 +198,7 @@ export class GridChartComp extends Component {
             chartOptionsToRestore: this.params.chartOptionsToRestore,
             chartPaletteToRestore: this.params.chartPaletteToRestore,
             seriesChartTypes: this.chartController.getSeriesChartTypes(),
+            translate: (toTranslate: string, defaultText?: string) => this.chartTranslationService.translate(toTranslate, defaultText),
         };
 
         // ensure 'restoring' options are not reused when switching chart types

--- a/enterprise-modules/charts/src/charts/chartComp/services/chartTranslationService.ts
+++ b/enterprise-modules/charts/src/charts/chartComp/services/chartTranslationService.ts
@@ -108,6 +108,7 @@ export class ChartTranslationService extends BeanStub {
         chartLinkToolbarTooltip: 'Linked to Grid',
         chartUnlinkToolbarTooltip: 'Unlinked from Grid',
         chartDownloadToolbarTooltip: 'Download Chart',
+        histogramFrequency: "Frequency",
         seriesChartType: 'Series Chart Type',
         seriesType: 'Series Type',
         secondaryAxis: 'Secondary Axis',

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/localisation/examples/localisation/locale.en.js
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/localisation/examples/localisation/locale.en.js
@@ -156,6 +156,7 @@ const AG_GRID_LOCALE_EN = {
     normalizedArea: '100% Stacked',
 
     histogramChart: 'Histogram',
+    histogramFrequency: "Frequency",
 
     combinationChart: 'Combination',
     columnLineCombo: 'Column & Line',


### PR DESCRIPTION
* Add ability to update histogram "Frequency" label in localisation file
* Fix bug where xKey was used instead of "Frequency" label in histogram

# Screenshots

Before - using `xKey` in series
https://ag-grid.com/javascript-data-grid/integrated-charts-customisation/#example-histogram-chart-overrides
![Screenshot 2022-09-08 at 2 37 52 pm](https://user-images.githubusercontent.com/79451/189136911-8cfd9876-f891-44ae-8a4c-870b30507906.png)

After - with label `Frequency` in series
https://ag-grid.com/javascript-data-grid/integrated-charts-customisation/#example-histogram-chart-overrides
![Screenshot 2022-09-08 at 2 37 24 pm](https://user-images.githubusercontent.com/79451/189136949-a5f21345-7f49-4050-9f69-d49abd61df7e.png)

With localisation
https://ag-grid.com/javascript-data-grid/localisation/
![Screenshot 2022-09-08 at 2 39 34 pm](https://user-images.githubusercontent.com/79451/189137227-ca3dd3b1-11f4-459f-a4de-01da18185a5f.png)

