### PR TITLE
RTI-1094 Fixed CrossFilter click error

### DIFF
--- a/charts-packages/ag-charts-community/src/chart/chart.ts
+++ b/charts-packages/ag-charts-community/src/chart/chart.ts
@@ -987,8 +987,15 @@ export abstract class Chart extends Observable {
     }
 
     private onSeriesNodeClick(event: SourceEvent<Series<any>>) {
-        // Use `Object.create` to preserve deprecation warnings
-        const seriesNodeClickEvent = Object.create(event, { type: { value: 'seriesNodeClick', enumerable: true } });
+        const seriesNodeClickEvent = {
+            ...event,
+            type: 'seriesNodeClick',
+        };
+        Object.defineProperty(seriesNodeClickEvent, 'series', {
+            enumerable: false,
+            // Should display the deprecation warning
+            get: () => (event as any).series,
+        });
         this.fireEvent(seriesNodeClickEvent);
     }
 

--- a/charts-packages/ag-charts-community/src/util/observable.ts
+++ b/charts-packages/ag-charts-community/src/util/observable.ts
@@ -153,8 +153,7 @@ export class Observable {
         );
 
         if (listeners) {
-            // Use `Object.create` to preserve deprecation warnings
-            const eventWithSource = Object.create(event, { source: { value: this, enumerable: true } });
+            const eventWithSource = Object.assign(event, { source: this });
             listeners.forEach((scopes, listener) => {
                 scopes.forEach((scope) => listener.call(scope, eventWithSource));
             });

--- a/enterprise-modules/charts/src/charts/chartComp/chartProxies/cartesian/scatterChartProxy.ts
+++ b/enterprise-modules/charts/src/charts/chartComp/chartProxies/cartesian/scatterChartProxy.ts
@@ -138,7 +138,7 @@ export class ScatterChartProxy extends CartesianChartProxy {
                 listeners: {
                     ...series.listeners,
                     nodeClick: (e: any) => {
-                        const value = e.datum[e.series.xKey!];
+                        const value = e.datum[filteredOutKey(xKey!)];
 
                         // Need to remove the `-filtered-out` suffixes from the event so that
                         // upstream processing maps the event correctly onto grid column ids.


### PR DESCRIPTION
- The use of event.series is deprecated.
- Make the keys (except deprecated) enumerable in the fired event.