### PR TITLE
AG-7277 - Flip expanded icon when RTL is enabled

### DIFF
--- a/community-modules/styles/src/internal/base/parts/_common-structural.scss
+++ b/community-modules/styles/src/internal/base/parts/_common-structural.scss
@@ -1621,6 +1621,11 @@
             display: block;
             transform: rotate(180deg);
         }
+
+        .ag-icon-expanded {
+            display: block;
+            transform: rotate(180deg);
+        }
     }
 
     .ag-body .ag-body-viewport {


### PR DESCRIPTION
## Screenshots

https://localhost:8000/javascript-data-grid/column-groups/ with `enableRtl: true`

Contracted

![Screenshot 2022-09-21 at 12 25 40 pm](https://user-images.githubusercontent.com/79451/191492158-577236a1-77f0-4b8f-b30f-3aaa30aff24a.png)

Expanded (was not previously flipped)

![Screenshot 2022-09-21 at 12 25 35 pm](https://user-images.githubusercontent.com/79451/191492209-b1ef7f96-16d2-40ac-846c-5aa6fc48cf80.png)
