### PR TITLE
AG-7431 - Mark path dirty transofrm when seriesRoot transformed durin…

### DIFF
--- a/charts-packages/ag-charts-community/src/scene/node.ts
+++ b/charts-packages/ag-charts-community/src/scene/node.ts
@@ -251,6 +251,9 @@ export abstract class Node extends ChangeDetectable {
     markDirtyTransform() {
         this._dirtyTransform = true;
         this.markDirty(this, RedrawType.MAJOR);
+        for (const child of this.children) {
+            child.markDirtyTransform();
+        }
     }
 
     @SceneChangeDetection({ type: 'transform' })


### PR DESCRIPTION
Path render was not being invoked during re-render to apply the new transform