### PR TITLE
Ag 7234/histogram series

### DIFF
--- a/charts-packages/ag-charts-community/src/chart/series/cartesian/histogramSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/cartesian/histogramSeries.ts
@@ -32,6 +32,8 @@ class HistogramSeriesLabel extends Label {
     formatter?: (params: { value: number }) => string = undefined;
 }
 
+const defaultBinCount = 10;
+
 export { HistogramTooltipRendererParams };
 
 interface HistogramNodeDatum extends SeriesNodeDatum {
@@ -119,8 +121,6 @@ export class HistogramSeries extends CartesianSeries<SeriesNodeDataContext<Histo
     static className = 'HistogramSeries';
     static type = 'histogram' as const;
 
-    readonly defaultBinCount = 10;
-
     private binnedData: HistogramBin[] = [];
     private xDomain: number[] = [];
     private yDomain: number[] = [];
@@ -207,8 +207,8 @@ export class HistogramSeries extends CartesianSeries<SeriesNodeDataContext<Histo
                 return bins;
             }
 
-            const binStarts = ticks(xDomain[0], xDomain[1], this.defaultBinCount);
-            const binSize = tickStep(xDomain[0], xDomain[1], this.defaultBinCount);
+            const binStarts = ticks(xDomain[0], xDomain[1], defaultBinCount);
+            const binSize = tickStep(xDomain[0], xDomain[1], defaultBinCount);
             const firstBinEnd = binStarts[0];
 
             const expandStartToBin: (n: number) => [number, number] = (n) => [n, n + binSize];
@@ -262,6 +262,7 @@ export class HistogramSeries extends CartesianSeries<SeriesNodeDataContext<Histo
     private placeDataInBins(data: any[]): HistogramBin[] {
         const { xKey } = this;
         const derivedBins = this.deriveBins();
+        this.bins = derivedBins;
 
         // creating a sorted copy allows binning in O(n) rather than O(n²)
         // but at the expense of more temporary memory

--- a/charts-packages/ag-charts-community/src/chart/series/cartesian/histogramSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/cartesian/histogramSeries.ts
@@ -199,14 +199,14 @@ export class HistogramSeries extends CartesianSeries<SeriesNodeDataContext<Histo
             return [];
         }
 
-        if (bins) {
-            return bins;
-        }
-
         const xData = this.data.map((datum) => datum[this.xKey]);
         const xDomain = this.fixNumericExtent(extent(xData, isContinuous));
 
         if (this.binCount === undefined) {
+            if (bins) {
+                return bins;
+            }
+
             const binStarts = ticks(xDomain[0], xDomain[1], this.binCount || defaultBinCount);
             const binSize = tickStep(xDomain[0], xDomain[1], this.binCount || defaultBinCount);
             const firstBinEnd = binStarts[0];
@@ -262,6 +262,7 @@ export class HistogramSeries extends CartesianSeries<SeriesNodeDataContext<Histo
     private placeDataInBins(data: any[]): HistogramBin[] {
         const { xKey } = this;
         const derivedBins = this.deriveBins();
+        this.bins = derivedBins;
 
         // creating a sorted copy allows binning in O(n) rather than O(n²)
         // but at the expense of more temporary memory

--- a/charts-packages/ag-charts-community/src/chart/series/cartesian/histogramSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/cartesian/histogramSeries.ts
@@ -32,8 +32,6 @@ class HistogramSeriesLabel extends Label {
     formatter?: (params: { value: number }) => string = undefined;
 }
 
-const defaultBinCount = 10;
-
 export { HistogramTooltipRendererParams };
 
 interface HistogramNodeDatum extends SeriesNodeDatum {
@@ -121,6 +119,8 @@ export class HistogramSeries extends CartesianSeries<SeriesNodeDataContext<Histo
     static className = 'HistogramSeries';
     static type = 'histogram' as const;
 
+    readonly defaultBinCount = 10;
+
     private binnedData: HistogramBin[] = [];
     private xDomain: number[] = [];
     private yDomain: number[] = [];
@@ -207,8 +207,8 @@ export class HistogramSeries extends CartesianSeries<SeriesNodeDataContext<Histo
                 return bins;
             }
 
-            const binStarts = ticks(xDomain[0], xDomain[1], this.binCount || defaultBinCount);
-            const binSize = tickStep(xDomain[0], xDomain[1], this.binCount || defaultBinCount);
+            const binStarts = ticks(xDomain[0], xDomain[1], this.defaultBinCount);
+            const binSize = tickStep(xDomain[0], xDomain[1], this.defaultBinCount);
             const firstBinEnd = binStarts[0];
 
             const expandStartToBin: (n: number) => [number, number] = (n) => [n, n + binSize];
@@ -262,7 +262,6 @@ export class HistogramSeries extends CartesianSeries<SeriesNodeDataContext<Histo
     private placeDataInBins(data: any[]): HistogramBin[] {
         const { xKey } = this;
         const derivedBins = this.deriveBins();
-        this.bins = derivedBins;
 
         // creating a sorted copy allows binning in O(n) rather than O(n²)
         // but at the expense of more temporary memory

--- a/enterprise-modules/charts/src/charts/chartComp/menu/format/series/seriesPanel.ts
+++ b/enterprise-modules/charts/src/charts/chartComp/menu/format/series/seriesPanel.ts
@@ -26,7 +26,7 @@ export class SeriesPanel extends Component {
 
     public static TEMPLATE = /* html */
         `<div>
-            <ag-group-component ref="seriesGroup">                
+            <ag-group-component ref="seriesGroup">
             </ag-group-component>
         </div>`;
 
@@ -228,7 +228,7 @@ export class SeriesPanel extends Component {
     }
 
     private initBins() {
-        const currentValue = this.getSeriesOption<number>("binCount");
+        const currentValue = this.getSeriesOption<any>("bins").length;
 
         const seriesBinCountSlider = this.createBean(new AgSlider());
         seriesBinCountSlider

--- a/enterprise-modules/charts/src/charts/chartComp/menu/format/series/seriesPanel.ts
+++ b/enterprise-modules/charts/src/charts/chartComp/menu/format/series/seriesPanel.ts
@@ -228,10 +228,7 @@ export class SeriesPanel extends Component {
     }
 
     private initBins() {
-        const currentValue =
-            this.getSeriesOption<any>('binCount') ||
-            this.getSeriesOption<any>('bins')?.length ||
-            this.getSeriesOption<any>('defaultBinCount');
+        const currentValue = this.getSeriesOption<any>("bins").length;
 
         const seriesBinCountSlider = this.createBean(new AgSlider());
         seriesBinCountSlider

--- a/enterprise-modules/charts/src/charts/chartComp/menu/format/series/seriesPanel.ts
+++ b/enterprise-modules/charts/src/charts/chartComp/menu/format/series/seriesPanel.ts
@@ -228,7 +228,10 @@ export class SeriesPanel extends Component {
     }
 
     private initBins() {
-        const currentValue = this.getSeriesOption<any>("bins").length;
+        const currentValue =
+            this.getSeriesOption<any>('binCount') ||
+            this.getSeriesOption<any>('bins')?.length ||
+            this.getSeriesOption<any>('defaultBinCount');
 
         const seriesBinCountSlider = this.createBean(new AgSlider());
         seriesBinCountSlider

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-histogram-series/index.md
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-histogram-series/index.md
@@ -57,7 +57,7 @@ series: [{
 ```
 
 [[warning]]
-| Note that if you give the `bins` property you should not also give `binCount`, but if both are present `bins` takes precedence.
+| Note that if you give the `bins` property you should not also give `binCount`, but if both are present `binCount` takes precedence.
 
 <chart-example title='Irregular Intervals' name='irregular-intervals' type='generated'></chart-example>
 


### PR DESCRIPTION
PR for https://ag-grid.atlassian.net/browse/AG-7234. 

If both `binCount` and `bins` specified in the histogram series options, `binCount` will now take precedence. Integrated charts now reads from `bin` and writes to `binCount` to get an accurate count for the formatting panel.