### PR TITLE
AG-5220 Fix for Treemap formatter docs

### DIFF
--- a/charts-packages/ag-charts-community/src/chart/agChartOptions.ts
+++ b/charts-packages/ag-charts-community/src/chart/agChartOptions.ts
@@ -1383,9 +1383,11 @@ export interface AgTreemapSeriesOptions<DatumType = any> extends AgBaseSeriesOpt
     nodePadding?: PixelSize;
     /** Whether or not to use gradients for treemap tiles. */
     gradient?: boolean;
+    /** A callback function for adjusting the styles of a particular treemap tile based on the input parameters */
     formatter?: (params: AgTreemapSeriesFormatterParams<DataValue>) => AgTreemapSeriesFormat;
 }
 
+/** The parameters of the treemap series formatter function */
 export interface AgTreemapSeriesFormatterParams<DataValue = any> {
     /** Datum from the series data array that the treemap tile is being rendered for. */
     readonly datum: DataValue;
@@ -1411,6 +1413,7 @@ export interface AgTreemapSeriesFormatterParams<DataValue = any> {
     readonly highlighted: boolean;
 }
 
+/** The formatted style of a treemap tile */
 export interface AgTreemapSeriesFormat {
     /** The colour of the fill for the treemap tile. */
     readonly fill?: string;

--- a/community-modules/core/src/ts/interfaces/iAgChartOptions.ts
+++ b/community-modules/core/src/ts/interfaces/iAgChartOptions.ts
@@ -1383,9 +1383,11 @@ export interface AgTreemapSeriesOptions<DatumType = any> extends AgBaseSeriesOpt
     nodePadding?: PixelSize;
     /** Whether or not to use gradients for treemap tiles. */
     gradient?: boolean;
+    /** A callback function for adjusting the styles of a particular treemap tile based on the input parameters */
     formatter?: (params: AgTreemapSeriesFormatterParams<DataValue>) => AgTreemapSeriesFormat;
 }
 
+/** The parameters of the treemap series formatter function */
 export interface AgTreemapSeriesFormatterParams<DataValue = any> {
     /** Datum from the series data array that the treemap tile is being rendered for. */
     readonly datum: DataValue;
@@ -1411,6 +1413,7 @@ export interface AgTreemapSeriesFormatterParams<DataValue = any> {
     readonly highlighted: boolean;
 }
 
+/** The formatted style of a treemap tile */
 export interface AgTreemapSeriesFormat {
     /** The colour of the fill for the treemap tile. */
     readonly fill?: string;

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/doc-interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/doc-interfaces.AUTO.json
@@ -3679,6 +3679,7 @@
       "type": { "returnType": "boolean", "optional": true }
     },
     "formatter": {
+      "description": "/** A callback function for adjusting the styles of a particular treemap tile based on the input parameters */",
       "type": {
         "arguments": { "params": "AgTreemapSeriesFormatterParams<DataValue>" },
         "returnType": "AgTreemapSeriesFormat",

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
@@ -2394,6 +2394,7 @@
       "tooltip?": "/** Series-specific tooltip configuration. */",
       "nodePadding?": "/** The amount of padding in pixels inside of each treemap tile. Increasing `nodePadding` will reserve more space for parent labels. */",
       "gradient?": "/** Whether or not to use gradients for treemap tiles. */",
+      "formatter?": "/** A callback function for adjusting the styles of a particular treemap tile based on the input parameters */",
       "data?": "/** The data to use when rendering the series. If this is not supplied, data must be set on the chart instead. */",
       "visible?": "/** Whether or not to display the series. */",
       "showInLegend?": "/** Whether or not to include the series in the legend. */",
@@ -2403,7 +2404,10 @@
     }
   },
   "AgTreemapSeriesFormatterParams": {
-    "meta": { "typeParams": ["DataValue = any"] },
+    "meta": {
+      "typeParams": ["DataValue = any"],
+      "doc": "/** The parameters of the treemap series formatter function */"
+    },
     "type": {
       "datum": "DataValue",
       "labelKey": "string",
@@ -2432,7 +2436,7 @@
     }
   },
   "AgTreemapSeriesFormat": {
-    "meta": {},
+    "meta": { "doc": "/** The formatted style of a treemap tile */" },
     "type": {
       "fill?": "string",
       "fillOpacity?": "string",

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/doc-interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/doc-interfaces.AUTO.json
@@ -15777,6 +15777,7 @@
       "type": { "returnType": "boolean", "optional": true }
     },
     "formatter": {
+      "description": "/** A callback function for adjusting the styles of a particular treemap tile based on the input parameters */",
       "type": {
         "arguments": { "params": "AgTreemapSeriesFormatterParams<DataValue>" },
         "returnType": "AgTreemapSeriesFormat",

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/interfaces.AUTO.json
@@ -9182,6 +9182,7 @@
       "tooltip?": "/** Series-specific tooltip configuration. */",
       "nodePadding?": "/** The amount of padding in pixels inside of each treemap tile. Increasing `nodePadding` will reserve more space for parent labels. */",
       "gradient?": "/** Whether or not to use gradients for treemap tiles. */",
+      "formatter?": "/** A callback function for adjusting the styles of a particular treemap tile based on the input parameters */",
       "data?": "/** The data to use when rendering the series. If this is not supplied, data must be set on the chart instead. */",
       "visible?": "/** Whether or not to display the series. */",
       "showInLegend?": "/** Whether or not to include the series in the legend. */",
@@ -9191,7 +9192,10 @@
     }
   },
   "AgTreemapSeriesFormatterParams": {
-    "meta": { "typeParams": ["DataValue = any"] },
+    "meta": {
+      "typeParams": ["DataValue = any"],
+      "doc": "/** The parameters of the treemap series formatter function */"
+    },
     "type": {
       "datum": "DataValue",
       "labelKey": "string",
@@ -9220,7 +9224,7 @@
     }
   },
   "AgTreemapSeriesFormat": {
-    "meta": {},
+    "meta": { "doc": "/** The formatted style of a treemap tile */" },
     "type": {
       "fill?": "string",
       "fillOpacity?": "string",


### PR DESCRIPTION
The description for the formatter property was missing.

Before:
<img width="605" alt="Screenshot 2022-09-23 at 12 49 31" src="https://user-images.githubusercontent.com/9638588/191957273-881b89bd-2e8d-486c-8b84-6acbe98324e7.png">


After:
<img width="609" alt="Screenshot 2022-09-23 at 13 11 12" src="https://user-images.githubusercontent.com/9638588/191957369-416e549e-e632-4dde-9b6f-6eaa2bf6b14d.png">
