### PR TITLE
AG-7502 - Simplify how integrated charts passes chart options and theme to standalone charts

### DIFF
--- a/charts-packages/ag-charts-community/src/chart/mapping/themes.ts
+++ b/charts-packages/ag-charts-community/src/chart/mapping/themes.ts
@@ -60,17 +60,3 @@ export function getChartTheme(value?: string | ChartTheme | AgChartTheme): Chart
 
     return lightTheme;
 }
-
-export function getIntegratedChartTheme(value?: string | ChartTheme | AgChartTheme): ChartTheme {
-    const theme = getChartTheme(value);
-    const themeConfig = theme.config;
-
-    for (const chartType in themeConfig) {
-        const axes = themeConfig[chartType].axes;
-        for (const axis in axes) {
-            delete axes[axis].crossLines;
-        }
-    }
-
-    return theme;
-}

--- a/charts-packages/ag-charts-community/src/integrated-charts-theme.ts
+++ b/charts-packages/ag-charts-community/src/integrated-charts-theme.ts
@@ -1,2 +1,2 @@
-export { getChartTheme, getIntegratedChartTheme, themes } from './chart/mapping/themes';
+export { getChartTheme, themes } from './chart/mapping/themes';
 export { ChartTheme } from './chart/themes/chartTheme';

--- a/community-modules/core/src/ts/utils/object.test.ts
+++ b/community-modules/core/src/ts/utils/object.test.ts
@@ -1,0 +1,20 @@
+import { set } from './object';
+
+describe('object', () => {
+    describe.each([
+        { target: undefined, expression: 'a', value: 100, expected: undefined },
+        { target: {}, expression: '', value: 100, expected: { '': 100 } },
+        { target: {}, expression: 'a', value: undefined, expected: { a: undefined } },
+        { target: { b: 50 }, expression: 'a', value: 100, expected: { a: 100, b: 50 } },
+        { target: { a: 50 }, expression: 'a', value: 100, expected: { a: 100 } },
+        { target: {}, expression: 'a', value: 100, expected: { a: 100 } },
+        { target: {}, expression: 'a.b', value: 100, expected: { a: { b: 100 } } },
+        { target: {}, expression: 'a.b.c', value: 100, expected: { a: { b: { c: 100 } } } },
+        { target: { c: 50 }, expression: 'a.b', value: 100, expected: { a: { b: 100 }, c: 50 } },
+      ])('set($target, $expression, $value)', ({ target, expression, value, expected }) => {
+        test(`returns ${JSON.stringify(expected)}`, () => {
+            set(target, expression, value);
+            expect(target).toEqual(expected);
+        });
+    });
+});

--- a/community-modules/core/src/ts/utils/object.ts
+++ b/community-modules/core/src/ts/utils/object.ts
@@ -177,17 +177,20 @@ export function set(target: any, expression: string, value: any) {
     if (target == null) { return; }
 
     const keys = expression.split('.');
+    
     let objectToUpdate = target;
-
-    while (keys.length > 1) {
-        objectToUpdate = objectToUpdate[keys.shift()!];
-
-        if (objectToUpdate == null) {
-            return;
+    // Create empty objects
+    keys.forEach((key, i) => {
+        if (!objectToUpdate[key]) {
+            objectToUpdate[key] = {};
         }
-    }
 
-    objectToUpdate[keys[0]] = value;
+        if (i < keys.length - 1) {
+            objectToUpdate = objectToUpdate[key];
+        }
+    });
+
+    objectToUpdate[keys[keys.length - 1]] = value;
 }
 
 export function deepFreeze(object: any): any {

--- a/enterprise-modules/charts/src/charts/chartComp/chartProxies/cartesian/areaChartProxy.ts
+++ b/enterprise-modules/charts/src/charts/chartComp/chartProxies/cartesian/areaChartProxy.ts
@@ -22,12 +22,12 @@ export class AreaChartProxy extends CartesianChartProxy {
         const axisOptions = this.getAxesOptions();
         const axes = [
             {
-                ...deepMerge(axisOptions[this.xAxisType], axisOptions[this.xAxisType].bottom),
+                ...(axisOptions ? deepMerge(axisOptions[this.xAxisType], axisOptions[this.xAxisType].bottom) : {}),
                 type: this.xAxisType,
                 position: 'bottom',
             },
             {
-                ...deepMerge(axisOptions[this.yAxisType], axisOptions[this.yAxisType].left),
+                ...(axisOptions ? deepMerge(axisOptions[this.yAxisType], axisOptions[this.yAxisType].left) : {}),
                 type: this.yAxisType,
                 position: 'left',
             },

--- a/enterprise-modules/charts/src/charts/chartComp/chartProxies/cartesian/barChartProxy.ts
+++ b/enterprise-modules/charts/src/charts/chartComp/chartProxies/cartesian/barChartProxy.ts
@@ -67,14 +67,14 @@ export class BarChartProxy extends CartesianChartProxy {
     }
 
     private extractCrossFilterSeries(series: AgBarSeriesOptions[]): AgBarSeriesOptions[] {
-        const palette = this.chartTheme.palette;
+        const palette = this.chartPalette;
 
         const updatePrimarySeries = (seriesOptions: AgBarSeriesOptions, index: number) => {
             return {
                 ...seriesOptions,
                 highlightStyle: { item: { fill: undefined } },
-                fill: palette.fills[index],
-                stroke: palette.strokes[index],
+                fill: palette?.fills[index],
+                stroke: palette?.strokes[index],
                 listeners: {
                     ...this.extractSeriesOverrides().listeners,
                     nodeClick: this.crossFilterCallback

--- a/enterprise-modules/charts/src/charts/chartComp/chartProxies/cartesian/barChartProxy.ts
+++ b/enterprise-modules/charts/src/charts/chartComp/chartProxies/cartesian/barChartProxy.ts
@@ -27,12 +27,12 @@ export class BarChartProxy extends CartesianChartProxy {
         const axisOptions = this.getAxesOptions();
         const axes = [
             {
-                ...deepMerge(axisOptions[this.xAxisType], axisOptions[this.xAxisType].bottom),
+                ...(axisOptions ? deepMerge(axisOptions[this.xAxisType], axisOptions[this.xAxisType].bottom) : {}),
                 type: this.xAxisType,
                 position: isBar ? 'left' : 'bottom',
             },
             {
-                ...deepMerge(axisOptions[this.yAxisType], axisOptions[this.yAxisType].left),
+                ...(axisOptions ? deepMerge(axisOptions[this.yAxisType], axisOptions[this.yAxisType].left) : {}),
                 type: this.yAxisType,
                 position: isBar ? 'bottom' : 'left',
             },

--- a/enterprise-modules/charts/src/charts/chartComp/chartProxies/cartesian/cartesianChartProxy.ts
+++ b/enterprise-modules/charts/src/charts/chartComp/chartProxies/cartesian/cartesianChartProxy.ts
@@ -30,8 +30,7 @@ export abstract class CartesianChartProxy extends ChartProxy {
 
     protected createChart(): AgChartInstance {
         return AgChart.create({
-            container: this.chartProxyParams.parentElement,
-            theme: this.chartTheme,
+            container: this.chartProxyParams.parentElement
         });
     }
 

--- a/enterprise-modules/charts/src/charts/chartComp/chartProxies/cartesian/cartesianChartProxy.ts
+++ b/enterprise-modules/charts/src/charts/chartComp/chartProxies/cartesian/cartesianChartProxy.ts
@@ -30,7 +30,8 @@ export abstract class CartesianChartProxy extends ChartProxy {
 
     protected createChart(): AgChartInstance {
         return AgChart.create({
-            container: this.chartProxyParams.parentElement
+            container: this.chartProxyParams.parentElement,
+            theme: this.agChartTheme
         });
     }
 
@@ -83,7 +84,9 @@ export abstract class CartesianChartProxy extends ChartProxy {
     }
 
     protected extractSeriesOverrides(chartSeriesType?: ChartSeriesType) {
-        const seriesOverrides = this.chartOptions[chartSeriesType ? chartSeriesType : this.standaloneChartType].series;
+        const seriesOverrides = this.chartOptions[chartSeriesType ? chartSeriesType : this.standaloneChartType]?.series;
+
+        if (!seriesOverrides) { return {}; }
 
         // TODO: remove once `yKeys` and `yNames` have been removed from the options
         delete seriesOverrides.yKeys;
@@ -111,7 +114,7 @@ export abstract class CartesianChartProxy extends ChartProxy {
     }
 
     protected getAxesOptions(chartSeriesType: ChartSeriesType = this.standaloneChartType) {
-        return this.chartOptions[chartSeriesType].axes;
+        return this.chartOptions[chartSeriesType]?.axes;
     }
 
     private static isTimeAxis(params: UpdateChartParams): boolean {

--- a/enterprise-modules/charts/src/charts/chartComp/chartProxies/cartesian/histogramChartProxy.ts
+++ b/enterprise-modules/charts/src/charts/chartComp/chartProxies/cartesian/histogramChartProxy.ts
@@ -35,12 +35,12 @@ export class HistogramChartProxy extends CartesianChartProxy {
         const axisOptions = this.getAxesOptions();
         return [
             {
-                ...deepMerge(axisOptions[this.xAxisType], axisOptions[this.xAxisType].bottom),
+                ...(axisOptions ? deepMerge(axisOptions[this.xAxisType], axisOptions[this.xAxisType].bottom) : {}),
                 type: this.xAxisType,
                 position: 'bottom',
             },
             {
-                ...deepMerge(axisOptions[this.yAxisType], axisOptions[this.yAxisType].left),
+                ...(axisOptions ? deepMerge(axisOptions[this.yAxisType], axisOptions[this.yAxisType].left) : {}),
                 type: this.yAxisType,
                 position: 'left',
             },

--- a/enterprise-modules/charts/src/charts/chartComp/chartProxies/cartesian/lineChartProxy.ts
+++ b/enterprise-modules/charts/src/charts/chartComp/chartProxies/cartesian/lineChartProxy.ts
@@ -22,12 +22,12 @@ export class LineChartProxy extends CartesianChartProxy {
         const axisOptions = this.getAxesOptions();
         return [
             {
-                ...deepMerge(axisOptions[this.xAxisType], axisOptions[this.xAxisType].bottom),
+                ...(axisOptions ? deepMerge(axisOptions[this.xAxisType], axisOptions[this.xAxisType].bottom) : {}),
                 type: this.xAxisType,
                 position: 'bottom'
             },
             {
-                ...deepMerge(axisOptions[this.yAxisType], axisOptions[this.yAxisType].left),
+                ...(axisOptions ? deepMerge(axisOptions[this.yAxisType], axisOptions[this.yAxisType].left) : {}),
                 type: this.yAxisType,
                 position: 'left'
             },

--- a/enterprise-modules/charts/src/charts/chartComp/chartProxies/cartesian/scatterChartProxy.ts
+++ b/enterprise-modules/charts/src/charts/chartComp/chartProxies/cartesian/scatterChartProxy.ts
@@ -71,7 +71,7 @@ export class ScatterChartProxy extends CartesianChartProxy {
         params: UpdateChartParams,
     ): AgScatterSeriesOptions[] {
         const { data } = params;
-        const { chartTheme: { palette } } = this;
+        const palette = this.chartPalette;
 
         const filteredOutKey = (key: string) => `${key}-filtered-out`;
 
@@ -96,8 +96,8 @@ export class ScatterChartProxy extends CartesianChartProxy {
 
         const updatePrimarySeries = (series: AgScatterSeriesOptions, idx: number): AgScatterSeriesOptions => {
             const { sizeKey } = series;
-            const fill = palette.fills[idx];
-            const stroke = palette.strokes[idx];
+            const fill = palette?.fills[idx];
+            const stroke = palette?.strokes[idx];
 
             let markerDomain = calcMarkerDomain(data, sizeKey);
             const marker: AgScatterSeriesMarker<any> = {

--- a/enterprise-modules/charts/src/charts/chartComp/chartProxies/cartesian/scatterChartProxy.ts
+++ b/enterprise-modules/charts/src/charts/chartComp/chartProxies/cartesian/scatterChartProxy.ts
@@ -30,12 +30,12 @@ export class ScatterChartProxy extends CartesianChartProxy {
         const axisOptions = this.getAxesOptions();
         return [
             {
-                ...deepMerge(axisOptions[this.xAxisType], axisOptions[this.xAxisType].bottom),
+                ...(axisOptions ? deepMerge(axisOptions[this.xAxisType], axisOptions[this.xAxisType].bottom) : {}),
                 type: this.xAxisType,
                 position: 'bottom',
             },
             {
-                ...deepMerge(axisOptions[this.yAxisType], axisOptions[this.yAxisType].left),
+                ...(axisOptions ? deepMerge(axisOptions[this.yAxisType], axisOptions[this.yAxisType].left) : {}),
                 type: this.yAxisType,
                 position: 'left',
             },
@@ -43,7 +43,7 @@ export class ScatterChartProxy extends CartesianChartProxy {
     }
 
     public getSeries(params: UpdateChartParams): AgScatterSeriesOptions[] {
-        const paired = this.chartOptions[this.standaloneChartType].paired;
+        const paired = this.chartOptions[this.standaloneChartType]?.paired;
         const seriesDefinitions = this.getSeriesDefinitions(params.fields, paired);
         const labelFieldDefinition = params.category.id === ChartDataModel.DEFAULT_CATEGORY ? undefined : params.category;
 

--- a/enterprise-modules/charts/src/charts/chartComp/chartProxies/chartProxy.ts
+++ b/enterprise-modules/charts/src/charts/chartComp/chartProxies/chartProxy.ts
@@ -48,10 +48,9 @@ export abstract class ChartProxy {
 
     protected chart: AgChartInstance;
     protected chartOptions: AgChartThemeOverrides;
-    protected chartTheme: _Theme.ChartTheme;
     protected crossFiltering: boolean;
     protected crossFilterCallback: (event: any, reset?: boolean) => void;
-    private readonly chartPalette: AgChartThemePalette | undefined;
+    protected readonly chartPalette: AgChartThemePalette | undefined;
 
     protected constructor(protected readonly chartProxyParams: ChartProxyParams) {
         this.chartType = chartProxyParams.chartType;
@@ -62,14 +61,12 @@ export abstract class ChartProxy {
         if (this.chartProxyParams.chartOptionsToRestore) {
             this.chartOptions = this.chartProxyParams.chartOptionsToRestore;
             this.chartPalette = this.chartProxyParams.chartPaletteToRestore;
-            const themeOverrides = { overrides:  this.chartOptions, palette: this.chartPalette } as any;
-            this.chartTheme = _Theme.getIntegratedChartTheme({baseTheme: this.getSelectedTheme(), ...themeOverrides});
             return;
         }
 
-        this.chartTheme = this.createChartTheme();
-        this.chartOptions = this.convertConfigToOverrides(this.chartTheme.config);
-        this.chartPalette = this.chartTheme.palette;
+        const { config, palette } = this.createChartTheme();
+        this.chartOptions = this.convertConfigToOverrides(config);
+        this.chartPalette = palette;
     }
 
     public abstract crossFilteringReset(): void;

--- a/enterprise-modules/charts/src/charts/chartComp/chartProxies/chartProxy.ts
+++ b/enterprise-modules/charts/src/charts/chartComp/chartProxies/chartProxy.ts
@@ -43,11 +43,45 @@ export interface UpdateChartParams {
 type CommonChartPropertyKeys = 'padding' | 'legend' | 'background' | 'title' | 'subtitle' | 'tooltip' | 'navigator';
 
 export abstract class ChartProxy {
+    /**
+     * Integrated Charts specific chart theme overrides
+     */
+    private readonly integratedThemeOverrides = {
+        common: {
+            padding: {
+                top: 25,
+                right: 20,
+                bottom: 20,
+                left: 20,
+            }
+        },
+        pie: {
+            series: {
+                sectorLabel: {
+                    enabled: false,
+                }
+            }
+        }
+    };
+    /**
+     * Integrated Charts specific chart options
+     */
+    private readonly integratedThemeOptions = {
+        scatter: {
+            // Special handling to make scatter charts operate in paired mode by default, where 
+            // columns alternate between being X and Y (and size for bubble). In standard mode,
+            // the first column is used for X and every other column is treated as Y
+            // (or alternates between Y and size for bubble)
+            paired: true
+        }
+    };
+
     protected readonly chartType: ChartType;
     protected readonly standaloneChartType: ChartSeriesType;
 
     protected chart: AgChartInstance;
     protected chartOptions: AgChartThemeOverrides;
+    protected agChartTheme?: AgChartTheme;
     protected crossFiltering: boolean;
     protected crossFilterCallback: (event: any, reset?: boolean) => void;
     protected readonly chartPalette: AgChartThemePalette | undefined;
@@ -58,15 +92,16 @@ export abstract class ChartProxy {
         this.crossFilterCallback = chartProxyParams.crossFilterCallback;
         this.standaloneChartType = getSeriesType(this.chartType);
 
+        this.agChartTheme = this.createAgChartTheme();
+
         if (this.chartProxyParams.chartOptionsToRestore) {
             this.chartOptions = this.chartProxyParams.chartOptionsToRestore;
             this.chartPalette = this.chartProxyParams.chartPaletteToRestore;
             return;
         }
 
-        const { config, palette } = this.createChartTheme();
-        this.chartOptions = this.convertConfigToOverrides(config);
-        this.chartPalette = palette;
+        this.chartOptions = deepMerge(this.integratedThemeOptions, this.agChartTheme?.overrides);
+        this.chartPalette = this.createChartPalette();
     }
 
     public abstract crossFilteringReset(): void;
@@ -92,21 +127,35 @@ export abstract class ChartProxy {
         return this.chart;
     }
 
-    private createChartTheme(): _Theme.ChartTheme {
+    private createAgChartTheme(): undefined | AgChartTheme {
         const themeName = this.getSelectedTheme();
         const stockTheme = this.isStockTheme(themeName);
         const gridOptionsThemeOverrides = this.chartProxyParams.getGridOptionsChartThemeOverrides();
         const apiThemeOverrides = this.chartProxyParams.apiChartThemeOverrides;
 
         if (gridOptionsThemeOverrides || apiThemeOverrides) {
-            const themeOverrides = {
-                overrides: ChartProxy.mergeThemeOverrides(gridOptionsThemeOverrides, apiThemeOverrides)
-            };
-            const mergedThemeOverrides = deepMerge(this.getIntegratedThemeOverrides(), themeOverrides);
-            const getCustomTheme = () => deepMerge(this.lookupCustomChartTheme(themeName), mergedThemeOverrides);
-            return _Theme.getIntegratedChartTheme(stockTheme ? {baseTheme: themeName, ...mergedThemeOverrides} : getCustomTheme());
+            const themeOverrides = ChartProxy.mergeThemeOverrides(gridOptionsThemeOverrides, apiThemeOverrides);
+            const mergedThemeOverrides = deepMerge(this.integratedThemeOverrides, themeOverrides);
+
+            return stockTheme
+                ? { baseTheme: themeName, overrides: mergedThemeOverrides }
+                : deepMerge(this.lookupCustomChartTheme(themeName), {      
+                    overrides: mergedThemeOverrides
+                });
         }
-        return _Theme.getIntegratedChartTheme(stockTheme ? themeName : this.lookupCustomChartTheme(themeName));
+
+        const theme = stockTheme ? { baseTheme: themeName } as AgChartTheme : this.lookupCustomChartTheme(themeName);
+        return deepMerge({ overrides: this.integratedThemeOverrides }, theme);
+    }
+
+    private createChartPalette(): AgChartThemePalette | undefined {
+        const selectedTheme = this.getSelectedTheme();
+        const stockTheme = this.isStockTheme(selectedTheme);
+
+        const themeName = stockTheme ? selectedTheme : this.lookupCustomChartTheme(selectedTheme);
+        const { palette } = _Theme.getChartTheme(themeName);
+
+        return palette;
     }
 
     public isStockTheme(themeName: string): boolean {
@@ -136,7 +185,7 @@ export abstract class ChartProxy {
         return customChartTheme;
     }
 
-    private static mergeThemeOverrides(gridOptionsThemeOverrides?: AgChartThemeOverrides, apiThemeOverrides?: AgChartThemeOverrides) {
+    private static mergeThemeOverrides(gridOptionsThemeOverrides?: AgChartThemeOverrides, apiThemeOverrides?: AgChartThemeOverrides): AgChartThemeOverrides | undefined {
         if (!gridOptionsThemeOverrides) { return apiThemeOverrides; }
         if (!apiThemeOverrides) { return gridOptionsThemeOverrides; }
         return deepMerge(gridOptionsThemeOverrides, apiThemeOverrides);
@@ -195,25 +244,6 @@ export abstract class ChartProxy {
         };
     }
 
-    private convertConfigToOverrides(config: any) {
-        const isComboChart = ['columnLineCombo', 'areaColumnCombo', 'customCombo'].includes(this.chartType);
-        const overrideObjs = isComboChart ? ['line', 'area', 'column', 'cartesian'] : [this.standaloneChartType];
-
-        const overrides: {[overrideObj: string]: any} = {};
-        overrideObjs.forEach(overrideObj => {
-            const chartOverrides = deepMerge({}, config[overrideObj]);
-            chartOverrides.series = chartOverrides.series[overrideObj];
-
-            // special handing to add the scatter paired mode to the chart options
-            if (overrideObj === 'scatter') {
-                chartOverrides.paired = true;
-            }
-            overrides[overrideObj] = chartOverrides;
-        });
-
-        return overrides;
-    }
-
     public destroy(): void {
         this.destroyChart();
     }
@@ -223,27 +253,5 @@ export abstract class ChartProxy {
             this.chart.destroy();
             (this.chart as any) = undefined;
         }
-    }
-
-    private getIntegratedThemeOverrides() {
-        return {
-            overrides: {
-                common: {
-                    padding: {
-                        top: 25,
-                        right: 20,
-                        bottom: 20,
-                        left: 20,
-                    }
-                },
-                pie: {
-                    series: {
-                        sectorLabel: {
-                            enabled: false,
-                        }
-                    }
-                }
-            }
-        };
     }
 }

--- a/enterprise-modules/charts/src/charts/chartComp/chartProxies/combo/comboChartProxy.ts
+++ b/enterprise-modules/charts/src/charts/chartComp/chartProxies/combo/comboChartProxy.ts
@@ -113,10 +113,14 @@ export class ComboChartProxy extends CartesianChartProxy {
 
     private getAxisOptions() {
         const axisOptions = this.getAxesOptions('cartesian');
-        return {
+        return axisOptions ? {
             bottomOptions: deepMerge(axisOptions[this.xAxisType], axisOptions[this.xAxisType].bottom),
             leftOptions: deepMerge(axisOptions[this.yAxisType], axisOptions[this.yAxisType].left),
             rightOptions: deepMerge(axisOptions[this.yAxisType], axisOptions[this.yAxisType].right),
+        } : {
+            bottomOptions: {},
+            leftOptions: {},
+            rightOptions: {},
         };
     }
 

--- a/enterprise-modules/charts/src/charts/chartComp/chartProxies/polar/pieChartProxy.ts
+++ b/enterprise-modules/charts/src/charts/chartComp/chartProxies/polar/pieChartProxy.ts
@@ -26,8 +26,7 @@ export class PieChartProxy extends ChartProxy {
     protected createChart(): AgChartInstance {
         return AgChart.create({
             type: 'pie',
-            container: this.chartProxyParams.parentElement,
-            theme: this.chartTheme,
+            container: this.chartProxyParams.parentElement
         });
     }
 
@@ -84,7 +83,7 @@ export class PieChartProxy extends ChartProxy {
                     },
                     calloutLine: {
                         ...seriesDefaults.calloutLine,
-                        colors: this.chartTheme.palette.strokes,
+                        colors: this.chartPalette?.strokes,
                     }
                 }
             }
@@ -128,7 +127,7 @@ export class PieChartProxy extends ChartProxy {
     }
 
     private extractCrossFilterSeries(series: AgPieSeriesOptions[]) {
-        const palette = this.chartTheme.palette;
+        const palette = this.chartPalette;
         const seriesOverrides = this.extractSeriesOverrides();
 
         const primaryOptions = (seriesOptions: AgPieSeriesOptions) => {
@@ -158,10 +157,10 @@ export class PieChartProxy extends ChartProxy {
                 calloutLabel: seriesOverrides.calloutLabel, // labels can be shown on the 'filtered-out' series
                 calloutLine: seriesOverrides.calloutLine && {
                     ...seriesOverrides.calloutLine,
-                    colors: seriesOverrides.calloutLine.colors ?? palette.strokes,
+                    colors: seriesOverrides.calloutLine.colors ?? palette!.strokes,
                 },
-                fills: changeOpacity(seriesOptions.fills ?? palette.fills, 0.3),
-                strokes: changeOpacity(seriesOptions.strokes ?? palette.strokes, 0.3),
+                fills: changeOpacity(seriesOptions.fills ?? palette!.fills, 0.3),
+                strokes: changeOpacity(seriesOptions.strokes ?? palette!.strokes, 0.3),
                 showInLegend: false,
             };
         }

--- a/enterprise-modules/charts/src/charts/chartComp/chartProxies/polar/pieChartProxy.ts
+++ b/enterprise-modules/charts/src/charts/chartComp/chartProxies/polar/pieChartProxy.ts
@@ -26,7 +26,8 @@ export class PieChartProxy extends ChartProxy {
     protected createChart(): AgChartInstance {
         return AgChart.create({
             type: 'pie',
-            container: this.chartProxyParams.parentElement
+            container: this.chartProxyParams.parentElement,
+            theme: this.agChartTheme
         });
     }
 
@@ -77,12 +78,12 @@ export class PieChartProxy extends ChartProxy {
                     outerRadiusOffset,
                     innerRadiusOffset,
                     title: {
-                        ...seriesDefaults.title,
-                        text: seriesDefaults.title.text || f.displayName,
+                        ...seriesDefaults?.title,
+                        text: seriesDefaults?.title?.text || f.displayName,
                         showInLegend: numFields > 1,
                     },
                     calloutLine: {
-                        ...seriesDefaults.calloutLine,
+                        ...seriesDefaults?.calloutLine,
                         colors: this.chartPalette?.strokes,
                     }
                 }
@@ -202,7 +203,7 @@ export class PieChartProxy extends ChartProxy {
     }
 
     protected extractSeriesOverrides() {
-        return this.chartOptions[this.standaloneChartType].series;
+        return this.chartOptions[this.standaloneChartType]?.series || {};
     }
 
     public crossFilteringReset() {

--- a/enterprise-modules/charts/src/charts/chartComp/services/chartOptionsService.ts
+++ b/enterprise-modules/charts/src/charts/chartComp/services/chartOptionsService.ts
@@ -10,7 +10,7 @@ import {
     GridApi,
     WithoutGridCommon
 } from "@ag-grid-community/core";
-import { AgChartInstance } from "ag-charts-community";
+import { AgCartesianAxisType, AgChartInstance } from "ag-charts-community";
 import { ChartController } from "../chartController";
 import { ChartSeriesType, getSeriesType } from "../utils/seriesTypeMapper";
 
@@ -122,17 +122,28 @@ export class ChartOptionsService extends BeanStub {
         return (chart.axes && chart.axes[1].direction === 'y') ? chart.axes[1] : chart.axes[0];
     }
 
+    private getAxisOptionExpression({ optionsType, axisType, expression }: {
+        optionsType: ChartSeriesType,
+        axisType: AgCartesianAxisType,
+        expression: string
+    }): string {
+        return `${optionsType}.axes.${axisType}.${expression}`
+    }
+
     private updateAxisOptions<T = string>(chartAxis: ChartAxis, expression: string, value: T) {
         const optionsType = getSeriesType(this.getChartType());
-        const axisOptions = this.getChartOptions()[optionsType].axes;
-        if (chartAxis.type === 'number') {
-            _.set(axisOptions.number, expression, value);
-        } else if (chartAxis.type === 'category') {
-            _.set(axisOptions.category, expression, value);
-        } else if (chartAxis.type === 'time') {
-            _.set(axisOptions.time, expression, value);
-        } else if (chartAxis.type === 'groupedCategory') {
-            _.set(axisOptions.groupedCategory, expression, value);
+        const validAxisTypes: AgCartesianAxisType[] = ['number', 'category', 'time', 'groupedCategory'];
+
+        if (validAxisTypes.includes(chartAxis.type)) {
+            _.set(
+                this.getChartOptions(),
+                this.getAxisOptionExpression({
+                    optionsType,
+                    axisType: chartAxis.type,
+                    expression
+                }), 
+                value
+            );
         }
     }
 

--- a/enterprise-modules/charts/src/charts/chartComp/services/chartOptionsService.ts
+++ b/enterprise-modules/charts/src/charts/chartComp/services/chartOptionsService.ts
@@ -40,9 +40,7 @@ export class ChartOptionsService extends BeanStub {
 
         // we need to update chart options on each series type for combo charts
         chartSeriesTypes.forEach(optionsType => {
-            // update options
-            const options = _.get(this.getChartOptions(), `${optionsType}`, undefined);
-            _.set(options, expression, value);
+            _.set(this.getChartOptions(), `${optionsType}.${expression}`, value);
         });
 
         // update chart
@@ -88,12 +86,7 @@ export class ChartOptionsService extends BeanStub {
     }
 
     public setSeriesOption<T = string>(expression: string, value: T, seriesType: ChartSeriesType): void {
-        // update series options
-        const options = this.getChartOptions();
-        if (!options[seriesType]) {
-            options[seriesType] = {};
-        }
-        _.set(options[seriesType].series, expression, value);
+        _.set(this.getChartOptions(), `${seriesType}.series.${expression}`, value);
 
         // update chart
         this.updateChart();
@@ -108,8 +101,7 @@ export class ChartOptionsService extends BeanStub {
 
     public setPairedMode(paired: boolean): void {
         const optionsType = getSeriesType(this.getChartType());
-        const options = _.get(this.getChartOptions(), `${optionsType}`, undefined);
-        _.set(options, 'paired', paired);
+        _.set(this.getChartOptions(), `${optionsType}.paired`, paired);
     }
 
     private getAxis(axisType: string): ChartAxis | undefined {

--- a/enterprise-modules/charts/src/charts/chartComp/utils/object.ts
+++ b/enterprise-modules/charts/src/charts/chartComp/utils/object.ts
@@ -52,7 +52,7 @@ function propertyIsUnsafe(target: any, key: string) {
             && Object.propertyIsEnumerable.call(target, key)); // and also unsafe if they're nonenumerable.
 }
 
-function mergeObject(target: any, source: any, options: any) {
+function mergeObject(target: Record<string, any> = {}, source: Record<string, any> = {}, options: any) {
     const destination: any = {};
     if (options.isMergeableObject(target)) {
         getKeys(target).forEach(function(key) {


### PR DESCRIPTION
## Changes

* Replace ChartTheme instance with AgChartTheme config in Integrated Charts
   Don’t need `ChartTheme` inside Grid, since we can just use `AgChartTheme` (just a plain object). Previously, Grid was getting the `ChartTheme` from Charts, merging `AgChartTheme` overrides and then passing it back to Charts. Now, we just pass in the necessary `AgChartTheme` config directly into Charts, without merging with `ChartTheme` from Charts. Charts will be in charge of managing and merging the theme with the overrides.
  * Allow chart options to be empty in all the chart proxies
  * Create `agChartTheme` field to store Grid theme overrides, to pass into chart creation
  * Use Chart `getChartTheme` to get palette
  * Use `_.set` in `chartOptionsService` for all chart option updates, so it creates objects if they are empty
* Make `set` utility function, create children objects by default if it doesn't exist
* Set chart options in `updateAxisOption` using expression
* Allow `mergeObject` target and source to be undefined

### Before and After

To view the user options sent, you can add `window.agChartsDebug = true` to an Integrated Chart, and view in the console.

#### Before

Integrated Charts would send the complete theme/override user option to Standalone Charts for any chart that was created:

```
{
  palette: {
     strokes,
     fills
  },
  config: {
    cartesian: {
       axes,
       series,
       background,
       // ... All options merged from theme and overrides
    },
    groupedCategory: {
      // ... All options merged from theme and overrides
    },
    // ... All other charts
    common,
  }
}
```

On update, it would send all theme/overrides config

```
{
  data,
  axes: [
    {
      position: "bottom",
      type: "category",

      // All axes theme/override styles
      top,
      bottom,
      label,
      title,
      // ...
    },
    // Other axes
  ],
  series: [
    {
      "type": "column",
      "grouped": true,
      "xKey": "country",
      "xName": "Country",
      "yKey": "sugar",
      "yName": "Sugar",

       // All series theme/override styles,
       tooltip,
       fillOpacity,
       label,
       shadow,
       // ...
    },
    // Other series
  ] 

  // All chart theme/override styles
  padding,
  background,
}
```

#### After

With this PR, on chart creation, it only sends Integrated Charts specific overrides (NOTE: `palette` works as before, and is copied from the theme. This is so that it can be restored from a save)

```
{
  theme: {
    palette,
    overrides: {
      common,
      cartesian
      // Whatever overrides are set in Integrated Charts
    }
  }
}
```

On update, only data specific options are passed through

```
{
  data,
  axes: [
    {
      position: "bottom",
      type: "category"
    },
    // Other axes
  ],
  series: [
    {
      "type": "column",
      "grouped": true,
      "xKey": "country",
      "xName": "Country",
      "yKey": "sugar",
      "yName": "Sugar"
    },
    // Other series
  ] 
}
```


### Clean up

* Move special handling for scatter charts to be in paired mode by default to `integratedThemeOptions` object in `chartProxy`. Allows `getIntegratedChartTheme` function in from chart theme mapping to be removed
* Move integrated theme overrides to an object
