### PR TITLE
AG-5026 - Allow customizing chart tool panels

### DIFF
--- a/community-modules/angular-legacy/projects/ag-grid-angular/src/lib/ag-grid-angular.component.ts
+++ b/community-modules/angular-legacy/projects/ag-grid-angular/src/lib/ag-grid-angular.component.ts
@@ -40,6 +40,7 @@ import {
     ChartOptionsChanged,
     ChartRangeSelectionChanged,
     ChartRefParams,
+    ChartToolPanels,
     ColDef,
     ColGroupDef,
     ColumnAggFuncChangeRequestEvent,
@@ -463,6 +464,8 @@ export class AgGridAngular<TData = any, TColDef extends ColDef<TData> = ColDef<a
     @Input() public chartThemeOverrides: AgChartThemeOverrides | undefined = undefined;
     /** Set to `true` to show the Chart Tool Panels button. Note this will also remove the 'hamburger' menu option from the Chart Toolbar and always display the remaining toolbar buttons. Default: `false`     */
     @Input() public enableChartToolPanelsButton: boolean | undefined = undefined;
+    /** Chart Tool Panel overrides.     */
+    @Input() public chartToolPanels: ChartToolPanels | undefined = undefined;
     /** Provide your own loading cell renderer to use when data is loading via a DataSource.
      * See [Loading Cell Renderer](https://www.ag-grid.com/javascript-data-grid/component-loading-cell-renderer/) for framework specific implementation details.     */
     @Input() public loadingCellRenderer: any = undefined;

--- a/community-modules/angular/projects/ag-grid-angular/src/lib/ag-grid-angular.component.ts
+++ b/community-modules/angular/projects/ag-grid-angular/src/lib/ag-grid-angular.component.ts
@@ -40,6 +40,7 @@ import {
     ChartOptionsChanged,
     ChartRangeSelectionChanged,
     ChartRefParams,
+    ChartToolPanels,
     ColDef,
     ColGroupDef,
     ColumnAggFuncChangeRequestEvent,
@@ -457,6 +458,8 @@ export class AgGridAngular<TData = any, TColDef extends ColDef<TData> = ColDef<a
     @Input() public chartThemeOverrides: AgChartThemeOverrides | undefined = undefined;
     /** Set to `true` to show the Chart Tool Panels button. Note this will also remove the 'hamburger' menu option from the Chart Toolbar and always display the remaining toolbar buttons. Default: `false`     */
     @Input() public enableChartToolPanelsButton: boolean | undefined = undefined;
+    /** Chart Tool Panel overrides.     */
+    @Input() public chartToolPanels: ChartToolPanels | undefined = undefined;
     /** Provide your own loading cell renderer to use when data is loading via a DataSource.
      * See [Loading Cell Renderer](https://www.ag-grid.com/javascript-data-grid/component-loading-cell-renderer/) for framework specific implementation details.     */
     @Input() public loadingCellRenderer: any = undefined;

--- a/community-modules/core/src/styles/structural/_common-structural.scss
+++ b/community-modules/core/src/styles/structural/_common-structural.scss
@@ -18,6 +18,10 @@ ag-grid, ag-grid-angular, ag-grid-ng2, ag-grid-polymer, ag-grid-aurelia  {
     visibility: hidden !important;
 }
 
+.ag-no-transition {
+    transition: none !important;
+}
+
 .ag-drag-handle {
     cursor: grab;
 }

--- a/community-modules/core/src/ts/entities/gridOptions.ts
+++ b/community-modules/core/src/ts/entities/gridOptions.ts
@@ -70,7 +70,7 @@ import {
     ProcessCellForExportParams, ProcessGroupHeaderForExportParams, ProcessHeaderForExportParams
 } from "../interfaces/exportParams";
 import { AgChartTheme, AgChartThemeOverrides } from "../interfaces/iAgChartOptions";
-import { ChartMenuOptions } from "../interfaces/iChartOptions";
+import { ChartMenuOptions, ChartToolPanels } from "../interfaces/iChartOptions";
 import { AgGridCommon } from "../interfaces/iCommon";
 import { IDatasource } from "../interfaces/iDatasource";
 import { ExcelExportParams, ExcelStyle } from "../interfaces/iExcelCreator";
@@ -306,6 +306,8 @@ export interface GridOptions<TData = any> {
     chartThemeOverrides?: AgChartThemeOverrides;
     /** Set to `true` to show the Chart Tool Panels button. Note this will also remove the 'hamburger' menu option from the Chart Toolbar and always display the remaining toolbar buttons. Default: `false` */
     enableChartToolPanelsButton?: boolean;
+    /** Chart Tool Panel overrides. */
+    chartToolPanels?: ChartToolPanels;
 
     // *** Loading Cell Renderers *** //
     /**

--- a/community-modules/core/src/ts/gridOptionsWrapper.ts
+++ b/community-modules/core/src/ts/gridOptionsWrapper.ts
@@ -32,6 +32,7 @@ import { exists, missing, values } from './utils/generic';
 import { isNumeric } from './utils/number';
 import { iterateObject } from './utils/object';
 import { capitalise } from './utils/string';
+import { ChartToolPanels } from './interfaces/iChartOptions';
 
 const DEFAULT_ROW_HEIGHT = 25;
 const DEFAULT_DETAIL_ROW_HEIGHT = 300;
@@ -1543,6 +1544,10 @@ export class GridOptionsWrapper {
     public getChartThemes(): string[] {
         // return default themes if user hasn't supplied any
         return this.gridOptions.chartThemes || ['ag-default', 'ag-material', 'ag-pastel', 'ag-vivid', 'ag-solar'];
+    }
+
+    public getChartToolPanels(): ChartToolPanels | undefined {
+        return this.gridOptions.chartToolPanels;
     }
 
     public getClipboardDelimiter() {

--- a/community-modules/core/src/ts/interfaces/IChartService.ts
+++ b/community-modules/core/src/ts/interfaces/IChartService.ts
@@ -1,4 +1,4 @@
-import { ChartType, SeriesChartType } from "./iChartOptions";
+import { ChartToolPanelName, ChartType, SeriesChartType } from "./iChartOptions";
 import { ChartRef } from "../entities/gridOptions";
 import { CreateCrossFilterChartParams, CreatePivotChartParams, CreateRangeChartParams } from "../gridApi";
 import { CellRangeParams } from "./IRangeService";
@@ -46,8 +46,6 @@ export interface CloseChartToolPanelParams {
 }
 
 export type ChartModelType = 'range' | 'pivot';
-
-export type ChartToolPanelName = 'settings' | 'data' | 'format';
 
 export interface OpenChartToolPanelParams {
     /** The id of the created chart. */

--- a/community-modules/core/src/ts/interfaces/iChartOptions.ts
+++ b/community-modules/core/src/ts/interfaces/iChartOptions.ts
@@ -83,10 +83,13 @@ export const DEFAULT_CHART_GROUPS: PartialChartGroups = {
     ]
 }
 
+export type ChartToolPanelName = 'settings' | 'data' | 'format';
+
 export type ChartToolPanels = {
-    settingsPanel: {
-        chartGroups: PartialChartGroups
-    }
+    settingsPanel?: {
+        chartGroups: PartialChartGroups,
+    },
+    panels?: ChartToolPanelName[]
 }
 
 export type ChartType =
@@ -121,13 +124,25 @@ export type CrossFilterChartType =
     | 'doughnut'
     | 'area';
 
-export type ChartMenuOptions =
-      'chartSettings'
-    | 'chartData'
-    | 'chartFormat'
-    | 'chartLink'
-    | 'chartUnlink'
-    | 'chartDownload';
+export type ChartToolPanelMenuOptions = 'chartSettings' | 'chartData' | 'chartFormat';
+export type ChartToolbarMenuItemOptions = 'chartLink' | 'chartUnlink' | 'chartDownload';
+export type ChartMenuOptions = ChartToolPanelMenuOptions | ChartToolbarMenuItemOptions;
+export const CHART_TOOL_PANEL_ALLOW_LIST: ChartToolPanelMenuOptions[] = [
+    'chartSettings', 
+    'chartData', 
+    'chartFormat'
+];
+export const CHART_TOOLBAR_ALLOW_LIST: ChartMenuOptions[] = [
+    'chartUnlink',
+    'chartLink',
+    'chartDownload'
+];
+
+export const CHART_TOOL_PANEL_MENU_OPTIONS: { [key in ChartToolPanelName]: ChartToolPanelMenuOptions } = {
+    settings: "chartSettings",
+    data: "chartData",
+    format: "chartFormat"
+}
 
 export interface SeriesChartType {
     colId: string;

--- a/community-modules/core/src/ts/interfaces/iChartOptions.ts
+++ b/community-modules/core/src/ts/interfaces/iChartOptions.ts
@@ -1,3 +1,94 @@
+export const CHART_TYPE_KEYS = {
+    columnGroup: {
+        column: 'column',
+        stackedColumn: 'stackedColumn',
+        normalizedColumn: 'normalizedColumn'
+    },
+    barGroup: {
+        bar: 'bar',
+        stackedBar: 'stackedBar',
+        normalizedBar: 'normalizedBar'
+    },
+    pieGroup: {
+        pie: 'pie',
+        doughnut: 'doughnut'
+    },
+    lineGroup: {
+        line: 'line'
+    },
+    scatterGroup: {
+        scatter: 'scatter',
+        bubble: 'bubble'
+    },
+    areaGroup: {
+        area: 'area',
+        stackedArea: 'stackedArea',
+        normalizedArea: 'normalizedArea'
+    },
+    histogramGroup: {
+        histogram: 'histogram'
+    },
+    combinationGroup: {
+        columnLineCombo: 'columnLineCombo',
+        areaColumnCombo: 'areaColumnCombo',
+        customCombo: 'customCombo'
+    }
+}
+
+export type ChartTypeKeys = typeof CHART_TYPE_KEYS;
+
+export type ChartGroups = {
+    [chartType in keyof ChartTypeKeys]: (keyof ChartTypeKeys[chartType])[];
+};
+
+export type PartialChartGroups = Partial<ChartGroups>;
+
+/************************************************************************************************
+ * If you update these, then also update the `integrated-charts-toolbar` docs. *
+ ************************************************************************************************/
+export const DEFAULT_CHART_GROUPS: PartialChartGroups = {
+    columnGroup: [
+        'column',
+        'stackedColumn',
+        'normalizedColumn'
+    ],
+    barGroup: [
+        'bar',
+        'stackedBar',
+        'normalizedBar'
+    ],
+    pieGroup: [
+        'pie',
+        'doughnut'
+    ],
+    lineGroup: [
+        'line'
+    ],
+    scatterGroup: [
+        'scatter',
+        'bubble'
+    ],
+    areaGroup: [
+        'area',
+        'stackedArea',
+        'normalizedArea'
+    ],
+    histogramGroup: [
+        'histogram'
+    ],
+    combinationGroup: [
+        'columnLineCombo',
+        'areaColumnCombo',
+        'customCombo'
+    ]
+}
+
+export type ChartToolPanels = {
+    settingsPanel: {
+        chartGroups: PartialChartGroups
+    }
+}
+
 export type ChartType =
       'column'
     | 'groupedColumn'

--- a/community-modules/core/src/ts/interfaces/iChartOptions.ts
+++ b/community-modules/core/src/ts/interfaces/iChartOptions.ts
@@ -89,7 +89,8 @@ export type ChartToolPanels = {
     settingsPanel?: {
         chartGroups: PartialChartGroups,
     },
-    panels?: ChartToolPanelName[]
+    panels?: ChartToolPanelName[],
+    defaultToolPanel?: ChartToolPanelName
 }
 
 export type ChartType =

--- a/community-modules/core/src/ts/main.ts
+++ b/community-modules/core/src/ts/main.ts
@@ -265,7 +265,6 @@ export {
     ChartDownloadParams,
     OpenChartToolPanelParams,
     CloseChartToolPanelParams,
-    ChartToolPanelName,
     ChartModel,
     GetChartImageDataUrlParams,
     ChartModelType,

--- a/community-modules/core/src/ts/propertyKeys.ts
+++ b/community-modules/core/src/ts/propertyKeys.ts
@@ -16,7 +16,7 @@ export class PropertyKeys {
         'defaultColGroupDef', 'defaultColDef', 'defaultExportParams', 'defaultCsvExportParams', 'defaultExcelExportParams', 'columnTypes',
         'rowClassRules', 'detailCellRendererParams', 'loadingCellRendererParams', 'loadingOverlayComponentParams',
         'noRowsOverlayComponentParams', 'popupParent', 'colResizeDefault', 'statusBar', 'sideBar', 'chartThemeOverrides',
-        'customChartThemes'
+        'customChartThemes', 'chartToolPanels'
     ];
 
     public static ARRAY_PROPERTIES = [

--- a/community-modules/styles/src/internal/base/parts/_common-structural.scss
+++ b/community-modules/styles/src/internal/base/parts/_common-structural.scss
@@ -20,6 +20,10 @@
         visibility: hidden !important;
     }
 
+    .ag-no-transition {
+        transition: none !important;
+    }
+
     .ag-drag-handle {
         cursor: grab;
     }

--- a/enterprise-modules/charts/src/charts/chartComp/gridChartComp.ts
+++ b/enterprise-modules/charts/src/charts/chartComp/gridChartComp.ts
@@ -7,7 +7,6 @@ import {
     CellRange,
     ChartCreated,
     ChartDestroyed,
-    ChartMenuOptions,
     ChartModel,
     ChartToolPanelName,
     ChartType,
@@ -19,7 +18,8 @@ import {
     PostConstruct,
     RefSelector,
     SeriesChartType,
-    WithoutGridCommon
+    WithoutGridCommon,
+    CHART_TOOL_PANEL_MENU_OPTIONS
 } from "@ag-grid-community/core";
 import { ChartMenu } from "./menu/chartMenu";
 import { TitleEdit } from "./chartTitle/titleEdit";
@@ -411,13 +411,7 @@ export class GridChartComp extends Component {
     }
 
     public openChartToolPanel(panel?: ChartToolPanelName) {
-        const chartToolPanelTabMapping: { [key in ChartToolPanelName]: ChartMenuOptions } = {
-            settings: "chartSettings",
-            data: "chartData",
-            format: "chartFormat"
-        }
-        const menuPanel = panel ? chartToolPanelTabMapping[panel] : panel;
-
+        const menuPanel = panel ? CHART_TOOL_PANEL_MENU_OPTIONS[panel] : panel;
         this.chartMenu.showMenu(menuPanel);
     }
 

--- a/enterprise-modules/charts/src/charts/chartComp/menu/chartMenu.ts
+++ b/enterprise-modules/charts/src/charts/chartComp/menu/chartMenu.ts
@@ -5,11 +5,15 @@ import {
     AgPromise,
     Autowired,
     ChartMenuOptions,
+    ChartToolPanelMenuOptions,
     Component,
     GetChartToolbarItemsParams,
     PostConstruct,
     WithoutGridCommon,
-    RefSelector
+    RefSelector,
+    CHART_TOOL_PANEL_MENU_OPTIONS,
+    CHART_TOOLBAR_ALLOW_LIST,
+    CHART_TOOL_PANEL_ALLOW_LIST
 } from "@ag-grid-community/core";
 
 import { TabbedChartMenu } from "./tabbedChartMenu";
@@ -25,7 +29,7 @@ export class ChartMenu extends Component {
     @Autowired('chartTranslationService') private chartTranslationService: ChartTranslationService;
 
     public static EVENT_DOWNLOAD_CHART = "downloadChart";
-    private static DEFAULT_PANEL: ChartMenuOptions = "chartSettings";
+    private static DEFAULT_PANEL: ChartToolPanelMenuOptions = "chartSettings";
 
     private buttons: ChartToolbarButtons = {
         chartSettings: ['menu', () => this.showMenu(ChartMenu.DEFAULT_PANEL)],
@@ -36,7 +40,7 @@ export class ChartMenu extends Component {
         chartDownload: ['save', () => this.saveChart()]
     };
 
-    private panels: ChartMenuOptions[] = [];
+    private panels: ChartToolPanelMenuOptions[] = [];
 
     private static TEMPLATE = `<div>
         <div class="ag-chart-menu" ref="eMenu"></div>
@@ -85,43 +89,85 @@ export class ChartMenu extends Component {
     }
 
     private getToolbarOptions(): ChartMenuOptions[] {
-        let tabOptions: ChartMenuOptions[] = [
-            'chartSettings',
-            'chartData',
-            'chartFormat',
-            this.chartController.isChartLinked() ? 'chartLink' : 'chartUnlink',
-            'chartDownload'
-        ];
+        const useChartToolPanelCustomisation = Boolean(this.gridOptionsWrapper.getChartToolPanels())
 
-        const toolbarItemsFunc = this.gridOptionsWrapper.getChartToolbarItemsFunc();
-
-        if (toolbarItemsFunc) {
+        if (useChartToolPanelCustomisation) {
+            const defaultChartToolbarOptions: ChartMenuOptions[] = [
+                this.chartController.isChartLinked() ? 'chartLink' : 'chartUnlink',
+                'chartDownload'
+            ];
+    
+            const toolbarItemsFunc = this.gridOptionsWrapper.getChartToolbarItemsFunc();
             const params: WithoutGridCommon<GetChartToolbarItemsParams> = {
-                defaultItems: tabOptions
+                defaultItems: defaultChartToolbarOptions
             };
+            let chartToolbarOptions = toolbarItemsFunc
+                ? toolbarItemsFunc(params).filter(option => {
+                    if (!CHART_TOOLBAR_ALLOW_LIST.includes(option)) {
+                        const msg = CHART_TOOL_PANEL_ALLOW_LIST.includes(option as any)
+                            ? `AG Grid: '${option}' is a Chart Tool Panel option and will be ignored since 'chartToolPanels' is used. Please use 'chartToolPanels.panels' grid option instead`
+                            : `AG Grid: '${option}' is not a valid Chart Toolbar Option`;
+                        console.warn(msg);
+                        return false;
+                    }
 
-            tabOptions = toolbarItemsFunc(params).filter(option => {
-                if (!this.buttons[option]) {
-                    console.warn(`AG Grid: '${option} is not a valid Chart Toolbar Option`);
-                    return false;
-                }
+                    return true;
+                })
+                : defaultChartToolbarOptions;
 
-                return true;
-            });
+            const panelsOverride = this.gridOptionsWrapper.getChartToolPanels()?.panels;
+            this.panels = panelsOverride
+                ? panelsOverride.map(panel => CHART_TOOL_PANEL_MENU_OPTIONS[panel])
+                : Object.values(CHART_TOOL_PANEL_MENU_OPTIONS);
+
+            // pivot charts use the column tool panel instead of the data panel
+            if (this.chartController.isPivotChart()) {
+                this.panels = this.panels.filter(panel => panel !== 'chartData');
+            }
+
+            return this.panels.length > 0
+                // Only one panel is required to display menu icon in toolbar
+                ? [this.panels[0], ...chartToolbarOptions]
+                : chartToolbarOptions;
+        } else { // To be deprecated in future. Toolbar options will be different to chart tool panels.
+            let tabOptions: ChartMenuOptions[] = [
+                'chartSettings',
+                'chartData',
+                'chartFormat',
+                this.chartController.isChartLinked() ? 'chartLink' : 'chartUnlink',
+                'chartDownload'
+            ];
+    
+            const toolbarItemsFunc = this.gridOptionsWrapper.getChartToolbarItemsFunc();
+    
+            if (toolbarItemsFunc) {
+                const params: WithoutGridCommon<GetChartToolbarItemsParams> = {
+                    defaultItems: tabOptions
+                };
+    
+                tabOptions = toolbarItemsFunc(params).filter(option => {
+                    if (!this.buttons[option]) {
+                        console.warn(`AG Grid: '${option}' is not a valid Chart Toolbar Option`);
+                        return false;
+                    }
+    
+                    return true;
+                });
+            }
+    
+            // pivot charts use the column tool panel instead of the data panel
+            if (this.chartController.isPivotChart()) {
+                tabOptions = tabOptions.filter(option => option !== 'chartData');
+            }
+    
+            const ignoreOptions: ChartMenuOptions[] = ['chartUnlink', 'chartLink', 'chartDownload'];
+            this.panels = tabOptions.filter(option => ignoreOptions.indexOf(option) === -1) as ChartToolPanelMenuOptions[];
+    
+            return tabOptions.filter(value =>
+                ignoreOptions.indexOf(value) !== -1 ||
+                (this.panels.length && value === this.panels[0])
+            );
         }
-
-        // pivot charts use the column tool panel instead of the data panel
-        if (this.chartController.isPivotChart()) {
-            tabOptions = tabOptions.filter(option => option !== 'chartData');
-        }
-
-        const ignoreOptions: ChartMenuOptions[] = ['chartUnlink', 'chartLink', 'chartDownload'];
-        this.panels = tabOptions.filter(option => ignoreOptions.indexOf(option) === -1);
-
-        return tabOptions.filter(value =>
-            ignoreOptions.indexOf(value) !== -1 ||
-            (this.panels.length && value === this.panels[0])
-        );
     }
 
     private toggleDetached(e: MouseEvent): void {
@@ -233,7 +279,7 @@ export class ChartMenu extends Component {
         this.menuVisible ? this.hideMenu() : this.showMenu();
     }
 
-    public showMenu(panel?: ChartMenuOptions): void {
+    public showMenu(panel?: ChartToolPanelMenuOptions): void {
         const menuPanel = panel || ChartMenu.DEFAULT_PANEL;
         let tab = this.panels.indexOf(menuPanel);
         if (tab < 0) {

--- a/enterprise-modules/charts/src/charts/chartComp/menu/settings/chartSettingsPanel.ts
+++ b/enterprise-modules/charts/src/charts/chartComp/menu/settings/chartSettingsPanel.ts
@@ -75,7 +75,7 @@ export class ChartSettingsPanel extends Component {
 
     private resetPalettes(forceReset?: boolean): void {
         const palettes = this.chartController.getPalettes();
-        const chartGroups = this.gridOptionsWrapper.getChartToolPanels()?.settingsPanel.chartGroups;
+        const chartGroups = this.gridOptionsWrapper.getChartToolPanels()?.settingsPanel?.chartGroups;
 
         if ((_.shallowCompare(palettes, this.palettes) && !forceReset) || this.isAnimating) {
             return;

--- a/enterprise-modules/charts/src/charts/chartComp/menu/settings/chartSettingsPanel.ts
+++ b/enterprise-modules/charts/src/charts/chartComp/menu/settings/chartSettingsPanel.ts
@@ -75,6 +75,7 @@ export class ChartSettingsPanel extends Component {
 
     private resetPalettes(forceReset?: boolean): void {
         const palettes = this.chartController.getPalettes();
+        const chartGroups = this.gridOptionsWrapper.getChartToolPanels()?.settingsPanel.chartGroups;
 
         if ((_.shallowCompare(palettes, this.palettes) && !forceReset) || this.isAnimating) {
             return;
@@ -92,7 +93,7 @@ export class ChartSettingsPanel extends Component {
         this.palettes.forEach((palette, index) => {
             const isActivePalette = this.activePaletteIndex === index;
             const { fills, strokes } = palette;
-            const miniChartsContainer = this.createBean(new MiniChartsContainer(this.chartController, fills, strokes));
+            const miniChartsContainer = this.createBean(new MiniChartsContainer(this.chartController, fills, strokes, chartGroups));
 
             this.miniCharts.push(miniChartsContainer);
             this.eMiniChartsContainer.appendChild(miniChartsContainer.getGui());

--- a/grid-packages/ag-grid-angular-legacy/projects/ag-grid-angular/src/lib/ag-grid-angular.component.ts
+++ b/grid-packages/ag-grid-angular-legacy/projects/ag-grid-angular/src/lib/ag-grid-angular.component.ts
@@ -40,6 +40,7 @@ import {
     ChartOptionsChanged,
     ChartRangeSelectionChanged,
     ChartRefParams,
+    ChartToolPanels,
     ColDef,
     ColGroupDef,
     ColumnAggFuncChangeRequestEvent,
@@ -463,6 +464,8 @@ export class AgGridAngular<TData = any, TColDef extends ColDef<TData> = ColDef<a
     @Input() public chartThemeOverrides: AgChartThemeOverrides | undefined = undefined;
     /** Set to `true` to show the Chart Tool Panels button. Note this will also remove the 'hamburger' menu option from the Chart Toolbar and always display the remaining toolbar buttons. Default: `false`     */
     @Input() public enableChartToolPanelsButton: boolean | undefined = undefined;
+    /** Chart Tool Panel overrides.     */
+    @Input() public chartToolPanels: ChartToolPanels | undefined = undefined;
     /** Provide your own loading cell renderer to use when data is loading via a DataSource.
      * See [Loading Cell Renderer](https://www.ag-grid.com/javascript-data-grid/component-loading-cell-renderer/) for framework specific implementation details.     */
     @Input() public loadingCellRenderer: any = undefined;

--- a/grid-packages/ag-grid-angular/projects/ag-grid-angular/src/lib/ag-grid-angular.component.ts
+++ b/grid-packages/ag-grid-angular/projects/ag-grid-angular/src/lib/ag-grid-angular.component.ts
@@ -40,6 +40,7 @@ import {
     ChartOptionsChanged,
     ChartRangeSelectionChanged,
     ChartRefParams,
+    ChartToolPanels,
     ColDef,
     ColGroupDef,
     ColumnAggFuncChangeRequestEvent,
@@ -457,6 +458,8 @@ export class AgGridAngular<TData = any, TColDef extends ColDef<TData> = ColDef<a
     @Input() public chartThemeOverrides: AgChartThemeOverrides | undefined = undefined;
     /** Set to `true` to show the Chart Tool Panels button. Note this will also remove the 'hamburger' menu option from the Chart Toolbar and always display the remaining toolbar buttons. Default: `false`     */
     @Input() public enableChartToolPanelsButton: boolean | undefined = undefined;
+    /** Chart Tool Panel overrides.     */
+    @Input() public chartToolPanels: ChartToolPanels | undefined = undefined;
     /** Provide your own loading cell renderer to use when data is loading via a DataSource.
      * See [Loading Cell Renderer](https://www.ag-grid.com/javascript-data-grid/component-loading-cell-renderer/) for framework specific implementation details.     */
     @Input() public loadingCellRenderer: any = undefined;

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/doc-interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/doc-interfaces.AUTO.json
@@ -2670,6 +2670,10 @@
       "description": "/** Set to `true` to show the Chart Tool Panels button. Note this will also remove the 'hamburger' menu option from the Chart Toolbar and always display the remaining toolbar buttons. Default: `false` */",
       "type": { "returnType": "boolean", "optional": true }
     },
+    "chartToolPanels": {
+      "description": "/** Chart Tool Panel overrides. */",
+      "type": { "returnType": "ChartToolPanels", "optional": true }
+    },
     "loadingCellRenderer": {
       "description": "/** Provide your own loading cell renderer to use when data is loading via a DataSource.\n * See [Loading Cell Renderer](https://www.ag-grid.com/javascript-data-grid/component-loading-cell-renderer/) for framework specific implementation details. */",
       "type": { "returnType": "any", "optional": true }
@@ -16461,6 +16465,10 @@
       }
     }
   },
+  "ChartTypeKeys": {},
+  "ChartGroups": {},
+  "PartialChartGroups": {},
+  "ChartToolPanels": {},
   "ChartType": {},
   "CrossFilterChartType": {},
   "ChartMenuOptions": {},
@@ -25112,6 +25120,10 @@
       "description": "/** Set to `true` to show the Chart Tool Panels button. Note this will also remove the 'hamburger' menu option from the Chart Toolbar and always display the remaining toolbar buttons. Default: `false` */",
       "type": { "returnType": "boolean", "optional": true }
     },
+    "chartToolPanels": {
+      "description": "/** Chart Tool Panel overrides. */",
+      "type": { "returnType": "ChartToolPanels", "optional": true }
+    },
     "loadingCellRenderer": {
       "description": "/** Provide your own loading cell renderer to use when data is loading via a DataSource.\n * See [Loading Cell Renderer](https://www.ag-grid.com/javascript-data-grid/component-loading-cell-renderer/) for framework specific implementation details. */",
       "type": { "returnType": "any", "optional": true }
@@ -27920,6 +27932,10 @@
     "enableChartToolPanelsButton": {
       "description": "/** Set to `true` to show the Chart Tool Panels button. Note this will also remove the 'hamburger' menu option from the Chart Toolbar and always display the remaining toolbar buttons. Default: `false` */",
       "type": { "returnType": "boolean", "optional": true }
+    },
+    "chartToolPanels": {
+      "description": "/** Chart Tool Panel overrides. */",
+      "type": { "returnType": "ChartToolPanels", "optional": true }
     },
     "loadingCellRenderer": {
       "description": "/** Provide your own loading cell renderer to use when data is loading via a DataSource.\n * See [Loading Cell Renderer](https://www.ag-grid.com/javascript-data-grid/component-loading-cell-renderer/) for framework specific implementation details. */",
@@ -30739,6 +30755,10 @@
     "enableChartToolPanelsButton": {
       "description": "/** Set to `true` to show the Chart Tool Panels button. Note this will also remove the 'hamburger' menu option from the Chart Toolbar and always display the remaining toolbar buttons. Default: `false` */",
       "type": { "returnType": "boolean", "optional": true }
+    },
+    "chartToolPanels": {
+      "description": "/** Chart Tool Panel overrides. */",
+      "type": { "returnType": "ChartToolPanels", "optional": true }
     },
     "loadingCellRenderer": {
       "description": "/** Provide your own loading cell renderer to use when data is loading via a DataSource.\n * See [Loading Cell Renderer](https://www.ag-grid.com/javascript-data-grid/component-loading-cell-renderer/) for framework specific implementation details. */",

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/doc-interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/doc-interfaces.AUTO.json
@@ -16468,9 +16468,12 @@
   "ChartTypeKeys": {},
   "ChartGroups": {},
   "PartialChartGroups": {},
+  "ChartToolPanelName": {},
   "ChartToolPanels": {},
   "ChartType": {},
   "CrossFilterChartType": {},
+  "ChartToolPanelMenuOptions": {},
+  "ChartToolbarMenuItemOptions": {},
   "ChartMenuOptions": {},
   "SeriesChartType": {
     "colId": { "type": { "returnType": "string", "optional": false } },
@@ -16515,7 +16518,6 @@
     }
   },
   "ChartModelType": {},
-  "ChartToolPanelName": {},
   "OpenChartToolPanelParams": {
     "chartId": {
       "description": "/** The id of the created chart. */",

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/grid-options.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/grid-options.AUTO.json
@@ -307,6 +307,10 @@
     "description": "/** Set to `true` to show the Chart Tool Panels button. Note this will also remove the 'hamburger' menu option from the Chart Toolbar and always display the remaining toolbar buttons. Default: `false` */",
     "type": { "returnType": "boolean" }
   },
+  "chartToolPanels": {
+    "description": "/** Chart Tool Panel overrides. */",
+    "type": { "returnType": "ChartToolPanels" }
+  },
   "loadingCellRenderer": {
     "description": "/** Provide your own loading cell renderer to use when data is loading via a DataSource.\n * See [Loading Cell Renderer](https://www.ag-grid.com/javascript-data-grid/component-loading-cell-renderer/) for framework specific implementation details. */",
     "type": { "returnType": "any" }

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/interfaces.AUTO.json
@@ -9578,7 +9578,7 @@
   },
   "ChartToolPanels": {
     "meta": { "isTypeAlias": true },
-    "type": "{ settingsPanel?: { chartGroups: PartialChartGroups; }; panels?: ChartToolPanelName[]; }"
+    "type": "{ settingsPanel?: { chartGroups: PartialChartGroups; }; panels?: ChartToolPanelName[]; defaultToolPanel?: ChartToolPanelName; }"
   },
   "ChartType": {
     "meta": { "isTypeAlias": true },

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/interfaces.AUTO.json
@@ -9572,9 +9572,13 @@
     "meta": { "isTypeAlias": true },
     "type": "Partial<ChartGroups>"
   },
+  "ChartToolPanelName": {
+    "meta": { "isTypeAlias": true },
+    "type": "'settings' | 'data' | 'format'"
+  },
   "ChartToolPanels": {
     "meta": { "isTypeAlias": true },
-    "type": "{ settingsPanel: { chartGroups: PartialChartGroups; }; }"
+    "type": "{ settingsPanel?: { chartGroups: PartialChartGroups; }; panels?: ChartToolPanelName[]; }"
   },
   "ChartType": {
     "meta": { "isTypeAlias": true },
@@ -9584,9 +9588,17 @@
     "meta": { "isTypeAlias": true },
     "type": "'column' | 'bar' | 'line' | 'scatter' | 'bubble' | 'pie' | 'doughnut' | 'area'"
   },
+  "ChartToolPanelMenuOptions": {
+    "meta": { "isTypeAlias": true },
+    "type": "'chartSettings' | 'chartData' | 'chartFormat'"
+  },
+  "ChartToolbarMenuItemOptions": {
+    "meta": { "isTypeAlias": true },
+    "type": "'chartLink' | 'chartUnlink' | 'chartDownload'"
+  },
   "ChartMenuOptions": {
     "meta": { "isTypeAlias": true },
-    "type": "'chartSettings' | 'chartData' | 'chartFormat' | 'chartLink' | 'chartUnlink' | 'chartDownload'"
+    "type": "ChartToolPanelMenuOptions | ChartToolbarMenuItemOptions"
   },
   "SeriesChartType": {
     "meta": {},
@@ -9627,10 +9639,6 @@
   "ChartModelType": {
     "meta": { "isTypeAlias": true },
     "type": "'range' | 'pivot'"
-  },
-  "ChartToolPanelName": {
-    "meta": { "isTypeAlias": true },
-    "type": "'settings' | 'data' | 'format'"
   },
   "OpenChartToolPanelParams": {
     "meta": {},

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/interfaces.AUTO.json
@@ -1563,6 +1563,7 @@
       "customChartThemes?": "{ [name: string]: AgChartTheme; }",
       "chartThemeOverrides?": "AgChartThemeOverrides",
       "enableChartToolPanelsButton?": "boolean",
+      "chartToolPanels?": "ChartToolPanels",
       "loadingCellRenderer?": "any",
       "loadingCellRendererFramework?": "any",
       "loadingCellRendererParams?": "any",
@@ -1954,6 +1955,7 @@
       "customChartThemes?": "/** A map containing custom chart themes. */",
       "chartThemeOverrides?": "/** Chart theme overrides applied to all themes. */",
       "enableChartToolPanelsButton?": "/** Set to `true` to show the Chart Tool Panels button. Note this will also remove the 'hamburger' menu option from the Chart Toolbar and always display the remaining toolbar buttons. Default: `false` */",
+      "chartToolPanels?": "/** Chart Tool Panel overrides. */",
       "loadingCellRenderer?": "/** Provide your own loading cell renderer to use when data is loading via a DataSource.\n * See [Loading Cell Renderer](https://www.ag-grid.com/javascript-data-grid/component-loading-cell-renderer/) for framework specific implementation details. */",
       "loadingCellRendererFramework?": "/** @deprecated As of v27, use `loadingCellRenderer` for framework components too.\n */",
       "loadingCellRendererParams?": "/** Params to be passed to the `loadingCellRenderer` component. */",
@@ -9558,6 +9560,22 @@
       "init?(params: T)": "/** The init(params) method is called on the component once. */"
     }
   },
+  "ChartTypeKeys": {
+    "meta": { "isTypeAlias": true },
+    "type": "typeof CHART_TYPE_KEYS"
+  },
+  "ChartGroups": {
+    "meta": { "isTypeAlias": true },
+    "type": "{[chartType in keyof ChartTypeKeys]: (keyof ChartTypeKeys[chartType])[]}"
+  },
+  "PartialChartGroups": {
+    "meta": { "isTypeAlias": true },
+    "type": "Partial<ChartGroups>"
+  },
+  "ChartToolPanels": {
+    "meta": { "isTypeAlias": true },
+    "type": "{ settingsPanel: { chartGroups: PartialChartGroups; }; }"
+  },
   "ChartType": {
     "meta": { "isTypeAlias": true },
     "type": "'column' | 'groupedColumn' | 'stackedColumn' | 'normalizedColumn' | 'bar' | 'groupedBar' | 'stackedBar' | 'normalizedBar' | 'line' | 'scatter' | 'bubble' | 'pie' | 'doughnut' | 'area' | 'stackedArea' | 'normalizedArea' | 'histogram' | 'columnLineCombo' | 'areaColumnCombo' | 'customCombo'"
@@ -14144,6 +14162,7 @@
       "customChartThemes?": "{ [name: string]: AgChartTheme; }",
       "chartThemeOverrides?": "AgChartThemeOverrides",
       "enableChartToolPanelsButton?": "boolean",
+      "chartToolPanels?": "ChartToolPanels",
       "loadingCellRenderer?": "any",
       "loadingCellRendererFramework?": "any",
       "loadingCellRendererParams?": "any",
@@ -14535,6 +14554,7 @@
       "customChartThemes?": "/** A map containing custom chart themes. */",
       "chartThemeOverrides?": "/** Chart theme overrides applied to all themes. */",
       "enableChartToolPanelsButton?": "/** Set to `true` to show the Chart Tool Panels button. Note this will also remove the 'hamburger' menu option from the Chart Toolbar and always display the remaining toolbar buttons. Default: `false` */",
+      "chartToolPanels?": "/** Chart Tool Panel overrides. */",
       "loadingCellRenderer?": "/** Provide your own loading cell renderer to use when data is loading via a DataSource.\n * See [Loading Cell Renderer](https://www.ag-grid.com/javascript-data-grid/component-loading-cell-renderer/) for framework specific implementation details. */",
       "loadingCellRendererFramework?": "/** @deprecated As of v27, use `loadingCellRenderer` for framework components too.\n */",
       "loadingCellRendererParams?": "/** Params to be passed to the `loadingCellRenderer` component. */",
@@ -14928,6 +14948,7 @@
       "customChartThemes?": "{ [name: string]: AgChartTheme; }",
       "chartThemeOverrides?": "AgChartThemeOverrides",
       "enableChartToolPanelsButton?": "boolean",
+      "chartToolPanels?": "ChartToolPanels",
       "loadingCellRenderer?": "any",
       "loadingCellRendererFramework?": "any",
       "loadingCellRendererParams?": "any",
@@ -15319,6 +15340,7 @@
       "customChartThemes?": "/** A map containing custom chart themes. */",
       "chartThemeOverrides?": "/** Chart theme overrides applied to all themes. */",
       "enableChartToolPanelsButton?": "/** Set to `true` to show the Chart Tool Panels button. Note this will also remove the 'hamburger' menu option from the Chart Toolbar and always display the remaining toolbar buttons. Default: `false` */",
+      "chartToolPanels?": "/** Chart Tool Panel overrides. */",
       "loadingCellRenderer?": "/** Provide your own loading cell renderer to use when data is loading via a DataSource.\n * See [Loading Cell Renderer](https://www.ag-grid.com/javascript-data-grid/component-loading-cell-renderer/) for framework specific implementation details. */",
       "loadingCellRendererFramework?": "/** @deprecated As of v27, use `loadingCellRenderer` for framework components too.\n */",
       "loadingCellRendererParams?": "/** Params to be passed to the `loadingCellRenderer` component. */",
@@ -15716,6 +15738,7 @@
       "customChartThemes?": "{ [name: string]: AgChartTheme; }",
       "chartThemeOverrides?": "AgChartThemeOverrides",
       "enableChartToolPanelsButton?": "boolean",
+      "chartToolPanels?": "ChartToolPanels",
       "loadingCellRenderer?": "any",
       "loadingCellRendererFramework?": "any",
       "loadingCellRendererParams?": "any",
@@ -16107,6 +16130,7 @@
       "customChartThemes?": "/** A map containing custom chart themes. */",
       "chartThemeOverrides?": "/** Chart theme overrides applied to all themes. */",
       "enableChartToolPanelsButton?": "/** Set to `true` to show the Chart Tool Panels button. Note this will also remove the 'hamburger' menu option from the Chart Toolbar and always display the remaining toolbar buttons. Default: `false` */",
+      "chartToolPanels?": "/** Chart Tool Panel overrides. */",
       "loadingCellRenderer?": "/** Provide your own loading cell renderer to use when data is loading via a DataSource.\n * See [Loading Cell Renderer](https://www.ag-grid.com/javascript-data-grid/component-loading-cell-renderer/) for framework specific implementation details. */",
       "loadingCellRendererFramework?": "/** @deprecated As of v27, use `loadingCellRenderer` for framework components too.\n */",
       "loadingCellRendererParams?": "/** Params to be passed to the `loadingCellRenderer` component. */",

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/grid-options/properties.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/grid-options/properties.json
@@ -393,8 +393,14 @@
         },
         "chartThemeOverrides": {
             "more": {
-                "name": "Overriding Existing Themes",
+                "name": "Chart Groups and Types Customisation",
                 "url": "/integrated-charts-customisation/#overriding-existing-themes"
+            }
+        },
+        "chartToolPanels": {
+            "more": {
+                "name": "Chart Tool Panel customisation",
+                "url": "/integrated-charts-toolbar/#chart-tool-panel-customisation"
             }
         }
     },

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/integrated-charts-toolbar/examples/customise-chart-groups/data.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/integrated-charts-toolbar/examples/customise-chart-groups/data.ts
@@ -1,0 +1,33 @@
+export function getData(): any[] {
+    var countries = [
+        'Ireland',
+        'Spain',
+        'United Kingdom',
+        'France',
+        'Germany',
+        'Luxembourg',
+        'Sweden',
+        'Norway',
+        'Italy',
+        'Greece',
+        'Iceland',
+        'Portugal',
+        'Malta',
+        'Brazil',
+        'Argentina',
+        'Colombia',
+        'Peru',
+        'Venezuela',
+        'Uruguay',
+        'Belgium',
+    ]
+
+    return countries.map(function (country, index) {
+        return {
+            country: country,
+            gold: Math.floor(((index + 1 / 7) * 333) % 100),
+            silver: Math.floor(((index + 1 / 3) * 555) % 100),
+            bronze: Math.floor(((index + 1 / 7.3) * 777) % 100),
+        }
+    })
+}

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/integrated-charts-toolbar/examples/customise-chart-groups/index.html
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/integrated-charts-toolbar/examples/customise-chart-groups/index.html
@@ -1,0 +1,1 @@
+<div id="myGrid" style="height: 100%;" class="ag-theme-alpine"></div>

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/integrated-charts-toolbar/examples/customise-chart-groups/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/integrated-charts-toolbar/examples/customise-chart-groups/main.ts
@@ -1,0 +1,95 @@
+import { ChartCreated, ColDef, CreateRangeChartParams, FirstDataRenderedEvent, Grid, GridOptions } from '@ag-grid-community/core';
+import { getData } from "./data";
+
+const columnDefs: ColDef[] = [
+  { field: 'country', width: 150, chartDataType: 'category' },
+  { field: 'gold', chartDataType: 'series' },
+  { field: 'silver', chartDataType: 'series' },
+  { field: 'bronze', chartDataType: 'series' },
+  {
+    headerName: 'A',
+    valueGetter: 'Math.floor(Math.random()*1000)',
+    chartDataType: 'series',
+  },
+  {
+    headerName: 'B',
+    valueGetter: 'Math.floor(Math.random()*1000)',
+    chartDataType: 'series',
+  },
+  {
+    headerName: 'C',
+    valueGetter: 'Math.floor(Math.random()*1000)',
+    chartDataType: 'series',
+  },
+  {
+    headerName: 'D',
+    valueGetter: 'Math.floor(Math.random()*1000)',
+    chartDataType: 'series',
+  },
+]
+
+const gridOptions: GridOptions = {
+  defaultColDef: {
+    editable: true,
+    sortable: true,
+    flex: 1,
+    minWidth: 100,
+    filter: true,
+    resizable: true,
+  },
+  columnDefs: columnDefs,
+  rowData: getData(),
+  popupParent: document.body,
+  enableRangeSelection: true,
+  onFirstDataRendered: onFirstDataRendered,
+  onChartCreated: onChartCreated,
+  enableCharts: true,
+  chartToolPanels: {
+    settingsPanel: {        
+        chartGroups: {
+          pieGroup: [
+              'pie',
+              'doughnut'
+          ],
+          columnGroup: [
+              'stackedColumn',
+              'column',
+              'normalizedColumn'
+          ],
+          barGroup: [
+              'bar'
+          ],
+        }
+    },
+  },
+}
+
+function onFirstDataRendered(params: FirstDataRenderedEvent) {
+  var createRangeChartParams: CreateRangeChartParams = {
+    cellRange: {
+      rowStartIndex: 0,
+      rowEndIndex: 4,
+      columns: ['country', 'gold', 'silver', 'bronze'],
+    },
+    chartType: 'column',
+    chartThemeOverrides: {
+      column: {
+        legend: {
+          position: 'bottom'
+        }
+      }
+    }
+  }
+
+  params.api.createRangeChart(createRangeChartParams)
+}
+
+function onChartCreated(params: ChartCreated) {
+  params.api.openChartToolPanel(params)
+}
+
+// setup the grid after the page has finished loading
+document.addEventListener('DOMContentLoaded', function () {
+  var gridDiv = document.querySelector<HTMLElement>('#myGrid')!
+  new Grid(gridDiv, gridOptions)
+})

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/integrated-charts-toolbar/examples/customise-panels/data.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/integrated-charts-toolbar/examples/customise-panels/data.ts
@@ -1,0 +1,33 @@
+export function getData(): any[] {
+    var countries = [
+        'Ireland',
+        'Spain',
+        'United Kingdom',
+        'France',
+        'Germany',
+        'Luxembourg',
+        'Sweden',
+        'Norway',
+        'Italy',
+        'Greece',
+        'Iceland',
+        'Portugal',
+        'Malta',
+        'Brazil',
+        'Argentina',
+        'Colombia',
+        'Peru',
+        'Venezuela',
+        'Uruguay',
+        'Belgium',
+    ]
+
+    return countries.map(function (country, index) {
+        return {
+            country: country,
+            gold: Math.floor(((index + 1 / 7) * 333) % 100),
+            silver: Math.floor(((index + 1 / 3) * 555) % 100),
+            bronze: Math.floor(((index + 1 / 7.3) * 777) % 100),
+        }
+    })
+}

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/integrated-charts-toolbar/examples/customise-panels/index.html
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/integrated-charts-toolbar/examples/customise-panels/index.html
@@ -1,0 +1,1 @@
+<div id="myGrid" style="height: 100%;" class="ag-theme-alpine"></div>

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/integrated-charts-toolbar/examples/customise-panels/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/integrated-charts-toolbar/examples/customise-panels/main.ts
@@ -1,0 +1,80 @@
+import { ChartCreated, ColDef, CreateRangeChartParams, FirstDataRenderedEvent, Grid, GridOptions } from '@ag-grid-community/core';
+import { getData } from "./data";
+
+const columnDefs: ColDef[] = [
+  { field: 'country', width: 150, chartDataType: 'category' },
+  { field: 'gold', chartDataType: 'series' },
+  { field: 'silver', chartDataType: 'series' },
+  { field: 'bronze', chartDataType: 'series' },
+  {
+    headerName: 'A',
+    valueGetter: 'Math.floor(Math.random()*1000)',
+    chartDataType: 'series',
+  },
+  {
+    headerName: 'B',
+    valueGetter: 'Math.floor(Math.random()*1000)',
+    chartDataType: 'series',
+  },
+  {
+    headerName: 'C',
+    valueGetter: 'Math.floor(Math.random()*1000)',
+    chartDataType: 'series',
+  },
+  {
+    headerName: 'D',
+    valueGetter: 'Math.floor(Math.random()*1000)',
+    chartDataType: 'series',
+  },
+]
+
+const gridOptions: GridOptions = {
+  defaultColDef: {
+    editable: true,
+    sortable: true,
+    flex: 1,
+    minWidth: 100,
+    filter: true,
+    resizable: true,
+  },
+  columnDefs: columnDefs,
+  rowData: getData(),
+  popupParent: document.body,
+  enableRangeSelection: true,
+  onFirstDataRendered: onFirstDataRendered,
+  onChartCreated: onChartCreated,
+  enableCharts: true,
+  chartToolPanels: {
+    panels: ['format', 'settings']
+  },
+}
+
+function onFirstDataRendered(params: FirstDataRenderedEvent) {
+  var createRangeChartParams: CreateRangeChartParams = {
+    cellRange: {
+      rowStartIndex: 0,
+      rowEndIndex: 4,
+      columns: ['country', 'gold', 'silver', 'bronze'],
+    },
+    chartType: 'column',
+    chartThemeOverrides: {
+      column: {
+        legend: {
+          position: 'bottom'
+        }
+      }
+    }
+  }
+
+  params.api.createRangeChart(createRangeChartParams)
+}
+
+function onChartCreated(params: ChartCreated) {
+  params.api.openChartToolPanel(params)
+}
+
+// setup the grid after the page has finished loading
+document.addEventListener('DOMContentLoaded', function () {
+  var gridDiv = document.querySelector<HTMLElement>('#myGrid')!
+  new Grid(gridDiv, gridOptions)
+})

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/integrated-charts-toolbar/examples/customise-panels/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/integrated-charts-toolbar/examples/customise-panels/main.ts
@@ -1,4 +1,4 @@
-import { ChartCreated, ColDef, CreateRangeChartParams, FirstDataRenderedEvent, Grid, GridOptions } from '@ag-grid-community/core';
+import { ColDef, CreateRangeChartParams, FirstDataRenderedEvent, Grid, GridOptions } from '@ag-grid-community/core';
 import { getData } from "./data";
 
 const columnDefs: ColDef[] = [
@@ -42,10 +42,10 @@ const gridOptions: GridOptions = {
   popupParent: document.body,
   enableRangeSelection: true,
   onFirstDataRendered: onFirstDataRendered,
-  onChartCreated: onChartCreated,
   enableCharts: true,
   chartToolPanels: {
-    panels: ['format', 'settings']
+    panels: ['data', 'format', 'settings'],
+    defaultToolPanel: 'format'
   },
 }
 
@@ -67,10 +67,6 @@ function onFirstDataRendered(params: FirstDataRenderedEvent) {
   }
 
   params.api.createRangeChart(createRangeChartParams)
-}
-
-function onChartCreated(params: ChartCreated) {
-  params.api.openChartToolPanel(params)
 }
 
 // setup the grid after the page has finished loading

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/integrated-charts-toolbar/index.md
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/integrated-charts-toolbar/index.md
@@ -151,11 +151,11 @@ The example below shows a reordering of chart groups with some chart groups and 
 
 ### Customising panels
 
-The Chart Tool Panels can be reorganised using the `chartToolPanels.panels` grid option.
+The Chart Tool Panels can be reorganised using the `chartToolPanels.panels` grid option, and a tool panel can be opened when the chart is loaded using the `chartToolPanels.defaultToolPanel` grid option.
 
 Note that when the `chartToolPanels` grid option is used, the panels returned from `gridOptions.getChartToolbarItems(params)` are ignored. If `chartToolPanels` is set without `chartToolPanels.panels`, **all panels** will be shown regardless of the results of `gridOptions.getChartToolbarItems(params)`.
 
-The example below shows panels being reorganised:
+The example below shows panels being reorganised with the `format` tool panel open by default:
 
 <grid-example title='Customising panels' name='customise-panels' type='generated' options='{ "enterprise": true, "modules": ["clientside", "menu", "charts"] }'></grid-example>
 

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/integrated-charts-toolbar/index.md
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/integrated-charts-toolbar/index.md
@@ -149,6 +149,16 @@ The example below shows a reordering of chart groups with some chart groups and 
 
 <grid-example title='Customising settings panel chart groups' name='customise-chart-groups' type='generated' options='{ "enterprise": true, "modules": ["clientside", "menu", "charts"] }'></grid-example>
 
+### Customising panels
+
+The Chart Tool Panels can be reorganised using the `chartToolPanels.panels` grid option.
+
+Note that when the `chartToolPanels` grid option is used, the panels returned from `gridOptions.getChartToolbarItems(params)` are ignored. If `chartToolPanels` is set without `chartToolPanels.panels`, **all panels** will be shown regardless of the results of `gridOptions.getChartToolbarItems(params)`.
+
+The example below shows panels being reorganised:
+
+<grid-example title='Customising panels' name='customise-panels' type='generated' options='{ "enterprise": true, "modules": ["clientside", "menu", "charts"] }'></grid-example>
+
 ## Chart Tool Panels Button
 
 The Chart Tool Panels Button offers an alternative way to access the Chart Tool Panels and is enabled as shown below:

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/integrated-charts-toolbar/index.md
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/integrated-charts-toolbar/index.md
@@ -90,6 +90,65 @@ The example below shows how the toolbar can be customised. Notice the following:
 
 <grid-example title='Toolbar Customisation' name='custom-toolbar' type='generated' options='{ "enterprise": true, "modules": ["clientside", "menu", "charts"] }'></grid-example>
 
+## Chart Tool Panel Customisation
+
+The Chart Tool Panel can be customised within the `chartToolPanels` grid option.
+
+<api-documentation source='grid-options/properties.json' section='charts' names='["chartToolPanels"]' ></api-documentation>
+
+### Customising settings panel chart groups
+
+The list of chart groups shown on the settings panel can be customised using the `chartToolPanels.settingsPanel.chartGroups` grid option. The full list of chart groups are as follows:
+
+<snippet>
+const gridOptions = {
+    chartToolPanels: {
+        settingsPanel: {
+            chartGroups: {
+                columnGroup: [
+                    'column',
+                    'stackedColumn',
+                    'normalizedColumn'
+                ],
+                barGroup: [
+                    'bar',
+                    'stackedBar',
+                    'normalizedBar'
+                ],
+                pieGroup: [
+                    'pie',
+                    'doughnut'
+                ],
+                lineGroup: [
+                    'line'
+                ],
+                scatterGroup: [
+                    'scatter',
+                    'bubble'
+                ],
+                areaGroup: [
+                    'area',
+                    'stackedArea',
+                    'normalizedArea'
+                ],
+                histogramGroup: [
+                    'histogram'
+                ],
+                combinationGroup: [
+                    'columnLineCombo',
+                    'areaColumnCombo',
+                    'customCombo'
+                ]
+            }
+        }
+    }
+}
+</snippet>
+
+The example below shows a reordering of chart groups with some chart groups and types removed:
+
+<grid-example title='Customising settings panel chart groups' name='customise-chart-groups' type='generated' options='{ "enterprise": true, "modules": ["clientside", "menu", "charts"] }'></grid-example>
+
 ## Chart Tool Panels Button
 
 The Chart Tool Panels Button offers an alternative way to access the Chart Tool Panels and is enabled as shown below:

--- a/grid-packages/ag-grid-enterprise/src/main.ts
+++ b/grid-packages/ag-grid-enterprise/src/main.ts
@@ -186,7 +186,7 @@ export { PopupService, AgPopup } from "ag-grid-community";
 export { TouchListener, TapEvent, LongTapEvent } from "ag-grid-community";
 export { VirtualList, VirtualListModel } from "ag-grid-community";
 export { CellRange, CellRangeParams, CellRangeType, RangeSelection, AddRangeSelectionParams, IRangeService, ISelectionHandle, SelectionHandleType, ISelectionHandleFactory } from "ag-grid-community";
-export { IChartService, ChartDownloadParams, OpenChartToolPanelParams, CloseChartToolPanelParams, ChartToolPanelName, ChartModel, GetChartImageDataUrlParams, ChartModelType, } from "ag-grid-community";
+export { IChartService, ChartDownloadParams, OpenChartToolPanelParams, CloseChartToolPanelParams, ChartModel, GetChartImageDataUrlParams, ChartModelType, } from "ag-grid-community";
 export { IDetailCellRendererParams, GetDetailRowData, GetDetailRowDataParams, IDetailCellRenderer, IDetailCellRendererCtrl } from "ag-grid-community";
 export { CsvExportParams, CsvCell, CsvCellData, CsvCustomContent, ExportParams, PackageFileParams, ProcessCellForExportParams, ProcessHeaderForExportParams, ProcessGroupHeaderForExportParams, ProcessRowGroupForExportParams, ShouldRowBeSkippedParams, BaseExportParams } from "ag-grid-community";
 export { HeaderElement, PrefixedXmlAttributes, XmlElement } from "ag-grid-community";


### PR DESCRIPTION
## Changes

* Allow customizing the list of available chart groups in the Chart Tool Panel settings panel
* Allow customizing chart tool panels
    * Separate chart toolbar and chart tool panels logic
    * Override `getChartToolbarItems()` panels (use `chartToolPanels.settingsPanel.panels` instead)
    * Move `ChartToolPanelName` type to `iChartOptions`
    * Add `ChartToolPanelMenuOptions` type to be more specific than `ChartMenuOptions`
* Allow default tool panel to be set and open
    * If there is no default panel set, then the first panel is used
    * Don't animate when first shown
 * Added docs to `/javascript-data-grid/integrated-charts-toolbar/#chart-tool-panel-customisation` 

## Updated grid options

```
const gridOptions: GridOptions = {
  // ...
  chartToolPanels: {
    settingsPanel: {        
        chartGroups: {
          pieGroup: [
              'pie',
              'doughnut'
          ],
          columnGroup: [
              'stackedColumn',
              'column',
              'normalizedColumn'
          ],
          barGroup: [
              'bar'
          ],
        }
    },
    panels: ['data', 'format', 'settings'],
    defaultToolPanel: 'format'
  },
}
```