### PR TITLE
AG-7300 - Fix Chart  layer bbox changes not triggering rerender.

### DIFF
--- a/charts-packages/ag-charts-community/src/scene/bbox.ts
+++ b/charts-packages/ag-charts-community/src/scene/bbox.ts
@@ -27,6 +27,10 @@ export class BBox {
         return new BBox(x, y, width, height);
     }
 
+    equals(other: BBox) {
+        return this.x === other.x && this.y === other.y && this.width === other.width && this.height === other.height;
+    }
+
     isValid(): boolean {
         return isFinite(this.x) && isFinite(this.y) && isFinite(this.width) && isFinite(this.height);
     }

--- a/charts-packages/ag-charts-community/src/scene/group.ts
+++ b/charts-packages/ag-charts-community/src/scene/group.ts
@@ -187,6 +187,7 @@ export class Group extends Node {
         this.basicRender(renderCtx);
     }
 
+    private lastBBox?: BBox = undefined;
     private basicRender(renderCtx: RenderContext) {
         const { opts: { name = undefined } = {} } = this;
         const { _debug: { consoleLog = false } = {} } = this;
@@ -204,6 +205,13 @@ export class Group extends Node {
             // By default there is no need to force redraw a group which has it's own canvas layer
             // as the layer is independent of any other layer.
             forceRender = false;
+
+            // If bounding-box of a layer changes, force re-render.
+            const currentBBox = this.computeBBox();
+            if (this.lastBBox === undefined || !this.lastBBox.equals(currentBBox)) {
+                forceRender = true;
+                this.lastBBox = currentBBox;
+            }
         }
 
         if (!isDirty && !isChildDirty && !forceRender) {


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-7300

Fixes some edge cases where Chart layout changes don't trigger  rerender of the main series area.