### PR TITLE
AG-5117 - Add pie sector label UI to integrated charts

### DIFF
--- a/enterprise-modules/charts/src/charts/chartComp/chartProxies/chartProxy.ts
+++ b/enterprise-modules/charts/src/charts/chartComp/chartProxies/chartProxy.ts
@@ -238,6 +238,13 @@ export abstract class ChartProxy {
                         bottom: 20,
                         left: 20,
                     }
+                },
+                pie: {
+                    series: {
+                        sectorLabel: {
+                            enabled: false,
+                        }
+                    }
                 }
             }
         };

--- a/enterprise-modules/charts/src/charts/chartComp/chartProxies/polar/pieChartProxy.ts
+++ b/enterprise-modules/charts/src/charts/chartComp/chartProxies/polar/pieChartProxy.ts
@@ -64,6 +64,7 @@ export class PieChartProxy extends ChartProxy {
                 type: this.standaloneChartType,
                 angleKey: f.colId,
                 angleName: f.displayName!,
+                sectorLabelKey: f.colId,
                 calloutLabelKey: params.category.id,
                 calloutLabelName: params.category.name,
             }

--- a/enterprise-modules/charts/src/charts/chartComp/menu/format/series/fontPanelParams.ts
+++ b/enterprise-modules/charts/src/charts/chartComp/menu/format/series/fontPanelParams.ts
@@ -6,7 +6,7 @@ interface InitFontPanelParams {
     labelName: string,
     chartOptionsService: ChartOptionsService,
     getSelectedSeries: () => ChartSeriesType,
-    seriesOptionLabelProperty: 'calloutLabel' | 'label'
+    seriesOptionLabelProperty: 'calloutLabel' | 'sectorLabel' | 'label'
 }
 
 export function initFontPanelParams({

--- a/enterprise-modules/charts/src/charts/chartComp/menu/format/series/fontPanelParams.ts
+++ b/enterprise-modules/charts/src/charts/chartComp/menu/format/series/fontPanelParams.ts
@@ -1,16 +1,23 @@
-import { ChartTranslationService } from "../../../services/chartTranslationService";
 import { Font, FontPanelParams } from "../fontPanel";
 import { ChartOptionsService } from "../../../services/chartOptionsService";
 import { ChartSeriesType } from "../../../utils/seriesTypeMapper";
 
-export function initFontPanelParams(
-    chartTranslationService: ChartTranslationService,
+interface InitFontPanelParams {
+    labelName: string,
     chartOptionsService: ChartOptionsService,
-    getSelectedSeries: () => ChartSeriesType) {
+    getSelectedSeries: () => ChartSeriesType,
+    seriesOptionLabelProperty: 'calloutLabel' | 'label'
+}
+
+export function initFontPanelParams({
+    labelName,
+    chartOptionsService,
+    getSelectedSeries,
+    seriesOptionLabelProperty
+}: InitFontPanelParams) {
 
     const getFontOptionExpression = (fontOption: string) => {
-        const labelProperty = getSelectedSeries() === 'pie' ? 'calloutLabel' : 'label';
-        return `${labelProperty}.${fontOption}`;
+        return `${seriesOptionLabelProperty}.${fontOption}`;
     };
     const getFontOption = <T = string>(fontOption: string) => {
         const expression = getFontOptionExpression(fontOption);
@@ -47,10 +54,8 @@ export function initFontPanelParams(
         }
     };
 
-
-
     const params: FontPanelParams = {
-        name: chartTranslationService.translate('labels'),
+        name: labelName,
         enabled: getFontOption('enabled') || false,
         setEnabled: (enabled: boolean) => setFontOption('enabled', enabled),
         suppressEnabledCheckbox: false,

--- a/enterprise-modules/charts/src/charts/chartComp/menu/format/series/seriesPanel.ts
+++ b/enterprise-modules/charts/src/charts/chartComp/menu/format/series/seriesPanel.ts
@@ -219,8 +219,14 @@ export class SeriesPanel extends Component {
     }
 
     private initLabels() {
-        const params = initFontPanelParams(this.chartTranslationService, this.chartOptionsService, () => this.seriesType);
-        const labelPanelComp = this.createBean(new FontPanel(params));
+        const seriesOptionLabelProperty = this.seriesType === 'pie' ? 'calloutLabel' : 'label';
+        const labelParams = initFontPanelParams({
+            labelName: this.chartTranslationService.translate('labels'),
+            chartOptionsService: this.chartOptionsService,
+            getSelectedSeries: () => this.seriesType,
+            seriesOptionLabelProperty
+        });
+        const labelPanelComp = this.createBean(new FontPanel(labelParams));
 
         if (this.seriesType === 'pie') {
             const calloutPanelComp = this.createBean(new CalloutPanel(this.chartOptionsService, () => this.seriesType));

--- a/enterprise-modules/charts/src/charts/chartComp/menu/format/series/seriesPanel.ts
+++ b/enterprise-modules/charts/src/charts/chartComp/menu/format/series/seriesPanel.ts
@@ -220,8 +220,11 @@ export class SeriesPanel extends Component {
 
     private initLabels() {
         const seriesOptionLabelProperty = this.seriesType === 'pie' ? 'calloutLabel' : 'label';
+        const labelName = this.seriesType === 'pie'
+            ? this.chartTranslationService.translate('calloutLabels')
+            : this.chartTranslationService.translate('labels');
         const labelParams = initFontPanelParams({
-            labelName: this.chartTranslationService.translate('labels'),
+            labelName,
             chartOptionsService: this.chartOptionsService,
             getSelectedSeries: () => this.seriesType,
             seriesOptionLabelProperty
@@ -235,6 +238,17 @@ export class SeriesPanel extends Component {
         }
 
         this.addWidget(labelPanelComp);
+
+        if (this.seriesType === 'pie') {
+            const sectorParams = initFontPanelParams({
+                labelName: this.chartTranslationService.translate('sectorLabels'),
+                chartOptionsService: this.chartOptionsService,
+                getSelectedSeries: () => this.seriesType,
+                seriesOptionLabelProperty: 'sectorLabel'
+            });
+            const sectorPanelComp = this.createBean(new FontPanel(sectorParams));
+            this.addWidget(sectorPanelComp);
+        }
     }
 
     private initShadow() {

--- a/enterprise-modules/charts/src/charts/chartComp/services/chartTranslationService.ts
+++ b/enterprise-modules/charts/src/charts/chartComp/services/chartTranslationService.ts
@@ -42,6 +42,8 @@ export class ChartTranslationService extends BeanStub {
         bottom: 'Bottom',
         left: 'Left',
         labels: 'Labels',
+        calloutLabels: 'Callout Labels',
+        sectorLabels: 'Sector Labels',
         size: 'Size',
         shape: 'Shape',
         minSize: 'Minimum Size',


### PR DESCRIPTION
## Changes

* Extend pie chart series labels to have sector labels 
  * Show sector labels on pie charts from grid values
  * Separate out callout labels and sector labels
  * Add font panel for sector labels
* Disable sector label by default in integrated charts

## Screenshots

<img width="761" alt="Screenshot 2022-11-04 at 11 52 48 am" src="https://user-images.githubusercontent.com/79451/199966400-8c394c80-adb7-48b2-a1c7-5cb5c5ea99ed.png">

## Grid options

UI for the `sectorLabel` grid options:

```
const gridOptions: GridOptions = {
  chartThemeOverrides: {
    pie: {
      series: {
        // Can update sector label here too
        sectorLabel: {
          enabled: true,
          fontSize: 20
        },
      },
    },
  },
}

```