### PR TITLE
AG-7381 - Fix case insensitive value handling in set filter

### DIFF
--- a/enterprise-modules/set-filter/src/setFilter/setValueModel.ts
+++ b/enterprise-modules/set-filter/src/setFilter/setValueModel.ts
@@ -61,6 +61,8 @@ export class SetValueModel implements IEventEmitter {
 
     private initialised: boolean = false;
 
+    private caseSensitive?: boolean;
+
     constructor(
         private readonly filterParams: ISetFilterParams,
         private readonly setIsLoading: (loading: boolean) => void,
@@ -85,12 +87,13 @@ export class SetValueModel implements IEventEmitter {
         this.doesRowPassOtherFilters = doesRowPassOtherFilter;
         this.suppressSorting = suppressSorting || false;
         this.comparator = comparator || colDef.comparator as (a: any, b: any) => number || _.defaultComparator;
+        this.caseSensitive = caseSensitive;
 
         if (rowModel.getType() === Constants.ROW_MODEL_TYPE_CLIENT_SIDE) {
             this.clientSideValuesExtractor = new ClientSideValuesExtractor(
                 rowModel as IClientSideRowModel,
                 this.filterParams,
-                this.caseFormat
+                value => this.uniqueKey(value)
             );
         }
 
@@ -228,7 +231,9 @@ export class SetValueModel implements IEventEmitter {
     }
 
     private updateAvailableValues(allValues: (string | null)[]): void {
-        const availableValues = this.showAvailableOnly() ? this.sortValues(this.getValuesFromRows(true)) : allValues;
+        // if case insensitive, we need to know the case from the original values
+        const uniqueValues = this.caseSensitive ? undefined : this.uniqueValues(allValues);
+        const availableValues = this.showAvailableOnly() ? this.sortValues(this.getValuesFromRows(true, uniqueValues)) : allValues;
 
         this.availableValues = _.convertToSet(availableValues);
         this.localEventService.dispatchEvent({ type: SetValueModel.EVENT_AVAILABLE_VALUES_CHANGED });
@@ -247,7 +252,7 @@ export class SetValueModel implements IEventEmitter {
         return values.filter(v => v != null)!.sort(this.comparator).concat(null);
     }
 
-    private getValuesFromRows(removeUnavailableValues = false): (string | null)[] {
+    private getValuesFromRows(removeUnavailableValues = false, uniqueValues?: { [key: string]: string | null }): (string | null)[] {
         if (!this.clientSideValuesExtractor) {
             console.error('AG Grid: Set Filter cannot initialise because you are using a row model that does not contain all rows in the browser. Either use a different filter type, or configure Set Filter such that you provide it with values');
             return [];
@@ -255,7 +260,7 @@ export class SetValueModel implements IEventEmitter {
 
         const predicate = (node: RowNode) => (!removeUnavailableValues || this.doesRowPassOtherFilters(node));
 
-        return this.clientSideValuesExtractor.extractUniqueValues(predicate);
+        return this.clientSideValuesExtractor.extractUniqueValues(predicate, uniqueValues);
     }
 
     /** Sets mini filter value. Returns true if it changed from last value, otherwise false. */


### PR DESCRIPTION
When we have multiple values that are the same except for a different case, the set filter list is created based off of the first value. If the first value is later filtered out, the value in the filter list no longer matches the value retrieved from the rows.

This change compares the values selected from the rows back against the original filter list to use the matching value with the same case.