### PR TITLE
AG-7336 - Area series missing data docs example

### DIFF
--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-area-series/examples/missing-data-area/data.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-area-series/examples/missing-data-area/data.ts
@@ -1,0 +1,70 @@
+export function getData() {
+  return [
+    {
+      year: new Date("2009"),
+      ie: 64.97,
+      firefox: 26.85,
+      chrome: 1.37,
+    },
+    {
+      year: new Date("2010"),
+      ie: 54.39,
+      firefox: 31.15,
+      chrome: 5.94,
+    },
+    {
+      year: new Date("2011"),
+      ie: 44.03,
+      firefox: 29.36,
+      chrome: 15.01,
+    },
+    {
+      year: new Date("2012"),
+      ie: 34.27,
+      firefox: 22.69,
+      chrome: 25.99,
+    },
+    {
+      year: new Date("2013"),
+      ie: 26.55,
+      firefox: 18.55,
+      chrome: 31.71,
+    },
+    {
+      year: new Date("2014"),
+      ie: 17.75,
+      firefox: 14.77,
+      chrome: 35.85,
+    },
+    {
+      year: new Date("2015"),
+      ie: 13.3,
+      firefox: 11.82,
+      chrome: 42.27,
+    },
+    {
+      year: new Date("2016"),
+      ie: 8.94,
+      firefox: 8.97,
+      chrome: 47.79,
+    },
+    {
+      year: new Date("2017"),
+      ie: 4.77,
+      firefox: 6.75,
+      chrome: 51.76,
+    },
+    {
+      year: new Date("2018"),
+      ie: 3.2,
+      firefox: 5.66,
+      chrome: 56.31,
+    },
+    {
+      year: new Date("2019"),
+      ie: 2.7,
+      firefox: 4.66,
+      chrome: 61.72,
+    },
+  ]
+}

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-area-series/examples/missing-data-area/index.html
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-area-series/examples/missing-data-area/index.html
@@ -1,0 +1,14 @@
+<div class="wrapper">
+    <div id="toolPanel">
+        <button onclick="missingYValues()">Missing Y Values</button>
+        <button onclick="missingXValues()">Missing X Values</button>
+    </div>
+    <div id="toolPanel">
+        <button onclick="stack()">Stack</button>
+        <button onclick="group()">Group</button>
+    </div>
+    <div id="toolPanel" style="position: absolute; top: 0; right: 0">
+        <button onclick="reset()">Reset</button>
+    </div>
+    <div id="myChart"></div>
+</div>

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-area-series/examples/missing-data-area/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-area-series/examples/missing-data-area/main.ts
@@ -1,0 +1,99 @@
+import * as agCharts from "ag-charts-community"
+import { AgAreaSeriesOptions, AgChartOptions } from "ag-charts-community"
+import { getData } from "./data"
+
+function buildSeries(name: string): AgAreaSeriesOptions {
+  return {
+    type: "area",
+    xKey: "year",
+    yKey: name.toLowerCase(),
+    yName: name,
+  }
+}
+
+const series = [
+  buildSeries("IE"),
+  buildSeries("Chrome"),
+  buildSeries("Firefox"),
+]
+
+const options: AgChartOptions = {
+  container: document.getElementById("myChart"),
+  theme: {
+    palette: {
+      fills: ["#141259", "#7E88BF", "#F2DCE0", "#8C7326"],
+      strokes: ["#141259", "#7E88BF", "#F2DCE0", "#8C7326"],
+    },
+    overrides: {
+      area: {
+        series: {
+          fillOpacity: 0.9,
+          marker: {
+            enabled: true,
+          },
+        },
+        legend: {
+          position: "bottom",
+        },
+      },
+    },
+  },
+  title: {
+    text: "Browser Usage Statistics",
+  },
+  subtitle: {
+    text: "2009-2019",
+  },
+  data: getData(),
+  series,
+  axes: [
+    {
+      position: "left",
+      type: "number",
+    },
+    {
+      position: "bottom",
+      type: "time",
+    },
+  ],
+}
+
+let chart = agCharts.AgChart.create(options)
+
+function missingYValues() {
+  const data = getData()
+  data[2].firefox = undefined
+  data[8].chrome = undefined
+
+  options.data = data
+
+  agCharts.AgChart.update(chart, options)
+}
+
+function missingXValues() {
+  const data = getData()
+
+  data[4].year = undefined
+  data[5].year = undefined
+  data[6].year = undefined
+
+  options.data = data
+
+  agCharts.AgChart.update(chart, options)
+}
+
+function stack() {
+  options.series = series.map(s => ({ ...s, stacked: true }))
+  agCharts.AgChart.update(chart, options)
+}
+
+function group() {
+  options.series = series.map(s => ({ ...s, stacked: false }))
+  agCharts.AgChart.update(chart, options)
+}
+
+function reset() {
+  options.data = getData()
+  options.series = series
+  agCharts.AgChart.update(chart, options)
+}

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-area-series/examples/missing-data-area/styles.css
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-area-series/examples/missing-data-area/styles.css
@@ -1,0 +1,22 @@
+.wrapper {
+    height: 100%;
+    display: flex;
+    position: relative;
+    flex-direction: column;
+}
+
+#toolPanel {
+    text-align: center;
+    font-family: Verdana, Geneva, Tahoma, sans-serif;
+    font-size: 13px;
+    margin-bottom: 5px;
+}
+
+.spacer {
+    display: inline-block;
+    min-width: 20px;
+}
+
+#myChart {
+    height: 100%;
+}

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-area-series/index.md
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-area-series/index.md
@@ -125,6 +125,27 @@ normalizedTo: 100
 
 <chart-example title='Normalized Stacked Area Series' name='normalized-area' type='generated'></chart-example>
 
+## Missing Data
+
+Sometimes data for certain items or time periods might be missing.
+
+If the `yKey` value of a data point is `+/-Infinity`, `null`, `undefined` or `NaN`, that data point will be rendered as a gap.
+
+If the bottom axis is also continuous, a `'time'` or `'number'` axis, rather than being rendered as a gap, invalid `xKey` values from the data will be skipped all together.
+
+[[note]]
+| For category X axes, the data can be any category value including number, object, `+/-Infinity`, `null`, `undefined` or `NaN`. In this case the data point will not be skipped, it will still be renered as a category along the X axis.
+
+The following example demonstrates how missing data is handled in Area Series:
+
+- Initially there is no missing data, all values are valid for their associated axes.
+- The first row of buttons at the top change the data to show the behaviour when Y values are missing compared to when X values are missing.
+- Missing Y values are rendered as a gap in the area whereas missing X values are skipped.
+- The second row of buttons allow switching between stacked and grouped area series.
+
+<chart-example title='Area Series with Incomplete Data' name='missing-data-area' type='generated'></chart-example>
+
+
 ## API Reference
 
 <interface-documentation interfaceName='AgAreaSeriesOptions' overridesrc="charts-api/api.json" config='{ "showSnippets": false }'></interface-documentation>


### PR DESCRIPTION
Pr for https://ag-grid.atlassian.net/browse/AG-7336

Added docs example in Area docs page to show handling of missing data.

Example has buttons to switch between missing X and missing Y values, as well as from grouped to stacked area series.
