### PR TITLE
AG-7412 - Add simple filter placeholder text colDef option

### DIFF
--- a/community-modules/core/src/ts/main.ts
+++ b/community-modules/core/src/ts/main.ts
@@ -105,7 +105,7 @@ export { FilterManager, FilterWrapper, FilterRequestSource } from "./filter/filt
 export { IMultiFilter, IMultiFilterModel, IMultiFilterComp, IMultiFilterParams, IMultiFilterDef } from './interfaces/iMultiFilter';
 
 export { ProvidedFilter, IProvidedFilter, IProvidedFilterParams } from "./filter/provided/providedFilter";
-export { ISimpleFilter, SimpleFilter, ISimpleFilterParams, ISimpleFilterModel, ICombinedSimpleModel, JoinOperator } from "./filter/provided/simpleFilter";
+export { ISimpleFilter, SimpleFilter, ISimpleFilterParams, ISimpleFilterModel, ICombinedSimpleModel, JoinOperator, IFilterPlaceholderFunctionParams, FilterPlaceholderFunction } from "./filter/provided/simpleFilter";
 export { ScalarFilter, IScalarFilterParams } from "./filter/provided/scalarFilter";
 
 export { NumberFilter, INumberFilterParams, NumberFilterModel } from "./filter/provided/number/numberFilter";

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/filter-provided-simple/examples/filter-placeholder-text/index.html
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/filter-provided-simple/examples/filter-placeholder-text/index.html
@@ -1,0 +1,1 @@
+<div id="myGrid" class="ag-theme-alpine" style="height: 100%;"></div>

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/filter-provided-simple/examples/filter-placeholder-text/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/filter-provided-simple/examples/filter-placeholder-text/main.ts
@@ -1,0 +1,54 @@
+import { Grid, GridOptions, IFilterPlaceholderFunctionParams } from '@ag-grid-community/core'
+
+const columnDefs = [
+  {
+    field: 'athlete'
+  },
+  {
+    field: 'country',
+    filter: 'agTextColumnFilter',
+    filterParams: {
+      filterPlaceholder: 'Country...'
+    }
+  },
+  {
+    field: 'sport',
+    filter: 'agTextColumnFilter',
+    filterParams: {
+      filterPlaceholder: (params: IFilterPlaceholderFunctionParams) => {
+        const { filterOptionKey, placeholder } = params;
+        return `${filterOptionKey} - ${placeholder}`;
+      }
+    },
+  },
+  {
+    field: 'total',
+    filter: 'agNumberColumnFilter',
+    filterParams: {
+      filterPlaceholder: (params: IFilterPlaceholderFunctionParams) => {
+        const { filterOption } = params;
+        return `${filterOption} total`;
+      }
+    }
+  }
+]
+
+const gridOptions: GridOptions<IOlympicData> = {
+  defaultColDef: {
+    flex: 1,
+    sortable: true,
+    filter: true,
+  },
+  columnDefs: columnDefs,
+  rowData: null,
+}
+
+// setup the grid after the page has finished loading
+document.addEventListener('DOMContentLoaded', function () {
+  const gridDiv = document.querySelector<HTMLElement>('#myGrid')!
+  new Grid(gridDiv, gridOptions)
+
+  fetch('https://www.ag-grid.com/example-assets/olympic-winners.json')
+    .then(response => response.json())
+    .then((data) => gridOptions.api!.setRowData(data))
+})

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/filter-provided-simple/index.md
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/filter-provided-simple/index.md
@@ -318,3 +318,44 @@ Each time a filter is applied to a column the CSS class `ag-header-cell-filtered
 In the example below, we've added some styling to `ag-header-cell-filtered`, so when you filter a column you will notice the column header change.
 
 <grid-example title='Style Header' name='style-header-on-filter' type='generated' options='{ "exampleHeight": 520 }'></grid-example>
+
+## Customising filter placeholder text
+
+Filter placeholder text can be customised on a per column basis using `filterParams.filterPlaceholder` within the grid option `columnDefs`. The placeholder can be either a string or a function as shown in the snippet below:
+
+<snippet>
+const gridOptions = {
+    columnDefs: [
+        {
+            field: 'age',
+            filter: 'agNumberColumnFilter',
+            filterParams: {
+                filterPlaceholder: 'Age...'
+            }
+        },
+        {
+            field: 'total',
+            filter: 'agNumberColumnFilter',
+            filterParams: {
+                filterPlaceholder: (params) => {
+                    const { filterOption, placeholder } = params;
+                    return `${filterOption} ${placeholder}`;
+                }
+            }
+        }
+    ]
+}
+</snippet>
+
+When `filterPlaceholder` is a function, the parameters are made up of the following:
+
+<interface-documentation interfaceName='IFilterPlaceholderFunctionParams' config='{"hideHeader":false, "headerLevel": 3, "description":""}'></interface-documentation>
+
+The following example shows the various ways of specifying filter placeholders. Click on the filter menu for the different columns in the header row to see the following:
+
+* `Athlete` column shows the default placeholder of `Filter...` with no configuration
+* `Country` column shows the string `Country...` for all filter options
+* `Sport` column shows the filter option key with the default placeholder eg, for the `Contains` filter option, it shows `contains - Filter...`. The [filter option keys](#simple-filter-options) are listed in the table above.
+* `Total` column shows the filter option name with the suffix `total` eg, for the `Equals` filter option, it shows `Equals total`. The [filter option names](#simple-filter-options) are listed in the table above.
+
+<grid-example title='Filter placeholder text' name='filter-placeholder-text' type='generated' options='{ "exampleHeight": 560 }'></grid-example>

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/doc-interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/doc-interfaces.AUTO.json
@@ -9689,6 +9689,13 @@
       "description": "/** By default, only one condition is shown, and a second is made visible once a first condition has been entered.\n * Set this to `true` to always show both conditions.\n * In this case the second condition will be disabled until a first condition has been entered.\n * Default: `false` */",
       "type": { "returnType": "boolean", "optional": true }
     },
+    "filterPlaceholder": {
+      "description": "/** Placeholder text for the filter textbox */",
+      "type": {
+        "returnType": "FilterPlaceholderFunction | string",
+        "optional": true
+      }
+    },
     "buttons": {
       "description": "/** Specifies the buttons to be shown in the filter, in the order they should be displayed in.\n * The options are:\n * \n *   - `'apply'`: If the Apply button is present, the filter is only applied after the user hits the Apply button.\n *   - `'clear'`: The Clear button will clear the (form) details of the filter without removing any active filters on the column.\n *   - `'reset'`: The Reset button will clear the details of the filter and any active filters on that column.\n *   - `'cancel'`: The Cancel button will discard any changes that have been made to the filter in the UI, restoring the applied model. */",
       "type": { "returnType": "FilterButtonType[]", "optional": true }
@@ -9832,6 +9839,13 @@
     "alwaysShowBothConditions": {
       "description": "/** By default, only one condition is shown, and a second is made visible once a first condition has been entered.\n * Set this to `true` to always show both conditions.\n * In this case the second condition will be disabled until a first condition has been entered.\n * Default: `false` */",
       "type": { "returnType": "boolean", "optional": true }
+    },
+    "filterPlaceholder": {
+      "description": "/** Placeholder text for the filter textbox */",
+      "type": {
+        "returnType": "FilterPlaceholderFunction | string",
+        "optional": true
+      }
     },
     "buttons": {
       "description": "/** Specifies the buttons to be shown in the filter, in the order they should be displayed in.\n * The options are:\n * \n *   - `'apply'`: If the Apply button is present, the filter is only applied after the user hits the Apply button.\n *   - `'clear'`: The Clear button will clear the (form) details of the filter without removing any active filters on the column.\n *   - `'reset'`: The Reset button will clear the details of the filter and any active filters on that column.\n *   - `'cancel'`: The Cancel button will discard any changes that have been made to the filter in the UI, restoring the applied model. */",
@@ -10069,6 +10083,13 @@
       "description": "/** By default, only one condition is shown, and a second is made visible once a first condition has been entered.\n * Set this to `true` to always show both conditions.\n * In this case the second condition will be disabled until a first condition has been entered.\n * Default: `false` */",
       "type": { "returnType": "boolean", "optional": true }
     },
+    "filterPlaceholder": {
+      "description": "/** Placeholder text for the filter textbox */",
+      "type": {
+        "returnType": "FilterPlaceholderFunction | string",
+        "optional": true
+      }
+    },
     "buttons": {
       "description": "/** Specifies the buttons to be shown in the filter, in the order they should be displayed in.\n * The options are:\n * \n *   - `'apply'`: If the Apply button is present, the filter is only applied after the user hits the Apply button.\n *   - `'clear'`: The Clear button will clear the (form) details of the filter without removing any active filters on the column.\n *   - `'reset'`: The Reset button will clear the details of the filter and any active filters on that column.\n *   - `'cancel'`: The Cancel button will discard any changes that have been made to the filter in the UI, restoring the applied model. */",
       "type": { "returnType": "FilterButtonType[]", "optional": true }
@@ -10203,6 +10224,21 @@
       }
     }
   },
+  "IFilterPlaceholderFunctionParams": {
+    "filterOptionKey": {
+      "description": "/** The filter option key */",
+      "type": { "returnType": "ISimpleFilterModelType", "optional": false }
+    },
+    "filterOption": {
+      "description": "/** The filter option name as localised text */",
+      "type": { "returnType": "string", "optional": false }
+    },
+    "placeholder": {
+      "description": "/** The default placeholder text */",
+      "type": { "returnType": "string", "optional": false }
+    }
+  },
+  "FilterPlaceholderFunction": {},
   "ISimpleFilterParams": {
     "filterOptions": {
       "description": "/** Array of filter options to present to the user. */",
@@ -10226,6 +10262,13 @@
     "alwaysShowBothConditions": {
       "description": "/** By default, only one condition is shown, and a second is made visible once a first condition has been entered.\n * Set this to `true` to always show both conditions.\n * In this case the second condition will be disabled until a first condition has been entered.\n * Default: `false` */",
       "type": { "returnType": "boolean", "optional": true }
+    },
+    "filterPlaceholder": {
+      "description": "/** Placeholder text for the filter textbox */",
+      "type": {
+        "returnType": "FilterPlaceholderFunction | string",
+        "optional": true
+      }
     },
     "buttons": {
       "description": "/** Specifies the buttons to be shown in the filter, in the order they should be displayed in.\n * The options are:\n * \n *   - `'apply'`: If the Apply button is present, the filter is only applied after the user hits the Apply button.\n *   - `'clear'`: The Clear button will clear the (form) details of the filter without removing any active filters on the column.\n *   - `'reset'`: The Reset button will clear the details of the filter and any active filters on that column.\n *   - `'cancel'`: The Cancel button will discard any changes that have been made to the filter in the UI, restoring the applied model. */",
@@ -10420,6 +10463,13 @@
     "alwaysShowBothConditions": {
       "description": "/** By default, only one condition is shown, and a second is made visible once a first condition has been entered.\n * Set this to `true` to always show both conditions.\n * In this case the second condition will be disabled until a first condition has been entered.\n * Default: `false` */",
       "type": { "returnType": "boolean", "optional": true }
+    },
+    "filterPlaceholder": {
+      "description": "/** Placeholder text for the filter textbox */",
+      "type": {
+        "returnType": "FilterPlaceholderFunction | string",
+        "optional": true
+      }
     },
     "buttons": {
       "description": "/** Specifies the buttons to be shown in the filter, in the order they should be displayed in.\n * The options are:\n * \n *   - `'apply'`: If the Apply button is present, the filter is only applied after the user hits the Apply button.\n *   - `'clear'`: The Clear button will clear the (form) details of the filter without removing any active filters on the column.\n *   - `'reset'`: The Reset button will clear the details of the filter and any active filters on that column.\n *   - `'cancel'`: The Cancel button will discard any changes that have been made to the filter in the UI, restoring the applied model. */",

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/interfaces.AUTO.json
@@ -5494,6 +5494,7 @@
       "defaultJoinOperator?": "JoinOperator",
       "suppressAndOrCondition?": "boolean",
       "alwaysShowBothConditions?": "boolean",
+      "filterPlaceholder?": "FilterPlaceholderFunction | string",
       "buttons?": "FilterButtonType[]",
       "closeOnApply?": "boolean",
       "debounceMs?": "number",
@@ -5525,6 +5526,7 @@
       "defaultJoinOperator?": "/** By default, the two conditions are combined using `AND`.\n * You can change this default by setting this property.\n * Options: `AND`, `OR` */",
       "suppressAndOrCondition?": "/** If `true`, the filter will only allow one condition.\n * Default: `false` */",
       "alwaysShowBothConditions?": "/** By default, only one condition is shown, and a second is made visible once a first condition has been entered.\n * Set this to `true` to always show both conditions.\n * In this case the second condition will be disabled until a first condition has been entered.\n * Default: `false` */",
+      "filterPlaceholder?": "/** Placeholder text for the filter textbox */",
       "buttons?": "/** Specifies the buttons to be shown in the filter, in the order they should be displayed in.\n * The options are:\n * \n *   - `'apply'`: If the Apply button is present, the filter is only applied after the user hits the Apply button.\n *   - `'clear'`: The Clear button will clear the (form) details of the filter without removing any active filters on the column.\n *   - `'reset'`: The Reset button will clear the details of the filter and any active filters on that column.\n *   - `'cancel'`: The Cancel button will discard any changes that have been made to the filter in the UI, restoring the applied model. */",
       "closeOnApply?": "/** If the Apply button is present, the filter popup will be closed immediately when the Apply\n * or Reset button is clicked if this is set to `true`.\n * \n * Default: `false` */",
       "debounceMs?": "/** Overrides the default debounce time in milliseconds for the filter. Defaults are:\n * - `TextFilter` and `NumberFilter`: 500ms. (These filters have text field inputs, so a short delay before the input is formatted and the filtering applied is usually appropriate).\n * - `DateFilter` and `SetFilter`: 0ms */",
@@ -5578,6 +5580,7 @@
       "defaultJoinOperator?": "JoinOperator",
       "suppressAndOrCondition?": "boolean",
       "alwaysShowBothConditions?": "boolean",
+      "filterPlaceholder?": "FilterPlaceholderFunction | string",
       "buttons?": "FilterButtonType[]",
       "closeOnApply?": "boolean",
       "debounceMs?": "number",
@@ -5606,6 +5609,7 @@
       "defaultJoinOperator?": "/** By default, the two conditions are combined using `AND`.\n * You can change this default by setting this property.\n * Options: `AND`, `OR` */",
       "suppressAndOrCondition?": "/** If `true`, the filter will only allow one condition.\n * Default: `false` */",
       "alwaysShowBothConditions?": "/** By default, only one condition is shown, and a second is made visible once a first condition has been entered.\n * Set this to `true` to always show both conditions.\n * In this case the second condition will be disabled until a first condition has been entered.\n * Default: `false` */",
+      "filterPlaceholder?": "/** Placeholder text for the filter textbox */",
       "buttons?": "/** Specifies the buttons to be shown in the filter, in the order they should be displayed in.\n * The options are:\n * \n *   - `'apply'`: If the Apply button is present, the filter is only applied after the user hits the Apply button.\n *   - `'clear'`: The Clear button will clear the (form) details of the filter without removing any active filters on the column.\n *   - `'reset'`: The Reset button will clear the details of the filter and any active filters on that column.\n *   - `'cancel'`: The Cancel button will discard any changes that have been made to the filter in the UI, restoring the applied model. */",
       "closeOnApply?": "/** If the Apply button is present, the filter popup will be closed immediately when the Apply\n * or Reset button is clicked if this is set to `true`.\n * \n * Default: `false` */",
       "debounceMs?": "/** Overrides the default debounce time in milliseconds for the filter. Defaults are:\n * - `TextFilter` and `NumberFilter`: 500ms. (These filters have text field inputs, so a short delay before the input is formatted and the filtering applied is usually appropriate).\n * - `DateFilter` and `SetFilter`: 0ms */",
@@ -5703,6 +5707,7 @@
       "defaultJoinOperator?": "JoinOperator",
       "suppressAndOrCondition?": "boolean",
       "alwaysShowBothConditions?": "boolean",
+      "filterPlaceholder?": "FilterPlaceholderFunction | string",
       "buttons?": "FilterButtonType[]",
       "closeOnApply?": "boolean",
       "debounceMs?": "number",
@@ -5729,6 +5734,7 @@
       "defaultJoinOperator?": "/** By default, the two conditions are combined using `AND`.\n * You can change this default by setting this property.\n * Options: `AND`, `OR` */",
       "suppressAndOrCondition?": "/** If `true`, the filter will only allow one condition.\n * Default: `false` */",
       "alwaysShowBothConditions?": "/** By default, only one condition is shown, and a second is made visible once a first condition has been entered.\n * Set this to `true` to always show both conditions.\n * In this case the second condition will be disabled until a first condition has been entered.\n * Default: `false` */",
+      "filterPlaceholder?": "/** Placeholder text for the filter textbox */",
       "buttons?": "/** Specifies the buttons to be shown in the filter, in the order they should be displayed in.\n * The options are:\n * \n *   - `'apply'`: If the Apply button is present, the filter is only applied after the user hits the Apply button.\n *   - `'clear'`: The Clear button will clear the (form) details of the filter without removing any active filters on the column.\n *   - `'reset'`: The Reset button will clear the details of the filter and any active filters on that column.\n *   - `'cancel'`: The Cancel button will discard any changes that have been made to the filter in the UI, restoring the applied model. */",
       "closeOnApply?": "/** If the Apply button is present, the filter popup will be closed immediately when the Apply\n * or Reset button is clicked if this is set to `true`.\n * \n * Default: `false` */",
       "debounceMs?": "/** Overrides the default debounce time in milliseconds for the filter. Defaults are:\n * - `TextFilter` and `NumberFilter`: 500ms. (These filters have text field inputs, so a short delay before the input is formatted and the filtering applied is usually appropriate).\n * - `DateFilter` and `SetFilter`: 0ms */",
@@ -5784,6 +5790,23 @@
       "onFloatingFilterChanged(type: string | null, value: any)": "/** Notification that a new floating-filter value was input by the user.\n * @param type operation type selected.\n * @param value model-typed value entered.\n */"
     }
   },
+  "IFilterPlaceholderFunctionParams": {
+    "meta": {},
+    "type": {
+      "filterOptionKey": "ISimpleFilterModelType",
+      "filterOption": "string",
+      "placeholder": "string"
+    },
+    "docs": {
+      "filterOptionKey": "/** The filter option key */",
+      "filterOption": "/** The filter option name as localised text */",
+      "placeholder": "/** The default placeholder text */"
+    }
+  },
+  "FilterPlaceholderFunction": {
+    "meta": { "isTypeAlias": true },
+    "type": "(params: IFilterPlaceholderFunctionParams) => string"
+  },
   "ISimpleFilterParams": {
     "meta": {},
     "type": {
@@ -5792,6 +5815,7 @@
       "defaultJoinOperator?": "JoinOperator",
       "suppressAndOrCondition?": "boolean",
       "alwaysShowBothConditions?": "boolean",
+      "filterPlaceholder?": "FilterPlaceholderFunction | string",
       "buttons?": "FilterButtonType[]",
       "closeOnApply?": "boolean",
       "debounceMs?": "number",
@@ -5813,6 +5837,7 @@
       "defaultJoinOperator?": "/** By default, the two conditions are combined using `AND`.\n * You can change this default by setting this property.\n * Options: `AND`, `OR` */",
       "suppressAndOrCondition?": "/** If `true`, the filter will only allow one condition.\n * Default: `false` */",
       "alwaysShowBothConditions?": "/** By default, only one condition is shown, and a second is made visible once a first condition has been entered.\n * Set this to `true` to always show both conditions.\n * In this case the second condition will be disabled until a first condition has been entered.\n * Default: `false` */",
+      "filterPlaceholder?": "/** Placeholder text for the filter textbox */",
       "buttons?": "/** Specifies the buttons to be shown in the filter, in the order they should be displayed in.\n * The options are:\n * \n *   - `'apply'`: If the Apply button is present, the filter is only applied after the user hits the Apply button.\n *   - `'clear'`: The Clear button will clear the (form) details of the filter without removing any active filters on the column.\n *   - `'reset'`: The Reset button will clear the details of the filter and any active filters on that column.\n *   - `'cancel'`: The Cancel button will discard any changes that have been made to the filter in the UI, restoring the applied model. */",
       "closeOnApply?": "/** If the Apply button is present, the filter popup will be closed immediately when the Apply\n * or Reset button is clicked if this is set to `true`.\n * \n * Default: `false` */",
       "debounceMs?": "/** Overrides the default debounce time in milliseconds for the filter. Defaults are:\n * - `TextFilter` and `NumberFilter`: 500ms. (These filters have text field inputs, so a short delay before the input is formatted and the filtering applied is usually appropriate).\n * - `DateFilter` and `SetFilter`: 0ms */",
@@ -5925,6 +5950,7 @@
       "defaultJoinOperator?": "JoinOperator",
       "suppressAndOrCondition?": "boolean",
       "alwaysShowBothConditions?": "boolean",
+      "filterPlaceholder?": "FilterPlaceholderFunction | string",
       "buttons?": "FilterButtonType[]",
       "closeOnApply?": "boolean",
       "debounceMs?": "number",
@@ -5950,6 +5976,7 @@
       "defaultJoinOperator?": "/** By default, the two conditions are combined using `AND`.\n * You can change this default by setting this property.\n * Options: `AND`, `OR` */",
       "suppressAndOrCondition?": "/** If `true`, the filter will only allow one condition.\n * Default: `false` */",
       "alwaysShowBothConditions?": "/** By default, only one condition is shown, and a second is made visible once a first condition has been entered.\n * Set this to `true` to always show both conditions.\n * In this case the second condition will be disabled until a first condition has been entered.\n * Default: `false` */",
+      "filterPlaceholder?": "/** Placeholder text for the filter textbox */",
       "buttons?": "/** Specifies the buttons to be shown in the filter, in the order they should be displayed in.\n * The options are:\n * \n *   - `'apply'`: If the Apply button is present, the filter is only applied after the user hits the Apply button.\n *   - `'clear'`: The Clear button will clear the (form) details of the filter without removing any active filters on the column.\n *   - `'reset'`: The Reset button will clear the details of the filter and any active filters on that column.\n *   - `'cancel'`: The Cancel button will discard any changes that have been made to the filter in the UI, restoring the applied model. */",
       "closeOnApply?": "/** If the Apply button is present, the filter popup will be closed immediately when the Apply\n * or Reset button is clicked if this is set to `true`.\n * \n * Default: `false` */",
       "debounceMs?": "/** Overrides the default debounce time in milliseconds for the filter. Defaults are:\n * - `TextFilter` and `NumberFilter`: 500ms. (These filters have text field inputs, so a short delay before the input is formatted and the filtering applied is usually appropriate).\n * - `DateFilter` and `SetFilter`: 0ms */",

--- a/grid-packages/ag-grid-enterprise/src/main.ts
+++ b/grid-packages/ag-grid-enterprise/src/main.ts
@@ -71,7 +71,7 @@ export { ISetFilter, SetFilterModel, ISetFilterParams, SetFilterValues, SetFilte
 export { FilterManager, FilterWrapper, FilterRequestSource } from "ag-grid-community";
 export { IMultiFilter, IMultiFilterModel, IMultiFilterComp, IMultiFilterParams, IMultiFilterDef } from "ag-grid-community";
 export { ProvidedFilter, IProvidedFilter, IProvidedFilterParams } from "ag-grid-community";
-export { ISimpleFilter, SimpleFilter, ISimpleFilterParams, ISimpleFilterModel, ICombinedSimpleModel, JoinOperator } from "ag-grid-community";
+export { ISimpleFilter, SimpleFilter, ISimpleFilterParams, ISimpleFilterModel, ICombinedSimpleModel, JoinOperator, IFilterPlaceholderFunctionParams, FilterPlaceholderFunction } from "ag-grid-community";
 export { ScalarFilter, IScalarFilterParams } from "ag-grid-community";
 export { NumberFilter, INumberFilterParams, NumberFilterModel } from "ag-grid-community";
 export { TextFilter, ITextFilterParams, TextFilterModel, TextFormatter } from "ag-grid-community";


### PR DESCRIPTION
## Changes

* Add simple filter placeholder text colDef option
* Add docs to `/javascript-data-grid/filter-provided-simple/#customising-filter-placeholder-text`

## Grid option change

Adding `columnDefs` > `filterParams.filterPlaceholder`

```
const gridOptions = {
    columnDefs: [
        {
            field: 'age',
            filter: 'agNumberColumnFilter',
            filterParams: {
                filterPlaceholder: 'Age...'
            }
        },
        {
            field: 'total',
            filter: 'agNumberColumnFilter',
            filterParams: {
                filterPlaceholder: (params) => {
                    const { filterOption, placeholder } = params;
                    return `${filterOption} ${placeholder}`;
                }
            }
        }
    ]
}
```