### PR TITLE
AG-7142 - Charts promise based updates take 2

### DIFF
--- a/charts-packages/ag-charts-community/src/chart/agChart.test.ts
+++ b/charts-packages/ag-charts-community/src/chart/agChart.test.ts
@@ -8,6 +8,7 @@ import { ChartAxisPosition } from './chartAxis';
 import { NumberAxis } from './axis/numberAxis';
 import { ChartTheme } from './themes/chartTheme';
 import { AgChartV2 } from './agChartV2';
+import { waitForChartStability } from './test/utils';
 
 const revenueProfitData = [
     {
@@ -45,7 +46,7 @@ describe('update', () => {
         expect(console.warn).not.toBeCalled();
     });
 
-    test('cartesian chart top-level properties', () => {
+    test('cartesian chart top-level properties', async () => {
         const chart = AgChartV2.create({
             // chart type is optional because it defaults to `cartesian`
             container: document.body,
@@ -73,6 +74,7 @@ describe('update', () => {
                 },
             },
         });
+        await waitForChartStability(chart);
         AgChartV2.update(chart, {
             width: 500,
             height: 500,
@@ -114,6 +116,7 @@ describe('update', () => {
                 position: LegendPosition.Bottom,
             },
         });
+        await waitForChartStability(chart);
 
         const theme = new ChartTheme();
 
@@ -159,6 +162,7 @@ describe('update', () => {
                 },
             },
         });
+        await waitForChartStability(chart);
 
         expect(chart.title!.enabled).toBe(theme.getConfig('cartesian.title.enabled'));
         expect(chart.title!.text).toBe(theme.getConfig('cartesian.title.text'));
@@ -172,7 +176,7 @@ describe('update', () => {
         expect(chart.subtitle!.fontSize).toBe(20);
     });
 
-    test('series', () => {
+    test('series', async () => {
         const chart = AgChartV2.create({
             data: revenueProfitData,
             series: [
@@ -193,6 +197,7 @@ describe('update', () => {
                 },
             ],
         });
+        await waitForChartStability(chart);
         const createdSeries = chart.series;
 
         AgChartV2.update(chart, {
@@ -228,6 +233,7 @@ describe('update', () => {
                 },
             ],
         });
+        await waitForChartStability(chart);
         const updatedSeries = chart.series;
 
         expect(updatedSeries.length).toEqual(3);
@@ -267,6 +273,7 @@ describe('update', () => {
                 },
             ],
         });
+        await waitForChartStability(chart);
         const updatedSeries2 = chart.series;
 
         expect(updatedSeries2.length).toBe(2);
@@ -301,6 +308,7 @@ describe('update', () => {
                 },
             ],
         });
+        await waitForChartStability(chart);
         const updatedSeries3 = chart.series;
 
         expect(updatedSeries3.length).toBe(2);
@@ -342,6 +350,7 @@ describe('update', () => {
                 },
             ],
         });
+        await waitForChartStability(chart);
         const updatedSeries4 = chart.series;
 
         expect(updatedSeries4.length).toEqual(2);
@@ -350,7 +359,7 @@ describe('update', () => {
         expect(updatedSeries4[1]).not.toBe(lineSeries);
     });
 
-    test('axes', () => {
+    test('axes', async () => {
         let chart = AgChartV2.create({
             data: revenueProfitData,
             series: [
@@ -360,6 +369,7 @@ describe('update', () => {
                 },
             ],
         });
+        await waitForChartStability(chart);
 
         AgChartV2.update(chart, {
             data: revenueProfitData,
@@ -383,6 +393,7 @@ describe('update', () => {
                 },
             ],
         });
+        await waitForChartStability(chart);
 
         let axes = chart.axes;
         expect(axes.length).toBe(2);
@@ -431,6 +442,7 @@ describe('update', () => {
                 },
             ],
         });
+        await waitForChartStability(chart);
 
         leftAxis = chart.axes.find((axis) => axis.position === ChartAxisPosition.Left);
         expect(leftAxis!.gridStyle).toEqual([

--- a/charts-packages/ag-charts-community/src/chart/agChartV2.test.ts
+++ b/charts-packages/ag-charts-community/src/chart/agChartV2.test.ts
@@ -29,6 +29,7 @@ function consoleWarnAssertions(options: AgCartesianChartOptions) {
         jest.clearAllMocks();
         options.axes[0].label.format = '%X %M'; // format string for Date objects, not valid for number values
         AgChartV2.update(chart, options);
+        await waitForChartStability(chart);
 
         expect(console.warn).toBeCalledTimes(1);
         expect(console.warn).toBeCalledWith(
@@ -38,6 +39,7 @@ function consoleWarnAssertions(options: AgCartesianChartOptions) {
         jest.clearAllMocks();
         options.axes[0].label.format = '%'; // multiply by 100, and then decimal notation with a percent sign - valid format string for number values
         AgChartV2.update(chart, options);
+        await waitForChartStability(chart);
 
         expect(console.warn).not.toBeCalled();
 
@@ -94,6 +96,7 @@ describe('AgChartV2', () => {
                 options.height = CANVAS_HEIGHT;
 
                 chart = AgChartV2.create<any>(options);
+                await waitForChartStability(chart);
                 await example.assertions(chart);
             });
 

--- a/charts-packages/ag-charts-community/src/chart/agChartV2.ts
+++ b/charts-packages/ag-charts-community/src/chart/agChartV2.ts
@@ -158,6 +158,11 @@ export abstract class AgChartV2 {
         }
 
         chart.requestFactoryUpdate(async () => {
+            if (chart.destroyed) {
+                // Chart destroyed, skip processing.
+                return;
+            }
+
             await AgChartV2.updateDelta(chart, mergedOptions, userOptions);
         });
         return chart as T;
@@ -171,6 +176,11 @@ export abstract class AgChartV2 {
         }
 
         chart.requestFactoryUpdate(async () => {
+            if (chart.destroyed) {
+                // Chart destroyed, skip processing.
+                return;
+            }
+
             const mergedOptions = prepareOptions(userOptions, chart.userOptions as ChartOptionType<T>, mixinOpts);
 
             if (chartType(mergedOptions) !== chartType(chart.options as ChartOptionType<typeof chart>)) {

--- a/charts-packages/ag-charts-community/src/chart/agChartV2.ts
+++ b/charts-packages/ag-charts-community/src/chart/agChartV2.ts
@@ -161,7 +161,7 @@ export abstract class AgChartV2 {
         return chart as T;
     }
 
-    static update<T extends ChartType>(chart: Chart, userOptions: ChartOptionType<T>): void {
+    static update<T extends ChartType>(chart: Chart, userOptions: ChartOptionType<T>) {
         debug('user options', userOptions);
         const mixinOpts: any = {};
         if (AgChartV2.DEBUG()) {
@@ -190,12 +190,17 @@ export abstract class AgChartV2 {
         chart: T,
         update: Partial<ChartOptionType<T>>,
         userOptions: ChartOptionType<T>
-    ): void {
-        if (update.type == null) {
-            update = { ...update, type: chart.options.type || optionsType(update) };
-        }
-        debug('delta update', update);
-        applyChartOptions(chart, update as ChartOptionType<typeof chart>, userOptions);
+    ) {
+        return chart.registerPendingFactoryUpdate(async () => {
+            if (update.type == null) {
+                update = { ...update, type: chart.options.type || optionsType(update) };
+            }
+            debug('delta update', update);
+    
+            await chart.awaitUpdateCompletion();
+    
+            applyChartOptions(chart, update as ChartOptionType<typeof chart>, userOptions);
+        })
     }
 }
 

--- a/charts-packages/ag-charts-community/src/chart/axis/axisExamples.test.ts
+++ b/charts-packages/ag-charts-community/src/chart/axis/axisExamples.test.ts
@@ -182,6 +182,7 @@ describe('Axis Examples', () => {
         it(`for ${exampleName} it should create chart instance as expected`, async () => {
             const options: AgChartOptions = example.options;
             chart = AgChartV2.create<any>(options);
+            await waitForChartStability(chart);
             await example.assertions(chart);
         });
 
@@ -222,6 +223,7 @@ describe('Axis Examples', () => {
             it(`for ${exampleName} it should create chart instance as expected`, async () => {
                 const options: AgChartOptions = example.options;
                 chart = AgChartV2.create<any>(options);
+                await waitForChartStability(chart);
                 await example.assertions(chart);
             });
 

--- a/charts-packages/ag-charts-community/src/chart/cartesianChart.test.ts
+++ b/charts-packages/ag-charts-community/src/chart/cartesianChart.test.ts
@@ -206,17 +206,15 @@ describe('CartesianChart', () => {
                 options.autoSize = false;
                 options.width = CANVAS_WIDTH;
                 options.height = CANVAS_HEIGHT;
-
+    
                 chart = AgChartV2.create<any>(options);
                 await waitForChartStability(chart);
-
-                const seriesImpl = chart.series.find(
-                    (v: any) => v.yKey === yKey || v.yKeys?.some((s) => s.includes(yKey))
-                );
-
+    
+                const seriesImpl = chart.series.find((v: any) => v.yKey === yKey || v.yKeys?.some((s) => s.includes(yKey)));
+    
                 const nodeDataArray: SeriesNodeDataContext<any, any>[] = seriesImpl!['contextNodeData'];
                 const nodeData = nodeDataArray.find((n) => n.itemId === yKey);
-
+    
                 chart.changeHighlightDatum({ datum: nodeData?.nodeData[3] });
                 chart.update(ChartUpdateType.SERIES_UPDATE);
                 await compare(chart);

--- a/charts-packages/ag-charts-community/src/chart/cartesianChart.ts
+++ b/charts-packages/ag-charts-community/src/chart/cartesianChart.ts
@@ -27,7 +27,7 @@ export class CartesianChart extends Chart {
     readonly seriesRoot = new ClipRect();
     readonly navigator = new Navigator(this);
 
-    performLayout(): void {
+    async performLayout() {
         this.scene.root!.visible = true;
 
         const { width, height, legend, navigator } = this;

--- a/charts-packages/ag-charts-community/src/chart/chart.ts
+++ b/charts-packages/ag-charts-community/src/chart/chart.ts
@@ -350,7 +350,7 @@ export abstract class Chart extends Observable {
                 parentNode.removeChild(this.element);
             }
 
-            if (value) {
+            if (value && !this.destroyed) {
                 value.appendChild(this.element);
             }
 
@@ -458,6 +458,11 @@ export abstract class Chart extends Observable {
         return this._subtitle;
     }
 
+    private _destroyed: boolean = false;
+    get destroyed() {
+        return this._destroyed;
+    }
+
     private static tooltipDocuments: Document[] = [];
 
     protected constructor(document = window.document) {
@@ -470,7 +475,7 @@ export abstract class Chart extends Observable {
         root.appendChild(background.node);
 
         const element = (this.element = document.createElement('div'));
-        element.setAttribute('class', 'ag-chart-wrapper');
+        element.classList.add('ag-chart-wrapper');
         element.style.position = 'relative';
 
         this.scene = new Scene({ document });
@@ -521,6 +526,8 @@ export abstract class Chart extends Observable {
         this.scene.destroy();
         this.series.forEach((s) => s.destroy());
         this.series = [];
+
+        this._destroyed = true;
     }
 
     log(opts: any) {

--- a/charts-packages/ag-charts-community/src/chart/chartAxis.ts
+++ b/charts-packages/ag-charts-community/src/chart/chartAxis.ts
@@ -156,10 +156,6 @@ export class ChartAxis<S extends Scale<any, number> = Scale<any, number>> extend
     calculateDomain({ primaryTickCount }: { primaryTickCount?: number }) {
         const { direction, boundSeries, includeInvisibleDomains } = this;
 
-        if (boundSeries.length === 0) {
-            console.warn('AG Charts - chart series not initialised; check series and axes configuration.');
-        }
-
         if (this.linkedTo) {
             this.domain = this.linkedTo.domain;
         } else {

--- a/charts-packages/ag-charts-community/src/chart/crossline/crossLine.test.ts
+++ b/charts-packages/ag-charts-community/src/chart/crossline/crossLine.test.ts
@@ -200,6 +200,7 @@ describe('crossLines', () => {
                 options.height = CANVAS_HEIGHT;
 
                 chart = AgChartV2.create<CartesianChart>(options);
+                await waitForChartStability(chart);
                 await example.assertions(chart);
             });
 

--- a/charts-packages/ag-charts-community/src/chart/galleryExamples.test.ts
+++ b/charts-packages/ag-charts-community/src/chart/galleryExamples.test.ts
@@ -158,6 +158,7 @@ describe('Gallery Examples', () => {
             it(`for ${exampleName} it should create chart instance as expected`, async () => {
                 const options: AgChartOptions = example.options;
                 chart = AgChartV2.create<any>(options);
+                await waitForChartStability(chart);
                 await example.assertions(chart);
             });
 

--- a/charts-packages/ag-charts-community/src/chart/hierarchyChart.ts
+++ b/charts-packages/ag-charts-community/src/chart/hierarchyChart.ts
@@ -25,7 +25,7 @@ export class HierarchyChart extends Chart {
         return this._seriesRoot;
     }
 
-    performLayout(): void {
+    async performLayout() {
         this.scene.root!!.visible = true;
 
         const { width, height, legend } = this;

--- a/charts-packages/ag-charts-community/src/chart/polarChart.ts
+++ b/charts-packages/ag-charts-community/src/chart/polarChart.ts
@@ -20,7 +20,7 @@ export class PolarChart extends Chart {
         return this.scene.root!;
     }
 
-    performLayout(): void {
+    async performLayout() {
         const shrinkRect = new BBox(0, 0, this.width, this.height);
 
         const { captionAutoPadding = 0 } = this.positionCaptions();

--- a/charts-packages/ag-charts-community/src/chart/series/cartesian/areaSeries.test.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/cartesian/areaSeries.test.ts
@@ -106,6 +106,7 @@ describe('AreaSeries', () => {
                 options.height = CANVAS_HEIGHT;
 
                 chart = AgChartV2.create<any>(options);
+                await waitForChartStability(chart);
                 await example.assertions(chart);
             });
 

--- a/charts-packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
@@ -241,12 +241,12 @@ export class AreaSeries extends CartesianSeries<AreaSeriesNodeDataContext> {
 
     protected highlightedDatum?: MarkerSelectionDatum;
 
-    processData(): boolean {
+    async processData() {
         const { xKey, yKeys, seriesItemEnabled, xAxis, yAxis, normalizedTo } = this;
         const data = xKey && yKeys.length && this.data ? this.data : [];
 
         if (!xAxis || !yAxis) {
-            return false;
+            return;
         }
 
         // If the data is an array of rows like so:
@@ -392,8 +392,6 @@ export class AreaSeries extends CartesianSeries<AreaSeriesNodeDataContext> {
             yMin === undefined && yMax === undefined ? undefined : [yMin ?? 0, yMax ?? 0],
             yAxis
         );
-
-        return true;
     }
 
     getDomain(direction: ChartAxisDirection): any[] {
@@ -404,7 +402,7 @@ export class AreaSeries extends CartesianSeries<AreaSeriesNodeDataContext> {
         }
     }
 
-    createNodeData() {
+    async createNodeData() {
         const { data, xAxis, yAxis, xData, yData } = this;
 
         if (!data || !xAxis || !yAxis || !xData.length || !yData.length) {
@@ -594,11 +592,11 @@ export class AreaSeries extends CartesianSeries<AreaSeriesNodeDataContext> {
         return this.marker.isDirty();
     }
 
-    protected updatePaths(opts: {
+    protected async updatePaths(opts: {
         seriesHighlighted?: boolean;
         contextData: AreaSeriesNodeDataContext;
         paths: Path[];
-    }): void {
+    }) {
         const {
             contextData: { fillSelectionData, strokeSelectionData },
             paths: [fill, stroke],
@@ -617,12 +615,12 @@ export class AreaSeries extends CartesianSeries<AreaSeriesNodeDataContext> {
         stroke.pointerEvents = PointerEvents.None;
     }
 
-    protected updatePathNodes(opts: {
+    protected async updatePathNodes(opts: {
         seriesHighlighted?: boolean;
         itemId?: string;
         paths: Path[];
         seriesIdx: number;
-    }): void {
+    }) {
         const {
             paths: [fill, stroke],
             seriesIdx,
@@ -688,7 +686,7 @@ export class AreaSeries extends CartesianSeries<AreaSeriesNodeDataContext> {
         }
     }
 
-    protected updateMarkerSelection(opts: {
+    protected async updateMarkerSelection(opts: {
         nodeData: MarkerSelectionDatum[];
         markerSelection: Selection<Marker, Group, MarkerSelectionDatum, any>;
     }) {
@@ -713,7 +711,7 @@ export class AreaSeries extends CartesianSeries<AreaSeriesNodeDataContext> {
         return updateMarkerSelection.merge(enterMarkers);
     }
 
-    protected updateMarkerNodes(opts: {
+    protected async updateMarkerNodes(opts: {
         markerSelection: Selection<Marker, Group, MarkerSelectionDatum, any>;
         isHighlight: boolean;
     }) {
@@ -792,7 +790,7 @@ export class AreaSeries extends CartesianSeries<AreaSeriesNodeDataContext> {
         }
     }
 
-    protected updateLabelSelection(opts: {
+    protected async updateLabelSelection(opts: {
         labelData: LabelSelectionDatum[];
         labelSelection: Selection<Text, Group, LabelSelectionDatum, any>;
     }) {
@@ -806,7 +804,7 @@ export class AreaSeries extends CartesianSeries<AreaSeriesNodeDataContext> {
         return updateLabels.merge(enterLabels);
     }
 
-    protected updateLabelNodes(opts: { labelSelection: Selection<Text, Group, LabelSelectionDatum, any> }) {
+    protected async updateLabelNodes(opts: { labelSelection: Selection<Text, Group, LabelSelectionDatum, any> }) {
         const { labelSelection } = opts;
         const { enabled: labelEnabled, fontStyle, fontWeight, fontSize, fontFamily, color } = this.label;
         labelSelection.each((text, datum) => {

--- a/charts-packages/ag-charts-community/src/chart/series/cartesian/barSeries.test.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/cartesian/barSeries.test.ts
@@ -81,6 +81,7 @@ describe('BarSeries', () => {
                 options.height = CANVAS_HEIGHT;
 
                 chart = AgChartV2.create<any>(options);
+                await waitForChartStability(chart);
                 await example.assertions(chart);
             });
 

--- a/charts-packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
@@ -353,7 +353,7 @@ export class BarSeries extends CartesianSeries<SeriesNodeDataContext<BarNodeDatu
     shadow?: DropShadow = undefined;
 
     protected smallestDataInterval?: { x: number; y: number } = undefined;
-    processData(): boolean {
+    async processData() {
         const { xKey, yKeys, seriesItemEnabled } = this;
         const data = xKey && yKeys.length && this.data ? this.data : [];
 
@@ -361,7 +361,7 @@ export class BarSeries extends CartesianSeries<SeriesNodeDataContext<BarNodeDatu
         const yAxis = this.getValueAxis();
 
         if (!(xAxis && yAxis)) {
-            return false;
+            return;
         }
 
         const setSmallestXInterval = (curr: number, prev: number) => {
@@ -436,7 +436,7 @@ export class BarSeries extends CartesianSeries<SeriesNodeDataContext<BarNodeDatu
         if (yMin === Infinity && yMax === -Infinity) {
             // There's no data in the domain.
             this.yDomain = [];
-            return true;
+            return;
         }
 
         if (normalizedTo && isFinite(normalizedTo)) {
@@ -452,8 +452,6 @@ export class BarSeries extends CartesianSeries<SeriesNodeDataContext<BarNodeDatu
         }
 
         this.yDomain = this.fixNumericExtent([yMin, yMax], this.yAxis);
-
-        return true;
     }
 
     findLargestMinMax(groups: { min?: number; max?: number }[][]): { min: number; max: number } {
@@ -529,7 +527,7 @@ export class BarSeries extends CartesianSeries<SeriesNodeDataContext<BarNodeDatu
         return step;
     }
 
-    createNodeData() {
+    async createNodeData() {
         const { chart, data, visible } = this;
         const xAxis = this.getCategoryAxis();
         const yAxis = this.getValueAxis();
@@ -709,7 +707,7 @@ export class BarSeries extends CartesianSeries<SeriesNodeDataContext<BarNodeDatu
         return contexts.reduce((r, n) => r.concat(...n), []);
     }
 
-    protected updateDatumSelection(opts: {
+    protected async updateDatumSelection(opts: {
         nodeData: BarNodeDatum[];
         datumSelection: Selection<Rect, Group, BarNodeDatum, any>;
     }) {
@@ -723,7 +721,7 @@ export class BarSeries extends CartesianSeries<SeriesNodeDataContext<BarNodeDatu
         return updateRects.merge(enterRects);
     }
 
-    protected updateDatumNodes(opts: {
+    protected async updateDatumNodes(opts: {
         datumSelection: Selection<Rect, Group, BarNodeDatum, any>;
         isHighlight: boolean;
     }) {
@@ -800,7 +798,7 @@ export class BarSeries extends CartesianSeries<SeriesNodeDataContext<BarNodeDatu
         });
     }
 
-    protected updateLabelSelection(opts: {
+    protected async updateLabelSelection(opts: {
         labelData: BarNodeDatum[];
         labelSelection: Selection<Text, Group, BarNodeDatum, any>;
     }) {
@@ -818,7 +816,7 @@ export class BarSeries extends CartesianSeries<SeriesNodeDataContext<BarNodeDatu
         return updateLabels.merge(enterLabels);
     }
 
-    protected updateLabelNodes(opts: { labelSelection: Selection<Text, Group, BarNodeDatum, any> }) {
+    protected async updateLabelNodes(opts: { labelSelection: Selection<Text, Group, BarNodeDatum, any> }) {
         const { labelSelection } = opts;
         const {
             label: { enabled: labelEnabled, fontStyle, fontWeight, fontSize, fontFamily, color },

--- a/charts-packages/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
@@ -129,19 +129,19 @@ export abstract class CartesianSeries<
         return !isNaN(x) && !isNaN(y) && xAxis.inRange(x) && yAxis.inRange(y);
     }
 
-    update(): void {
+    async update() {
         const { seriesItemEnabled, visible, chart: { highlightedDatum: { series = undefined } = {} } = {} } = this;
         const seriesHighlighted = series ? series === this : undefined;
 
         const anySeriesItemEnabled =
             (visible && seriesItemEnabled.size === 0) || [...seriesItemEnabled.values()].some((v) => v === true);
 
-        this.updateSelections(seriesHighlighted, anySeriesItemEnabled);
-        this.updateNodes(seriesHighlighted, anySeriesItemEnabled);
+        await this.updateSelections(seriesHighlighted, anySeriesItemEnabled);
+        await this.updateNodes(seriesHighlighted, anySeriesItemEnabled);
     }
 
-    protected updateSelections(seriesHighlighted: boolean | undefined, anySeriesItemEnabled: boolean) {
-        this.updateHighlightSelection(seriesHighlighted);
+    protected async updateSelections(seriesHighlighted: boolean | undefined, anySeriesItemEnabled: boolean) {
+        await this.updateHighlightSelection(seriesHighlighted);
 
         if (!anySeriesItemEnabled) {
             return;
@@ -152,25 +152,35 @@ export abstract class CartesianSeries<
         if (this.nodeDataRefresh) {
             this.nodeDataRefresh = false;
 
-            this._contextNodeData = this.createNodeData();
-            this.updateSeriesGroups();
+            this._contextNodeData = await this.createNodeData();
+            await this.updateSeriesGroups();
         }
 
-        this.subGroups.forEach((subGroup, seriesIdx) => {
-            const { datumSelection, labelSelection, markerSelection, paths } = subGroup;
-            const contextData = this._contextNodeData[seriesIdx];
-            const { nodeData, labelData, itemId } = contextData;
-
-            this.updatePaths({ seriesHighlighted, itemId, contextData, paths, seriesIdx });
-            subGroup.datumSelection = this.updateDatumSelection({ nodeData, datumSelection, seriesIdx });
-            subGroup.labelSelection = this.updateLabelSelection({ labelData, labelSelection, seriesIdx });
-            if (markerSelection) {
-                subGroup.markerSelection = this.updateMarkerSelection({ nodeData, markerSelection, seriesIdx });
-            }
-        });
+        await Promise.all(this.subGroups.map((g, i) => this.updateSeriesGroupSelections(g, i, seriesHighlighted)));
     }
 
-    private updateSeriesGroups() {
+    private async updateSeriesGroupSelections(
+        subGroup: SubGroup<C, any>,
+        seriesIdx: number,
+        seriesHighlighted?: boolean
+    ) {
+        const { datumSelection, labelSelection, markerSelection, paths } = subGroup;
+        const contextData = this._contextNodeData[seriesIdx];
+        const { nodeData, labelData, itemId } = contextData;
+
+        await this.updatePaths({ seriesHighlighted, itemId, contextData, paths, seriesIdx });
+        subGroup.datumSelection = await this.updateDatumSelection({ nodeData, datumSelection, seriesIdx });
+        subGroup.labelSelection = await this.updateLabelSelection({ labelData, labelSelection, seriesIdx });
+        if (markerSelection) {
+            subGroup.markerSelection = await this.updateMarkerSelection({
+                nodeData,
+                markerSelection,
+                seriesIdx,
+            });
+        }
+    }
+
+    private async updateSeriesGroups() {
         const {
             _contextNodeData: contextNodeData,
             seriesGroup,
@@ -261,7 +271,7 @@ export abstract class CartesianSeries<
         }
     }
 
-    protected updateNodes(seriesHighlighted: boolean | undefined, anySeriesItemEnabled: boolean) {
+    protected async updateNodes(seriesHighlighted: boolean | undefined, anySeriesItemEnabled: boolean) {
         const {
             highlightSelection,
             highlightLabelSelection,
@@ -278,59 +288,65 @@ export abstract class CartesianSeries<
         this.seriesGroup.opacity = this.getOpacity();
 
         if (markersEnabled) {
-            this.updateMarkerNodes({ markerSelection: highlightSelection as any, isHighlight: true, seriesIdx: -1 });
+            await this.updateMarkerNodes({
+                markerSelection: highlightSelection as any,
+                isHighlight: true,
+                seriesIdx: -1,
+            });
         } else {
-            this.updateDatumNodes({ datumSelection: highlightSelection, isHighlight: true, seriesIdx: -1 });
+            await this.updateDatumNodes({ datumSelection: highlightSelection, isHighlight: true, seriesIdx: -1 });
         }
-        this.updateLabelNodes({ labelSelection: highlightLabelSelection, seriesIdx: -1 });
+        await this.updateLabelNodes({ labelSelection: highlightLabelSelection, seriesIdx: -1 });
 
-        this.subGroups.forEach((subGroup, seriesIdx) => {
-            const {
-                group,
-                markerGroup,
-                datumSelection,
-                labelSelection,
-                markerSelection,
-                paths,
-                labelGroup,
-                pickGroup,
-            } = subGroup;
-            const { itemId } = contextNodeData[seriesIdx];
+        await Promise.all(
+            this.subGroups.map(async (subGroup, seriesIdx) => {
+                const {
+                    group,
+                    markerGroup,
+                    datumSelection,
+                    labelSelection,
+                    markerSelection,
+                    paths,
+                    labelGroup,
+                    pickGroup,
+                } = subGroup;
+                const { itemId } = contextNodeData[seriesIdx];
 
-            const subGroupVisible = visible && (seriesItemEnabled.get(itemId) ?? true);
-            const subGroupOpacity = this.getOpacity({ itemId });
-            group.opacity = subGroupOpacity;
-            group.visible = subGroupVisible;
-            pickGroup.visible = subGroupVisible;
-            labelGroup.visible = subGroupVisible;
+                const subGroupVisible = visible && (seriesItemEnabled.get(itemId) ?? true);
+                const subGroupOpacity = this.getOpacity({ itemId });
+                group.opacity = subGroupOpacity;
+                group.visible = subGroupVisible;
+                pickGroup.visible = subGroupVisible;
+                labelGroup.visible = subGroupVisible;
 
-            if (markerGroup) {
-                markerGroup.opacity = subGroupOpacity;
-                markerGroup.zIndex = group.zIndex >= Layers.SERIES_LAYER_ZINDEX ? group.zIndex : group.zIndex + 1;
-                markerGroup.visible = subGroupVisible;
-            }
-
-            for (const path of paths) {
-                if (path.parent !== group) {
-                    path.opacity = subGroupOpacity;
-                    path.visible = subGroupVisible;
+                if (markerGroup) {
+                    markerGroup.opacity = subGroupOpacity;
+                    markerGroup.zIndex = group.zIndex >= Layers.SERIES_LAYER_ZINDEX ? group.zIndex : group.zIndex + 1;
+                    markerGroup.visible = subGroupVisible;
                 }
-            }
 
-            if (!group.visible) {
-                return;
-            }
+                for (const path of paths) {
+                    if (path.parent !== group) {
+                        path.opacity = subGroupOpacity;
+                        path.visible = subGroupVisible;
+                    }
+                }
 
-            this.updatePathNodes({ seriesHighlighted, itemId, paths, seriesIdx });
-            this.updateDatumNodes({ datumSelection, isHighlight: false, seriesIdx });
-            this.updateLabelNodes({ labelSelection, seriesIdx });
-            if (markersEnabled && markerSelection) {
-                this.updateMarkerNodes({ markerSelection, isHighlight: false, seriesIdx });
-            }
-        });
+                if (!group.visible) {
+                    return;
+                }
+
+                await this.updatePathNodes({ seriesHighlighted, itemId, paths, seriesIdx });
+                await this.updateDatumNodes({ datumSelection, isHighlight: false, seriesIdx });
+                await this.updateLabelNodes({ labelSelection, seriesIdx });
+                if (markersEnabled && markerSelection) {
+                    await this.updateMarkerNodes({ markerSelection, isHighlight: false, seriesIdx });
+                }
+            })
+        );
     }
 
-    protected updateHighlightSelection(seriesHighlighted?: boolean) {
+    protected async updateHighlightSelection(seriesHighlighted?: boolean) {
         const {
             chart: { highlightedDatum: { datum = undefined } = {}, highlightedDatum = undefined } = {},
             highlightSelection,
@@ -340,7 +356,7 @@ export abstract class CartesianSeries<
 
         const item =
             seriesHighlighted && highlightedDatum && datum ? (highlightedDatum as C['nodeData'][number]) : undefined;
-        this.highlightSelection = this.updateHighlightSelectionItem({ item, highlightSelection });
+        this.highlightSelection = await this.updateHighlightSelectionItem({ item, highlightSelection });
 
         let labelItem: C['labelData'][number] | undefined;
         if (this.label.enabled && item != null) {
@@ -355,7 +371,10 @@ export abstract class CartesianSeries<
             }
         }
 
-        this.highlightLabelSelection = this.updateHighlightSelectionLabel({ item: labelItem, highlightLabelSelection });
+        this.highlightLabelSelection = await this.updateHighlightSelectionLabel({
+            item: labelItem,
+            highlightLabelSelection,
+        });
     }
 
     protected pickNodeExactShape(point: Point): SeriesNodePickMatch | undefined {
@@ -506,30 +525,30 @@ export abstract class CartesianSeries<
         return [];
     }
 
-    protected updatePaths(opts: {
+    protected async updatePaths(opts: {
         seriesHighlighted?: boolean;
         itemId?: string;
         contextData: C;
         paths: Path[];
         seriesIdx: number;
-    }): void {
+    }): Promise<void> {
         // Override point for sub-classes.
         opts.paths.forEach((p) => (p.visible = false));
     }
 
-    protected updatePathNodes(_opts: {
+    protected async updatePathNodes(_opts: {
         seriesHighlighted?: boolean;
         itemId?: string;
         paths: Path[];
         seriesIdx: number;
-    }): void {
+    }): Promise<void> {
         // Override point for sub-classes.
     }
 
-    protected updateHighlightSelectionItem(opts: {
+    protected async updateHighlightSelectionItem(opts: {
         item?: C['nodeData'][number];
         highlightSelection: NodeDataSelection<N, C>;
-    }): NodeDataSelection<N, C> {
+    }): Promise<NodeDataSelection<N, C>> {
         const {
             opts: { features },
         } = this;
@@ -546,45 +565,45 @@ export abstract class CartesianSeries<
         }
     }
 
-    protected updateHighlightSelectionLabel(opts: {
+    protected async updateHighlightSelectionLabel(opts: {
         item?: C['labelData'][number];
         highlightLabelSelection: LabelDataSelection<Text, C>;
-    }): LabelDataSelection<Text, C> {
+    }): Promise<LabelDataSelection<Text, C>> {
         const { item, highlightLabelSelection } = opts;
         const labelData = item ? [item] : [];
 
         return this.updateLabelSelection({ labelData, labelSelection: highlightLabelSelection, seriesIdx: -1 });
     }
 
-    protected updateDatumSelection(opts: {
+    protected async updateDatumSelection(opts: {
         nodeData: C['nodeData'];
         datumSelection: NodeDataSelection<N, C>;
         seriesIdx: number;
-    }): NodeDataSelection<N, C> {
+    }): Promise<NodeDataSelection<N, C>> {
         // Override point for sub-classes.
         return opts.datumSelection;
     }
-    protected updateDatumNodes(_opts: {
+    protected async updateDatumNodes(_opts: {
         datumSelection: NodeDataSelection<N, C>;
         isHighlight: boolean;
         seriesIdx: number;
-    }): void {
+    }): Promise<void> {
         // Override point for sub-classes.
     }
 
-    protected updateMarkerSelection(opts: {
+    protected async updateMarkerSelection(opts: {
         nodeData: C['nodeData'];
         markerSelection: NodeDataSelection<Marker, C>;
         seriesIdx: number;
-    }): NodeDataSelection<Marker, C> {
+    }): Promise<NodeDataSelection<Marker, C>> {
         // Override point for sub-classes.
         return opts.markerSelection;
     }
-    protected updateMarkerNodes(_opts: {
+    protected async updateMarkerNodes(_opts: {
         markerSelection: NodeDataSelection<Marker, C>;
         isHighlight: boolean;
         seriesIdx: number;
-    }): void {
+    }): Promise<void> {
         // Override point for sub-classes.
     }
 
@@ -592,8 +611,11 @@ export abstract class CartesianSeries<
         labelData: C['labelData'];
         labelSelection: LabelDataSelection<Text, C>;
         seriesIdx: number;
-    }): LabelDataSelection<Text, C>;
-    protected abstract updateLabelNodes(opts: { labelSelection: LabelDataSelection<Text, C>; seriesIdx: number }): void;
+    }): Promise<LabelDataSelection<Text, C>>;
+    protected abstract updateLabelNodes(opts: {
+        labelSelection: LabelDataSelection<Text, C>;
+        seriesIdx: number;
+    }): Promise<void>;
 }
 
 export interface CartesianSeriesMarkerFormat {

--- a/charts-packages/ag-charts-community/src/chart/series/cartesian/histogramSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/cartesian/histogramSeries.ts
@@ -347,7 +347,7 @@ export class HistogramSeries extends CartesianSeries<SeriesNodeDataContext<Histo
         );
     }
 
-    processData(): boolean {
+    async processData() {
         const { xKey, data } = this;
 
         this.binnedData = this.placeDataInBins(xKey && data ? data : []);
@@ -362,8 +362,6 @@ export class HistogramSeries extends CartesianSeries<SeriesNodeDataContext<Histo
         const xMin = firstBin.domain[0];
         const xMax = lastBin.domain[1];
         this.xDomain = [xMin, xMax];
-
-        return true;
     }
 
     getDomain(direction: ChartAxisDirection): any[] {
@@ -384,7 +382,7 @@ export class HistogramSeries extends CartesianSeries<SeriesNodeDataContext<Histo
         });
     }
 
-    createNodeData() {
+    async createNodeData() {
         const { xAxis, yAxis } = this;
 
         if (!this.seriesItemEnabled || !xAxis || !yAxis) {
@@ -458,7 +456,7 @@ export class HistogramSeries extends CartesianSeries<SeriesNodeDataContext<Histo
         return [{ itemId: this.yKey, nodeData, labelData: nodeData }];
     }
 
-    protected updateDatumSelection(opts: {
+    protected async updateDatumSelection(opts: {
         nodeData: HistogramNodeDatum[];
         datumSelection: Selection<Rect, Group, HistogramNodeDatum, any>;
     }) {
@@ -474,7 +472,7 @@ export class HistogramSeries extends CartesianSeries<SeriesNodeDataContext<Histo
         return updateRects.merge(enterRects);
     }
 
-    protected updateDatumNodes(opts: {
+    protected async updateDatumNodes(opts: {
         datumSelection: Selection<Rect, Group, HistogramNodeDatum, any>;
         isHighlight: boolean;
     }) {
@@ -520,7 +518,7 @@ export class HistogramSeries extends CartesianSeries<SeriesNodeDataContext<Histo
         });
     }
 
-    protected updateLabelSelection(opts: {
+    protected async updateLabelSelection(opts: {
         labelData: HistogramNodeDatum[];
         labelSelection: Selection<Text, Group, HistogramNodeDatum, any>;
     }) {
@@ -538,7 +536,7 @@ export class HistogramSeries extends CartesianSeries<SeriesNodeDataContext<Histo
         return updateTexts.merge(enterTexts);
     }
 
-    protected updateLabelNodes(opts: { labelSelection: Selection<Text, Group, HistogramNodeDatum, any> }) {
+    protected async updateLabelNodes(opts: { labelSelection: Selection<Text, Group, HistogramNodeDatum, any> }) {
         const { labelSelection } = opts;
         const labelEnabled = this.label.enabled;
 

--- a/charts-packages/ag-charts-community/src/chart/series/cartesian/lineSeries.test.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/cartesian/lineSeries.test.ts
@@ -90,6 +90,7 @@ describe('LineSeries', () => {
                 options.height = CANVAS_HEIGHT;
 
                 chart = AgChartV2.create<any>(options);
+                await waitForChartStability(chart);
                 await example.assertions(chart);
             });
 

--- a/charts-packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
@@ -164,12 +164,12 @@ export class LineSeries extends CartesianSeries<LineContext> {
         return this.yDomain;
     }
 
-    processData(): boolean {
+    async processData() {
         const { xAxis, yAxis, xKey, yKey, xData, yData } = this;
         const data = xKey && yKey && this.data ? this.data : [];
 
         if (!xAxis || !yAxis) {
-            return false;
+            return;
         }
 
         const isContinuousX = xAxis.scale instanceof ContinuousScale;
@@ -196,11 +196,9 @@ export class LineSeries extends CartesianSeries<LineContext> {
 
         this.xDomain = isContinuousX ? this.fixNumericExtent(extent(xData, isContinuous), xAxis) : xData;
         this.yDomain = isContinuousY ? this.fixNumericExtent(extent(yData, isContinuous), yAxis) : yData;
-
-        return true;
     }
 
-    public createNodeData() {
+    async createNodeData() {
         const {
             data,
             xAxis,
@@ -300,7 +298,7 @@ export class LineSeries extends CartesianSeries<LineContext> {
         return this.marker.isDirty();
     }
 
-    protected updatePaths(opts: { seriesHighlighted?: boolean; contextData: LineContext; paths: Path[] }): void {
+    protected async updatePaths(opts: { seriesHighlighted?: boolean; contextData: LineContext; paths: Path[] }) {
         const {
             contextData: { nodeData },
             paths: [lineNode],
@@ -322,7 +320,7 @@ export class LineSeries extends CartesianSeries<LineContext> {
         lineNode.checkPathDirty();
     }
 
-    protected updatePathNodes(opts: { seriesHighlighted?: boolean; paths: Path[] }): void {
+    protected async updatePathNodes(opts: { seriesHighlighted?: boolean; paths: Path[] }) {
         const {
             paths: [lineNode],
         } = opts;
@@ -335,10 +333,10 @@ export class LineSeries extends CartesianSeries<LineContext> {
         lineNode.lineDashOffset = this.lineDashOffset;
     }
 
-    protected updateMarkerSelection(opts: {
+    protected async updateMarkerSelection(opts: {
         nodeData: LineNodeDatum[];
         markerSelection: Selection<Marker, Group, LineNodeDatum, any>;
-    }): Selection<Marker, Group, LineNodeDatum, any> {
+    }) {
         let { nodeData, markerSelection } = opts;
         const {
             marker: { shape, enabled },
@@ -357,7 +355,7 @@ export class LineSeries extends CartesianSeries<LineContext> {
         return updateMarkerSelection.merge(enterDatumSelection);
     }
 
-    protected updateMarkerNodes(opts: {
+    protected async updateMarkerNodes(opts: {
         markerSelection: Selection<Marker, Group, LineNodeDatum, any>;
         isHighlight: boolean;
     }) {
@@ -425,10 +423,10 @@ export class LineSeries extends CartesianSeries<LineContext> {
         }
     }
 
-    protected updateLabelSelection(opts: {
+    protected async updateLabelSelection(opts: {
         labelData: LineNodeDatum[];
         labelSelection: Selection<Text, Group, LineNodeDatum, any>;
-    }): Selection<Text, Group, LineNodeDatum, any> {
+    }) {
         let { labelData, labelSelection } = opts;
         const {
             marker: { shape, enabled },
@@ -441,7 +439,7 @@ export class LineSeries extends CartesianSeries<LineContext> {
         return updateTextSelection.merge(enterTextSelection);
     }
 
-    protected updateLabelNodes(opts: { labelSelection: Selection<Text, Group, LineNodeDatum, any> }) {
+    protected async updateLabelNodes(opts: { labelSelection: Selection<Text, Group, LineNodeDatum, any> }) {
         const { labelSelection } = opts;
         const { enabled: labelEnabled, fontStyle, fontWeight, fontSize, fontFamily, color } = this.label;
 

--- a/charts-packages/ag-charts-community/src/chart/series/cartesian/scatterSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/cartesian/scatterSeries.ts
@@ -169,11 +169,11 @@ export class ScatterSeries extends CartesianSeries<SeriesNodeDataContext<Scatter
         this.marker.stroke = strokes[0];
     }
 
-    processData(): boolean {
+    async processData() {
         const { xKey, yKey, sizeKey, xAxis, yAxis, marker } = this;
 
         if (!xAxis || !yAxis) {
-            return false;
+            return;
         }
 
         const data = xKey && yKey && this.data ? this.data : [];
@@ -202,7 +202,7 @@ export class ScatterSeries extends CartesianSeries<SeriesNodeDataContext<Scatter
             this.yDomain = this.yData;
         }
 
-        return true;
+        return;
     }
 
     getDomain(direction: ChartAxisDirection): any[] {
@@ -225,7 +225,7 @@ export class ScatterSeries extends CartesianSeries<SeriesNodeDataContext<Scatter
         });
     }
 
-    createNodeData() {
+    async createNodeData() {
         const { chart, data, visible, xAxis, yAxis, yKey, label, labelKey } = this;
 
         if (!(chart && data && visible && xAxis && yAxis)) {
@@ -288,10 +288,10 @@ export class ScatterSeries extends CartesianSeries<SeriesNodeDataContext<Scatter
         return this.contextNodeData?.reduce((r, n) => r.concat(n.labelData), [] as PointLabelDatum[]);
     }
 
-    protected updateMarkerSelection(opts: {
+    protected async updateMarkerSelection(opts: {
         nodeData: ScatterNodeDatum[];
         markerSelection: Selection<Marker, Group, ScatterNodeDatum, any>;
-    }): Selection<Marker, Group, ScatterNodeDatum, any> {
+    }) {
         let { nodeData, markerSelection } = opts;
         const {
             marker: { enabled, shape },
@@ -310,10 +310,10 @@ export class ScatterSeries extends CartesianSeries<SeriesNodeDataContext<Scatter
         return updateMarkers.merge(enterMarkers);
     }
 
-    protected updateMarkerNodes(opts: {
+    protected async updateMarkerNodes(opts: {
         markerSelection: Selection<Marker, Group, ScatterNodeDatum, any>;
         isHighlight: boolean;
-    }): void {
+    }) {
         const { markerSelection, isHighlight: isDatumHighlighted } = opts;
         const {
             marker,
@@ -391,10 +391,10 @@ export class ScatterSeries extends CartesianSeries<SeriesNodeDataContext<Scatter
         }
     }
 
-    protected updateLabelSelection(opts: {
+    protected async updateLabelSelection(opts: {
         labelData: ScatterNodeDatum[];
         labelSelection: Selection<Text, Group, ScatterNodeDatum, any>;
-    }): Selection<Text, Group, ScatterNodeDatum, any> {
+    }) {
         const { labelSelection } = opts;
 
         const placedLabels = this.chart?.placeLabels().get(this) ?? [];
@@ -415,7 +415,7 @@ export class ScatterSeries extends CartesianSeries<SeriesNodeDataContext<Scatter
         return updateLabels.merge(enterLabels);
     }
 
-    protected updateLabelNodes(opts: { labelSelection: Selection<Text, Group, ScatterNodeDatum, any> }): void {
+    protected async updateLabelNodes(opts: { labelSelection: Selection<Text, Group, ScatterNodeDatum, any> }) {
         const { labelSelection } = opts;
         const { label } = this;
 

--- a/charts-packages/ag-charts-community/src/chart/series/hierarchy/treemapSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/hierarchy/treemapSeries.ts
@@ -235,9 +235,9 @@ export class TreemapSeries extends HierarchySeries<TreemapNodeDatum> {
         };
     }
 
-    processData(): boolean {
+    async processData() {
         if (!this.data) {
-            return false;
+            return;
         }
 
         const { data, sizeKey, labelKey, colorKey, colorDomain, colorRange, colorParents } = this;
@@ -276,7 +276,7 @@ export class TreemapSeries extends HierarchySeries<TreemapNodeDatum> {
         }
         traverse(this.dataRoot);
 
-        return true;
+        return;
     }
 
     protected getLabelCenterX(datum: any): number {
@@ -287,16 +287,16 @@ export class TreemapSeries extends HierarchySeries<TreemapNodeDatum> {
         return (datum.y0 + datum.y1) / 2 + 2;
     }
 
-    createNodeData() {
+    async createNodeData() {
         return [];
     }
 
-    update(): void {
-        this.updateSelections();
-        this.updateNodes();
+    async update() {
+        await this.updateSelections();
+        await this.updateNodes();
     }
 
-    updateSelections() {
+    async updateSelections() {
         if (!this.nodeDataRefresh) {
             return;
         }
@@ -336,7 +336,7 @@ export class TreemapSeries extends HierarchySeries<TreemapNodeDatum> {
         this.highlightSelection = update(highlightSelection);
     }
 
-    updateNodes() {
+    async updateNodes() {
         if (!this.chart) {
             return;
         }

--- a/charts-packages/ag-charts-community/src/chart/series/polar/pieSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/polar/pieSeries.ts
@@ -314,7 +314,7 @@ export class PieSeries extends PolarSeries<PieNodeDatum> {
         }
     }
 
-    processData(): boolean {
+    async processData() {
         const { angleKey, radiusKey, seriesItemEnabled, angleScale, groupSelectionData, label } = this;
         const data = angleKey && this.data ? this.data : [];
 
@@ -449,15 +449,13 @@ export class PieSeries extends PolarSeries<PieNodeDatum> {
             datumIndex++;
             end = start; // Update for next iteration.
         });
-
-        return true;
     }
 
-    createNodeData() {
+    async createNodeData() {
         return [];
     }
 
-    update(): void {
+    async update() {
         const { radius, innerRadiusOffset, outerRadiusOffset, title } = this;
 
         this.radiusScale.range = [
@@ -479,15 +477,15 @@ export class PieSeries extends PolarSeries<PieNodeDatum> {
             }
         }
 
-        this.updateSelections();
-        this.updateNodes();
+        await this.updateSelections();
+        await this.updateNodes();
     }
 
-    private updateSelections() {
-        this.updateGroupSelection();
+    private async updateSelections() {
+        await this.updateGroupSelection();
     }
 
-    private updateGroupSelection() {
+    private async updateGroupSelection() {
         const { groupSelection, highlightSelection, labelSelection, innerLabelsSelection } = this;
 
         const update = (selection: typeof groupSelection) => {
@@ -527,7 +525,7 @@ export class PieSeries extends PolarSeries<PieNodeDatum> {
         this.innerLabelsSelection = updateInnerLabels.merge(enterFancy);
     }
 
-    private updateNodes() {
+    private async updateNodes() {
         if (!this.chart) {
             return;
         }

--- a/charts-packages/ag-charts-community/src/chart/series/polar/polarSeries.test.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/polar/polarSeries.test.ts
@@ -95,6 +95,7 @@ describe('PolarSeries', () => {
                 options.height = CANVAS_HEIGHT;
 
                 chart = AgChartV2.create<PolarChart>(options);
+                await waitForChartStability(chart);
                 await example.assertions(chart);
             });
 

--- a/charts-packages/ag-charts-community/src/chart/series/series.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/series.ts
@@ -289,10 +289,10 @@ export abstract class Series<C extends SeriesNodeDataContext = SeriesNodeDataCon
     abstract getDomain(direction: ChartAxisDirection): any[];
 
     // Fetch required values from the `chart.data` or `series.data` objects and process them.
-    abstract processData(): void;
+    abstract processData(): Promise<void>;
 
     // Using processed data, create data that backs visible nodes.
-    abstract createNodeData(): C[];
+    abstract createNodeData(): Promise<C[]>;
 
     // Indicate that something external changed and we should recalculate nodeData.
     markNodeDataDirty() {
@@ -304,7 +304,7 @@ export abstract class Series<C extends SeriesNodeDataContext = SeriesNodeDataCon
     }
 
     // Produce data joins and update selection's nodes using node data.
-    abstract update(): void;
+    abstract update(): Promise<void>;
 
     protected getOpacity(datum?: { itemId?: any }): number {
         const {

--- a/charts-packages/ag-charts-community/src/chart/series/seriesLabels.test.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/seriesLabels.test.ts
@@ -149,6 +149,7 @@ describe('series labels', () => {
                 options.height = CANVAS_HEIGHT;
 
                 chart = AgChartV2.create<any>(options);
+                await waitForChartStability(chart);
                 await example.assertions(chart);
             });
 

--- a/charts-packages/ag-charts-community/src/chart/themes/chartTheme.test.ts
+++ b/charts-packages/ag-charts-community/src/chart/themes/chartTheme.test.ts
@@ -13,6 +13,7 @@ import { AgChartV2 } from '../agChartV2';
 import { CartesianChart } from '../cartesianChart';
 import { PolarChart } from '../polarChart';
 import { LineSeries } from '../series/cartesian/lineSeries';
+import { waitForChartStability } from '../test/utils';
 
 const data = [
     { label: 'Android', v1: 5.67, v2: 8.63, v3: 8.14, v4: 6.45, v5: 1.37 },
@@ -315,41 +316,44 @@ describe('ChartTheme', () => {
             ],
         };
 
-        const cartesianChart = AgChartV2.create(cartesianChartOptions);
-        const polarChart = AgChartV2.create(polarChartOptions);
+        test('Cartesian chart instance properties', async () => {
+            let cartesianChart = AgChartV2.create(cartesianChartOptions);
+            await waitForChartStability(cartesianChart);
+    
+            expect(cartesianChart!.title && cartesianChart!.title.enabled).toBe(true);
+            expect(cartesianChart!.title && cartesianChart!.title.fontSize).toBe(24);
+            expect(cartesianChart!.title && cartesianChart!.title.fontWeight).toBe('normal');
 
-        test('Cartesian chart instance properties', () => {
-            expect(cartesianChart.title && cartesianChart.title.enabled).toBe(true);
-            expect(cartesianChart.title && cartesianChart.title.fontSize).toBe(24);
-            expect(cartesianChart.title && cartesianChart.title.fontWeight).toBe('normal');
+            expect(cartesianChart!.background.fill).toBe('red');
 
-            expect(cartesianChart.background.fill).toBe('red');
-
-            expect(cartesianChart.series[0].type).toBe('bar');
-            expect((cartesianChart.series[0] as BarSeries).fills).toEqual(['red', 'green', 'blue', 'red', 'green']);
-            expect((cartesianChart.series[0] as BarSeries).strokes).toEqual(['cyan', 'cyan', 'cyan', 'cyan', 'cyan']);
-            expect((cartesianChart.series[0] as BarSeries).label.enabled).toBe(true);
-            expect((cartesianChart.series[0] as BarSeries).label.color).toBe('blue');
-            expect((cartesianChart.series[0] as BarSeries).label.fontSize).toBe(18);
-            expect((cartesianChart.series[0] as BarSeries).tooltip.enabled).toBe(false);
-            expect((cartesianChart.series[0] as BarSeries).tooltip.renderer).toBe(columnTooltipRenderer);
+            expect(cartesianChart!.series[0].type).toBe('bar');
+            expect((cartesianChart!.series[0] as BarSeries).fills).toEqual(['red', 'green', 'blue', 'red', 'green']);
+            expect((cartesianChart!.series[0] as BarSeries).strokes).toEqual(['cyan', 'cyan', 'cyan', 'cyan', 'cyan']);
+            expect((cartesianChart!.series[0] as BarSeries).label.enabled).toBe(true);
+            expect((cartesianChart!.series[0] as BarSeries).label.color).toBe('blue');
+            expect((cartesianChart!.series[0] as BarSeries).label.fontSize).toBe(18);
+            expect((cartesianChart!.series[0] as BarSeries).tooltip.enabled).toBe(false);
+            expect((cartesianChart!.series[0] as BarSeries).tooltip.renderer).toBe(columnTooltipRenderer);
         });
 
-        test('Polar chart intstance properties', () => {
-            expect(polarChart.title && polarChart.title.enabled).toBe(true);
-            expect(polarChart.title && polarChart.title.fontSize).toBe(24);
-            expect(polarChart.title && polarChart.title.fontWeight).toBe('normal');
+        test('Polar chart intstance properties', async () => {
+            let polarChart = AgChartV2.create(polarChartOptions);
+            await waitForChartStability(polarChart);
+    
+            expect(polarChart!.title && polarChart!.title.enabled).toBe(true);
+            expect(polarChart!.title && polarChart!.title.fontSize).toBe(24);
+            expect(polarChart!.title && polarChart!.title.fontWeight).toBe('normal');
 
-            expect(polarChart.background.fill).toBe('red');
+            expect(polarChart!.background.fill).toBe('red');
 
-            expect(polarChart.series[0].type).toBe('pie');
-            expect((polarChart.series[0] as PieSeries).fills).toEqual(['red', 'green', 'blue']);
-            expect((polarChart.series[0] as PieSeries).strokes).toEqual(['cyan', 'cyan', 'cyan']);
-            expect((polarChart.series[0] as PieSeries).label.enabled).toBe(true);
-            expect((polarChart.series[0] as PieSeries).label.color).toBe('yellow');
-            expect((polarChart.series[0] as PieSeries).label.fontSize).toBe(18);
-            expect((polarChart.series[0] as PieSeries).tooltip.enabled).toBe(false);
-            expect((polarChart.series[0] as PieSeries).tooltip.renderer).toBe(pieTooltipRenderer);
+            expect(polarChart!.series[0].type).toBe('pie');
+            expect((polarChart!.series[0] as PieSeries).fills).toEqual(['red', 'green', 'blue']);
+            expect((polarChart!.series[0] as PieSeries).strokes).toEqual(['cyan', 'cyan', 'cyan']);
+            expect((polarChart!.series[0] as PieSeries).label.enabled).toBe(true);
+            expect((polarChart!.series[0] as PieSeries).label.color).toBe('yellow');
+            expect((polarChart!.series[0] as PieSeries).label.fontSize).toBe(18);
+            expect((polarChart!.series[0] as PieSeries).tooltip.enabled).toBe(false);
+            expect((polarChart!.series[0] as PieSeries).tooltip.renderer).toBe(pieTooltipRenderer);
         });
     });
 
@@ -419,7 +423,7 @@ describe('ChartTheme', () => {
             defaultTheme = null;
         });
 
-        test('Themed bottom category, unthemed left number', () => {
+        test('Themed bottom category, unthemed left number', async () => {
             const chart = AgChartV2.create({
                 theme,
                 data,
@@ -431,6 +435,7 @@ describe('ChartTheme', () => {
                     },
                 ],
             } as AgCartesianChartOptions);
+            await waitForChartStability(chart);
 
             expect(chart.axes[0].type).toBe('number');
             expect(chart.axes[0].position).toBe('left');
@@ -443,7 +448,7 @@ describe('ChartTheme', () => {
             expect(chart.axes[1].label.fontSize).toBe(18);
         });
 
-        test('Specialized chart type themed bottom category, unthemed left number', () => {
+        test('Specialized chart type themed bottom category, unthemed left number', async () => {
             const chart = AgChartV2.create({
                 type: 'area',
                 theme,
@@ -455,6 +460,7 @@ describe('ChartTheme', () => {
                     },
                 ],
             } as AgCartesianChartOptions);
+            await waitForChartStability(chart);
 
             expect(chart.axes[0].type).toBe('number');
             expect(chart.axes[0].position).toBe('left');
@@ -467,7 +473,7 @@ describe('ChartTheme', () => {
             expect(chart.axes[1].label.fontSize).toBe(18);
         });
 
-        test('Themed right number, unthemed top category', () => {
+        test('Themed right number, unthemed top category', async () => {
             const chart = AgChartV2.create({
                 theme,
                 data,
@@ -489,6 +495,7 @@ describe('ChartTheme', () => {
                     },
                 ],
             } as AgCartesianChartOptions);
+            await waitForChartStability(chart);
 
             expect(chart.axes[0].type).toBe('number');
             expect(chart.axes[0].position).toBe('right');
@@ -501,7 +508,7 @@ describe('ChartTheme', () => {
             expect(chart.axes[1].label.fontSize).toBe(12);
         });
 
-        test('Partially themed axes', () => {
+        test('Partially themed axes', async () => {
             const chart = AgChartV2.create({
                 theme,
                 data,
@@ -540,6 +547,7 @@ describe('ChartTheme', () => {
                     },
                 ],
             } as AgCartesianChartOptions);
+            await waitForChartStability(chart);
 
             expect(chart.axes[0].type).toBe('number');
             expect(chart.axes[0].position).toBe('right');
@@ -650,8 +658,9 @@ describe('ChartTheme', () => {
             ],
         };
 
-        test('Cartesian chart instance properties', () => {
+        test('Cartesian chart instance properties', async () => {
             const cartesianChart = AgChartV2.create(cartesianChartOptions);
+            await waitForChartStability(cartesianChart);
             const { series } = cartesianChart;
 
             expect(series[0].type).toEqual('bar');

--- a/charts-packages/ag-charts-community/src/scene/scene.ts
+++ b/charts-packages/ag-charts-community/src/scene/scene.ts
@@ -252,7 +252,7 @@ export class Scene {
         layers.splice(0, layers.length);
     }
 
-    render(opts?: { debugSplitTimes: number[]; extraDebugStats: Record<string, number> }) {
+    async render(opts?: { debugSplitTimes: number[]; extraDebugStats: Record<string, number> }) {
         const { debugSplitTimes = [performance.now()], extraDebugStats = {} } = opts || {};
         const {
             canvas,
@@ -344,7 +344,7 @@ export class Scene {
         debugSplitTimes: number[],
         ctx: CanvasRenderingContext2D,
         renderCtxStats: RenderContext['stats'],
-        extraDebugStats = {}
+        extraDebugStats = {},
     ) {
         const end = performance.now();
 
@@ -359,7 +359,12 @@ export class Scene {
             const time = (start: number, end: number) => {
                 return `${Math.round((end - start) * 100) / 100}ms`;
             };
-            const { layersRendered = 0, layersSkipped = 0, nodesRendered = 0, nodesSkipped = 0 } = renderCtxStats ?? {};
+            const {
+                layersRendered = 0,
+                layersSkipped = 0,
+                nodesRendered = 0,
+                nodesSkipped = 0,
+            } = renderCtxStats ?? {};
 
             const splits = debugSplitTimes
                 .map((t, i) => (i > 0 ? time(debugSplitTimes[i - 1], t) : null))

--- a/charts-packages/ag-charts-community/src/util/async.ts
+++ b/charts-packages/ag-charts-community/src/util/async.ts
@@ -1,0 +1,5 @@
+export function sleep(sleepTimeoutMs: number): Promise<void> {
+    return new Promise((resolve) => {
+        setTimeout(() => resolve(undefined), sleepTimeoutMs);
+    });
+}

--- a/charts-packages/ag-charts-community/src/util/render.ts
+++ b/charts-packages/ag-charts-community/src/util/render.ts
@@ -1,31 +1,76 @@
-type Callback = (params: { count: number }) => void;
+type Callback = (params: { count: number }) => Promise<void> | void;
 
 /**
  * Wrap a function in debouncing trigger function. A requestAnimationFrame() is scheduled
  * after the first schedule() call, and subsequent schedule() calls will be ignored until the
  * animation callback executes.
  */
-export function debouncedAnimationFrame(cb: Callback): { schedule(): void } {
+export function debouncedAnimationFrame(cb: Callback): { schedule(): void; await(): Promise<void> } {
     return buildScheduler((cb) => requestAnimationFrame(cb), cb);
 }
 
-export function debouncedCallback(cb: Callback): { schedule(): void } {
+export function debouncedCallback(cb: Callback): { schedule(): void; await(): Promise<void> } {
     return buildScheduler((cb) => setTimeout(cb, 0), cb);
 }
 
 function buildScheduler(scheduleFn: (cb: () => void) => void, cb: Callback) {
     let scheduleCount = 0;
+    let promiseRunning = false;
+    let awaitingPromise: Promise<void> | undefined;
+    let awaitingDone: (() => void) | undefined;
+
+    const busy = () => {
+        return promiseRunning;
+    };
+
+    const done = () => {
+        promiseRunning = false;
+
+        awaitingDone?.();
+        awaitingDone = undefined;
+        awaitingPromise = undefined;
+
+        if (scheduleCount > 0) {
+            scheduleFn(scheduleCb);
+        }
+    };
+
+    const scheduleCb = () => {
+        const count = scheduleCount;
+
+        scheduleCount = 0;
+        promiseRunning = true;
+        const maybePromise = cb({ count });
+
+        if (!maybePromise) {
+            done();
+            return;
+        }
+
+        maybePromise.then(done).catch(done);
+    };
 
     return {
         schedule() {
-            if (scheduleCount === 0) {
-                scheduleFn(() => {
-                    const count = scheduleCount;
-                    scheduleCount = 0;
-                    cb({ count });
-                });
+            if (scheduleCount === 0 && !busy()) {
+                scheduleFn(scheduleCb);
             }
             scheduleCount++;
+        },
+        async await() {
+            if (!busy()) {
+                return;
+            }
+
+            if (!awaitingPromise) {
+                awaitingPromise = new Promise((resolve) => {
+                    awaitingDone = resolve;
+                });
+            }
+
+            while (busy()) {
+                await awaitingPromise;
+            }
         },
     };
 }

--- a/enterprise-modules/charts/src/charts/chartComp/chartProxies/chartProxy.ts
+++ b/enterprise-modules/charts/src/charts/chartComp/chartProxies/chartProxy.ts
@@ -95,10 +95,6 @@ export abstract class ChartProxy {
         return this.chart;
     }
 
-    public getChartContainer(): HTMLElement {
-        return this.chartProxyParams.parentElement;
-    }
-
     private createChartTheme(): ChartTheme {
         const themeName = this.getSelectedTheme();
         const stockTheme = this.isStockTheme(themeName);

--- a/enterprise-modules/charts/src/charts/chartComp/chartProxies/chartProxy.ts
+++ b/enterprise-modules/charts/src/charts/chartComp/chartProxies/chartProxy.ts
@@ -95,6 +95,10 @@ export abstract class ChartProxy {
         return this.chart;
     }
 
+    public getChartContainer(): HTMLElement {
+        return this.chartProxyParams.parentElement;
+    }
+
     private createChartTheme(): ChartTheme {
         const themeName = this.getSelectedTheme();
         const stockTheme = this.isStockTheme(themeName);

--- a/enterprise-modules/charts/src/charts/chartComp/gridChartComp.ts
+++ b/enterprise-modules/charts/src/charts/chartComp/gridChartComp.ts
@@ -374,7 +374,7 @@ export class GridChartComp extends Component {
     }
 
     private handleEmptyChart(data: any[], fields: any[]): boolean {
-        const container = this.chartProxy.getChart().container;
+        const container = this.chartProxy.getChartContainer();
         const pivotModeDisabled = this.chartController.isPivotChart() && !this.chartController.isPivotMode();
         let minFieldsRequired = 1;
 

--- a/enterprise-modules/charts/src/charts/chartComp/gridChartComp.ts
+++ b/enterprise-modules/charts/src/charts/chartComp/gridChartComp.ts
@@ -374,7 +374,6 @@ export class GridChartComp extends Component {
     }
 
     private handleEmptyChart(data: any[], fields: any[]): boolean {
-        const container = this.chartProxy.getChartContainer();
         const pivotModeDisabled = this.chartController.isPivotChart() && !this.chartController.isPivotMode();
         let minFieldsRequired = 1;
 
@@ -383,7 +382,7 @@ export class GridChartComp extends Component {
         }
         const isEmptyChart = fields.length < minFieldsRequired || data.length === 0;
 
-        if (container) {
+        if (this.eChart) {
             const isEmpty = pivotModeDisabled || isEmptyChart;
             _.setDisplayed(this.eChart, !isEmpty);
             _.setDisplayed(this.eEmpty, isEmpty);

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
@@ -3645,7 +3645,7 @@
   },
   "Callback": {
     "meta": { "isTypeAlias": true },
-    "type": "(params: { count: number; }) => void"
+    "type": "(params: { count: number; }) => Promise<void> | void"
   },
   "OnSizeChange": {
     "meta": { "isTypeAlias": true },


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-7142

Re-instates changes in #5509 to move to `Promise`-based chart contracts. Additionally:
- Fixes race / synchronous execution assumptions in Integrated Charts.
- Respects `Chart.destroy()` calls WRT pending chart updates.