### PR TITLE
AG-7298 - Add validation tests and cross field validations

### DIFF
--- a/charts-packages/ag-charts-community/src/axis.ts
+++ b/charts-packages/ag-charts-community/src/axis.ts
@@ -31,25 +31,24 @@ import { ChartAxisDirection } from './chart/chartAxis';
 import { Layers } from './chart/layers';
 
 const TICK_COUNT = predicateWithMessage(
-    (v: any) => NUMBER(0)(v) || v instanceof TimeInterval,
+    (v: any, ctx) => NUMBER(0)(v, ctx) || v instanceof TimeInterval,
     `expecting a tick count Number value or, for a time axis, a Time Interval such as 'agCharts.time.month'`
 );
 const OPT_TICK_COUNT = predicateWithMessage(
-    (v: any) => OPTIONAL(v, TICK_COUNT),
+    (v: any, ctx) => OPTIONAL(v, ctx, TICK_COUNT),
     `expecting an optional tick count Number value or, for a time axis, a Time Interval such as 'agCharts.time.month'`
 );
 
 const GRID_STYLE_KEYS = ['stroke', 'lineDash'];
 const GRID_STYLE = predicateWithMessage(
-    (v: any) =>
-        ARRAY()(v, (o) => {
-            for (let key in o) {
-                if (!GRID_STYLE_KEYS.includes(key)) {
-                    return false;
-                }
+    ARRAY(undefined, (o) => {
+        for (let key in o) {
+            if (!GRID_STYLE_KEYS.includes(key)) {
+                return false;
             }
-            return true;
-        }),
+        }
+        return true;
+    }),
     `expecting an Array of objects with gridline style properties such as 'stroke' and 'lineDash'`
 );
 

--- a/charts-packages/ag-charts-community/src/chart/axis/numberAxis.ts
+++ b/charts-packages/ag-charts-community/src/chart/axis/numberAxis.ts
@@ -5,7 +5,7 @@ import { extent } from '../../util/array';
 import { isContinuous } from '../../util/value';
 import { ChartAxis } from '../chartAxis';
 import { doOnce } from '../../util/function';
-import { BOOLEAN, predicateWithMessage, Validate } from '../../util/validation';
+import { BOOLEAN, predicateWithMessage, Validate, GREATER_THAN, AND, LESS_THAN } from '../../util/validation';
 
 function NUMBER_OR_NAN(min?: number, max?: number) {
     // Can be NaN or finite number
@@ -102,10 +102,10 @@ export class NumberAxis extends ChartAxis {
         return this.scale.domain;
     }
 
-    @Validate(NUMBER_OR_NAN())
+    @Validate(AND(NUMBER_OR_NAN(), LESS_THAN('max')))
     min: number = NaN;
 
-    @Validate(NUMBER_OR_NAN())
+    @Validate(AND(NUMBER_OR_NAN(), GREATER_THAN('min')))
     max: number = NaN;
 
     formatDatum(datum: number): string {

--- a/charts-packages/ag-charts-community/src/chart/axis/timeAxis.ts
+++ b/charts-packages/ag-charts-community/src/chart/axis/timeAxis.ts
@@ -1,4 +1,4 @@
-import { BOOLEAN, Validate, OPT_DATE } from '../../util/validation';
+import { BOOLEAN, Validate, OPT_DATE, AND, LESS_THAN, GREATER_THAN } from '../../util/validation';
 import { TimeScale } from '../../scale/timeScale';
 import { extent } from '../../util/array';
 import { isContinuous } from '../../util/value';
@@ -37,10 +37,10 @@ export class TimeAxis extends ChartAxis<TimeScale> {
         return this.scale.domain;
     }
 
-    @Validate(OPT_DATE)
+    @Validate(AND(OPT_DATE, LESS_THAN('max')))
     min?: Date = undefined;
 
-    @Validate(OPT_DATE)
+    @Validate(AND(OPT_DATE, GREATER_THAN('min')))
     max?: Date = undefined;
 
     private setDomain(domain: Date[], _primaryTickCount?: number) {

--- a/charts-packages/ag-charts-community/src/chart/crossline/crossLine.ts
+++ b/charts-packages/ag-charts-community/src/chart/crossline/crossLine.ts
@@ -54,12 +54,12 @@ const CROSSLINE_LABEL_POSITIONS = [
 ];
 
 const OPT_CROSSLINE_LABEL_POSITION = predicateWithMessage(
-    (v: any) => OPTIONAL(v, (v: any) => CROSSLINE_LABEL_POSITIONS.includes(v)),
+    (v: any, ctx) => OPTIONAL(v, ctx, (v: any) => CROSSLINE_LABEL_POSITIONS.includes(v)),
     `expecting an optional crossLine label position keyword such as 'topLeft', 'topRight' or 'inside'`
 );
 
 const OPT_CROSSLINE_TYPE = predicateWithMessage(
-    (v: any) => OPTIONAL(v, (v: any) => v === 'range' || v === 'line'),
+    (v: any, ctx) => OPTIONAL(v, ctx, (v: any) => v === 'range' || v === 'line'),
     `expecting a crossLine type keyword such as 'range' or 'line'`
 );
 

--- a/charts-packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
@@ -37,11 +37,13 @@ import {
     COLOR_STRING_ARRAY,
     Validate,
     OPTIONAL,
+    ValidatePredicate,
 } from '../../../util/validation';
 import { CategoryAxis } from '../../axis/categoryAxis';
 
 const BAR_LABEL_PLACEMENTS = ['inside', 'outside'];
-const OPT_BAR_LABEL_PLACEMENT = (v: any) => OPTIONAL(v, (v: any) => BAR_LABEL_PLACEMENTS.includes(v));
+const OPT_BAR_LABEL_PLACEMENT: ValidatePredicate = (v: any, ctx) =>
+    OPTIONAL(v, ctx, (v: any) => BAR_LABEL_PLACEMENTS.includes(v));
 
 export interface BarSeriesNodeClickEvent extends TypedEvent {
     readonly type: 'nodeClick';

--- a/charts-packages/ag-charts-community/src/util/validation.test.ts
+++ b/charts-packages/ag-charts-community/src/util/validation.test.ts
@@ -1,0 +1,254 @@
+import { describe, expect, it, jest, beforeEach } from '@jest/globals';
+import {
+    Validate,
+    OPT_NUMBER,
+    OPT_STRING,
+    OPT_DATE,
+    OPT_NUMBER_ARRAY,
+    COLOR_STRING,
+    LESS_THAN,
+    AND,
+    NUMBER,
+    GREATER_THAN,
+} from './validation';
+
+class TestValidate {
+    @Validate(OPT_NUMBER(0))
+    num?: number = undefined;
+
+    @Validate(OPT_STRING)
+    str?: string = undefined;
+
+    @Validate(OPT_DATE)
+    date?: Date = undefined;
+
+    @Validate(OPT_NUMBER_ARRAY)
+    array?: number[] = undefined;
+
+    @Validate(COLOR_STRING)
+    colour: string = 'black';
+
+    @Validate(AND(NUMBER(0), LESS_THAN('max')))
+    min: number = 0;
+
+    @Validate(AND(NUMBER(undefined, 100), GREATER_THAN('min')))
+    max: number = 100;
+}
+
+describe('validation module', () => {
+    let test: TestValidate;
+
+    beforeEach(() => {
+        test = new TestValidate();
+        console.warn = jest.fn();
+    });
+
+    describe('basic validations', () => {
+        describe('OPT_NUMBER', () => {
+            it('should set TestValidate.num to undefined without warning', () => {
+                test.num = undefined;
+
+                expect(console.warn).not.toBeCalled();
+            });
+
+            it('should not set TestValidate.num to null with warning', () => {
+                (test as any).num = null;
+
+                expect(console.warn).toHaveBeenCalledWith(expect.stringMatching(/cannot be set to/));
+                expect(test.num).toBe(undefined);
+            });
+
+            it('should set TestValidate.num to a valid value without warning', () => {
+                test.num = 3;
+
+                expect(console.warn).not.toBeCalled();
+                expect(test.num).toBe(3);
+            });
+        });
+
+        describe('OPT_STRING', () => {
+            it('should set TestValidate.str to undefined without warning', () => {
+                test.str = undefined;
+
+                expect(console.warn).not.toBeCalled();
+            });
+
+            it('should not set TestValidate.str to null with warning', () => {
+                (test as any).str = null;
+
+                expect(console.warn).toHaveBeenCalledWith(expect.stringMatching(/cannot be set to/));
+                expect(test.str).toBe(undefined);
+            });
+
+            it('should set TestValidate.str to a valid value without warning', () => {
+                test.str = 'hello world!';
+
+                expect(console.warn).not.toBeCalled();
+                expect(test.str).toBe('hello world!');
+            });
+        });
+
+        describe('OPT_DATE', () => {
+            it('should set TestValidate.date to undefined without warning', () => {
+                test.date = undefined;
+
+                expect(console.warn).not.toBeCalled();
+            });
+
+            it('should not set TestValidate.date to null with warning', () => {
+                (test as any).date = null;
+
+                expect(console.warn).toHaveBeenCalledWith(expect.stringMatching(/cannot be set to/));
+                expect(test.date).toBe(undefined);
+            });
+
+            it('should set TestValidate.date to a valid value without warning', () => {
+                const date = new Date();
+                test.date = date;
+
+                expect(console.warn).not.toBeCalled();
+                expect(test.date).toBe(date);
+            });
+        });
+
+        describe('OPT_NUMBER_ARRAY', () => {
+            it('should set TestValidate.array to undefined without warning', () => {
+                test.array = undefined;
+
+                expect(console.warn).not.toBeCalled();
+            });
+
+            it('should not set TestValidate.array to null with warning', () => {
+                (test as any).array = null;
+
+                expect(console.warn).toHaveBeenCalledWith(expect.stringMatching(/cannot be set to/));
+                expect(test.array).toBe(undefined);
+            });
+
+            it('should set TestValidate.array to a valid value without warning', () => {
+                test.array = [];
+                test.array = [1, 2, 3];
+
+                expect(console.warn).not.toBeCalled();
+                expect(test.array).toStrictEqual([1, 2, 3]);
+            });
+
+            it('should not set TestValidate.array to a invalid value with warning', () => {
+                test.array = ['a', 'b', 3] as any;
+
+                expect(console.warn).toHaveBeenCalledWith(expect.stringMatching(/cannot be set to/));
+                expect(test.array).toBe(undefined);
+            });
+        });
+
+        describe('COLOUR_STRING', () => {
+            it('should not set TestValidate.colour to undefined with warning', () => {
+                (test as any).colour = undefined;
+
+                expect(console.warn).toHaveBeenCalledWith(expect.stringMatching(/cannot be set to/));
+                expect(test.colour).toBe('black');
+            });
+
+            it('should not set TestValidate.colour to null with warning', () => {
+                (test as any).colour = null;
+
+                expect(console.warn).toHaveBeenCalledWith(expect.stringMatching(/cannot be set to/));
+                expect(test.colour).toBe('black');
+            });
+
+            it('should not set TestValidate.colour to an invalid value with warning', () => {
+                test.colour = 'rainbow-unicorn';
+                test.colour = 'rgb(ha, ha, ha)';
+                test.colour = '#hahahaha';
+
+                expect(console.warn).toHaveBeenCalledWith(expect.stringMatching(/cannot be set to/));
+                expect(test.colour).toBe('black');
+            });
+
+            it('should set TestValidate.colour to a valid value without warning', () => {
+                test.colour = '#fff';
+                test.colour = '#ffffff';
+                test.colour = '#ffffffff';
+                test.colour = 'rgb(0, 0, 0)';
+                test.colour = 'rgba(0, 0, 0, 0)';
+
+                expect(console.warn).not.toBeCalled();
+                expect(test.colour).toBe('rgba(0, 0, 0, 0)');
+            });
+        });
+    });
+
+    describe('complex validations', () => {
+        describe('AND', () => {
+            it('should not set TestValidate.min to an invalid number', () => {
+                test.min = 'a' as any;
+                test.min = new Date() as any;
+                test.min = [] as any;
+                test.min = -1;
+
+                expect(console.warn).toHaveBeenCalledWith(expect.stringMatching(/cannot be set to/));
+                expect(test.min).toBe(0);
+            });
+
+            it('should not set TestValidate.max to an invalid number', () => {
+                test.max = 'a' as any;
+                test.max = new Date() as any;
+                test.max = [] as any;
+                test.max = 101;
+
+                expect(console.warn).toHaveBeenCalledWith(expect.stringMatching(/cannot be set to/));
+                expect(test.max).toBe(100);
+            });
+
+            describe('with LESS_THAN', () => {
+                it('should not set TestValidate.min to a value > max', () => {
+                    test.min = Infinity;
+                    test.min = 101;
+
+                    expect(console.warn).toHaveBeenCalledWith(expect.stringMatching(/cannot be set to/));
+                    expect(test.min).toBe(0);
+                });
+
+                it('should not set TestValidate.min to a value === max', () => {
+                    test.min = test.max;
+
+                    expect(console.warn).toHaveBeenCalledWith(expect.stringMatching(/cannot be set to/));
+                    expect(test.min).toBe(0);
+                });
+
+                it('should set TestValidate.min to a value < max', () => {
+                    test.min = 5;
+                    test.min = 99;
+
+                    expect(console.warn).not.toHaveBeenCalled();
+                    expect(test.min).toBe(99);
+                });
+            });
+
+            describe('with GREATER_THAN', () => {
+                it('should not set TestValidate.max to a value < min', () => {
+                    test.max = Infinity;
+                    test.max = -1;
+
+                    expect(console.warn).toHaveBeenCalledWith(expect.stringMatching(/cannot be set to/));
+                    expect(test.max).toBe(100);
+                });
+
+                it('should not set TestValidate.max to a value === min', () => {
+                    test.max = test.min;
+
+                    expect(console.warn).toHaveBeenCalledWith(expect.stringMatching(/cannot be set to/));
+                    expect(test.max).toBe(100);
+                });
+
+                it('should set TestValidate.max to a value > min', () => {
+                    test.max = 99;
+                    test.max = 1;
+
+                    expect(console.warn).not.toHaveBeenCalled();
+                    expect(test.max).toBe(1);
+                });
+            });
+        });
+    });
+});

--- a/charts-packages/ag-charts-community/src/util/validation.ts
+++ b/charts-packages/ag-charts-community/src/util/validation.ts
@@ -1,7 +1,8 @@
 import { Color } from './color';
 import { SceneChangeDetection, SceneChangeDetectionOptions } from '../scene/changeDetectable';
+type ValidationContext = { target: any };
 export type ValidatePredicate = {
-    (v: any, additionalPredicate?: (v: any) => boolean): boolean;
+    (v: any, ctx: ValidationContext): boolean;
     message?: string;
 };
 
@@ -15,7 +16,7 @@ export function Validate(predicate: ValidatePredicate) {
         prevSet = descriptor?.set;
 
         const setter = function (v: any) {
-            if (predicate(v)) {
+            if (predicate(v, { target: this })) {
                 if (prevSet) {
                     prevSet.call(this, v);
                 } else {
@@ -53,33 +54,64 @@ export function predicateWithMessage(predicate: ValidatePredicate, message: stri
     return predicate;
 }
 
-export const OPTIONAL = (v: any, predicate: ValidatePredicate) => v === undefined || predicate(v);
+export const OPTIONAL = (v: any, ctx: ValidationContext, predicate: ValidatePredicate) =>
+    v === undefined || predicate(v, ctx);
 
-export const ARRAY = (length?: number) => {
+export const ARRAY = (length?: number, predicate?: ValidatePredicate) => {
     return predicateWithMessage(
-        (v: any, predicate?: ValidatePredicate) =>
+        (v: any, ctx) =>
             Array.isArray(v) &&
             (length ? v.length === length : true) &&
-            (predicate ? v.every((e) => predicate(e)) : true),
+            (predicate ? v.every((e) => predicate(e, ctx)) : true),
         `expecting an Array`
     );
 };
 export const OPT_ARRAY = (length?: number) => {
-    return predicateWithMessage((v: any) => OPTIONAL(v, ARRAY(length)), 'expecting an optional Array');
+    return predicateWithMessage((v: any, ctx) => OPTIONAL(v, ctx, ARRAY(length)), 'expecting an optional Array');
 };
 
+export const AND = (...predicates: ValidatePredicate[]) => {
+    return predicateWithMessage(
+        (v: any, ctx) => predicates.every((p) => p(v, ctx)),
+        predicates
+            .map((p) => p.message)
+            .filter((m) => m != null)
+            .join(' AND ')
+    );
+};
+
+export const LESS_THAN = (otherField: string) =>
+    predicateWithMessage(
+        (v: number | Date, ctx) => ctx.target[otherField] == null || v < ctx.target[otherField],
+        `expected to be less than ${otherField}`
+    );
+export const GREATER_THAN = (otherField: string) =>
+    predicateWithMessage(
+        (v: number | Date, ctx) => ctx.target[otherField] == null || v > ctx.target[otherField],
+        `expected to be less than ${otherField}`
+    );
+
 export const FUNCTION = predicateWithMessage((v: any) => typeof v === 'function', 'expecting a Function');
-export const OPT_FUNCTION = predicateWithMessage((v: any) => OPTIONAL(v, FUNCTION), `expecting an optional Function`);
+export const OPT_FUNCTION = predicateWithMessage(
+    (v: any, ctx) => OPTIONAL(v, ctx, FUNCTION),
+    `expecting an optional Function`
+);
 
 export const BOOLEAN = predicateWithMessage((v: any) => v === true || v === false, 'expecting a Boolean');
-export const OPT_BOOLEAN = predicateWithMessage((v: any) => OPTIONAL(v, BOOLEAN), 'expecting an optional Boolean');
+export const OPT_BOOLEAN = predicateWithMessage(
+    (v: any, ctx) => OPTIONAL(v, ctx, BOOLEAN),
+    'expecting an optional Boolean'
+);
 
 export const STRING = predicateWithMessage((v: any) => typeof v === 'string', 'expecting a String');
-export const OPT_STRING = predicateWithMessage((v: any) => OPTIONAL(v, STRING), 'expecting an optional String');
+export const OPT_STRING = predicateWithMessage(
+    (v: any, ctx) => OPTIONAL(v, ctx, STRING),
+    'expecting an optional String'
+);
 
 export const DATE = predicateWithMessage((v: any) => v instanceof Date && !isNaN(+v), 'expecting a Date object');
-export const OPT_DATE = predicateWithMessage((v: any) => OPTIONAL(v, DATE), 'expecting an optional Date');
-export const DATE_ARRAY = predicateWithMessage((v: any) => ARRAY()(v, DATE), 'expecting an Array of Date objects');
+export const OPT_DATE = predicateWithMessage((v: any, ctx) => OPTIONAL(v, ctx, DATE), 'expecting an optional Date');
+export const DATE_ARRAY = predicateWithMessage(ARRAY(undefined, DATE), 'expecting an Array of Date objects');
 
 const colorMessage = `A color string can be in one of the following formats to be valid: #rgb, #rrggbb, rgb(r, g, b), rgba(r, g, b, a) or a CSS color name such as 'white', 'orange', 'cyan', etc`;
 
@@ -91,16 +123,16 @@ export const COLOR_STRING = predicateWithMessage((v: any) => {
     return Color.validColorString(v);
 }, `expecting a color String. ${colorMessage}`);
 export const OPT_COLOR_STRING = predicateWithMessage(
-    (v: any) => OPTIONAL(v, COLOR_STRING),
+    (v: any, ctx) => OPTIONAL(v, ctx, COLOR_STRING),
     `expecting an optional color String. ${colorMessage}`
 );
 
 export const COLOR_STRING_ARRAY = predicateWithMessage(
-    (v: any) => ARRAY()(v, COLOR_STRING),
+    ARRAY(undefined, COLOR_STRING),
     `expecting an Array of color strings. ${colorMessage}`
 );
 export const OPT_COLOR_STRING_ARRAY = predicateWithMessage(
-    (v: any) => OPTIONAL(v, COLOR_STRING_ARRAY),
+    (v: any, ctx) => OPTIONAL(v, ctx, COLOR_STRING_ARRAY),
     `expecting an optional Array of color strings. ${colorMessage}`
 );
 
@@ -123,27 +155,24 @@ export function OPT_NUMBER(min?: number, max?: number) {
         (min !== undefined ? ', more than or equal to ' + min : '') +
         (max !== undefined ? ', less than or equal to ' + max : '')
     }`;
-    return predicateWithMessage((v: any) => OPTIONAL(v, NUMBER(min, max)), message);
+    return predicateWithMessage((v: any, ctx) => OPTIONAL(v, ctx, NUMBER(min, max)), message);
 }
 
-export const NUMBER_ARRAY = predicateWithMessage((v: any) => ARRAY()(v, NUMBER()), 'expecting an Array of numbers');
+export const NUMBER_ARRAY = predicateWithMessage(ARRAY(undefined, NUMBER()), 'expecting an Array of numbers');
 export const OPT_NUMBER_ARRAY = predicateWithMessage(
-    (v: any) => OPTIONAL(v, NUMBER_ARRAY),
+    (v: any, ctx) => OPTIONAL(v, ctx, NUMBER_ARRAY),
     'expecting an optional Array of numbers'
 );
 
-export const STRING_ARRAY = predicateWithMessage((v: any) => ARRAY()(v, STRING), 'expecting an Array of strings');
+export const STRING_ARRAY = predicateWithMessage(ARRAY(undefined, STRING), 'expecting an Array of strings');
 export const OPT_STRING_ARRAY = predicateWithMessage(
-    (v: any) => OPTIONAL(v, STRING_ARRAY),
+    (v: any, ctx) => OPTIONAL(v, ctx, STRING_ARRAY),
     'expecting an optional Array of strings'
 );
 
-export const BOOLEAN_ARRAY = predicateWithMessage(
-    (v: any) => ARRAY()(v, BOOLEAN),
-    'expecting an Array of boolean values'
-);
+export const BOOLEAN_ARRAY = predicateWithMessage(ARRAY(undefined, BOOLEAN), 'expecting an Array of boolean values');
 export const OPT_BOOLEAN_ARRAY = predicateWithMessage(
-    (v: any) => OPTIONAL(v, BOOLEAN_ARRAY),
+    (v: any, ctx) => OPTIONAL(v, ctx, BOOLEAN_ARRAY),
     'expecting an optional Array of boolean values'
 );
 
@@ -168,7 +197,7 @@ export const FONT_STYLE = predicateWithMessage(
     `expecting a font style keyword such as 'normal', 'italic' or 'oblique'`
 );
 export const OPT_FONT_STYLE = predicateWithMessage(
-    (v: any) => OPTIONAL(v, FONT_STYLE),
+    (v: any, ctx) => OPTIONAL(v, ctx, FONT_STYLE),
     `expecting an optional font style keyword such as 'normal', 'italic' or 'oblique'`
 );
 
@@ -177,16 +206,16 @@ export const FONT_WEIGHT = predicateWithMessage(
     `expecting a font weight keyword such as 'normal', 'bold' or 'bolder' or a numeric value such as 100, 300 or 600`
 );
 export const OPT_FONT_WEIGHT = predicateWithMessage(
-    (v: any) => OPTIONAL(v, FONT_WEIGHT),
+    (v: any, ctx) => OPTIONAL(v, ctx, FONT_WEIGHT),
     `expecting an optional font weight keyword such as 'normal', 'bold' or 'bolder' or a numeric value such as 100, 300 or 600`
 );
 
 export const LINE_DASH = predicateWithMessage(
-    (v: any) => ARRAY()(v, NUMBER(0)),
+    ARRAY(undefined, NUMBER(0)),
     'expecting an Array of numbers specifying the length in pixels of alternating dashes and gaps, for example, [6, 3] means dashes with a length of 6 pixels with gaps between of 3 pixels.'
 );
 export const OPT_LINE_DASH = predicateWithMessage(
-    (v: any) => OPTIONAL(v, LINE_DASH),
+    (v: any, ctx) => OPTIONAL(v, ctx, LINE_DASH),
     'expecting an optional Array of numbers specifying the length in pixels of alternating dashes and gaps, for example, [6, 3] means dashes with a length of 6 pixels with gaps between of 3 pixels.'
 );
 
@@ -196,7 +225,7 @@ export const LINE_CAP = predicateWithMessage(
     `expecting a line cap keyword such as 'butt', 'round' or 'square'`
 );
 export const OPT_LINE_CAP = predicateWithMessage(
-    (v: any) => OPTIONAL(v, LINE_CAP),
+    (v: any, ctx) => OPTIONAL(v, ctx, LINE_CAP),
     `expecting an optional line cap keyword such as 'butt', 'round' or 'square'`
 );
 
@@ -206,7 +235,7 @@ export const LINE_JOIN = predicateWithMessage(
     `expecting a line join keyword such as 'round', 'bevel' or 'miter'`
 );
 export const OPT_LINE_JOIN = predicateWithMessage(
-    (v: any) => OPTIONAL(v, LINE_JOIN),
+    (v: any, ctx) => OPTIONAL(v, ctx, LINE_JOIN),
     `expecting an optional line join keyword such as 'round', 'bevel' or 'miter'`
 );
 

--- a/charts-packages/ag-charts-community/src/util/validation.ts
+++ b/charts-packages/ag-charts-community/src/util/validation.ts
@@ -80,15 +80,20 @@ export const AND = (...predicates: ValidatePredicate[]) => {
     );
 };
 
+const isComparable = (v: any) => {
+    return v != null && !isNaN(v);
+};
 export const LESS_THAN = (otherField: string) =>
     predicateWithMessage(
-        (v: number | Date, ctx) => ctx.target[otherField] == null || v < ctx.target[otherField],
+        (v: number | Date, ctx) =>
+            !isComparable(v) || !isComparable(ctx.target[otherField]) || v < ctx.target[otherField],
         `expected to be less than ${otherField}`
     );
 export const GREATER_THAN = (otherField: string) =>
     predicateWithMessage(
-        (v: number | Date, ctx) => ctx.target[otherField] == null || v > ctx.target[otherField],
-        `expected to be less than ${otherField}`
+        (v: number | Date, ctx) =>
+            !isComparable(v) || !isComparable(ctx.target[otherField]) || v > ctx.target[otherField],
+        `expected to be greater than ${otherField}`
     );
 
 export const FUNCTION = predicateWithMessage((v: any) => typeof v === 'function', 'expecting a Function');

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/doc-interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/doc-interfaces.AUTO.json
@@ -5094,5 +5094,6 @@
   "OffsetFn": {},
   "CountFn": {},
   "FieldFn": {},
+  "ValidationContext": {},
   "ValidatePredicate": {}
 }

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
@@ -3842,8 +3842,12 @@
     "meta": { "isTypeAlias": true },
     "type": "(date: Date) => number"
   },
+  "ValidationContext": {
+    "meta": { "isTypeAlias": true },
+    "type": "{ target: any; }"
+  },
   "ValidatePredicate": {
     "meta": { "isTypeAlias": true },
-    "type": "{ (v: any, additionalPredicate?: (v: any) => boolean): boolean; message?: string; }"
+    "type": "{ (v: any, ctx: ValidationContext): boolean; message?: string; }"
   }
 }


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-7298?focusedCommentId=44546

Adds:
- Cross-field validations (specifically for `min`/`max` validations).
- Unit-tests for the `validation.ts` module.

Side-note: I'm not 100% happy with the pattern we landed on for `OPTIONAL` (it's not very composition friendly), but let's circle back on this distinctly as the scope of this PR is already much larger than I'd like :-/