### PR TITLE
RTI-1074 Hide doughnut inner circle when radius <0

### DIFF
--- a/charts-packages/ag-charts-community/src/chart/series/polar/pieSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/polar/pieSeries.ts
@@ -594,7 +594,7 @@ export class PieSeries extends PolarSeries<PieNodeDatum> {
     private getInnerRadius() {
         const { radius, innerRadiusRatio, innerRadiusOffset } = this;
         const innerRadius = radius * (innerRadiusRatio ?? 1) + (innerRadiusOffset ? innerRadiusOffset : 0);
-        if (innerRadius === radius) {
+        if (innerRadius === radius || innerRadius < 0) {
             return 0;
         }
         return innerRadius;
@@ -603,6 +603,9 @@ export class PieSeries extends PolarSeries<PieNodeDatum> {
     private getOuterRadius() {
         const { radius, outerRadiusRatio, outerRadiusOffset } = this;
         const outerRadius = radius * (outerRadiusRatio ?? 1) + (outerRadiusOffset ? outerRadiusOffset : 0);
+        if (outerRadius < 0) {
+            return 0;
+        }
         return outerRadius;
     }
 


### PR DESCRIPTION
When the chart's radius appears to be less than the `innerRadiusOffset`, the doughnut inner circle should be hidden.

In future we should warn when outer radius is smaller than inner radius or less than 0.