### PR TITLE
AG-7477 - Improve date formatting in Integrated time-axis examples.

### DIFF
--- a/grid-packages/ag-grid-docs/documentation/doc-pages/integrated-charts-time-series/examples/time-axis-config/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/integrated-charts-time-series/examples/time-axis-config/main.ts
@@ -39,19 +39,21 @@ const gridOptions: GridOptions = {
             format: '%H:%M',
           },
         },
-        category: {
-          label: {
-            rotation: 0,
-            formatter: (params) => {
-              return moment(new Date(params.value)).format('DD MMM')
-            },
-          },
-        },
         number: {
           label: {
             formatter: (params) => {
               return params.value + '%'
             },
+          },
+        },
+      },
+      series: {
+        tooltip: {
+          renderer: ({ xValue, yValue }) => {
+            xValue = xValue instanceof Date ? xValue : new Date(xValue);
+            return {
+              content: `${moment(xValue).format('HH:mm:ss')}: ${yValue}%`,
+            };
           },
         },
       },

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/integrated-charts-time-series/examples/time-combination-chart/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/integrated-charts-time-series/examples/time-combination-chart/main.ts
@@ -44,14 +44,6 @@ const gridOptions: GridOptions = {
             enabled: true
           }
         },
-        time: {
-          label: {
-            rotation: 45,
-            formatter: (params: AgAxisLabelFormatterParams) => {
-              return moment(new Date(params.value)).format('DD MMM')
-            },
-          },
-        },
       },
     },
     column: {

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/integrated-charts-time-series/examples/time-combination-chart/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/integrated-charts-time-series/examples/time-combination-chart/main.ts
@@ -1,10 +1,13 @@
 import {
   FirstDataRenderedEvent,
   Grid,
-  GridOptions, ValueParserParams
+  GridOptions,
+  ValueParserParams,
+  AgCartesianSeriesTooltipRendererParams,
+  AgAxisLabelFormatterParams,
 } from '@ag-grid-community/core';
 import { getData } from "./data";
-
+declare var moment: any;
 
 const gridOptions: GridOptions = {
   columnDefs: [
@@ -40,19 +43,33 @@ const gridOptions: GridOptions = {
           title: {
             enabled: true
           }
-        }
-      }
+        },
+        time: {
+          label: {
+            rotation: 45,
+            formatter: (params: AgAxisLabelFormatterParams) => {
+              return moment(new Date(params.value)).format('DD MMM')
+            },
+          },
+        },
+      },
     },
     column: {
       series: {
         strokeWidth: 2,
         fillOpacity: 0.8,
+        tooltip: {
+          renderer: chartTooltipRenderer,
+        },
       },
     },
     line: {
       series: {
         strokeWidth: 5,
         strokeOpacity: 0.8,
+        tooltip: {
+          renderer: chartTooltipRenderer,
+        },
       },
     },
   },
@@ -83,6 +100,12 @@ function numberParser(params: ValueParserParams) {
   return parseFloat(value);
 }
 
+function chartTooltipRenderer({ xValue, yValue }: AgCartesianSeriesTooltipRendererParams) {
+  xValue = xValue instanceof Date ? xValue : new Date(xValue);
+  return {
+    content: `${moment(xValue).format('DD MMM')}: ${yValue}`,
+  };
+}
 
 // set up the grid after the page has finished loading
 document.addEventListener('DOMContentLoaded', function () {

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/integrated-charts-time-series/examples/time-vs-category/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/integrated-charts-time-series/examples/time-vs-category/main.ts
@@ -59,6 +59,16 @@ const gridOptions: GridOptions = {
           },
         },
       },
+      series: {
+        tooltip: {
+          renderer: ({ xValue, yValue }) => {
+            xValue = xValue instanceof Date ? xValue : new Date(xValue);
+            return {
+              content: `${moment(xValue).format('DD MMM')}: ${Math.round(yValue)}°C`,
+            };
+          },
+        },
+      },
     },
   },
   getChartToolbarItems: getChartToolbarItems,

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/integrated-charts-time-series/index.md
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/integrated-charts-time-series/index.md
@@ -62,7 +62,7 @@ A time axis can also be used in combination charts as shown in the following exa
 
 For more details on how to configure a combination chart, see the [Range Chart API example](/integrated-charts-api-range-chart/#combination-charts).
 
-<grid-example title='Time Axis Combination Chart' name='time-combination-chart' type='generated' options='{ "enterprise": true, "modules": ["clientside", "menu", "charts", "rowgrouping"], "exampleHeight": 790 }'></grid-example>
+<grid-example title='Time Axis Combination Chart' name='time-combination-chart' type='generated' options='{ "enterprise": true, "modules": ["clientside", "menu", "charts", "rowgrouping"], "exampleHeight": 790, "extras": ["momentjs"] }'></grid-example>
 
 ## Next Up
 


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-7477

Attempts to improve Integrated Charts Time Axis example date formatting (primarily tooltip rendering) to guide users on the supported approach to formatting date/times in Integrated Charts.

The motivation for this is an incoming support request asking how to do this and referencing our time-axis examples as source of truth on how to manage time formatting.

**Time vs Category Axis Example**

Before:
![Screenshot 2022-11-03 at 09 41 59](https://user-images.githubusercontent.com/17544187/199689986-d1a4afce-05ab-405f-9902-7a4d8513698c.png)
![Screenshot 2022-11-03 at 09 41 31](https://user-images.githubusercontent.com/17544187/199690005-04235a20-3260-4cd5-97d5-7706215df15b.png)

After:
![Screenshot 2022-11-03 at 09 47 08](https://user-images.githubusercontent.com/17544187/199690144-b2813bea-c856-4817-8f05-861f9e25c54b.png)
![Screenshot 2022-11-03 at 09 47 17](https://user-images.githubusercontent.com/17544187/199690113-e2d8f733-04f6-4617-8b56-d832c2e96756.png)

**Time Axis Configuration Example**

Before:
![Screenshot 2022-11-03 at 09 49 38](https://user-images.githubusercontent.com/17544187/199691348-0a42dcec-670b-4c27-be3c-b62023f633a3.png)

After:
![Screenshot 2022-11-03 at 09 49 47](https://user-images.githubusercontent.com/17544187/199691382-2cfe2d78-5a87-42f9-a862-37ddc35b46ee.png)

**Time Axis Combination Chart**

Before:
![Screenshot 2022-11-03 at 09 52 49](https://user-images.githubusercontent.com/17544187/199691518-64df4b6f-3d70-4085-bb57-093df3484621.png)

After:
![Screenshot 2022-11-03 at 09 52 57](https://user-images.githubusercontent.com/17544187/199691552-7c08fe8e-a1f6-404f-bc29-8e465a572635.png)
