### PR TITLE
AG-7502 - Get chart options from Chart instead of storing in `chartProxy.chartOptions`

### DIFF
--- a/enterprise-modules/charts/src/charts/chartComp/chartController.ts
+++ b/enterprise-modules/charts/src/charts/chartComp/chartController.ts
@@ -1,7 +1,6 @@
 import {
     _,
     AgChartThemePalette,
-    AgEvent,
     Autowired,
     BeanStub,
     CellRange,
@@ -117,8 +116,8 @@ export class ChartController extends BeanStub {
             modelType,
             chartId: this.model.chartId,
             chartType: this.model.chartType,
-            chartThemeName: this.model.chartThemeName,
-            chartOptions: this.chartProxy.getChartOptions(),
+            chartThemeName: this.getChartThemeName(),
+            chartOptions: this.chartProxy.getChartThemeOverrides(),
             chartPalette: this.chartProxy.getChartPalette(),
             cellRange: this.getCellRangeParams(),
             suppressChartRanges: this.model.suppressChartRanges,
@@ -362,8 +361,8 @@ export class ChartController extends BeanStub {
             type: Events.EVENT_CHART_OPTIONS_CHANGED,
             chartId,
             chartType,
-            chartThemeName: this.model.chartThemeName,
-            chartOptions: this.chartProxy.getChartOptions()
+            chartThemeName: this.getChartThemeName(),
+            chartOptions: this.chartProxy.getChartThemeOverrides()
         });
 
         this.eventService.dispatchEvent(event);

--- a/enterprise-modules/charts/src/charts/chartComp/chartProxies/cartesian/areaChartProxy.ts
+++ b/enterprise-modules/charts/src/charts/chartComp/chartProxies/cartesian/areaChartProxy.ts
@@ -1,7 +1,6 @@
 import { AgAreaSeriesOptions, AgCartesianAxisOptions } from "ag-charts-community";
 import { ChartProxyParams, UpdateChartParams } from "../chartProxy";
 import { CartesianChartProxy } from "./cartesianChartProxy";
-import { deepMerge } from "../../utils/object";
 
 export class AreaChartProxy extends CartesianChartProxy {
 
@@ -19,15 +18,12 @@ export class AreaChartProxy extends CartesianChartProxy {
     }
 
     public getAxes(): AgCartesianAxisOptions[] {
-        const axisOptions = this.getAxesOptions();
-        const axes = [
+        const axes: AgCartesianAxisOptions[] = [
             {
-                ...(axisOptions ? deepMerge(axisOptions[this.xAxisType], axisOptions[this.xAxisType]?.bottom) : {}),
                 type: this.xAxisType,
                 position: 'bottom',
             },
             {
-                ...(axisOptions ? deepMerge(axisOptions[this.yAxisType], axisOptions[this.yAxisType]?.left) : {}),
                 type: this.yAxisType,
                 position: 'left',
             },
@@ -45,7 +41,6 @@ export class AreaChartProxy extends CartesianChartProxy {
     public getSeries(params: UpdateChartParams) {
         const series: AgAreaSeriesOptions[] = params.fields.map(f => (
             {
-                ...this.extractSeriesOverrides(),
                 type: this.standaloneChartType,
                 xKey: params.category.id,
                 xName: params.category.name,
@@ -53,7 +48,7 @@ export class AreaChartProxy extends CartesianChartProxy {
                 yName: f.displayName,
                 normalizedTo: this.chartType === 'normalizedArea' ? 100 : undefined,
                 stacked: ['normalizedArea', 'stackedArea'].includes(this.chartType)
-            }
+            } as AgAreaSeriesOptions
         ));
 
         return this.crossFiltering ? this.extractLineAreaCrossFilterSeries(series, params) : series;

--- a/enterprise-modules/charts/src/charts/chartComp/chartProxies/cartesian/barChartProxy.ts
+++ b/enterprise-modules/charts/src/charts/chartComp/chartProxies/cartesian/barChartProxy.ts
@@ -23,16 +23,12 @@ export class BarChartProxy extends CartesianChartProxy {
 
     public getAxes(): AgCartesianAxisOptions[] {
         const isBar = this.standaloneChartType === 'bar';
-
-        const axisOptions = this.getAxesOptions();
-        const axes = [
+        const axes: AgCartesianAxisOptions[] = [
             {
-                ...(axisOptions ? deepMerge(axisOptions[this.xAxisType], axisOptions[this.xAxisType]?.bottom) : {}),
                 type: this.xAxisType,
                 position: isBar ? 'left' : 'bottom',
             },
             {
-                ...(axisOptions ? deepMerge(axisOptions[this.yAxisType], axisOptions[this.yAxisType]?.left) : {}),
                 type: this.yAxisType,
                 position: isBar ? 'bottom' : 'left',
             },
@@ -52,7 +48,6 @@ export class BarChartProxy extends CartesianChartProxy {
 
         const series: AgBarSeriesOptions[] = params.fields.map(f => (
             {
-                ...this.extractSeriesOverrides(),
                 type: this.standaloneChartType,
                 grouped: isGrouped,
                 normalizedTo: this.isNormalised() ? 100 : undefined,
@@ -60,14 +55,14 @@ export class BarChartProxy extends CartesianChartProxy {
                 xName: params.category.name,
                 yKey: f.colId,
                 yName: f.displayName
-            }
+            } as AgBarSeriesOptions
         ));
 
         return this.crossFiltering ? this.extractCrossFilterSeries(series) : series;
     }
 
     private extractCrossFilterSeries(series: AgBarSeriesOptions[]): AgBarSeriesOptions[] {
-        const palette = this.chartPalette;
+        const palette = this.getChartPalette();
 
         const updatePrimarySeries = (seriesOptions: AgBarSeriesOptions, index: number) => {
             return {
@@ -76,7 +71,6 @@ export class BarChartProxy extends CartesianChartProxy {
                 fill: palette?.fills[index],
                 stroke: palette?.strokes[index],
                 listeners: {
-                    ...this.extractSeriesOverrides().listeners,
                     nodeClick: this.crossFilterCallback
                 }
             }

--- a/enterprise-modules/charts/src/charts/chartComp/chartProxies/cartesian/histogramChartProxy.ts
+++ b/enterprise-modules/charts/src/charts/chartComp/chartProxies/cartesian/histogramChartProxy.ts
@@ -1,7 +1,6 @@
 import { AgCartesianAxisOptions, AgHistogramSeriesOptions } from "ag-charts-community";
 import { ChartProxyParams, UpdateChartParams } from "../chartProxy";
 import { CartesianChartProxy } from "./cartesianChartProxy";
-import { deepMerge } from "../../utils/object";
 
 export class HistogramChartProxy extends CartesianChartProxy {
 
@@ -21,26 +20,24 @@ export class HistogramChartProxy extends CartesianChartProxy {
 
     public getSeries(params: UpdateChartParams): AgHistogramSeriesOptions[] {
         const firstField = params.fields[0]; // multiple series are not supported!
-        return [{
-            ...this.extractSeriesOverrides(),
-            type: this.standaloneChartType,
-            xKey: firstField.colId,
-            xName: firstField.displayName,
-            yName: this.chartProxyParams.translate("histogramFrequency"),
-            areaPlot: false, // only constant width is supported via integrated charts
-        }];
+        return [
+            {
+                type: this.standaloneChartType,
+                xKey: firstField.colId,
+                xName: firstField.displayName,
+                yName: this.chartProxyParams.translate("histogramFrequency"),
+                areaPlot: false, // only constant width is supported via integrated charts
+            } as AgHistogramSeriesOptions
+        ];
     }
 
     public getAxes(): AgCartesianAxisOptions[] {
-        const axisOptions = this.getAxesOptions();
         return [
             {
-                ...(axisOptions ? deepMerge(axisOptions[this.xAxisType], axisOptions[this.xAxisType]?.bottom) : {}),
                 type: this.xAxisType,
                 position: 'bottom',
             },
             {
-                ...(axisOptions ? deepMerge(axisOptions[this.yAxisType], axisOptions[this.yAxisType]?.left) : {}),
                 type: this.yAxisType,
                 position: 'left',
             },

--- a/enterprise-modules/charts/src/charts/chartComp/chartProxies/cartesian/lineChartProxy.ts
+++ b/enterprise-modules/charts/src/charts/chartComp/chartProxies/cartesian/lineChartProxy.ts
@@ -1,7 +1,6 @@
 import { AgCartesianAxisOptions, AgLineSeriesOptions } from "ag-charts-community";
 import { ChartProxyParams, UpdateChartParams } from "../chartProxy";
 import { CartesianChartProxy } from "./cartesianChartProxy";
-import { deepMerge } from "../../utils/object";
 
 export class LineChartProxy extends CartesianChartProxy {
 
@@ -19,15 +18,12 @@ export class LineChartProxy extends CartesianChartProxy {
     }
 
     public getAxes(): AgCartesianAxisOptions[] {
-        const axisOptions = this.getAxesOptions();
         return [
             {
-                ...(axisOptions ? deepMerge(axisOptions[this.xAxisType], axisOptions[this.xAxisType]?.bottom) : {}),
                 type: this.xAxisType,
                 position: 'bottom'
             },
             {
-                ...(axisOptions ? deepMerge(axisOptions[this.yAxisType], axisOptions[this.yAxisType]?.left) : {}),
                 type: this.yAxisType,
                 position: 'left'
             },
@@ -37,13 +33,12 @@ export class LineChartProxy extends CartesianChartProxy {
     public getSeries(params: UpdateChartParams) {
         const series: AgLineSeriesOptions[] = params.fields.map(f => (
             {
-                ...this.extractSeriesOverrides(),
                 type: this.standaloneChartType,
                 xKey: params.category.id,
                 xName: params.category.name,
                 yKey: f.colId,
                 yName: f.displayName
-            }
+            } as AgLineSeriesOptions
         ));
 
         return this.crossFiltering ? this.extractLineAreaCrossFilterSeries(series, params) : series;

--- a/enterprise-modules/charts/src/charts/chartComp/chartProxies/cartesian/scatterChartProxy.ts
+++ b/enterprise-modules/charts/src/charts/chartComp/chartProxies/cartesian/scatterChartProxy.ts
@@ -1,7 +1,6 @@
 import { AgCartesianAxisOptions, AgScatterSeriesMarker, AgScatterSeriesOptions } from "ag-charts-community";
 import { ChartProxyParams, FieldDefinition, UpdateChartParams } from "../chartProxy";
 import { CartesianChartProxy } from "./cartesianChartProxy";
-import { deepMerge } from "../../utils/object";
 import { ChartDataModel } from "../../chartDataModel";
 
 interface SeriesDefinition {
@@ -27,15 +26,12 @@ export class ScatterChartProxy extends CartesianChartProxy {
     }
 
     public getAxes(): AgCartesianAxisOptions[] {
-        const axisOptions = this.getAxesOptions();
         return [
             {
-                ...(axisOptions ? deepMerge(axisOptions[this.xAxisType], axisOptions[this.xAxisType]?.bottom) : {}),
                 type: this.xAxisType,
                 position: 'bottom',
             },
             {
-                ...(axisOptions ? deepMerge(axisOptions[this.yAxisType], axisOptions[this.yAxisType]?.left) : {}),
                 type: this.yAxisType,
                 position: 'left',
             },
@@ -43,13 +39,12 @@ export class ScatterChartProxy extends CartesianChartProxy {
     }
 
     public getSeries(params: UpdateChartParams): AgScatterSeriesOptions[] {
-        const paired = this.chartOptions[this.standaloneChartType]?.paired;
+        const paired = this.getIntegratedThemeOptions()[this.standaloneChartType]?.paired;
         const seriesDefinitions = this.getSeriesDefinitions(params.fields, paired);
         const labelFieldDefinition = params.category.id === ChartDataModel.DEFAULT_CATEGORY ? undefined : params.category;
 
         const series: AgScatterSeriesOptions[] = seriesDefinitions.map(seriesDefinition => (
             {
-                ...this.extractSeriesOverrides(),
                 type: this.standaloneChartType,
                 xKey: seriesDefinition!.xField.colId,
                 xName: seriesDefinition!.xField.displayName,
@@ -60,7 +55,7 @@ export class ScatterChartProxy extends CartesianChartProxy {
                 sizeName: seriesDefinition!.sizeField ? seriesDefinition!.sizeField.displayName : undefined,
                 labelKey: labelFieldDefinition ? labelFieldDefinition.id : seriesDefinition!.yField.colId,
                 labelName: labelFieldDefinition ? labelFieldDefinition.name : undefined,
-            }
+            } as AgScatterSeriesOptions
         ));
 
         return this.crossFiltering ? this.extractCrossFilterSeries(series, params) : series;
@@ -71,7 +66,7 @@ export class ScatterChartProxy extends CartesianChartProxy {
         params: UpdateChartParams,
     ): AgScatterSeriesOptions[] {
         const { data } = params;
-        const palette = this.chartPalette;
+        const palette = this.getChartPalette();
 
         const filteredOutKey = (key: string) => `${key}-filtered-out`;
 

--- a/enterprise-modules/charts/src/charts/chartComp/chartProxies/combo/comboChartProxy.ts
+++ b/enterprise-modules/charts/src/charts/chartComp/chartProxies/combo/comboChartProxy.ts
@@ -2,7 +2,6 @@ import { AgCartesianAxisOptions } from "ag-charts-community";
 import { ChartType, SeriesChartType } from "@ag-grid-community/core";
 import { ChartProxyParams, FieldDefinition, UpdateChartParams } from "../chartProxy";
 import { CartesianChartProxy } from "../cartesian/cartesianChartProxy";
-import { deepMerge } from "../../utils/object";
 import { getSeriesType } from "../../utils/seriesTypeMapper";
 
 export class ComboChartProxy extends CartesianChartProxy {
@@ -25,11 +24,9 @@ export class ComboChartProxy extends CartesianChartProxy {
         const fieldsMap = new Map(fields.map(f => [f.colId, f]));
 
         const { primaryYKeys, secondaryYKeys } = this.getYKeys(fields, params.seriesChartTypes);
-        const { bottomOptions, leftOptions, rightOptions } = this.getAxisOptions();
 
-        const axes = [
+        const axes: AgCartesianAxisOptions[] = [
             {
-                ...bottomOptions,
                 type: this.xAxisType,
                 position: 'bottom',
                 gridStyle: [{ stroke: undefined }],
@@ -38,18 +35,14 @@ export class ComboChartProxy extends CartesianChartProxy {
 
         if (primaryYKeys.length > 0) {
             axes.push({
-                ...leftOptions,
                 type: this.yAxisType,
                 keys: primaryYKeys,
                 position: 'left',
                 title: {
-                    ...deepMerge(leftOptions.title, {
-                        enabled: leftOptions.title?.enabled,
-                        text: primaryYKeys.map(key => {
-                            const field = fieldsMap.get(key);
-                            return field ? field.displayName : key;
-                        }).join(' / '),
-                    })
+                    text: primaryYKeys.map(key => {
+                        const field = fieldsMap.get(key);
+                        return field ? field.displayName : key;
+                    }).join(' / '),
                 },
             });
         }
@@ -62,16 +55,12 @@ export class ComboChartProxy extends CartesianChartProxy {
                     return;
                 }
 
-                const secondaryAxisOptions = {
-                    ...rightOptions,
+                const secondaryAxisOptions: AgCartesianAxisOptions = {
                     type: this.yAxisType,
                     keys: [secondaryYKey],
                     position: 'right',
                     title: {
-                        ...deepMerge(rightOptions.title, {
-                            enabled: rightOptions.title?.enabled,
-                            text: field ? field.displayName : secondaryYKey,
-                        })
+                        text: field ? field.displayName! : secondaryYKey,
                     },
                 }
 
@@ -99,7 +88,6 @@ export class ComboChartProxy extends CartesianChartProxy {
             if (seriesChartType) {
                 const chartType: ChartType = seriesChartType.chartType;
                 return {
-                    ...this.extractSeriesOverrides(getSeriesType(seriesChartType.chartType)),
                     type: getSeriesType(chartType),
                     xKey: category.id,
                     yKey: field.colId,
@@ -109,19 +97,6 @@ export class ComboChartProxy extends CartesianChartProxy {
                 }
             }
         });
-    }
-
-    private getAxisOptions() {
-        const axisOptions = this.getAxesOptions('cartesian');
-        return axisOptions ? {
-            bottomOptions: deepMerge(axisOptions[this.xAxisType], axisOptions[this.xAxisType]?.bottom),
-            leftOptions: deepMerge(axisOptions[this.yAxisType], axisOptions[this.yAxisType]?.left),
-            rightOptions: deepMerge(axisOptions[this.yAxisType], axisOptions[this.yAxisType]?.right),
-        } : {
-            bottomOptions: {},
-            leftOptions: {},
-            rightOptions: {},
-        };
     }
 
     private getYKeys(fields: FieldDefinition[], seriesChartTypes: SeriesChartType[]) {

--- a/enterprise-modules/charts/src/charts/chartComp/services/chartOptionsService.ts
+++ b/enterprise-modules/charts/src/charts/chartComp/services/chartOptionsService.ts
@@ -1,13 +1,10 @@
 import {
     _,
     AgChartThemeOverrides,
-    Autowired,
     BeanStub,
     ChartOptionsChanged,
     ChartType,
-    ColumnApi,
     Events,
-    GridApi,
     WithoutGridCommon
 } from "@ag-grid-community/core";
 import { AgCartesianAxisType, AgChartInstance } from "ag-charts-community";
@@ -18,10 +15,6 @@ import { ChartSeriesType, getSeriesType } from "../utils/seriesTypeMapper";
 type ChartAxis = NonNullable<AgChartActual['axes']>[number];
 type SupportedSeries = AgChartActual['series'][number];
 export class ChartOptionsService extends BeanStub {
-
-    @Autowired('gridApi') private readonly gridApi: GridApi;
-    @Autowired('columnApi') private readonly columnApi: ColumnApi;
-
     private readonly chartController: ChartController;
 
     constructor(chartController: ChartController) {


### PR DESCRIPTION
Follow up to https://github.com/ag-grid/ag-grid/pull/5765

## Changes

* Get chart options from Chart `getOptions()` and delete `chartOptions` and `chartPalette` in `chartProxy`.  `chartProxy.agChartTheme` stores theme on creation, but during updates, changes are made directly to the chart using `AgChart.updateDelta`. Hence the Chart stores the state of the options and to retrieve it `getOptions()` can be used.
  * Special handling for `scatter.paired` to be persisted in `chartProxy` to make it explicit that it's only for Integrated Charts
* Remove chart options merges within child chart proxies since these were for styles, and this is now managed by the Chart