### PR TITLE
AG-5296 Excel export customisation docs

### DIFF
--- a/community-modules/core/src/ts/columns/columnApi.ts
+++ b/community-modules/core/src/ts/columns/columnApi.ts
@@ -32,7 +32,7 @@ export class ColumnApi {
     /** Returns the display name for a column. Useful if you are doing your own header rendering and want the grid to work out if `headerValueGetter` is used, or if you are doing your own column management GUI, to know what to show as the column name. */
     public getDisplayNameForColumn(column: Column, location: string | null): string { return this.columnModel.getDisplayNameForColumn(column, location) || ''; }
     /** Returns the display name for a column group (when grouping columns). */
-    public getDisplayNameForColumnGroup(columnGroup: ColumnGroup, location: string): string { return this.columnModel.getDisplayNameForColumnGroup(columnGroup, location) || ''; }
+    public getDisplayNameForColumnGroup(columnGroup: ColumnGroup, location: string | null): string { return this.columnModel.getDisplayNameForColumnGroup(columnGroup, location) || ''; }
 
     /** Returns the column with the given `colKey`, which can either be the `colId` (a string) or the `colDef` (an object). */
     public getColumn(key: any): Column | null { return this.columnModel.getPrimaryColumn(key); }

--- a/community-modules/core/src/ts/columns/columnModel.ts
+++ b/community-modules/core/src/ts/columns/columnModel.ts
@@ -2603,7 +2603,7 @@ export class ColumnModel extends BeanStub {
     public getDisplayNameForProvidedColumnGroup(
         columnGroup: ColumnGroup | null,
         providedColumnGroup: ProvidedColumnGroup | null,
-        location: string
+        location: string | null
     ): string | null {
         const colGroupDef = providedColumnGroup ? providedColumnGroup.getColGroupDef() : null;
 
@@ -2614,7 +2614,7 @@ export class ColumnModel extends BeanStub {
         return null;
     }
 
-    public getDisplayNameForColumnGroup(columnGroup: ColumnGroup, location: string): string | null {
+    public getDisplayNameForColumnGroup(columnGroup: ColumnGroup, location: string | null): string | null {
         return this.getDisplayNameForProvidedColumnGroup(columnGroup, columnGroup.getProvidedColumnGroup(), location);
     }
 

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/column-api/column-api.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/column-api/column-api.AUTO.json
@@ -37,7 +37,10 @@
   "getDisplayNameForColumnGroup": {
     "description": "/** Returns the display name for a column group (when grouping columns). */",
     "type": {
-      "arguments": { "columnGroup": "ColumnGroup", "location": "string" },
+      "arguments": {
+        "columnGroup": "ColumnGroup",
+        "location": "string | null"
+      },
       "returnType": "string"
     }
   },

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/excel-export-extra-content/examples/excel-export-customisation/index.html
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/excel-export-extra-content/examples/excel-export-customisation/index.html
@@ -1,0 +1,8 @@
+<div class="container">
+    <div>
+        <button onclick="onBtExport()" style="margin: 5px 0px; font-weight: bold;">Export to Excel</button>
+    </div>
+    <div class="grid-wrapper">
+        <div id="myGrid" class="ag-theme-alpine"></div>
+    </div>
+</div>

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/excel-export-extra-content/examples/excel-export-customisation/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/excel-export-extra-content/examples/excel-export-customisation/main.ts
@@ -1,0 +1,75 @@
+import {
+  ExcelExportParams,
+  Grid,
+  GridOptions,
+  ProcessCellForExportParams,
+  ProcessGroupHeaderForExportParams,
+  ProcessHeaderForExportParams,
+  ProcessRowGroupForExportParams,
+} from "@ag-grid-community/core"
+
+const gridOptions: GridOptions<IOlympicData> = {
+  columnDefs: [
+    {
+      headerName: 'Athlete details',
+      children: [
+        { field: "athlete", minWidth: 200 },
+        { field: "country", minWidth: 200, rowGroup: true, hide: true },
+        { field: "sport", minWidth: 150 },
+      ]
+    },
+    {
+      headerName: 'Medal results',
+      children: [
+        { field: "gold" },
+        { field: "silver" },
+        { field: "bronze" },
+        { field: "total" },
+      ]
+    }
+  ],
+
+  defaultColDef: {
+    sortable: true,
+    filter: true,
+    resizable: true,
+    minWidth: 100,
+    flex: 1,
+  },
+
+  popupParent: document.body,
+}
+
+const getParams: () => ExcelExportParams = () => ({
+  processCellCallback(params: ProcessCellForExportParams): string {
+    const value = params.value
+    return value === undefined ? '' : `_${value}_`
+  },
+  processHeaderCallback({ columnApi, column }: ProcessHeaderForExportParams): string {
+    return `header: ${columnApi.getDisplayNameForColumn(column, null)}`
+  },
+  processGroupHeaderCallback({ columnApi, columnGroup }: ProcessGroupHeaderForExportParams): string {
+    return `group header: ${columnApi.getDisplayNameForColumnGroup(columnGroup, null)}`
+  },
+  processRowGroupCallback(params: ProcessRowGroupForExportParams): string {
+    return `row group: ${params.node.key}`
+  },
+})
+
+function onBtExport() {
+  gridOptions.api!.exportDataAsExcel(getParams())
+}
+
+// setup the grid after the page has finished loading
+document.addEventListener("DOMContentLoaded", () => {
+  const gridDiv = document.querySelector<HTMLElement>("#myGrid")!
+  new Grid(gridDiv, gridOptions)
+
+  fetch("https://www.ag-grid.com/example-assets/small-olympic-winners.json")
+    .then(response => response.json())
+    .then(data =>
+      gridOptions.api!.setRowData(
+        data.filter((rec: any) => rec.country != null)
+      )
+    )
+})

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/excel-export-extra-content/examples/excel-export-customisation/styles.css
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/excel-export-extra-content/examples/excel-export-customisation/styles.css
@@ -1,0 +1,32 @@
+
+.details > label {
+    margin-bottom: 10px;
+}
+.details > label:first-of-type {
+    margin-top: 10px;
+}
+.details > label:last-of-type {
+    margin-bottom: 0;
+}
+.option {
+    display: block;
+    margin: 5px 10px 5px 0;
+}
+.grid-wrapper {
+    display: flex;
+    flex: 1 1 0px;
+}
+.grid-wrapper > div {
+    width: 100%;
+    height: 100%;
+}
+.container {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+}
+.columns {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+}

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/excel-export-extra-content/index.md
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/excel-export-extra-content/index.md
@@ -50,6 +50,35 @@ In addition to exporting the Grid in the Excel file, you can also provide additi
 
 <grid-example title='Excel Export - Cover Page' name='excel-export-cover-page' type='generated' options='{ "enterprise": true, "modules": ["clientside", "csv", "excel", "menu", "setfilter"]}'></grid-example>
 
+## Export Customisation
+
+The Excel export can be customised using the following function params for `exportDataAsExcel`:
+
+<snippet>
+gridOptions.api.exportDataAsExcel({
+    processCellCallback: () => {},
+    processHeaderCallback: () => {},
+    processGroupHeaderCallback: () => {},
+    processRowGroupCallback: () => {},
+})
+</snippet>
+
+<api-documentation source='grid-api/api.json' config='{"isApi": true}' section='export' names='["exportDataAsExcel"]'></api-documentation>
+
+<interface-documentation interfaceName='ExcelExportParams' names='["exportDataAsExcel", "processGroupHeaderCallback", "processHeaderCallback", "processRowGroupCallback", "processCellCallback"]' ></interface-documentation>
+
+The following example shows Excel customisations where the exported document has the following:
+
+* Group headers with the prefix `group header: `
+* Headers with the prefix `header: `
+* All row groups with the prefix `row group: `
+* All cell values are surrounded by `_`, unless they are `undefined`, in which case they are empty
+
+[[note]]
+| Row groups are also cells, so will also have the `_` surrounding the value, whereas group headers and headers are not.
+
+<grid-example title='Excel Export - Customisation' name='excel-export-customisation' type='generated' options='{ "enterprise": true, "modules": ["clientside", "rowgrouping", "csv", "excel", "menu", "setfilter"]}'></grid-example>
+
 ## Next Up
 
 Continue to the next section: [Images](../excel-export-images/).


### PR DESCRIPTION
## Changes

* Allow `getDisplayNameForColumnGroup` location to be null. Just like `getDisplayNameForColumn`
* Add excel export customisation docs at `/javascript-data-grid/excel-export-extra-content/#export-customisation`

## Screenshots

![Screenshot 2022-10-12 at 11 14 38 am](https://user-images.githubusercontent.com/79451/195316591-b2054f7d-e287-48ef-87bd-5fc499211a8d.png)
