### PR TITLE
AG-7457 Fix callout line color mismatch

### DIFF
--- a/charts-packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
@@ -202,11 +202,6 @@ export class AreaSeries extends CartesianSeries<AreaSeriesNodeDataContext> {
         this._yKeys.forEach((key, idx) => seriesItemEnabled.set(key, visibles[idx] ?? true));
     }
 
-    setColors(fills: string[], strokes: string[]) {
-        this.fills = fills;
-        this.strokes = strokes;
-    }
-
     @Validate(STRING_ARRAY)
     yNames: string[] = [];
 

--- a/charts-packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
@@ -289,11 +289,6 @@ export class BarSeries extends CartesianSeries<SeriesNodeDataContext<BarNodeDatu
         return this._yNames;
     }
 
-    setColors(fills: string[], strokes: string[]) {
-        this.fills = fills;
-        this.strokes = strokes;
-    }
-
     /**
      * The value to normalize the bars to.
      * Should be a finite positive value or `undefined`.

--- a/charts-packages/ag-charts-community/src/chart/series/cartesian/histogramSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/cartesian/histogramSeries.ts
@@ -219,11 +219,6 @@ export class HistogramSeries extends CartesianSeries<SeriesNodeDataContext<Histo
 
     shadow?: DropShadow = undefined;
 
-    setColors(fills: string[], strokes: string[]) {
-        this.fill = fills[0];
-        this.stroke = strokes[0];
-    }
-
     protected highlightedDatum?: HistogramNodeDatum;
 
     // During processData phase, used to unify different ways of the user specifying

--- a/charts-packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
@@ -119,12 +119,6 @@ export class LineSeries extends CartesianSeries<LineContext> {
         label.enabled = false;
     }
 
-    setColors(fills: string[], strokes: string[]) {
-        this.stroke = fills[0];
-        this.marker.stroke = strokes[0];
-        this.marker.fill = fills[0];
-    }
-
     @Validate(STRING)
     protected _xKey: string = '';
     set xKey(value: string) {

--- a/charts-packages/ag-charts-community/src/chart/series/cartesian/scatterSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/cartesian/scatterSeries.ts
@@ -130,11 +130,6 @@ export class ScatterSeries extends CartesianSeries<SeriesNodeDataContext<Scatter
         label.enabled = false;
     }
 
-    setColors(fills: string[], strokes: string[]) {
-        this.marker.fill = fills[0];
-        this.marker.stroke = strokes[0];
-    }
-
     async processData() {
         const { xKey, yKey, sizeKey, xAxis, yAxis, marker } = this;
 

--- a/charts-packages/ag-charts-community/src/chart/series/polar/pieSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/polar/pieSeries.ts
@@ -30,6 +30,7 @@ import {
     OPT_STRING,
     STRING,
     COLOR_STRING_ARRAY,
+    OPT_COLOR_STRING_ARRAY,
     Validate,
     COLOR_STRING,
 } from '../../../util/validation';
@@ -122,8 +123,8 @@ class PieSeriesSectorLabel extends Label {
 }
 
 class PieSeriesCalloutLine {
-    @Validate(COLOR_STRING_ARRAY)
-    colors: string[] = ['#874349', '#718661', '#a48f5f', '#5a7088', '#7f637a', '#5d8692'];
+    @Validate(OPT_COLOR_STRING_ARRAY)
+    colors: string[] | undefined = undefined;
 
     @Validate(NUMBER(0))
     length: number = 10;
@@ -826,7 +827,8 @@ export class PieSeries extends PolarSeries<PieNodeDatum> {
             }
         });
 
-        const { colors: calloutColors, length: calloutLength, strokeWidth: calloutStrokeWidth } = calloutLine;
+        const { length: calloutLength, strokeWidth: calloutStrokeWidth } = calloutLine;
+        const calloutColors = calloutLine.colors || this.strokes;
 
         this.calloutLabelSelection.selectByTag<Line>(PieNodeTag.Callout).each((line, datum, index) => {
             const radius = radiusScale.convert(datum.radius, clamper);

--- a/charts-packages/ag-charts-community/src/chart/series/polar/pieSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/polar/pieSeries.ts
@@ -417,12 +417,6 @@ export class PieSeries extends PolarSeries<PieNodeDatum> {
         this.seriesItemEnabled = data?.map(() => visible) || [];
     }
 
-    setColors(fills: string[], strokes: string[]) {
-        this.fills = fills;
-        this.strokes = strokes;
-        this.calloutLine.colors = strokes;
-    }
-
     getDomain(direction: ChartAxisDirection): any[] {
         if (direction === ChartAxisDirection.X) {
             return this.angleScale.domain;

--- a/charts-packages/ag-charts-community/src/chart/series/series.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/series.ts
@@ -230,10 +230,6 @@ export abstract class Series<C extends SeriesNodeDataContext = SeriesNodeDataCon
         }
     }
 
-    setColors(_fills: string[], _strokes: string[]) {
-        // Override point for subclasses.
-    }
-
     // Returns the actual keys used (to fetch the values from `data` items) for the given direction.
     getKeys(direction: ChartAxisDirection): string[] {
         const { directionKeys } = this;


### PR DESCRIPTION
- Use sectors stroke colors for callout line if unset.
- Remove unused Series.setColors method.