### PR TITLE
AG-4460 - Add downloadChart to gridApi to allow custom size chart

### DIFF
--- a/community-modules/core/src/ts/gridApi.ts
+++ b/community-modules/core/src/ts/gridApi.ts
@@ -57,7 +57,7 @@ import { AgChartThemeOverrides } from "./interfaces/iAgChartOptions";
 import { IAggFuncService } from "./interfaces/iAggFuncService";
 import { ICellEditor } from "./interfaces/iCellEditor";
 import { ChartType, CrossFilterChartType, SeriesChartType } from "./interfaces/iChartOptions";
-import { ChartModel, GetChartImageDataUrlParams, IChartService } from "./interfaces/IChartService";
+import { ChartDownloadParams, ChartModel, GetChartImageDataUrlParams, IChartService } from "./interfaces/IChartService";
 import { ClientSideRowModelSteps, IClientSideRowModel, RefreshModelParams } from "./interfaces/iClientSideRowModel";
 import { IClipboardCopyParams, IClipboardCopyRowsParams, IClipboardService } from "./interfaces/iClipboardService";
 import { IContextMenuFactory } from "./interfaces/iContextMenuFactory";
@@ -1624,6 +1624,14 @@ export class GridApi<TData = any> {
         if (ModuleRegistry.assertRegistered(ModuleNames.RangeSelectionModule, 'api.getChartImageDataURL') &&
             ModuleRegistry.assertRegistered(ModuleNames.GridChartsModule, 'api.getChartImageDataURL')) {
             return this.chartService.getChartImageDataURL(params);
+        }
+    }
+
+    /** Downloads the chart image in the browser. */
+    public downloadChart(params: ChartDownloadParams) {
+        if (ModuleRegistry.assertRegistered(ModuleNames.RangeSelectionModule, 'api.downloadChart') &&
+            ModuleRegistry.assertRegistered(ModuleNames.GridChartsModule, 'api.downloadChart')) {
+            return this.chartService.downloadChart(params);
         }
     }
 

--- a/community-modules/core/src/ts/interfaces/IChartService.ts
+++ b/community-modules/core/src/ts/interfaces/IChartService.ts
@@ -16,6 +16,20 @@ export interface GetChartImageDataUrlParams {
     fileFormat?: string;
 }
 
+export interface ChartDownloadParams {
+    /** The id of the created chart. */
+    chartId: string;
+
+    /**
+     * Dimensions of the chart.
+     * If undefined, uses the browser image dimensions.
+     */
+    dimensions?: {
+        width: number,
+        height: number
+    }
+}
+
 export type ChartModelType = 'range' | 'pivot';
 
 export interface ChartModel {
@@ -42,4 +56,5 @@ export interface IChartService {
     createPivotChart(params: CreatePivotChartParams): ChartRef | undefined;
     restoreChart(model: ChartModel, chartContainer?: HTMLElement): ChartRef | undefined;
     getChartImageDataURL(params: GetChartImageDataUrlParams): string | undefined;
+    downloadChart(params: ChartDownloadParams): void;
 }

--- a/community-modules/core/src/ts/main.ts
+++ b/community-modules/core/src/ts/main.ts
@@ -260,7 +260,7 @@ export {
     CellRange, CellRangeParams, CellRangeType, RangeSelection, AddRangeSelectionParams, IRangeService,
     ISelectionHandle, SelectionHandleType, ISelectionHandleFactory
 } from "./interfaces/IRangeService";
-export { IChartService, ChartModel, GetChartImageDataUrlParams, ChartModelType } from "./interfaces/IChartService";
+export { IChartService, ChartDownloadParams, ChartModel, GetChartImageDataUrlParams, ChartModelType } from "./interfaces/IChartService";
 
 // master detail
 export { IDetailCellRendererParams, GetDetailRowData, GetDetailRowDataParams, IDetailCellRenderer, IDetailCellRendererCtrl } from './interfaces/masterDetail';

--- a/enterprise-modules/charts/src/charts/chartComp/chartProxies/chartProxy.ts
+++ b/enterprise-modules/charts/src/charts/chartComp/chartProxies/chartProxy.ts
@@ -144,10 +144,25 @@ export abstract class ChartProxy {
         return deepMerge(gridOptionsThemeOverrides, apiThemeOverrides);
     }
 
-    public downloadChart(): void {
+    public async downloadChart(dimensions?: { width: number, height: number }): Promise<void> {
         const { chart } = this;
         const fileName = chart.title ? chart.title.text : 'chart';
-        chart.scene.download(fileName);
+
+        if (dimensions) {
+            const currentWidth = this.chart.width;
+            const currentHeight = this.chart.height;
+
+            this.chart.width = dimensions.width;
+            this.chart.height = dimensions.height;
+
+            await this.chart.waitForUpdate();
+            chart.scene.download(fileName);
+
+            this.chart.width = currentWidth;
+            this.chart.height = currentHeight;
+        } else {
+            chart.scene.download(fileName);
+        }
     }
 
     public getChartImageDataURL(type?: string) {

--- a/enterprise-modules/charts/src/charts/chartComp/gridChartComp.ts
+++ b/enterprise-modules/charts/src/charts/chartComp/gridChartComp.ts
@@ -400,8 +400,8 @@ export class GridChartComp extends Component {
         return false;
     }
 
-    private downloadChart(): void {
-        this.chartProxy.downloadChart();
+    public downloadChart(dimensions?: { width: number, height: number }): void {
+        this.chartProxy.downloadChart(dimensions);
     }
 
     public getChartId(): string {

--- a/enterprise-modules/charts/src/charts/chartService.ts
+++ b/enterprise-modules/charts/src/charts/chartService.ts
@@ -4,6 +4,7 @@ import {
     Autowired,
     Bean,
     BeanStub,
+    ChartDownloadParams,
     CellRange,
     CellRangeParams,
     ChartModel,
@@ -77,6 +78,11 @@ export class ChartService extends BeanStub implements IChartService {
             }
         });
         return url;
+    }
+
+    public downloadChart(params: ChartDownloadParams) {
+        const chartComp = Array.from(this.activeChartComps).find(c => c.getChartId() === params.chartId);
+        chartComp?.downloadChart(params.dimensions);
     }
 
     public createChartFromCurrentRange(chartType: ChartType = 'groupedColumn'): ChartRef | undefined {

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/api.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/api.json
@@ -652,7 +652,14 @@
                 "name": "Downloading Chart Image",
                 "url": "/integrated-charts-api-downloading-image/"
             }
+        },
+        "downloadChart": {
+            "more": {
+                "name": "Downloading Chart Image",
+                "url": "/integrated-charts-api-downloading-image/"
+            }
         }
+        
     },
     "miscellaneous": {
         "meta": {

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/doc-interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/doc-interfaces.AUTO.json
@@ -15974,6 +15974,19 @@
       "type": { "returnType": "string", "optional": true }
     }
   },
+  "ChartDownloadParams": {
+    "chartId": {
+      "description": "/** The id of the created chart. */",
+      "type": { "returnType": "string", "optional": false }
+    },
+    "dimensions": {
+      "description": "/** Dimensions of the chart.\n * If undefined, uses the browser image dimensions. */",
+      "type": {
+        "returnType": "{\n        width: number,\n        height: number\n    }",
+        "optional": true
+      }
+    }
+  },
   "ChartModelType": {},
   "ChartModel": {
     "version": { "type": { "returnType": "string", "optional": true } },
@@ -16060,6 +16073,13 @@
       "type": {
         "arguments": { "params": "GetChartImageDataUrlParams" },
         "returnType": "string | undefined",
+        "optional": false
+      }
+    },
+    "downloadChart": {
+      "type": {
+        "arguments": { "params": "ChartDownloadParams" },
+        "returnType": "void",
         "optional": false
       }
     }

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/grid-api.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/grid-api.AUTO.json
@@ -1096,6 +1096,10 @@
       "returnType": "string | undefined"
     }
   },
+  "downloadChart": {
+    "description": "/** Downloads the chart image in the browser. */",
+    "type": { "arguments": { "params": "ChartDownloadParams" } }
+  },
   "createRangeChart": {
     "description": "/** Used to programmatically create charts from a range. */",
     "type": {

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/interfaces.AUTO.json
@@ -9306,6 +9306,17 @@
       "fileFormat?": "/** A string indicating the image format.\n * The default format type is `image/png`.\n * Options: `image/png`, `image/jpeg` */"
     }
   },
+  "ChartDownloadParams": {
+    "meta": {},
+    "type": {
+      "chartId": "string",
+      "dimensions?": "{ width: number; height: number; }"
+    },
+    "docs": {
+      "chartId": "/** The id of the created chart. */",
+      "dimensions?": "/** Dimensions of the chart.\n * If undefined, uses the browser image dimensions. */"
+    }
+  },
   "ChartModelType": {
     "meta": { "isTypeAlias": true },
     "type": "'range' | 'pivot'"
@@ -9337,7 +9348,8 @@
       "createChartFromCurrentRange(chartType: ChartType)": "ChartRef | undefined",
       "createPivotChart(params: CreatePivotChartParams)": "ChartRef | undefined",
       "restoreChart(model: ChartModel, chartContainer?: HTMLElement)": "ChartRef | undefined",
-      "getChartImageDataURL(params: GetChartImageDataUrlParams)": "string | undefined"
+      "getChartImageDataURL(params: GetChartImageDataUrlParams)": "string | undefined",
+      "downloadChart(params: ChartDownloadParams)": "void"
     }
   },
   "ClientSideRowModelSteps": {

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/integrated-charts-api-downloading-image/examples/downloading-chart-image/index.html
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/integrated-charts-api-downloading-image/examples/downloading-chart-image/index.html
@@ -2,6 +2,7 @@
     <div id="buttons">
         <button onclick="downloadChartImage('image/png')">Download chart PNG</button>
         <button onclick="downloadChartImage('image/jpeg')">Download chart JPEG</button>
+        <button onclick="downloadChart({ width: 800, height: 500 })">Download 800x500 chart</button>
         <button onclick="openChartImage('image/png')">Open PNG</button>
         <button onclick="openChartImage('image/jpeg')">Open JPEG</button>
     </div>

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/integrated-charts-api-downloading-image/examples/downloading-chart-image/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/integrated-charts-api-downloading-image/examples/downloading-chart-image/main.ts
@@ -53,6 +53,17 @@ function onChartCreated(event: ChartCreated) {
   chartId = event.chartId
 }
 
+function downloadChart(dimensions: { width: number, height: number }) {
+  if (!chartId) {
+    return
+  }
+
+  gridOptions.api!.downloadChart({
+    chartId,
+    dimensions
+  });
+}
+
 function downloadChartImage(fileFormat: string) {
   if (!chartId) {
     return

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/integrated-charts-api-downloading-image/index.md
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/integrated-charts-api-downloading-image/index.md
@@ -9,10 +9,15 @@ It is possible to retrieve a base64 encoded image rendered from the chart using 
 
 <api-documentation source='grid-api/api.json' section='charts' names='["getChartImageDataURL"]'></api-documentation>
 
+It is also possible to download the chart image using custom dimensions.
+
+<api-documentation source='grid-api/api.json' section='charts' names='["downloadChart"]'></api-documentation>
+
 The example below demonstrates how you can retrieve images rendered from the chart in multiple formats.
 
 - Click "Download chart PNG" to download a PNG format image.
 - Click "Download chart JPEG" to download a JPEG format image.
+- Click "Download 800x500 chart" to download a custom size image.
 - Click "Open PNG" to open a PNG format image of the chart in a new window.
 - Click "Open JPEG" to open a JPEG format image of the chart in a new window.
 


### PR DESCRIPTION
## Screenshot

Added docs to https://ag-grid.com/react-data-grid/integrated-charts-api-downloading-image/

![Screenshot 2022-09-12 at 3 53 12 pm](https://user-images.githubusercontent.com/79451/189686265-9ff60b68-e35f-4044-9b7e-0235dbe4c4cb.png)
