### PR TITLE
AG-5988 - More parameters for pie label formatter

### DIFF
--- a/charts-packages/ag-charts-community/src/chart/agChartOptions.ts
+++ b/charts-packages/ag-charts-community/src/chart/agChartOptions.ts
@@ -1240,7 +1240,7 @@ export interface AgPieSeriesTooltipRendererParams extends AgPolarSeriesTooltipRe
 }
 
 export interface AgPieSeriesLabelFormatterParams<DatumType> {
-    /** Datum from the series data array that the tooltip is being rendered for. */
+    /** Datum from the series data array that the label is being rendered for. */
     readonly datum: DatumType;
 
     /** labelKey as specified on series options. */

--- a/charts-packages/ag-charts-community/src/chart/agChartOptions.ts
+++ b/charts-packages/ag-charts-community/src/chart/agChartOptions.ts
@@ -1143,7 +1143,7 @@ export interface AgPieSeriesLabelOptions<DatumType> extends AgChartLabelOptions 
     offset?: PixelSize;
     /** Minimum angle in degrees required for a segment to show a label. */
     minAngle?: number;
-    formatter?: (params: { value: DatumType }) => string;
+    formatter?: (params: AgPieSeriesLabelFormatterParams<DatumType>) => string;
 }
 
 export interface AgPieSeriesFormatterParams<DatumType> {
@@ -1237,6 +1237,39 @@ export interface AgPieSeriesTooltipRendererParams extends AgPolarSeriesTooltipRe
     labelKey?: string;
     /** labelName as specified on series options. */
     labelName?: string;
+}
+
+export interface AgPieSeriesLabelFormatterParams<DatumType> {
+    /** Datum from the series data array that the tooltip is being rendered for. */
+    readonly datum: DatumType;
+
+    /** labelKey as specified on series options. */
+    readonly labelKey?: string;
+    /** labelValue as read from series data via the labelKey property. */
+    readonly labelValue?: string;
+    /** labelName as specified on series options. */
+    readonly labelName?: string;
+
+    /** angleKey as specified on series options. */
+    readonly angleKey: string;
+    /** angleValue as read from series data via the angleKey property. */
+    readonly angleValue?: any;
+    /** angleName as specified on series options. */
+    readonly angleName?: string;
+
+    /** radiusKey as specified on series options. */
+    readonly radiusKey?: string;
+    /** radiusValue as read from series data via the radiusKey property. */
+    readonly radiusValue?: any;
+    /** radiusName as specified on series options. */
+    readonly radiusName?: string;
+
+    /**
+     * The value of labelKey as specified on series options.
+     *
+     * @deprecated Use item.datum instead.
+     */
+    readonly value?: any;
 }
 
 export interface AgTreemapSeriesLabelOptions extends AgChartLabelOptions {

--- a/community-modules/core/src/ts/interfaces/iAgChartOptions.ts
+++ b/community-modules/core/src/ts/interfaces/iAgChartOptions.ts
@@ -1240,7 +1240,7 @@ export interface AgPieSeriesTooltipRendererParams extends AgPolarSeriesTooltipRe
 }
 
 export interface AgPieSeriesLabelFormatterParams<DatumType> {
-    /** Datum from the series data array that the tooltip is being rendered for. */
+    /** Datum from the series data array that the label is being rendered for. */
     readonly datum: DatumType;
 
     /** labelKey as specified on series options. */

--- a/community-modules/core/src/ts/interfaces/iAgChartOptions.ts
+++ b/community-modules/core/src/ts/interfaces/iAgChartOptions.ts
@@ -1143,7 +1143,7 @@ export interface AgPieSeriesLabelOptions<DatumType> extends AgChartLabelOptions 
     offset?: PixelSize;
     /** Minimum angle in degrees required for a segment to show a label. */
     minAngle?: number;
-    formatter?: (params: { value: DatumType }) => string;
+    formatter?: (params: AgPieSeriesLabelFormatterParams<DatumType>) => string;
 }
 
 export interface AgPieSeriesFormatterParams<DatumType> {
@@ -1237,6 +1237,39 @@ export interface AgPieSeriesTooltipRendererParams extends AgPolarSeriesTooltipRe
     labelKey?: string;
     /** labelName as specified on series options. */
     labelName?: string;
+}
+
+export interface AgPieSeriesLabelFormatterParams<DatumType> {
+    /** Datum from the series data array that the tooltip is being rendered for. */
+    readonly datum: DatumType;
+
+    /** labelKey as specified on series options. */
+    readonly labelKey?: string;
+    /** labelValue as read from series data via the labelKey property. */
+    readonly labelValue?: string;
+    /** labelName as specified on series options. */
+    readonly labelName?: string;
+
+    /** angleKey as specified on series options. */
+    readonly angleKey: string;
+    /** angleValue as read from series data via the angleKey property. */
+    readonly angleValue?: any;
+    /** angleName as specified on series options. */
+    readonly angleName?: string;
+
+    /** radiusKey as specified on series options. */
+    readonly radiusKey?: string;
+    /** radiusValue as read from series data via the radiusKey property. */
+    readonly radiusValue?: any;
+    /** radiusName as specified on series options. */
+    readonly radiusName?: string;
+
+    /**
+     * The value of labelKey as specified on series options.
+     *
+     * @deprecated Use item.datum instead.
+     */
+    readonly value?: any;
 }
 
 export interface AgTreemapSeriesLabelOptions extends AgChartLabelOptions {

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/doc-interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/doc-interfaces.AUTO.json
@@ -3251,7 +3251,7 @@
   },
   "AgPieSeriesLabelFormatterParams": {
     "datum": {
-      "description": "/** Datum from the series data array that the tooltip is being rendered for. */",
+      "description": "/** Datum from the series data array that the label is being rendered for. */",
       "type": { "returnType": "DatumType", "optional": false }
     },
     "labelKey": {

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/doc-interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/doc-interfaces.AUTO.json
@@ -2965,7 +2965,7 @@
     },
     "formatter": {
       "type": {
-        "arguments": { "params": "{ value: DatumType; }" },
+        "arguments": { "params": "AgPieSeriesLabelFormatterParams<DatumType>" },
         "returnType": "string",
         "optional": true
       }
@@ -3248,6 +3248,53 @@
       "description": "/** Series primary colour, as selected from the active theme, series options or formatter. */",
       "type": { "returnType": "CssColor", "optional": true }
     }
+  },
+  "AgPieSeriesLabelFormatterParams": {
+    "datum": {
+      "description": "/** Datum from the series data array that the tooltip is being rendered for. */",
+      "type": { "returnType": "DatumType", "optional": false }
+    },
+    "labelKey": {
+      "description": "/** labelKey as specified on series options. */",
+      "type": { "returnType": "string", "optional": true }
+    },
+    "labelValue": {
+      "description": "/** labelValue as read from series data via the labelKey property. */",
+      "type": { "returnType": "string", "optional": true }
+    },
+    "labelName": {
+      "description": "/** labelName as specified on series options. */",
+      "type": { "returnType": "string", "optional": true }
+    },
+    "angleKey": {
+      "description": "/** angleKey as specified on series options. */",
+      "type": { "returnType": "string", "optional": false }
+    },
+    "angleValue": {
+      "description": "/** angleValue as read from series data via the angleKey property. */",
+      "type": { "returnType": "any", "optional": true }
+    },
+    "angleName": {
+      "description": "/** angleName as specified on series options. */",
+      "type": { "returnType": "string", "optional": true }
+    },
+    "radiusKey": {
+      "description": "/** radiusKey as specified on series options. */",
+      "type": { "returnType": "string", "optional": true }
+    },
+    "radiusValue": {
+      "description": "/** radiusValue as read from series data via the radiusKey property. */",
+      "type": { "returnType": "any", "optional": true }
+    },
+    "radiusName": {
+      "description": "/** radiusName as specified on series options. */",
+      "type": { "returnType": "string", "optional": true }
+    },
+    "value": {
+      "description": "/** The value of labelKey as specified on series options.\n * @deprecated Use item.datum instead.\n */",
+      "type": { "returnType": "any", "optional": true }
+    },
+    "meta": { "typeParams": ["DatumType"] }
   },
   "AgTreemapSeriesLabelOptions": {
     "padding": {
@@ -4120,6 +4167,19 @@
     "fill": { "type": { "returnType": "string", "optional": true } },
     "stroke": { "type": { "returnType": "string", "optional": true } },
     "strokeWidth": { "type": { "returnType": "number", "optional": true } }
+  },
+  "PieSeriesLabelFormatterParams": {
+    "datum": { "type": { "returnType": "any", "optional": false } },
+    "labelKey": { "type": { "returnType": "string", "optional": true } },
+    "labelValue": { "type": { "returnType": "string", "optional": true } },
+    "labelName": { "type": { "returnType": "string", "optional": true } },
+    "angleKey": { "type": { "returnType": "string", "optional": false } },
+    "angleValue": { "type": { "returnType": "any", "optional": true } },
+    "angleName": { "type": { "returnType": "string", "optional": true } },
+    "radiusKey": { "type": { "returnType": "string", "optional": true } },
+    "radiusValue": { "type": { "returnType": "any", "optional": true } },
+    "radiusName": { "type": { "returnType": "string", "optional": true } },
+    "value": { "type": { "returnType": "any", "optional": true } }
   },
   "PolarSeriesMarkerFormatterParams": {
     "angleKey": { "type": { "returnType": "string", "optional": false } },

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
@@ -1943,7 +1943,7 @@
     "type": {
       "offset?": "PixelSize",
       "minAngle?": "number",
-      "formatter?": "(params: { value: DatumType; }) => string",
+      "formatter?": "(params: AgPieSeriesLabelFormatterParams<DatumType>) => string",
       "enabled?": "boolean",
       "fontStyle?": "FontStyle",
       "fontWeight?": "FontWeight",
@@ -2125,6 +2125,35 @@
       "datum": "/** Datum from the series data array that the tooltip is being rendered for. */",
       "title?": "/** Series title or yName depending on series configuration. */",
       "color?": "/** Series primary colour, as selected from the active theme, series options or formatter. */"
+    }
+  },
+  "AgPieSeriesLabelFormatterParams": {
+    "meta": { "typeParams": ["DatumType"] },
+    "type": {
+      "datum": "DatumType",
+      "labelKey?": "string",
+      "labelValue?": "string",
+      "labelName?": "string",
+      "angleKey": "string",
+      "angleValue?": "any",
+      "angleName?": "string",
+      "radiusKey?": "string",
+      "radiusValue?": "any",
+      "radiusName?": "string",
+      "value?": "any"
+    },
+    "docs": {
+      "datum": "/** Datum from the series data array that the tooltip is being rendered for. */",
+      "labelKey?": "/** labelKey as specified on series options. */",
+      "labelValue?": "/** labelValue as read from series data via the labelKey property. */",
+      "labelName?": "/** labelName as specified on series options. */",
+      "angleKey": "/** angleKey as specified on series options. */",
+      "angleValue?": "/** angleValue as read from series data via the angleKey property. */",
+      "angleName?": "/** angleName as specified on series options. */",
+      "radiusKey?": "/** radiusKey as specified on series options. */",
+      "radiusValue?": "/** radiusValue as read from series data via the radiusKey property. */",
+      "radiusName?": "/** radiusName as specified on series options. */",
+      "value?": "/** The value of labelKey as specified on series options.\n * @deprecated Use item.datum instead.\n */"
     }
   },
   "AgTreemapSeriesLabelOptions": {
@@ -3028,6 +3057,22 @@
   "PieSeriesFormat": {
     "meta": {},
     "type": { "fill?": "string", "stroke?": "string", "strokeWidth?": "number" }
+  },
+  "PieSeriesLabelFormatterParams": {
+    "meta": {},
+    "type": {
+      "datum": "any",
+      "labelKey?": "string",
+      "labelValue?": "string",
+      "labelName?": "string",
+      "angleKey": "string",
+      "angleValue?": "any",
+      "angleName?": "string",
+      "radiusKey?": "string",
+      "radiusValue?": "any",
+      "radiusName?": "string",
+      "value?": "any"
+    }
   },
   "PolarSeriesMarkerFormatterParams": {
     "meta": {},

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
@@ -2143,7 +2143,7 @@
       "value?": "any"
     },
     "docs": {
-      "datum": "/** Datum from the series data array that the tooltip is being rendered for. */",
+      "datum": "/** Datum from the series data array that the label is being rendered for. */",
       "labelKey?": "/** labelKey as specified on series options. */",
       "labelValue?": "/** labelValue as read from series data via the labelKey property. */",
       "labelName?": "/** labelName as specified on series options. */",

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-pie-series/index.md
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-pie-series/index.md
@@ -51,6 +51,22 @@ series: [{
 }]
 ```
 
+The labels can be customised via the `label.formatter` function.
+The `datum` property provides access to a data item associated with a segment.
+Some useful series config properties can be accessed too,
+please see the [API reference](#api-reference).
+
+```js
+series: [{
+    ...
+    label: {
+        formatter: ({ datum, labelKey, angleKey }) => {
+            return `${datum[labelKey]}: ${datum[angleKey]}`;
+        }
+    }
+}]
+```
+
 The label's callout can be configured to have a different `length`, `color` and `strokeWidth`, for example:
 
 ```js

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-pie-series/index.md
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-pie-series/index.md
@@ -51,10 +51,12 @@ series: [{
 }]
 ```
 
-The labels can be customised via the `label.formatter` function.
-The `datum` property provides access to a data item associated with a segment.
-Some useful series config properties can be accessed too,
-please see the [API reference](#api-reference).
+The `label.formatter` function can be used to change the text value displayed in the label.
+It receives a single object as a parameter containing values associated with a pie segment.
+Please see the [API reference](#api-reference) for the full list of available properties.
+
+For example, to display the numeric values for a given pie sector in the label,
+you can use the following label formatter function:
 
 ```js
 series: [{

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/doc-interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/doc-interfaces.AUTO.json
@@ -15305,7 +15305,7 @@
   },
   "AgPieSeriesLabelFormatterParams": {
     "datum": {
-      "description": "/** Datum from the series data array that the tooltip is being rendered for. */",
+      "description": "/** Datum from the series data array that the label is being rendered for. */",
       "type": { "returnType": "DatumType", "optional": false }
     },
     "labelKey": {

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/doc-interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/doc-interfaces.AUTO.json
@@ -15019,7 +15019,7 @@
     },
     "formatter": {
       "type": {
-        "arguments": { "params": "{ value: DatumType; }" },
+        "arguments": { "params": "AgPieSeriesLabelFormatterParams<DatumType>" },
         "returnType": "string",
         "optional": true
       }
@@ -15302,6 +15302,53 @@
       "description": "/** Series primary colour, as selected from the active theme, series options or formatter. */",
       "type": { "returnType": "CssColor", "optional": true }
     }
+  },
+  "AgPieSeriesLabelFormatterParams": {
+    "datum": {
+      "description": "/** Datum from the series data array that the tooltip is being rendered for. */",
+      "type": { "returnType": "DatumType", "optional": false }
+    },
+    "labelKey": {
+      "description": "/** labelKey as specified on series options. */",
+      "type": { "returnType": "string", "optional": true }
+    },
+    "labelValue": {
+      "description": "/** labelValue as read from series data via the labelKey property. */",
+      "type": { "returnType": "string", "optional": true }
+    },
+    "labelName": {
+      "description": "/** labelName as specified on series options. */",
+      "type": { "returnType": "string", "optional": true }
+    },
+    "angleKey": {
+      "description": "/** angleKey as specified on series options. */",
+      "type": { "returnType": "string", "optional": false }
+    },
+    "angleValue": {
+      "description": "/** angleValue as read from series data via the angleKey property. */",
+      "type": { "returnType": "any", "optional": true }
+    },
+    "angleName": {
+      "description": "/** angleName as specified on series options. */",
+      "type": { "returnType": "string", "optional": true }
+    },
+    "radiusKey": {
+      "description": "/** radiusKey as specified on series options. */",
+      "type": { "returnType": "string", "optional": true }
+    },
+    "radiusValue": {
+      "description": "/** radiusValue as read from series data via the radiusKey property. */",
+      "type": { "returnType": "any", "optional": true }
+    },
+    "radiusName": {
+      "description": "/** radiusName as specified on series options. */",
+      "type": { "returnType": "string", "optional": true }
+    },
+    "value": {
+      "description": "/** The value of labelKey as specified on series options.\n * @deprecated Use item.datum instead.\n */",
+      "type": { "returnType": "any", "optional": true }
+    },
+    "meta": { "typeParams": ["DatumType"] }
   },
   "AgTreemapSeriesLabelOptions": {
     "padding": {

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/interfaces.AUTO.json
@@ -8706,7 +8706,7 @@
     "type": {
       "offset?": "PixelSize",
       "minAngle?": "number",
-      "formatter?": "(params: { value: DatumType; }) => string",
+      "formatter?": "(params: AgPieSeriesLabelFormatterParams<DatumType>) => string",
       "enabled?": "boolean",
       "fontStyle?": "FontStyle",
       "fontWeight?": "FontWeight",
@@ -8888,6 +8888,35 @@
       "datum": "/** Datum from the series data array that the tooltip is being rendered for. */",
       "title?": "/** Series title or yName depending on series configuration. */",
       "color?": "/** Series primary colour, as selected from the active theme, series options or formatter. */"
+    }
+  },
+  "AgPieSeriesLabelFormatterParams": {
+    "meta": { "typeParams": ["DatumType"] },
+    "type": {
+      "datum": "DatumType",
+      "labelKey?": "string",
+      "labelValue?": "string",
+      "labelName?": "string",
+      "angleKey": "string",
+      "angleValue?": "any",
+      "angleName?": "string",
+      "radiusKey?": "string",
+      "radiusValue?": "any",
+      "radiusName?": "string",
+      "value?": "any"
+    },
+    "docs": {
+      "datum": "/** Datum from the series data array that the tooltip is being rendered for. */",
+      "labelKey?": "/** labelKey as specified on series options. */",
+      "labelValue?": "/** labelValue as read from series data via the labelKey property. */",
+      "labelName?": "/** labelName as specified on series options. */",
+      "angleKey": "/** angleKey as specified on series options. */",
+      "angleValue?": "/** angleValue as read from series data via the angleKey property. */",
+      "angleName?": "/** angleName as specified on series options. */",
+      "radiusKey?": "/** radiusKey as specified on series options. */",
+      "radiusValue?": "/** radiusValue as read from series data via the radiusKey property. */",
+      "radiusName?": "/** radiusName as specified on series options. */",
+      "value?": "/** The value of labelKey as specified on series options.\n * @deprecated Use item.datum instead.\n */"
     }
   },
   "AgTreemapSeriesLabelOptions": {

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/interfaces.AUTO.json
@@ -8906,7 +8906,7 @@
       "value?": "any"
     },
     "docs": {
-      "datum": "/** Datum from the series data array that the tooltip is being rendered for. */",
+      "datum": "/** Datum from the series data array that the label is being rendered for. */",
       "labelKey?": "/** labelKey as specified on series options. */",
       "labelValue?": "/** labelValue as read from series data via the labelKey property. */",
       "labelName?": "/** labelName as specified on series options. */",


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-5988

Improvements for Pie/Doughnut Chart segment label formatter:
- Allow access to associated data record through `datum` property.
- Access to config properties `labelKey`, `labelName`, `labelValue`, `angleKey`, `angleName`, `angleValue`, `radiusKey`, `radiusName`, `radiusValue`.
- `value` property becomes deprecated.