### PR TITLE
UndoRedoService Type Error

### DIFF
--- a/community-modules/core/src/ts/undoRedo/undoRedoService.ts
+++ b/community-modules/core/src/ts/undoRedo/undoRedoService.ts
@@ -163,7 +163,7 @@ export class UndoRedoService extends BeanStub {
             const extractedValue = valueExtractor(cellValueChange);
 
             // when values are 'complex objects' we need to invoke their `toString()` to obtain value
-            const value = (typeof extractedValue.toString === 'function') ? extractedValue.toString() : extractedValue;
+            const value = (typeof extractedValue?.toString === 'function') ? extractedValue.toString() : extractedValue;
 
             currentRow!.setDataValue(columnId, value);
         });


### PR DESCRIPTION
Since version 28.2.0 a type error occures, when trying to undo a change with an undefined oldValue.
`ERROR TypeError: extractedValue is undefined`

This pull requests adds a check for undefined or null values.

**Providing a Reproducible Scenario**
plunkr: https://plnkr.co/edit/nIVmfzwOK0rl5Bwe?open=main.js&preview
Steps to reproduce:
1. Fill a cell in the first row with a random value.
2. Try to undo the change using CTRL-Z
**Current behavior**
The change does not get removed.

**Expected behavior (v 28.1.0)**
plunkr: https://plnkr.co/edit/1RsGrF0VmkAOsq0e?open=main.js&preview
The change gets removed correctly.
