### PR TITLE
RTI-1072 Hide Doughnut inner circle when no data

### DIFF
--- a/charts-packages/ag-charts-community/src/chart/series/polar/pieSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/polar/pieSeries.ts
@@ -692,6 +692,7 @@ export class PieSeries extends PolarSeries<PieNodeDatum> {
 
         const isVisible = this.seriesItemEnabled.indexOf(true) >= 0;
         this.group.visible = isVisible;
+        this.backgroundGroup.visible = isVisible;
         this.seriesGroup.visible = isVisible;
         this.highlightGroup.visible = isVisible && this.chart?.highlightedDatum?.series === this;
         this.labelGroup!.visible = isVisible;


### PR DESCRIPTION
The circle was still visible when all data was hidden through legend.