### PR TITLE
AG-7290 Fixed warnings in Integrated docs

### DIFF
--- a/enterprise-modules/charts/src/charts/chartComp/chartProxies/polar/pieChartProxy.ts
+++ b/enterprise-modules/charts/src/charts/chartComp/chartProxies/polar/pieChartProxy.ts
@@ -152,9 +152,9 @@ export class PieChartProxy extends ChartProxy {
                 ...deepMerge({}, primaryOpts),
                 radiusKey: angleKey + '-filtered-out',
                 calloutLabel: seriesOverrides.calloutLabel, // labels can be shown on the 'filtered-out' series
-                calloutLine: {
-                    ...seriesOverrides.calloutLabel,
-                    colors: seriesOverrides.calloutLabel.colors ?? palette.strokes,
+                calloutLine: seriesOverrides.calloutLine && {
+                    ...seriesOverrides.calloutLine,
+                    colors: seriesOverrides.calloutLine.colors ?? palette.strokes,
                 },
                 fills: changeOpacity(seriesOptions.fills ?? palette.fills, 0.3),
                 strokes: changeOpacity(seriesOptions.strokes ?? palette.strokes, 0.3),

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/integrated-charts-api-cross-filter-chart/examples/sales-dashboard/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/integrated-charts-api-cross-filter-chart/examples/sales-dashboard/main.ts
@@ -116,7 +116,7 @@ function createSalesByRefChart(gridApi: GridApi) {
           title: {
             enabled: false,
           },
-          label: {
+          calloutLabel: {
             enabled: false,
           },
         },


### PR DESCRIPTION
- Fixed assigning wrong properties to calloutLine.
- Renamed deprecated property in example.