### PR TITLE
AG-4875 - Show/Hide charts tool panel proof of concepts

### DIFF
--- a/community-modules/styles/src/internal/base/parts/_charts.scss
+++ b/community-modules/styles/src/internal/base/parts/_charts.scss
@@ -220,14 +220,20 @@
         justify-content: center;
     }
 
+    .ag-chart-menu-close {
+        padding: 0;
+        display: block;
+        cursor: pointer;
+        height: 100%;
+        border: none;
+    }
+
     .ag-chart .ag-chart-menu {
-        opacity: 0;
-        pointer-events: none;
+        display: none;
     }
 
     .ag-chart-menu-hidden:hover .ag-chart-menu {
-        opacity: 1;
-        pointer-events: all;
+        display: block;
     }
 
     .ag-charts-font-size-color {

--- a/community-modules/styles/src/internal/base/parts/_charts.scss
+++ b/community-modules/styles/src/internal/base/parts/_charts.scss
@@ -220,20 +220,120 @@
         justify-content: center;
     }
 
-    .ag-chart-menu-close {
-        padding: 0;
-        display: block;
-        cursor: pointer;
-        height: 100%;
-        border: none;
-    }
-
     .ag-chart .ag-chart-menu {
         display: none;
     }
 
     .ag-chart-menu-hidden:hover .ag-chart-menu {
         display: block;
+    }
+
+    .ag-chart-menu-test-1,
+    .ag-chart-menu-test-2,
+    .ag-chart-menu-test-3,
+    .ag-chart-menu-test-4 {
+        .ag-chart-menu-close {
+            padding: 0;
+            display: block;
+            cursor: pointer;
+            height: 100%;
+            border: none;
+
+            .ag-icon {
+                padding: 9px 1px 9px 2px;
+            }
+        }
+    }
+
+    .ag-chart-menu-test-4-1 {
+        display: flex;
+
+        .ag-chart-menu-close {
+            position: absolute;
+            right: 0;
+            top: 45%;
+            padding: 0;
+            display: block;
+            cursor: pointer;
+            border: none;
+
+            .ag-icon {
+                padding: 9px 0 9px 0;
+            }
+        }
+    }
+
+    .ag-chart-menu-test-4-2 {
+        display: flex;
+
+        .ag-chart-menu-close {
+            position: absolute;
+            right: 0;
+            top: 45%;
+            padding: 0;
+            display: block;
+            cursor: pointer;
+            border: none;
+
+            .ag-icon {
+                padding: 9px 0 9px 1px;
+            }
+        }
+
+        .ag-chart-menu-close:hover {
+            .ag-icon {
+                padding: 9px 2px 9px 1px;
+            }
+        }
+    }
+
+    .ag-chart {
+        .ag-chart-toolbar-1 {
+            .ag-chart-menu {
+                display: flex;
+                flex-direction: row;
+                right: 25px;
+                overflow: auto;
+                top: 5px;
+                width: 70px;
+                justify-content: right;
+                gap: 5px;
+            }
+
+            // Hide burger menu
+            .ag-icon-menu {
+                display: none;
+            }
+        }
+
+        .ag-chart-toolbar-1-1 {
+            .ag-chart-menu {
+                display: flex;
+                flex-direction: row;
+                right: 5px;
+                overflow: auto;
+                top: 5px;
+                width: 70px;
+                justify-content: right;
+                gap: 5px;
+            }
+
+            // Hide burger menu
+            .ag-icon-menu {
+                display: none;
+            }
+        }
+
+        .ag-chart-toolbar-2 {
+            .ag-chart-menu {
+                display: flex;
+                flex-direction: row;
+                left: 10px;
+                overflow: auto;
+                top: 5px;
+                width: 100px;
+            }
+        }
     }
 
     .ag-charts-font-size-color {

--- a/community-modules/styles/src/internal/themes/alpine/_index.scss
+++ b/community-modules/styles/src/internal/themes/alpine/_index.scss
@@ -196,13 +196,97 @@
         }
     }
 
-    .ag-chart-menu-close {
-        background: var(--ag-header-background-color);
-
-        @include ag.theme-rtl((
-            border-left: var(--ag-borders) var(--ag-secondary-border-color)
-        ));
+    // Vertical bar
+    .ag-chart-menu-test-1 {
+        .ag-chart-menu-close {
+            background: var(--ag-header-background-color);
+    
+            @include ag.theme-rtl((
+                border-left: var(--ag-borders) var(--ag-secondary-border-color)
+            ));
+        }
     }
+
+    // Circle middle
+    .ag-chart-menu-test-2 {
+        .ag-chart-menu-close {
+            background: none;
+        }
+    
+        .ag-chart-menu-close .ag-icon {
+            color: var(--ag-border-color);
+            border: 1px solid var(--ag-secondary-border-color);
+            padding: 2px;
+            margin: 2px;
+            border-radius: 15px;
+        }
+    }
+
+    // Circle top
+    .ag-chart-menu-test-3 {
+        .ag-chart-menu-close {
+            background: none;
+            display: flex;
+            padding-top: 5px;
+        }
+
+        .ag-chart-menu-close .ag-icon {
+            color: var(--ag-border-color);
+            border: 1px solid var(--ag-secondary-border-color);
+            padding: 2px;
+            margin: 2px;
+            border-radius: 15px;
+        }
+    }
+
+    // Square tab
+    .ag-chart-menu-test-4 {
+        .ag-chart-menu-close {
+            background: none;
+        }
+
+        .ag-chart-menu-close .ag-icon {
+            background: none;
+            border-top: 1px solid var(--ag-secondary-border-color);
+            border-left: 1px solid var(--ag-secondary-border-color);
+            border-bottom: 1px solid var(--ag-secondary-border-color);
+            padding: 9px 1px 9px 2px;
+        }
+
+        .ag-chart-menu-close .ag-icon:hover {
+            background: var(--ag-header-background-color);
+        }
+    }
+
+    // Square tab with smaller click area
+    .ag-chart-menu-test-4-1,
+    // Square tab with smaller click area and hover expansion
+    .ag-chart-menu-test-4-2 {
+        .ag-chart-menu-close {
+            background: none;
+        }
+
+        .ag-chart-menu-close .ag-icon {
+            background: none;
+            border-top: 1px solid var(--ag-secondary-border-color);
+            border-left: 1px solid var(--ag-secondary-border-color);
+            border-bottom: 1px solid var(--ag-secondary-border-color);
+        }
+
+        .ag-chart-menu-close .ag-icon:hover {
+            background: var(--ag-header-background-color);
+        }
+    }
+
+    .ag-chart-menu-close-3 .ag-icon {
+        color: var(--ag-border-color);
+        border: 1px solid var(--ag-secondary-border-color);
+        padding: 2px;
+        margin: 2px;
+        border-radius: 15px;
+    }
+
+
 
     .ag-chart-settings-card-item.ag-not-selected:hover {
         opacity: 0.35;

--- a/community-modules/styles/src/internal/themes/alpine/_index.scss
+++ b/community-modules/styles/src/internal/themes/alpine/_index.scss
@@ -189,10 +189,19 @@
     .ag-column-select-header-icon,
     .ag-floating-filter-button-button,
     .ag-filter-toolpanel-expand,
-    .ag-chart-menu-icon {
+    .ag-chart-menu-icon,
+    .ag-chart-menu-close {
         &:hover {
             color: var(--ag-alpine-active-color);
         }
+    }
+
+    .ag-chart-menu-close {
+        background: var(--ag-header-background-color);
+
+        @include ag.theme-rtl((
+            border-left: var(--ag-borders) var(--ag-secondary-border-color)
+        ));
     }
 
     .ag-chart-settings-card-item.ag-not-selected:hover {

--- a/community-modules/styles/src/internal/themes/balham/_index.scss
+++ b/community-modules/styles/src/internal/themes/balham/_index.scss
@@ -126,6 +126,14 @@
     .ag-charts-format-sub-level-group-item {
         margin-bottom: calc(var(--ag-grid-size) * 1.5);
     }
+
+    .ag-chart-menu-close {
+        background: var(--ag-header-background-color);
+
+        @include ag.theme-rtl((
+            border-left: var(--ag-borders) var(--ag-secondary-border-color)
+        ));
+    }
 }
 
 .ag-theme-balham-dark {

--- a/community-modules/styles/src/internal/themes/material/_index.scss
+++ b/community-modules/styles/src/internal/themes/material/_index.scss
@@ -113,6 +113,10 @@
         padding-bottom: calc(var(--ag-grid-size) * 0.5);
     }
 
+    .ag-chart-menu-close {
+        background: var(--ag-header-background-color);
+    }
+
     @include ag.text-input {
         background: transparent;
         color: var(--ag-foreground-color);

--- a/enterprise-modules/charts/src/charts/chartComp/menu/chartMenu.ts
+++ b/enterprise-modules/charts/src/charts/chartComp/menu/chartMenu.ts
@@ -8,7 +8,8 @@ import {
     Component,
     GetChartToolbarItemsParams,
     PostConstruct,
-    WithoutGridCommon
+    WithoutGridCommon,
+    RefSelector
 } from "@ag-grid-community/core";
 
 import { TabbedChartMenu } from "./tabbedChartMenu";
@@ -37,7 +38,15 @@ export class ChartMenu extends Component {
 
     private tabs: ChartMenuOptions[] = [];
 
-    private static TEMPLATE = `<div class="ag-chart-menu"></div>`;
+    private static TEMPLATE = `<div>
+        <div class="ag-chart-menu" ref="eMenu"></div>
+        <button class="ag-chart-menu-close" ref="eHideButton">
+            <span class="ag-icon ag-icon-contracted" ref="eHideButtonIcon"></span>
+        </button>
+    </div>`;
+    @RefSelector("eMenu") private eMenu: HTMLButtonElement;
+    @RefSelector("eHideButton") private eHideButton: HTMLButtonElement;
+    @RefSelector("eHideButtonIcon") private eHideButtonIcon: HTMLSpanElement;
 
     private tabbedMenu: TabbedChartMenu;
     private menuPanel?: AgPanel;
@@ -64,6 +73,8 @@ export class ChartMenu extends Component {
         //         this.createMenuPanel(0);
         //     }
         // });
+
+        this.addManagedListener(this.eHideButton, 'click', this.toggleMenu.bind(this))
     }
 
     public isVisible(): boolean {
@@ -128,7 +139,7 @@ export class ChartMenu extends Component {
 
     private createButtons(): void {
         const chartToolbarOptions = this.getToolbarOptions();
-        const gui = this.getGui();
+        const gui = this.eMenu;
 
         chartToolbarOptions.forEach(button => {
             const buttonConfig = this.buttons[button];
@@ -215,6 +226,14 @@ export class ChartMenu extends Component {
         this.refreshMenuClasses();
     }
 
+    private toggleMenu() {
+        if (this.menuVisible) {
+            this.hideMenu();
+        } else {
+            this.showMenu();
+        }
+    }
+
     public showMenu(tabName?: ChartMenuOptions): void {
         const menuTabName = tabName || ChartMenu.DEFAULT_TAB;
         let tab = this.tabs.indexOf(menuTabName);
@@ -243,6 +262,9 @@ export class ChartMenu extends Component {
     private refreshMenuClasses() {
         this.eChartContainer.classList.toggle('ag-chart-menu-visible', this.menuVisible);
         this.eChartContainer.classList.toggle('ag-chart-menu-hidden', !this.menuVisible);
+
+        this.eHideButtonIcon.classList.toggle('ag-icon-contracted', this.menuVisible);
+        this.eHideButtonIcon.classList.toggle('ag-icon-expanded', !this.menuVisible);
     }
 
     private showParent(width: number): void {

--- a/enterprise-modules/charts/src/charts/chartComp/menu/chartMenu.ts
+++ b/enterprise-modules/charts/src/charts/chartComp/menu/chartMenu.ts
@@ -38,7 +38,7 @@ export class ChartMenu extends Component {
 
     private tabs: ChartMenuOptions[] = [];
 
-    private static TEMPLATE = `<div>
+    private static TEMPLATE = `<div class="ag-chart-menu-test-4-1 ag-chart-toolbar-1-1">
         <div class="ag-chart-menu" ref="eMenu"></div>
         <button class="ag-chart-menu-close" ref="eHideButton">
             <span class="ag-icon ag-icon-contracted" ref="eHideButtonIcon"></span>


### PR DESCRIPTION
Proof of concepts for adding a show/hide charts tool panel button

* `ag-chart-menu-test-1` - show vertical button
   ![Screenshot 2022-09-21 at 3 48 17 pm](https://user-images.githubusercontent.com/79451/191710234-bea8b314-92f5-481e-b52f-fa3dd34ee6dc.png)
* `ag-chart-menu-test-2` - show circle button in the vertical middle right position
   ![Screenshot 2022-09-21 at 3 06 25 pm](https://user-images.githubusercontent.com/79451/191710003-bb4c24a9-7a84-4870-b29c-5bf20b7ebed9.png)
* `ag-chart-menu-test-3` - show circle button in the top right position
* `ag-chart-menu-test-4` - show square tab button in the vertical middle right position (click area is 100% height)
* `ag-chart-menu-test-4-1` - show square tab button in the vertical middle right position with click area only covering the button
   ![Screenshot 2022-09-21 at 4 57 12 pm](https://user-images.githubusercontent.com/79451/191709863-654ff619-3e37-471f-836b-96c0d16b606f.png)

* `ag-chart-menu-test-4-2` - show square tab button in the vertical middle right position with click area only covering the button, and hover to enlarge the button

Also for reorganising the toolbar

* `ag-chart-toolbar-1` - hide burger menu + show horizontally on top right
* `ag-chart-toolbar-2` - show horizontally on top left

---

Update the [TEMPLATE class](https://github.com/ag-grid/ag-grid/pull/5577/files#diff-98a98e72358742eddf8e64a4449314243829cd517dab5b63bd5048badd0ddc01R41) to see the different configurations
