### PR TITLE
AG-7469 - Fix custom marker shape path not updating

### DIFF
--- a/charts-packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
@@ -778,7 +778,7 @@ export class AreaSeries extends CartesianSeries<AreaSeriesNodeDataContext> {
             node.visible =
                 node.size > 0 && !!seriesItemEnabled.get(datum.yKey) && !isNaN(datum.point.x) && !isNaN(datum.point.y);
 
-            if (!customMarker) {
+            if (!customMarker || node.dirtyPath) {
                 return;
             }
 

--- a/charts-packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
@@ -733,6 +733,8 @@ export class AreaSeries extends CartesianSeries<AreaSeriesNodeDataContext> {
         const { size, formatter } = marker;
         const markerStrokeWidth = marker.strokeWidth !== undefined ? marker.strokeWidth : this.strokeWidth;
 
+        const customMarker = typeof marker.shape === 'function';
+
         markerSelection.each((node, datum) => {
             const yKeyIndex = yKeys.indexOf(datum.yKey);
             const fill =
@@ -775,6 +777,15 @@ export class AreaSeries extends CartesianSeries<AreaSeriesNodeDataContext> {
             node.translationY = datum.point.y;
             node.visible =
                 node.size > 0 && !!seriesItemEnabled.get(datum.yKey) && !isNaN(datum.point.x) && !isNaN(datum.point.y);
+
+            if (!customMarker) {
+                return;
+            }
+
+            // Only for cutom marker shapes
+            node.path.clear({ trackChanges: true });
+            node.updatePath();
+            node.checkPathDirty();
         });
 
         if (!isDatumHighlighted) {

--- a/charts-packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
@@ -380,6 +380,8 @@ export class LineSeries extends CartesianSeries<LineContext> {
         const { size, formatter } = marker;
         const markerStrokeWidth = marker.strokeWidth !== undefined ? marker.strokeWidth : this.strokeWidth;
 
+        const customMarker = typeof marker.shape === 'function';
+
         markerSelection.each((node, datum) => {
             const fill = isDatumHighlighted && highlightedFill !== undefined ? highlightedFill : marker.fill;
             const fillOpacity = isDatumHighlighted ? highlightFillOpacity : markerFillOpacity;
@@ -415,6 +417,15 @@ export class LineSeries extends CartesianSeries<LineContext> {
             node.translationX = datum.point.x;
             node.translationY = datum.point.y;
             node.visible = node.size > 0 && !isNaN(datum.point.x) && !isNaN(datum.point.y);
+
+            if (!customMarker) {
+                return;
+            }
+
+            // Only for cutom marker shapes
+            node.path.clear({ trackChanges: true });
+            node.updatePath();
+            node.checkPathDirty();
         });
 
         if (!isDatumHighlighted) {

--- a/charts-packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
@@ -418,7 +418,7 @@ export class LineSeries extends CartesianSeries<LineContext> {
             node.translationY = datum.point.y;
             node.visible = node.size > 0 && !isNaN(datum.point.x) && !isNaN(datum.point.y);
 
-            if (!customMarker) {
+            if (!customMarker || node.dirtyPath) {
                 return;
             }
 

--- a/charts-packages/ag-charts-community/src/chart/series/cartesian/scatterSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/cartesian/scatterSeries.ts
@@ -333,6 +333,8 @@ export class ScatterSeries extends CartesianSeries<SeriesNodeDataContext<Scatter
 
         sizeScale.range = [marker.size, marker.maxSize];
 
+        const customMarker = typeof marker.shape === 'function';
+
         markerSelection.each((node, datum) => {
             const fill =
                 isDatumHighlighted && highlightedFill !== undefined ? highlightedFill : marker.fill || seriesFill;
@@ -372,6 +374,15 @@ export class ScatterSeries extends CartesianSeries<SeriesNodeDataContext<Scatter
             node.translationX = datum.point?.x ?? 0;
             node.translationY = datum.point?.y ?? 0;
             node.visible = node.size > 0;
+
+            if (!customMarker) {
+                return;
+            }
+
+            // Only for cutom marker shapes
+            node.path.clear({ trackChanges: true });
+            node.updatePath();
+            node.checkPathDirty();
         });
 
         if (!isDatumHighlighted) {

--- a/charts-packages/ag-charts-community/src/chart/series/cartesian/scatterSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/cartesian/scatterSeries.ts
@@ -375,7 +375,7 @@ export class ScatterSeries extends CartesianSeries<SeriesNodeDataContext<Scatter
             node.translationY = datum.point?.y ?? 0;
             node.visible = node.size > 0;
 
-            if (!customMarker) {
+            if (!customMarker || node.dirtyPath) {
                 return;
             }
 

--- a/charts-packages/ag-charts-community/src/scene/shape/path.ts
+++ b/charts-packages/ag-charts-community/src/scene/shape/path.ts
@@ -67,7 +67,7 @@ export class Path extends Shape {
     protected isDirtyPath() {
         // Override point for more expensive dirty checks.
     }
-    protected updatePath() {
+    updatePath() {
         // Override point for subclasses.
     }
 

--- a/charts-packages/ag-charts-community/src/scene/shape/rect.ts
+++ b/charts-packages/ag-charts-community/src/scene/shape/rect.ts
@@ -93,7 +93,7 @@ export class Rect extends Path {
      */
     private microPixelEffectOpacity: number = 1;
 
-    protected updatePath() {
+    updatePath() {
         const { path, borderPath, crisp } = this;
         let { x, y, width: w, height: h, strokeWidth } = this;
         const pixelRatio = this.scene?.canvas.pixelRatio ?? 1;


### PR DESCRIPTION
PR for https://ag-grid.atlassian.net/browse/AG-7530.

In the case of a custom marker shape, the shape path commands could be dependent on the node data and we may need to invoke updatePath() to update the path when the selections are updated (data for the marker node has changed).