### PR TITLE
Ag 6879/export chart as image

### DIFF
--- a/charts-packages/ag-charts-community/src/canvas/hdpiCanvas.ts
+++ b/charts-packages/ag-charts-community/src/canvas/hdpiCanvas.ts
@@ -22,6 +22,7 @@ export class HdpiCanvas {
         domLayer = false,
         zIndex = 0,
         name = undefined as undefined | string,
+        overrideDevicePixelRatio = undefined as undefined | number,
     }) {
         this.document = document;
         this.element = document.createElement('canvas');
@@ -45,7 +46,7 @@ export class HdpiCanvas {
             }
         }
 
-        this.setPixelRatio();
+        this.setPixelRatio(overrideDevicePixelRatio);
         this.resize(width, height);
     }
 

--- a/charts-packages/ag-charts-community/src/canvas/hdpiOffscreenCanvas.ts
+++ b/charts-packages/ag-charts-community/src/canvas/hdpiOffscreenCanvas.ts
@@ -22,12 +22,12 @@ export class HdpiOffscreenCanvas {
 
     // The width/height attributes of the Canvas element default to
     // 300/150 according to w3.org.
-    constructor({ width = 600, height = 300 }) {
+    constructor({ width = 600, height = 300, overrideDevicePixelRatio = undefined as undefined | number }) {
         this.canvas = new OffscreenCanvas(width, height);
         this.context = this.canvas.getContext('2d')!;
         this.imageSource = this.canvas.transferToImageBitmap();
 
-        this.setPixelRatio();
+        this.setPixelRatio(overrideDevicePixelRatio);
         this.resize(width, height);
     }
 

--- a/charts-packages/ag-charts-community/src/chart/agChartV2.ts
+++ b/charts-packages/ag-charts-community/src/chart/agChartV2.ts
@@ -82,7 +82,13 @@ type SeriesOptionType<T extends Series> = T extends LineSeries
     ? AgTreemapSeriesOptions
     : never;
 
-type DownloadOptions = { width?: number; height?: number; fileName?: string; fileFormat?: string };
+type DownloadOptions = {
+    width?: number;
+    height?: number;
+    fileName?: string;
+    /** The standard MIME type for the image format to return. If you do not specify this parameter, the default value is a PNG format image. See `Canvas.toDataURL()` */
+    fileFormat?: string;
+};
 
 function chartType<T extends ChartType>(options: ChartOptionType<T>): 'cartesian' | 'polar' | 'hierarchy' {
     if (isAgCartesianChartOptions(options)) {
@@ -211,6 +217,10 @@ export abstract class AgChartV2 {
         });
     }
 
+    /**
+     * Returns the content of the current canvas as an image.
+     * @param opts The download options including `width` and `height` of the image as well as `fileName` and `fileFormat`.
+     */
     static download(chart: Chart, opts?: DownloadOptions) {
         let { width, height, fileName, fileFormat } = opts || {};
         const currentWidth = chart.width;

--- a/charts-packages/ag-charts-community/src/chart/agChartV2.ts
+++ b/charts-packages/ag-charts-community/src/chart/agChartV2.ts
@@ -216,30 +216,33 @@ export abstract class AgChartV2 {
         const currentWidth = chart.width;
         const currentHeight = chart.height;
 
-        width = width ?? currentWidth;
-        height = height ?? currentHeight;
-
-        const unchanged = chart.scene.canvas.pixelRatio === 1 && currentWidth === width && currentHeight === height;
+        const unchanged =
+            (width === undefined && height === undefined) ||
+            (chart.scene.canvas.pixelRatio === 1 && currentWidth === width && currentHeight === height);
 
         if (unchanged) {
             chart.scene.download(fileName, fileFormat);
-        } else {
-            const options = {
-                ...chart.userOptions,
-                container: document.createElement('div'),
-                width,
-                height,
-                autoSize: false,
-                overrideDevicePixelRatio: 1,
-            };
-
-            const clonedChart = AgChartV2.create(options as any);
-
-            clonedChart.waitForUpdate().then(() => {
-                clonedChart.scene.download(fileName, fileFormat);
-                clonedChart.destroy();
-            });
+            return;
         }
+
+        width = width ?? currentWidth;
+        height = height ?? currentHeight;
+
+        const options = {
+            ...chart.userOptions,
+            container: document.createElement('div'),
+            width,
+            height,
+            autoSize: false,
+            overrideDevicePixelRatio: 1,
+        };
+
+        const clonedChart = AgChartV2.create(options as any);
+
+        clonedChart.waitForUpdate().then(() => {
+            clonedChart.scene.download(fileName, fileFormat);
+            clonedChart.destroy();
+        });
     }
 
     private static async updateDelta<T extends ChartType>(

--- a/charts-packages/ag-charts-community/src/chart/agChartV2.ts
+++ b/charts-packages/ag-charts-community/src/chart/agChartV2.ts
@@ -145,8 +145,10 @@ export abstract class AgChartV2 {
             mixinOpts['debug'] = true;
         }
 
-        const mergedOptions = prepareOptions(userOptions, mixinOpts);
         const { overrideDevicePixelRatio } = userOptions;
+        delete userOptions['overrideDevicePixelRatio'];
+
+        const mergedOptions = prepareOptions(userOptions, mixinOpts);
 
         const chart = isAgCartesianChartOptions(mergedOptions)
             ? mergedOptions.type === 'groupedCategory'
@@ -217,7 +219,11 @@ export abstract class AgChartV2 {
         width = width ?? currentWidth;
         height = height ?? currentHeight;
 
-        if (currentWidth !== width || currentHeight !== height) {
+        const unchanged = chart.scene.canvas.pixelRatio === 1 && currentWidth === width && currentHeight === height;
+
+        if (unchanged) {
+            chart.scene.download(fileName, fileFormat);
+        } else {
             const options = {
                 ...chart.userOptions,
                 container: document.createElement('div'),
@@ -233,8 +239,6 @@ export abstract class AgChartV2 {
                 clonedChart.scene.download(fileName, fileFormat);
                 clonedChart.destroy();
             });
-        } else {
-            chart.scene.download(fileName, fileFormat);
         }
     }
 

--- a/charts-packages/ag-charts-community/src/chart/agChartV2.ts
+++ b/charts-packages/ag-charts-community/src/chart/agChartV2.ts
@@ -138,7 +138,7 @@ export abstract class AgChart {
 export abstract class AgChartV2 {
     static DEBUG = () => windowValue('agChartsDebug') ?? false;
 
-    static create<T extends ChartType>(userOptions: ChartOptionType<T> & { devidePixelRatio?: number }): T {
+    static create<T extends ChartType>(userOptions: ChartOptionType<T> & { overrideDevicePixelRatio?: number }): T {
         debug('user options', userOptions);
         const mixinOpts: any = {};
         if (AgChartV2.DEBUG()) {
@@ -146,15 +146,16 @@ export abstract class AgChartV2 {
         }
 
         const mergedOptions = prepareOptions(userOptions, mixinOpts);
+        const { overrideDevicePixelRatio } = userOptions;
 
         const chart = isAgCartesianChartOptions(mergedOptions)
             ? mergedOptions.type === 'groupedCategory'
-                ? new GroupedCategoryChart(document)
-                : new CartesianChart(document)
+                ? new GroupedCategoryChart(document, overrideDevicePixelRatio)
+                : new CartesianChart(document, overrideDevicePixelRatio)
             : isAgHierarchyChartOptions(mergedOptions)
-            ? new HierarchyChart(document)
+            ? new HierarchyChart(document, overrideDevicePixelRatio)
             : isAgPolarChartOptions(mergedOptions)
-            ? new PolarChart(document)
+            ? new PolarChart(document, overrideDevicePixelRatio)
             : undefined;
 
         if (!chart) {
@@ -223,12 +224,13 @@ export abstract class AgChartV2 {
                 width,
                 height,
                 autoSize: false,
+                overrideDevicePixelRatio: 1,
             };
 
             const clonedChart = AgChartV2.create(options as any);
 
             clonedChart.waitForUpdate().then(() => {
-                clonedChart.scene.download();
+                clonedChart.scene.download(fileName, fileFormat);
                 clonedChart.destroy();
             });
         } else {

--- a/charts-packages/ag-charts-community/src/chart/cartesianChart.ts
+++ b/charts-packages/ag-charts-community/src/chart/cartesianChart.ts
@@ -10,8 +10,8 @@ export class CartesianChart extends Chart {
     static className = 'CartesianChart';
     static type: 'cartesian' | 'groupedCategory' = 'cartesian';
 
-    constructor(document = window.document) {
-        super(document);
+    constructor(document = window.document, overrideDevicePixelRatio?: number) {
+        super(document, overrideDevicePixelRatio);
 
         // Prevent the scene from rendering chart components in an invalid state
         // (before first layout is performed).

--- a/charts-packages/ag-charts-community/src/chart/chart.ts
+++ b/charts-packages/ag-charts-community/src/chart/chart.ts
@@ -465,7 +465,7 @@ export abstract class Chart extends Observable {
 
     private static tooltipDocuments: Document[] = [];
 
-    protected constructor(document = window.document) {
+    protected constructor(document = window.document, overrideDevicePixelRatio?: number) {
         super();
 
         const root = new Group({ name: 'root' });
@@ -478,7 +478,7 @@ export abstract class Chart extends Observable {
         element.classList.add('ag-chart-wrapper');
         element.style.position = 'relative';
 
-        this.scene = new Scene({ document });
+        this.scene = new Scene({ document, overrideDevicePixelRatio });
         this.scene.debug.consoleLog = this._debug;
         this.scene.root = root;
         this.scene.container = element;

--- a/charts-packages/ag-charts-community/src/chart/hierarchyChart.ts
+++ b/charts-packages/ag-charts-community/src/chart/hierarchyChart.ts
@@ -6,8 +6,8 @@ export class HierarchyChart extends Chart {
     static className = 'HierarchyChart';
     static type = 'hierarchy' as const;
 
-    constructor(document = window.document) {
-        super(document);
+    constructor(document = window.document, overrideDevicePixelRatio?: number) {
+        super(document, overrideDevicePixelRatio);
 
         // Prevent the scene from rendering chart components in an invalid state
         // (before first layout is performed).

--- a/charts-packages/ag-charts-community/src/chart/polarChart.ts
+++ b/charts-packages/ag-charts-community/src/chart/polarChart.ts
@@ -10,8 +10,8 @@ export class PolarChart extends Chart {
 
     padding = new Padding(40);
 
-    constructor(document = window.document) {
-        super(document);
+    constructor(document = window.document, overrideDevicePixelRatio?: number) {
+        super(document, overrideDevicePixelRatio);
 
         this.scene.root!.append(this.legend.group);
     }

--- a/enterprise-modules/charts/src/charts/chartComp/chartProxies/chartProxy.ts
+++ b/enterprise-modules/charts/src/charts/chartComp/chartProxies/chartProxy.ts
@@ -1,5 +1,5 @@
 import { _, AgChartThemeOverrides, ChartType, SeriesChartType } from "@ag-grid-community/core";
-import { AgChartTheme, AgChartThemePalette, Chart, ChartTheme, getIntegratedChartTheme, themes } from "ag-charts-community";
+import { AgChart, AgChartTheme, AgChartThemePalette, Chart, ChartTheme, getIntegratedChartTheme, themes } from "ag-charts-community";
 import { deepMerge } from "../utils/object";
 import { CrossFilteringContext } from "../../chartService";
 import { ChartSeriesType, getSeriesType } from "../utils/seriesTypeMapper";
@@ -144,28 +144,12 @@ export abstract class ChartProxy {
         return deepMerge(gridOptionsThemeOverrides, apiThemeOverrides);
     }
 
-    public downloadChart(dimensions?: { width: number, height: number }, fileName?: string, fileFormat?: string) {
+    public downloadChart(dimensions?: { width: number; height: number }, fileName?: string, fileFormat?: string) {
         const { chart } = this;
         const imageFileName = fileName || (chart.title ? chart.title.text : 'chart');
+        const { width, height } = dimensions || {};
 
-        if (dimensions) {
-            const currentWidth = this.chart.width;
-            const currentHeight = this.chart.height;
-
-            // resize chart dimensions
-            this.chart.width = dimensions.width;
-            this.chart.height = dimensions.height;
-
-            this.chart.waitForUpdate().then(() => {
-                chart.scene.download(imageFileName, fileFormat);
-
-                // restore chart dimensions
-                this.chart.width = currentWidth;
-                this.chart.height = currentHeight;
-            });
-        } else {
-            chart.scene.download(fileName, fileFormat);
-        }
+        AgChart.download(chart, { width, height, fileName: imageFileName, fileFormat });
     }
 
     public getChartImageDataURL(type?: string) {

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/doc-interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/doc-interfaces.AUTO.json
@@ -3989,6 +3989,7 @@
   "AgChartType": { "meta": { "typeParams": ["T"] } },
   "ChartOptionType": { "meta": { "typeParams": ["T extends ChartType"] } },
   "SeriesOptionType": { "meta": { "typeParams": ["T extends Series"] } },
+  "DownloadOptions": {},
   "ObservableLike": {},
   "ChartClickEvent": {
     "event": { "type": { "returnType": "MouseEvent", "optional": false } },

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
@@ -2597,6 +2597,10 @@
     "meta": { "isTypeAlias": true, "typeParams": ["T extends Series"] },
     "type": "T extends LineSeries ? AgLineSeriesOptions : T extends BarSeries ? AgBarSeriesOptions : T extends AreaSeries ? AgAreaSeriesOptions : T extends ScatterSeries ? AgScatterSeriesOptions : T extends HistogramSeries ? AgHistogramSeriesOptions : T extends PieSeries ? AgPieSeriesOptions : T extends TreemapSeries ? AgTreemapSeriesOptions : never"
   },
+  "DownloadOptions": {
+    "meta": { "isTypeAlias": true },
+    "type": "{ width?: number; height?: number; fileName?: string; fileFormat?: string; }"
+  },
   "ObservableLike": {
     "meta": { "isTypeAlias": true },
     "type": "{ addEventListener(key: string, cb: SourceEventListener<any>): void; clearEventListeners(): void; }"


### PR DESCRIPTION
PR for https://ag-grid.atlassian.net/browse/AG-6879

Allow downloading chart as image in a specified size without flashing/ re-rendering of the visible chart