### PR TITLE
Ag 7579 change detection via grid options service

### DIFF
--- a/community-modules/client-side-row-model/src/clientSideRowModel/clientSideRowModel.ts
+++ b/community-modules/client-side-row-model/src/clientSideRowModel/clientSideRowModel.ts
@@ -98,8 +98,8 @@ export class ClientSideRowModel extends BeanStub implements IClientSideRowModel 
             animate
         });
 
-        this.addManagedListener(this.gridOptionsWrapper, GridOptionsWrapper.PROP_GROUP_REMOVE_SINGLE_CHILDREN, refreshMapListener);
-        this.addManagedListener(this.gridOptionsWrapper, GridOptionsWrapper.PROP_GROUP_REMOVE_LOWEST_SINGLE_CHILDREN, refreshMapListener);
+        this.addManagedPropertyListener('groupRemoveSingleChildren', refreshMapListener);
+        this.addManagedPropertyListener('groupRemoveLowestSingleChildren', refreshMapListener);
 
         this.rootNode = new RowNode(this.beans);
         this.nodeManager = new ClientSideNodeManager(this.rootNode,

--- a/community-modules/core/src/ts/columns/columnModel.ts
+++ b/community-modules/core/src/ts/columns/columnModel.ts
@@ -268,9 +268,9 @@ export class ColumnModel extends BeanStub {
 
         this.usingTreeData = this.gridOptionsWrapper.isTreeData();
 
-        this.addManagedListener(this.gridOptionsWrapper, GridOptionsWrapper.PROP_GROUP_DISPLAY_TYPE, () => this.onAutoGroupColumnDefChanged());
-        this.addManagedListener(this.gridOptionsWrapper, GridOptionsWrapper.PROP_AUTO_GROUP_COLUMN_DEF, () => this.onAutoGroupColumnDefChanged());
-        this.addManagedListener(this.gridOptionsWrapper, GridOptionsWrapper.PROP_DEFAULT_COL_DEF, () => this.onDefaultColDefChanged());
+        this.addManagedPropertyListener('groupDisplayType', () => this.onAutoGroupColumnDefChanged());
+        this.addManagedPropertyListener('autoGroupColumnDef', () => this.onAutoGroupColumnDefChanged());
+        this.addManagedPropertyListener('defaultColDef', () => this.onDefaultColDefChanged());
     }
 
     public onAutoGroupColumnDefChanged() {

--- a/community-modules/core/src/ts/components/componentUtil.ts
+++ b/community-modules/core/src/ts/components/componentUtil.ts
@@ -41,6 +41,7 @@ export class ComponentUtil {
             ...ComponentUtil.ARRAY_PROPERTIES,
             ...ComponentUtil.OBJECT_PROPERTIES,
             ...ComponentUtil.STRING_PROPERTIES,
+            ...ComponentUtil.FUNCTION_PROPERTIES,
             ...ComponentUtil.getEventCallbacks(),
         ]
             .forEach((key: keyof GridOptions) => this.coercionLookup[key] = 'none');

--- a/community-modules/core/src/ts/components/componentUtil.ts
+++ b/community-modules/core/src/ts/components/componentUtil.ts
@@ -30,12 +30,54 @@ export class ComponentUtil {
     public static FUNCTION_PROPERTIES = PropertyKeys.FUNCTION_PROPERTIES;
     public static ALL_PROPERTIES = PropertyKeys.ALL_PROPERTIES;
 
+    private static coercionLookup: Record<keyof GridOptions, 'number' | 'boolean' | 'none'>;
+    private static getCoercionLookup() {
+        if (this.coercionLookup) {
+            return this.coercionLookup;
+        }
+
+        this.coercionLookup = {} as any
+        [
+            ...ComponentUtil.ARRAY_PROPERTIES,
+            ...ComponentUtil.OBJECT_PROPERTIES,
+            ...ComponentUtil.STRING_PROPERTIES,
+            ...ComponentUtil.getEventCallbacks(),
+        ]
+            .forEach((key: keyof GridOptions) => this.coercionLookup[key] = 'none');
+        ComponentUtil.BOOLEAN_PROPERTIES
+            .forEach(key => this.coercionLookup[key] = 'boolean');
+        ComponentUtil.NUMBER_PROPERTIES
+            .forEach(key => this.coercionLookup[key] = 'number');
+        return this.coercionLookup;
+    }
+
     public static getEventCallbacks(): string[] {
         if (!ComponentUtil.EVENT_CALLBACKS) {
             ComponentUtil.EVENT_CALLBACKS = ComponentUtil.EVENTS.map(event => ComponentUtil.getCallbackForEvent(event));
         }
-
         return ComponentUtil.EVENT_CALLBACKS;
+    }
+
+    private static getValue(key: string, rawValue: any) {
+        const coercionStep = ComponentUtil.getCoercionLookup()[key as keyof GridOptions];
+
+        if (coercionStep) {
+            let newValue = rawValue;
+            switch (coercionStep) {
+                case 'number':
+                    newValue = ComponentUtil.toNumber(rawValue);
+                case 'boolean':
+                    newValue = ComponentUtil.toBoolean(rawValue);
+                case 'none': {
+                    // if groupAggFiltering exists and isn't a function, handle as a boolean.
+                    if (key === 'groupAggFiltering' && typeof rawValue !== 'function') {
+                        newValue = ComponentUtil.toBoolean(rawValue);
+                    }
+                }
+            }
+            return newValue;
+        }
+        return undefined;
     }
 
     public static copyAttributesToGridOptions(gridOptions: GridOptions | undefined, component: any, skipEventDeprecationCheck: boolean = false): GridOptions {
@@ -44,36 +86,17 @@ export class ComponentUtil {
         if (typeof gridOptions !== 'object') {
             gridOptions = {} as GridOptions;
         }
-
         // to allow array style lookup in TypeScript, take type away from 'this' and 'gridOptions'
         const pGridOptions = gridOptions as any;
-        const keyExists = (key: string) => typeof component[key] !== 'undefined';
-
-        // if groupAggFiltering exists and isn't a function, handle as a boolean.
-        if (keyExists('groupAggFiltering') && typeof component.groupAggFiltering !== 'function') {
-            pGridOptions.groupAggFiltering = ComponentUtil.toBoolean(component.groupAggFiltering);
-            delete component.groupAggFiltering;
-        }
-
-        // add in all the simple properties
-        [
-            ...ComponentUtil.ARRAY_PROPERTIES,
-            ...ComponentUtil.STRING_PROPERTIES,
-            ...ComponentUtil.OBJECT_PROPERTIES,
-            ...ComponentUtil.FUNCTION_PROPERTIES,
-            ...ComponentUtil.getEventCallbacks(),
-        ]
-            .filter(keyExists)
-            .forEach(key => pGridOptions[key] = component[key]);
-
-        ComponentUtil.BOOLEAN_PROPERTIES
-            .filter(keyExists)
-            .forEach(key => pGridOptions[key] = ComponentUtil.toBoolean(component[key]));
-
-        ComponentUtil.NUMBER_PROPERTIES
-            .filter(keyExists)
-            .forEach(key => pGridOptions[key] = ComponentUtil.toNumber(component[key]));
-
+        // Loop through component props, if they are not undefined and a valid gridOption copy to gridOptions
+        Object.entries<GridOptions>(component).map(([key, value]) => {
+            if (typeof value !== 'undefined') {
+                const coercedValue = ComponentUtil.getValue(key, value);
+                if (coercedValue !== undefined) {
+                    pGridOptions[key] = coercedValue;
+                }
+            }
+        })
         return gridOptions;
     }
 
@@ -92,158 +115,44 @@ export class ComponentUtil {
 
         const changesToApply = { ...changes };
 
-        // to allow array style lookup in TypeScript, take type away from 'this' and 'gridOptions'
-        const pGridOptions = gridOptions as any;
-        const keyExists = (key: string) => changesToApply[key];
-
-        // if groupAggFiltering exists and isn't a function, handle as a boolean.
-        if (keyExists('groupAggFiltering')) {
-            if (typeof changesToApply.groupAggFiltering === 'function') {
-                pGridOptions.groupAggFiltering = changesToApply.groupAggFiltering;
-            } else {
-                pGridOptions.groupAggFiltering = ComponentUtil.toBoolean(changesToApply.groupAggFiltering);
-            }
-            delete changesToApply.groupAggFiltering;
-        }
-
-        if (keyExists('groupDisplayType')) {
-            if (typeof changesToApply.groupDisplayType.currentValue === 'string') {
-                api.setGroupDisplayType(changesToApply.groupDisplayType.currentValue);
-                delete changesToApply.groupDisplayType;
-            }
-        }
-        // *********  CODE ORDER TO AVOID BUGS *************** //
-        // If you want to call an update method that just calls through to gridOptionsWrapper.setProperty then it needs to be
-        // called before the values get copied across otherwise the change will not fire an event because the method
-        // gridOptionsWrapper.setProperty does a diff check first.
-
-        // All these manual calls are required in the current setup as changes to these properties are being listened to in the 
-        // rest of the code base which can be found by searching for: "addManagedListener(this.gridOptionsWrapper"
-
-        if (changesToApply.domLayout) {
-            api.setDomLayout(changesToApply.domLayout.currentValue);
-            delete changesToApply.domLayout;
-        }
-        if (changesToApply.rowClass) {
-            api.setRowClass(changesToApply.rowClass.currentValue);
-            delete changesToApply.rowClass;
-        }
-        if (changesToApply.paginationPageSize) {
-            api.paginationSetPageSize(ComponentUtil.toNumber(changesToApply.paginationPageSize.currentValue));
-            delete changesToApply.paginationPageSize;
-        }
-        if (changesToApply.rowGroupPanelShow) {
-            api.setRowGroupPanelShow(changesToApply.rowGroupPanelShow.currentValue);
-            delete changesToApply.rowGroupPanelShow;
-        }
-        if (changesToApply.groupRemoveSingleChildren) {
-            api.setGroupRemoveSingleChildren(ComponentUtil.toBoolean(changesToApply.groupRemoveSingleChildren.currentValue));
-            delete changesToApply.groupRemoveSingleChildren;
-        }
-        if (changesToApply.groupRemoveLowestSingleChildren) {
-            api.setGroupRemoveLowestSingleChildren(ComponentUtil.toBoolean(changesToApply.groupRemoveLowestSingleChildren.currentValue));
-            delete changesToApply.groupRemoveLowestSingleChildren;
-        }
-        if (changesToApply.suppressRowDrag) {
-            api.setSuppressRowDrag(ComponentUtil.toBoolean(changesToApply.suppressRowDrag.currentValue));
-            delete changesToApply.suppressRowDrag;
-        }
-        if (changesToApply.suppressMoveWhenRowDragging) {
-            api.setSuppressMoveWhenRowDragging(ComponentUtil.toBoolean(changesToApply.suppressMoveWhenRowDragging.currentValue));
-            delete changesToApply.suppressMoveWhenRowDragging;
-        }
-        if (changesToApply.suppressRowClickSelection) {
-            api.setSuppressRowClickSelection(ComponentUtil.toBoolean(changesToApply.suppressRowClickSelection.currentValue));
-            delete changesToApply.suppressRowClickSelection;
-        }
-        if (changesToApply.suppressClipboardPaste) {
-            api.setSuppressClipboardPaste(ComponentUtil.toBoolean(changesToApply.suppressClipboardPaste.currentValue));
-            delete changesToApply.suppressClipboardPaste;
-        }
-        if (changesToApply.headerHeight) {
-            api.setHeaderHeight(ComponentUtil.toNumber(changesToApply.headerHeight.currentValue));
-            delete changesToApply.headerHeight;
-        }
-        if (changesToApply.pivotHeaderHeight) {
-            api.setPivotHeaderHeight(ComponentUtil.toNumber(changesToApply.pivotHeaderHeight.currentValue));
-            delete changesToApply.pivotHeaderHeight;
-        }
-        if (changesToApply.groupHeaderHeight) {
-            api.setGroupHeaderHeight(ComponentUtil.toNumber(changesToApply.groupHeaderHeight.currentValue));
-            delete changesToApply.groupHeaderHeight;
-        }
-        if (changesToApply.pivotGroupHeaderHeight) {
-            api.setPivotGroupHeaderHeight(ComponentUtil.toNumber(changesToApply.pivotGroupHeaderHeight.currentValue));
-            delete changesToApply.pivotGroupHeaderHeight;
-        }
-        if (changesToApply.floatingFiltersHeight) {
-            api.setFloatingFiltersHeight(ComponentUtil.toNumber(changesToApply.floatingFiltersHeight.currentValue));
-            delete changesToApply.floatingFiltersHeight;
-        }
-        if (changesToApply.functionsReadOnly) {
-            api.setFunctionsReadOnly(ComponentUtil.toBoolean(changesToApply.functionsReadOnly.currentValue));
-            delete changesToApply.functionsReadOnly;
-        }
-        // *********  CODE ORDER TO AVOID BUGS *************** //
-
-        // check if any change for the simple types, and if so, then just copy in the new value
-        [
-            ...ComponentUtil.ARRAY_PROPERTIES,
-            ...ComponentUtil.OBJECT_PROPERTIES,
-            ...ComponentUtil.STRING_PROPERTIES,
-            ...ComponentUtil.getEventCallbacks(),
-        ]
-            .filter(keyExists)
-            .forEach(key => pGridOptions[key] = changesToApply[key].currentValue);
-
-        ComponentUtil.BOOLEAN_PROPERTIES
-            .filter(keyExists)
-            .forEach(key => pGridOptions[key] = ComponentUtil.toBoolean(changesToApply[key].currentValue));
-
-        ComponentUtil.NUMBER_PROPERTIES
-            .filter(keyExists)
-            .forEach(key => pGridOptions[key] = ComponentUtil.toNumber(changesToApply[key].currentValue));
-
-
-        // *********  CODE ORDER TO AVOID BUGS *************** //
-        // The following manual updates call directly into code models and rely on the simple copy being made by the
-        // code above to keep gridOptions in sync with the change.
-        if (changesToApply.enableCellTextSelection) {
-            api.setEnableCellTextSelection(ComponentUtil.toBoolean(changesToApply.enableCellTextSelection.currentValue));
-            delete changesToApply.enableCellTextSelection;
-        }
-        if (changesToApply.quickFilterText) {
-            api.setQuickFilter(changesToApply.quickFilterText.currentValue);
-            delete changesToApply.quickFilterText;
-        }
+        // We manually call these updates so that we can provide a different source of gridOptionsChanged
+        // We do not call __setProperty as this will be called by the grid api methods
         if (changesToApply.autoGroupColumnDef) {
             api.setAutoGroupColumnDef(changesToApply.autoGroupColumnDef.currentValue, "gridOptionsChanged");
             delete changesToApply.autoGroupColumnDef;
-        }
-        if (changesToApply.columnDefs) {
-            api.setColumnDefs(changesToApply.columnDefs.currentValue, "gridOptionsChanged");
-            delete changesToApply.columnDefs;
         }
         if (changesToApply.defaultColDef) {
             api.setDefaultColDef(changesToApply.defaultColDef.currentValue, "gridOptionsChanged");
             delete changesToApply.defaultColDef;
         }
-        if (changesToApply.pivotMode) {
-            columnApi.setPivotMode(ComponentUtil.toBoolean(changesToApply.pivotMode.currentValue));
-            delete changesToApply.pivotMode;
+        if (changesToApply.columnDefs) {
+            api.setColumnDefs(changesToApply.columnDefs.currentValue, "gridOptionsChanged");
+            delete changesToApply.columnDefs;
         }
 
-        // any remaining properties can be set in a generic way
-        // ie the setter takes the form of setXXX and the argument requires no formatting/translation first
         const dynamicApi = (api as any);
-        Object.keys(changesToApply)
-            .forEach(property => {
-                const setterName = `set${property.charAt(0).toUpperCase()}${property.substring(1)}`;
+        Object.keys(changesToApply).forEach(key => {
+            const gridKey = key as keyof GridOptions;
 
-                if (dynamicApi[setterName]) {
-                    dynamicApi[setterName](changes[property].currentValue);
-                }
-            });
+            const coercedValue = ComponentUtil.getValue(gridKey, changesToApply[gridKey].currentValue);
+            // Ensure the GridOptions property gets updated and fires the change event as we
+            // cannot assume that the dynamic Api call updated GridOptions or fired the event.
+            // If the dynamic api did already update GridOptions then the change detection in the 
+            // setter should prevent the event being fired twice.
+            api.__setProperty(gridKey, coercedValue);
+
+            const setterName = `set${key.charAt(0).toUpperCase()}${key.substring(1)}`;
+            if (dynamicApi[setterName]) {
+                dynamicApi[setterName](coercedValue);
+            }
+        });
+
+        if (changesToApply.quickFilterText) {
+            // Name of api method does not follow convention so we have to manually call it.
+            // GridOptions property will be set above and fire event which could be used by the 
+            // filter manager to trigger update instead of via this api call.
+            api.setQuickFilter(changesToApply.quickFilterText.currentValue);
+        }
 
         // copy changes into an event for dispatch
         const event: WithoutGridCommon<ComponentStateChangedEvent> = {

--- a/community-modules/core/src/ts/context/beanStub.ts
+++ b/community-modules/core/src/ts/context/beanStub.ts
@@ -116,7 +116,7 @@ export class BeanStub implements IEventEmitter {
         return destroyFunc;
     }
 
-    public addManagedOptionsListener(
+    public addManagedPropertyListener(
         event: keyof GridOptions,
         listener: PropertyChangedListener
     ): (() => null) | undefined {

--- a/community-modules/core/src/ts/gridApi.ts
+++ b/community-modules/core/src/ts/gridApi.ts
@@ -10,12 +10,14 @@ import { ColDef, ColGroupDef, IAggFunc } from "./entities/colDef";
 import { Column } from "./entities/column";
 import {
     ChartRef,
+    DomLayoutType,
     GetChartToolbarItems,
     GetContextMenuItems,
     GetMainMenuItems,
     GetRowIdFunc,
     GetRowNodeIdFunc,
     GetServerSideGroupKey,
+    GridOptions,
     IsApplyServerSideTransaction,
     IsRowMaster,
     IsRowSelectable,
@@ -233,6 +235,13 @@ export class GridApi<TData = any> {
         return this.context;
     }
 
+    /**
+     * Used internally by grid. Not intended to be used by the client. Interface may change between releases
+     */
+    public __setProperty<K extends keyof GridOptions>(propertyName: K, value: GridOptions[K]) {
+        this.gridOptionsService.set(propertyName, value);
+    }
+
     /** Register a detail grid with the master grid when it is created. */
     public addDetailGridInfo(id: string, gridInfo: DetailGridInfo): void {
         this.detailGridInfoMap[id] = gridInfo;
@@ -366,7 +375,7 @@ export class GridApi<TData = any> {
      * */
     public setCacheBlockSize(blockSize: number) {
         if (this.serverSideRowModel) {
-            this.gridOptionsWrapper.setProperty('cacheBlockSize', blockSize);
+            this.gridOptionsService.set('cacheBlockSize', blockSize);
             this.serverSideRowModel.resetRootStore();
         } else {
             this.logMissingRowModel('setCacheBlockSize', 'serverSide');
@@ -448,16 +457,18 @@ export class GridApi<TData = any> {
      */
     public setColumnDefs(colDefs: (ColDef | ColGroupDef)[], source: ColumnEventType = "api") {
         this.columnModel.setColumnDefs(colDefs, source);
+        // Keep gridOptions.columnDefs in sync
+        this.gridOptionsService.set('columnDefs', colDefs, true, { source });
     }
 
     /** Call to set new auto group column definition. The grid will recreate any auto-group columns if present. */
     public setAutoGroupColumnDef(colDef: ColDef, source: ColumnEventType = "api") {
-        this.gridOptionsWrapper.setProperty('autoGroupColumnDef', colDef, true);
+        this.gridOptionsService.set('autoGroupColumnDef', colDef, true, { source });
     }
 
     /** Call to set new Default Column Definition. */
     public setDefaultColDef(colDef: ColDef, source: ColumnEventType = "api") {
-        this.gridOptionsWrapper.setProperty('defaultColDef', colDef, true);
+        this.gridOptionsService.set('defaultColDef', colDef, true, { source });
     }
 
     public expireValueCache(): void {
@@ -484,12 +495,12 @@ export class GridApi<TData = any> {
 
     /** If `true`, the horizontal scrollbar will always be present, even if not required. Otherwise, it will only be displayed when necessary. */
     public setAlwaysShowHorizontalScroll(show: boolean) {
-        this.gridOptionsWrapper.setProperty('alwaysShowHorizontalScroll', show);
+        this.gridOptionsService.set('alwaysShowHorizontalScroll', show);
     }
 
     /** If `true`, the vertical scrollbar will always be present, even if not required. Otherwise it will only be displayed when necessary. */
     public setAlwaysShowVerticalScroll(show: boolean) {
-        this.gridOptionsWrapper.setProperty('alwaysShowVerticalScroll', show);
+        this.gridOptionsService.set('alwaysShowVerticalScroll', show);
     }
 
     /** Performs change detection on all cells, refreshing cells where required. */
@@ -509,7 +520,7 @@ export class GridApi<TData = any> {
     }
 
     public setFunctionsReadOnly(readOnly: boolean) {
-        this.gridOptionsWrapper.setProperty('functionsReadOnly', readOnly);
+        this.gridOptionsService.set('functionsReadOnly', readOnly);
     }
 
     /** Redraws the header. Useful if a column name changes, or something else that changes how the column header is displayed. */
@@ -925,17 +936,17 @@ export class GridApi<TData = any> {
 
     /** Sets the `suppressRowDrag` property. */
     public setSuppressRowDrag(value: boolean): void {
-        this.gridOptionsWrapper.setProperty('suppressRowDrag', value);
+        this.gridOptionsService.set('suppressRowDrag', value);
     }
 
     /** Sets the `suppressMoveWhenRowDragging` property. */
     public setSuppressMoveWhenRowDragging(value: boolean): void {
-        this.gridOptionsWrapper.setProperty('suppressMoveWhenRowDragging', value);
+        this.gridOptionsService.set('suppressMoveWhenRowDragging', value);
     }
 
     /** Sets the `suppressRowClickSelection` property. */
     public setSuppressRowClickSelection(value: boolean): void {
-        this.gridOptionsWrapper.setProperty('suppressRowClickSelection', value);
+        this.gridOptionsService.set('suppressRowClickSelection', value);
     }
 
     /** Adds a drop zone outside of the grid where rows can be dropped. */
@@ -959,15 +970,15 @@ export class GridApi<TData = any> {
 
     /** Sets the height in pixels for the row containing the column label header. */
     public setHeaderHeight(headerHeight?: number) {
-        this.gridOptionsWrapper.setProperty('headerHeight', headerHeight);
+        this.gridOptionsService.set('headerHeight', headerHeight);
     }
 
     /**
      * Switch between layout options: `normal`, `autoHeight`, `print`.
      * Defaults to `normal` if no domLayout provided.
      */
-    public setDomLayout(domLayout?: 'normal' | 'autoHeight' | 'print') {
-        this.gridOptionsWrapper.setProperty('domLayout', domLayout);
+    public setDomLayout(domLayout?: DomLayoutType) {
+        this.gridOptionsService.set('domLayout', domLayout);
     }
 
     /** Sets the `enableCellTextSelection` property. */
@@ -977,134 +988,138 @@ export class GridApi<TData = any> {
 
     /** Sets the preferred direction for the selection fill handle. */
     public setFillHandleDirection(direction: 'x' | 'y' | 'xy') {
-        this.gridOptionsWrapper.setProperty('fillHandleDirection', direction);
+        this.gridOptionsService.set('fillHandleDirection', direction);
     }
 
     /** Sets the height in pixels for the rows containing header column groups. */
     public setGroupHeaderHeight(headerHeight?: number) {
-        this.gridOptionsWrapper.setProperty('groupHeaderHeight', headerHeight);
+        this.gridOptionsService.set('groupHeaderHeight', headerHeight);
     }
 
     /** Sets the height in pixels for the row containing the floating filters. */
     public setFloatingFiltersHeight(headerHeight?: number) {
-        this.gridOptionsWrapper.setProperty('floatingFiltersHeight', headerHeight);
+        this.gridOptionsService.set('floatingFiltersHeight', headerHeight);
     }
 
     /** Sets the height in pixels for the row containing the columns when in pivot mode. */
     public setPivotHeaderHeight(headerHeight?: number) {
-        this.gridOptionsWrapper.setProperty('pivotHeaderHeight', headerHeight);
+        this.gridOptionsService.set('pivotHeaderHeight', headerHeight);
     }
 
     /** Sets the height in pixels for the row containing header column groups when in pivot mode. */
     public setPivotGroupHeaderHeight(headerHeight?: number) {
-        this.gridOptionsWrapper.setProperty('pivotGroupHeaderHeight', headerHeight);
+        this.gridOptionsService.set('pivotGroupHeaderHeight', headerHeight);
+    }
+
+    public setPivotMode(pivotMode: boolean) {
+        this.columnModel.setPivotMode(pivotMode);
     }
 
     public setIsExternalFilterPresent(isExternalFilterPresentFunc: () => boolean): void {
-        this.gridOptionsWrapper.setProperty('isExternalFilterPresent', isExternalFilterPresentFunc);
+        this.gridOptionsService.set('isExternalFilterPresent', isExternalFilterPresentFunc);
     }
 
     public setDoesExternalFilterPass(doesExternalFilterPassFunc: (node: RowNode) => boolean): void {
-        this.gridOptionsWrapper.setProperty('doesExternalFilterPass', doesExternalFilterPassFunc);
+        this.gridOptionsService.set('doesExternalFilterPass', doesExternalFilterPassFunc);
     }
 
     public setNavigateToNextCell(navigateToNextCellFunc: (params: NavigateToNextCellParams) => (CellPosition | null)): void {
-        this.gridOptionsWrapper.setProperty('navigateToNextCell', navigateToNextCellFunc);
+        this.gridOptionsService.set('navigateToNextCell', navigateToNextCellFunc);
     }
 
     public setTabToNextCell(tabToNextCellFunc: (params: TabToNextCellParams) => (CellPosition | null)): void {
-        this.gridOptionsWrapper.setProperty('tabToNextCell', tabToNextCellFunc);
+        this.gridOptionsService.set('tabToNextCell', tabToNextCellFunc);
     }
 
     public setTabToNextHeader(tabToNextHeaderFunc: (params: TabToNextHeaderParams) => (HeaderPosition | null)): void {
-        this.gridOptionsWrapper.setProperty('tabToNextHeader', tabToNextHeaderFunc);
+        this.gridOptionsService.set('tabToNextHeader', tabToNextHeaderFunc);
     }
 
     public setNavigateToNextHeader(navigateToNextHeaderFunc: (params: NavigateToNextHeaderParams) => (HeaderPosition | null)): void {
-        this.gridOptionsWrapper.setProperty('navigateToNextHeader', navigateToNextHeaderFunc);
+        this.gridOptionsService.set('navigateToNextHeader', navigateToNextHeaderFunc);
     }
 
     public setRowGroupPanelShow(rowGroupPanelShow: 'always' | 'onlyWhenGrouping' | 'never'): void {
-        this.gridOptionsWrapper.setProperty('rowGroupPanelShow', rowGroupPanelShow);
+        this.gridOptionsService.set('rowGroupPanelShow', rowGroupPanelShow);
     }
     /** @deprecated v27.2 - Use `setGetGroupRowAgg` instead. */
     public setGroupRowAggNodes(groupRowAggNodesFunc: (nodes: RowNode[]) => any): void {
-        this.gridOptionsWrapper.setProperty('groupRowAggNodes', groupRowAggNodesFunc);
+        this.gridOptionsService.set('groupRowAggNodes', groupRowAggNodesFunc);
     }
     public setGetGroupRowAgg(getGroupRowAggFunc: (params: GetGroupRowAggParams) => any): void {
-        this.gridOptionsWrapper.setProperty('getGroupRowAgg', getGroupRowAggFunc);
+        this.gridOptionsService.set('getGroupRowAgg', getGroupRowAggFunc);
     }
 
     public setGetBusinessKeyForNode(getBusinessKeyForNodeFunc: (nodes: RowNode) => string): void {
-        this.gridOptionsWrapper.setProperty('getBusinessKeyForNode', getBusinessKeyForNodeFunc);
+        this.gridOptionsService.set('getBusinessKeyForNode', getBusinessKeyForNodeFunc);
     }
 
     public setGetChildCount(getChildCountFunc: (dataItem: any) => number): void {
-        this.gridOptionsWrapper.setProperty('getChildCount', getChildCountFunc);
+        this.gridOptionsService.set('getChildCount', getChildCountFunc);
     }
 
     public setProcessRowPostCreate(processRowPostCreateFunc: (params: ProcessRowParams) => void): void {
-        this.gridOptionsWrapper.setProperty('processRowPostCreate', processRowPostCreateFunc);
+        this.gridOptionsService.set('processRowPostCreate', processRowPostCreateFunc);
     }
 
     /** @deprecated v27.1 Use `getRowId` instead  */
     public setGetRowNodeId(getRowNodeIdFunc: GetRowNodeIdFunc): void {
-        this.gridOptionsWrapper.setProperty('getRowNodeId', getRowNodeIdFunc);
+        this.gridOptionsService.set('getRowNodeId', getRowNodeIdFunc);
     }
     public setGetRowId(getRowIdFunc: GetRowIdFunc): void {
-        this.gridOptionsWrapper.setProperty('getRowId', getRowIdFunc);
+        this.gridOptionsService.set('getRowId', getRowIdFunc);
     }
 
     public setGetRowClass(rowClassFunc: (params: RowClassParams) => string | string[]): void {
-        this.gridOptionsWrapper.setProperty('getRowClass', rowClassFunc);
+        this.gridOptionsService.set('getRowClass', rowClassFunc);
     }
 
     /** @deprecated v27.2 Use `setIsFullWidthRow` instead. */
     public setIsFullWidthCell(isFullWidthCellFunc: (rowNode: RowNode) => boolean): void {
-        this.gridOptionsWrapper.setProperty('isFullWidthCell', isFullWidthCellFunc);
+        this.gridOptionsService.set('isFullWidthCell', isFullWidthCellFunc);
     }
     public setIsFullWidthRow(isFullWidthRowFunc: (params: IsFullWidthRowParams) => boolean): void {
-        this.gridOptionsWrapper.setProperty('isFullWidthRow', isFullWidthRowFunc);
+        this.gridOptionsService.set('isFullWidthRow', isFullWidthRowFunc);
     }
 
     public setIsRowSelectable(isRowSelectableFunc: IsRowSelectable): void {
-        this.gridOptionsWrapper.setProperty('isRowSelectable', isRowSelectableFunc);
+        this.gridOptionsService.set('isRowSelectable', isRowSelectableFunc);
     }
 
     public setIsRowMaster(isRowMasterFunc: IsRowMaster): void {
-        this.gridOptionsWrapper.setProperty('isRowMaster', isRowMasterFunc);
+        this.gridOptionsService.set('isRowMaster', isRowMasterFunc);
     }
 
     /** @deprecated v27.2 Use `setPostSortRows` instead */
     public setPostSort(postSortFunc: (nodes: RowNode[]) => void): void {
-        this.gridOptionsWrapper.setProperty('postSort', postSortFunc);
+        this.gridOptionsService.set('postSort', postSortFunc);
     }
     public setPostSortRows(postSortRowsFunc: (params: PostSortRowsParams) => void): void {
-        this.gridOptionsWrapper.setProperty('postSortRows', postSortRowsFunc);
+        this.gridOptionsService.set('postSortRows', postSortRowsFunc);
     }
 
     public setGetDocument(getDocumentFunc: () => Document): void {
-        this.gridOptionsWrapper.setProperty('getDocument', getDocumentFunc);
+        this.gridOptionsService.set('getDocument', getDocumentFunc);
     }
 
     public setGetContextMenuItems(getContextMenuItemsFunc: GetContextMenuItems): void {
-        this.gridOptionsWrapper.setProperty('getContextMenuItems', getContextMenuItemsFunc);
+        this.gridOptionsService.set('getContextMenuItems', getContextMenuItemsFunc);
     }
 
     public setGetMainMenuItems(getMainMenuItemsFunc: GetMainMenuItems): void {
-        this.gridOptionsWrapper.setProperty('getMainMenuItems', getMainMenuItemsFunc);
+        this.gridOptionsService.set('getMainMenuItems', getMainMenuItemsFunc);
     }
 
     public setProcessCellForClipboard(processCellForClipboardFunc: (params: ProcessCellForExportParams) => any): void {
-        this.gridOptionsWrapper.setProperty('processCellForClipboard', processCellForClipboardFunc);
+        this.gridOptionsService.set('processCellForClipboard', processCellForClipboardFunc);
     }
 
     public setSendToClipboard(sendToClipboardFunc: (params: { data: string }) => void): void {
-        this.gridOptionsWrapper.setProperty('sendToClipboard', sendToClipboardFunc);
+        this.gridOptionsService.set('sendToClipboard', sendToClipboardFunc);
     }
 
     public setProcessCellFromClipboard(processCellFromClipboardFunc: (params: ProcessCellForExportParams) => any): void {
-        this.gridOptionsWrapper.setProperty('processCellFromClipboard', processCellFromClipboardFunc);
+        this.gridOptionsService.set('processCellFromClipboard', processCellFromClipboardFunc);
     }
 
     /** @deprecated v28 use `setProcessPivotResultColDef` instead */
@@ -1120,31 +1135,31 @@ export class GridApi<TData = any> {
     }
 
     public setProcessPivotResultColDef(processPivotResultColDefFunc: (colDef: ColDef) => void): void {
-        this.gridOptionsWrapper.setProperty('processPivotResultColDef', processPivotResultColDefFunc);
+        this.gridOptionsService.set('processPivotResultColDef', processPivotResultColDefFunc);
     }
 
     public setProcessPivotResultColGroupDef(processPivotResultColGroupDefFunc: (colDef: ColDef) => void): void {
-        this.gridOptionsWrapper.setProperty('processPivotResultColGroupDef', processPivotResultColGroupDefFunc);
+        this.gridOptionsService.set('processPivotResultColGroupDef', processPivotResultColGroupDefFunc);
     }
 
     public setPostProcessPopup(postProcessPopupFunc: (params: PostProcessPopupParams) => void): void {
-        this.gridOptionsWrapper.setProperty('postProcessPopup', postProcessPopupFunc);
+        this.gridOptionsService.set('postProcessPopup', postProcessPopupFunc);
     }
 
     /** @deprecated v27.2 - Use `setInitialGroupOrderComparator` instead */
     public setDefaultGroupOrderComparator(defaultGroupOrderComparatorFunc: (nodeA: RowNode, nodeB: RowNode) => number): void {
-        this.gridOptionsWrapper.setProperty('defaultGroupOrderComparator', defaultGroupOrderComparatorFunc);
+        this.gridOptionsService.set('defaultGroupOrderComparator', defaultGroupOrderComparatorFunc);
     }
     public setInitialGroupOrderComparator(initialGroupOrderComparatorFunc: (params: InitialGroupOrderComparatorParams) => number): void {
-        this.gridOptionsWrapper.setProperty('initialGroupOrderComparator', initialGroupOrderComparatorFunc);
+        this.gridOptionsService.set('initialGroupOrderComparator', initialGroupOrderComparatorFunc);
     }
 
     public setGetChartToolbarItems(getChartToolbarItemsFunc: GetChartToolbarItems): void {
-        this.gridOptionsWrapper.setProperty('getChartToolbarItems', getChartToolbarItemsFunc);
+        this.gridOptionsService.set('getChartToolbarItems', getChartToolbarItemsFunc);
     }
 
     public setPaginationNumberFormatter(paginationNumberFormatterFunc: (params: PaginationNumberFormatterParams) => string): void {
-        this.gridOptionsWrapper.setProperty('paginationNumberFormatter', paginationNumberFormatterFunc);
+        this.gridOptionsService.set('paginationNumberFormatter', paginationNumberFormatterFunc);
     }
 
     /** @deprecated v28 use setGetServerSideGroupLevelParams instead */
@@ -1153,31 +1168,31 @@ export class GridApi<TData = any> {
     }
 
     public setGetServerSideGroupLevelParams(getServerSideGroupLevelParamsFunc: (params: GetServerSideGroupLevelParamsParams) => ServerSideGroupLevelParams): void {
-        this.gridOptionsWrapper.setProperty('getServerSideGroupLevelParams', getServerSideGroupLevelParamsFunc);
+        this.gridOptionsService.set('getServerSideGroupLevelParams', getServerSideGroupLevelParamsFunc);
     }
 
     public setIsServerSideGroupOpenByDefault(isServerSideGroupOpenByDefaultFunc: (params: IsServerSideGroupOpenByDefaultParams) => boolean): void {
-        this.gridOptionsWrapper.setProperty('isServerSideGroupOpenByDefault', isServerSideGroupOpenByDefaultFunc);
+        this.gridOptionsService.set('isServerSideGroupOpenByDefault', isServerSideGroupOpenByDefaultFunc);
     }
 
     public setIsApplyServerSideTransaction(isApplyServerSideTransactionFunc: IsApplyServerSideTransaction): void {
-        this.gridOptionsWrapper.setProperty('isApplyServerSideTransaction', isApplyServerSideTransactionFunc);
+        this.gridOptionsService.set('isApplyServerSideTransaction', isApplyServerSideTransactionFunc);
     }
 
     public setIsServerSideGroup(isServerSideGroupFunc: IsServerSideGroup): void {
-        this.gridOptionsWrapper.setProperty('isServerSideGroup', isServerSideGroupFunc);
+        this.gridOptionsService.set('isServerSideGroup', isServerSideGroupFunc);
     }
 
     public setGetServerSideGroupKey(getServerSideGroupKeyFunc: GetServerSideGroupKey): void {
-        this.gridOptionsWrapper.setProperty('getServerSideGroupKey', getServerSideGroupKeyFunc);
+        this.gridOptionsService.set('getServerSideGroupKey', getServerSideGroupKeyFunc);
     }
 
     public setGetRowStyle(rowStyleFunc: (params: RowClassParams) => {}): void {
-        this.gridOptionsWrapper.setProperty('getRowStyle', rowStyleFunc);
+        this.gridOptionsService.set('getRowStyle', rowStyleFunc);
     }
 
     public setGetRowHeight(rowHeightFunc: (params: RowHeightParams) => number): void {
-        this.gridOptionsWrapper.setProperty('getRowHeight', rowHeightFunc);
+        this.gridOptionsService.set('getRowHeight', rowHeightFunc);
     }
 
     private assertSideBarLoaded(apiMethod: keyof GridApi): boolean {
@@ -1256,11 +1271,11 @@ export class GridApi<TData = any> {
 
     /** Resets the side bar to the provided configuration. The parameter is the same as the sideBar grid property. The side bar is re-created from scratch with the new config. */
     public setSideBar(def: SideBarDef | string | string[] | boolean): void {
-        this.gridOptionsWrapper.setProperty('sideBar', SideBarDefParser.parse(def));
+        this.gridOptionsService.set('sideBar', SideBarDefParser.parse(def));
     }
 
     public setSuppressClipboardPaste(value: boolean): void {
-        this.gridOptionsWrapper.setProperty('suppressClipboardPaste', value);
+        this.gridOptionsService.set('suppressClipboardPaste', value);
     }
 
     /** Tells the grid to recalculate the row heights. */
@@ -1275,23 +1290,23 @@ export class GridApi<TData = any> {
     }
 
     public setGroupRemoveSingleChildren(value: boolean) {
-        this.gridOptionsWrapper.setProperty('groupRemoveSingleChildren', value);
+        this.gridOptionsService.set('groupRemoveSingleChildren', value);
     }
 
     public setGroupRemoveLowestSingleChildren(value: boolean) {
-        this.gridOptionsWrapper.setProperty('groupRemoveLowestSingleChildren', value);
+        this.gridOptionsService.set('groupRemoveLowestSingleChildren', value);
     }
 
     public setGroupDisplayType(value: RowGroupingDisplayType) {
-        this.gridOptionsWrapper.setProperty('groupDisplayType', value);
+        this.gridOptionsService.set('groupDisplayType', value);
     }
 
     public setRowClass(className: string | undefined): void {
-        this.gridOptionsWrapper.setProperty('rowClass', className);
+        this.gridOptionsService.set('rowClass', className);
     }
     /** Sets the `deltaSort` property */
     public setDeltaSort(enable: boolean): void {
-        this.gridOptionsWrapper.setProperty('deltaSort', enable);
+        this.gridOptionsService.set('deltaSort', enable);
     }
     /**
      * Sets the `rowCount` and `lastRowIndexKnown` properties.
@@ -1590,7 +1605,7 @@ export class GridApi<TData = any> {
 
     /** DOM element to use as the popup parent for grid popups (context menu, column menu etc). */
     public setPopupParent(ePopupParent: HTMLElement): void {
-        this.gridOptionsWrapper.setProperty('popupParent', ePopupParent);
+        this.gridOptionsService.set('popupParent', ePopupParent);
     }
 
     /** Navigates the grid focus to the next cell, as if tabbing. */
@@ -1868,7 +1883,7 @@ export class GridApi<TData = any> {
 
     /** Sets the `paginationPageSize`, then re-paginates the grid so the changes are applied immediately. */
     public paginationSetPageSize(size?: number): void {
-        this.gridOptionsWrapper.setProperty('paginationPageSize', size);
+        this.gridOptionsService.set('paginationPageSize', size);
     }
 
     /** Returns the 0-based index of the page which is showing. */

--- a/community-modules/core/src/ts/gridBodyComp/centerWidthFeature.ts
+++ b/community-modules/core/src/ts/gridBodyComp/centerWidthFeature.ts
@@ -18,7 +18,7 @@ export class CenterWidthFeature extends BeanStub {
     @PostConstruct
     private postConstruct(): void {
         const listener = this.setWidth.bind(this);
-        this.addManagedListener(this.gridOptionsWrapper, GridOptionsWrapper.PROP_DOM_LAYOUT, listener);
+        this.addManagedPropertyListener('domLayout', listener);
         this.addManagedListener(this.eventService, Events.EVENT_DISPLAYED_COLUMNS_CHANGED, listener);
         this.addManagedListener(this.eventService, Events.EVENT_DISPLAYED_COLUMNS_WIDTH_CHANGED, listener);
 

--- a/community-modules/core/src/ts/gridBodyComp/fakeHScrollCtrl.ts
+++ b/community-modules/core/src/ts/gridBodyComp/fakeHScrollCtrl.ts
@@ -50,8 +50,8 @@ export class FakeHScrollCtrl extends BeanStub {
         const spacerWidthsListener = this.setFakeHScrollSpacerWidths.bind(this);
         this.addManagedListener(this.eventService, Events.EVENT_DISPLAYED_COLUMNS_CHANGED, spacerWidthsListener);
         this.addManagedListener(this.eventService, Events.EVENT_DISPLAYED_COLUMNS_WIDTH_CHANGED, spacerWidthsListener);
-        this.addManagedListener(this.gridOptionsWrapper, GridOptionsWrapper.PROP_DOM_LAYOUT, spacerWidthsListener);
         this.addManagedListener(this.eventService, Events.EVENT_PINNED_ROW_DATA_CHANGED, this.onPinnedRowDataChanged.bind(this));
+        this.addManagedPropertyListener('domLayout', spacerWidthsListener);
         this.onScrollVisibilityChanged();
 
         this.ctrlsService.registerFakeHScrollCtrl(this);

--- a/community-modules/core/src/ts/gridBodyComp/pinnedWidthService.ts
+++ b/community-modules/core/src/ts/gridBodyComp/pinnedWidthService.ts
@@ -17,7 +17,7 @@ export class PinnedWidthService extends BeanStub {
         const listener = this.checkContainerWidths.bind(this);
         this.addManagedListener(this.eventService, Events.EVENT_DISPLAYED_COLUMNS_CHANGED, listener);
         this.addManagedListener(this.eventService, Events.EVENT_DISPLAYED_COLUMNS_WIDTH_CHANGED, listener);
-        this.addManagedListener(this.gridOptionsWrapper, GridOptionsWrapper.PROP_DOM_LAYOUT, listener);
+        this.addManagedPropertyListener('domLayout', listener);
     }
 
     private checkContainerWidths() {

--- a/community-modules/core/src/ts/gridBodyComp/rowContainer/rowContainerCtrl.ts
+++ b/community-modules/core/src/ts/gridBodyComp/rowContainer/rowContainerCtrl.ts
@@ -275,7 +275,7 @@ export class RowContainerCtrl extends BeanStub {
             const isPrintLayout = this.gridOptionsWrapper.getDomLayout() === 'print';
             this.comp.setDomOrder(isEnsureDomOrder || isPrintLayout);
         }
-        this.addManagedListener(this.gridOptionsWrapper, GridOptionsWrapper.PROP_DOM_LAYOUT, listener);
+        this.addManagedPropertyListener('domLayout', listener);
         listener();
     }
 

--- a/community-modules/core/src/ts/gridOptionsService.ts
+++ b/community-modules/core/src/ts/gridOptionsService.ts
@@ -87,7 +87,7 @@ export class GridOptionsService {
     * @param callback User provided callback
     * @returns Wrapped callback where the params object not require api, columnApi and context
     */
-    public mergeGridCommonParams<P extends AgGridCommon<any>, T>(callback: ((params: P) => T) | undefined):
+    private mergeGridCommonParams<P extends AgGridCommon<any>, T>(callback: ((params: P) => T) | undefined):
         ((params: WithoutGridCommon<P>) => T) | undefined {
         if (callback) {
             const wrapped = (callbackParams: WithoutGridCommon<P>): T => {

--- a/community-modules/core/src/ts/gridOptionsService.ts
+++ b/community-modules/core/src/ts/gridOptionsService.ts
@@ -1,5 +1,5 @@
 import { ComponentUtil } from "./components/componentUtil";
-import { Autowired, Bean } from "./context/context";
+import { Autowired, Bean, PostConstruct } from "./context/context";
 import { GridOptions } from "./entities/gridOptions";
 import { AgEvent } from "./events";
 import { EventService } from "./eventService";
@@ -39,7 +39,7 @@ export interface PropertyChangedEvent extends AgEvent {
     previousValue: any;
 }
 
-export type PropertyChangedListener = (event?: PropertyChangedEvent) => void
+export type PropertyChangedListener = (event: PropertyChangedEvent) => void
 
 export function toNumber(value: any): number | undefined {
     if (typeof value == 'number') {
@@ -60,20 +60,11 @@ export class GridOptionsService {
 
     @Autowired('gridOptions') private readonly gridOptions: GridOptions;
     private propertyEventService: EventService = new EventService();
-    private coercionLookup: Record<keyof GridOptions, 'number' | 'boolean' | 'none'>;
+    private gridOptionLookup: Set<string>;
 
-    private agWire(): void {
-        [
-            ...ComponentUtil.ARRAY_PROPERTIES,
-            ...ComponentUtil.OBJECT_PROPERTIES,
-            ...ComponentUtil.STRING_PROPERTIES,
-            ...ComponentUtil.getEventCallbacks(),
-        ]
-            .forEach((key: keyof GridOptions) => this.coercionLookup[key] = 'none');
-        ComponentUtil.BOOLEAN_PROPERTIES
-            .forEach(key => this.coercionLookup[key] = 'boolean');
-        ComponentUtil.NUMBER_PROPERTIES
-            .forEach(key => this.coercionLookup[key] = 'number');
+    @PostConstruct
+    public init(): void {
+        this.gridOptionLookup = new Set([...ComponentUtil.ALL_PROPERTIES, ...ComponentUtil.getEventCallbacks()]);
     }
 
     public is(property: BooleanProps): boolean {
@@ -108,44 +99,20 @@ export class GridOptionsService {
         return callback;
     }
 
-
-    public set<K extends keyof GridOptions>(key: K, value: GridOptions[K], force = false): void {
-        const previousValue = this.gridOptions[key];
-
-        const coercionStep = this.coercionLookup[key];
-
-        if (coercionStep) {
-            let newValue = value;
-            switch (coercionStep) {
-                case 'number':
-                    // local toNumber is using parseInt whereas the ComponentUtils version using Number() which can behave differently.  
-                    // GridOptionsWrapper used the local toNumber so was different to ComponentUtils
-                    newValue = ComponentUtil.toNumber(value);
-                case 'boolean':
-                    // This toBoolean converts empty string '' to true to handle component attributes. 
-                    // We might not want that within this function???
-                    // However, using the same means that we will get consistent change detection in the following diff
-                    // because we are using the same coercion as applied when copy attributes to gridOptions in setup.
-                    newValue = ComponentUtil.toBoolean(value);
-            }
-
-
-            if (force || previousValue !== value) {
-                this.gridOptions[key] = value;
+    public set<K extends keyof GridOptions>(key: K, newValue: GridOptions[K], force = false, eventParams: object = {}): void {
+        if (this.gridOptionLookup.has(key)) {
+            const previousValue = this.gridOptions[key];
+            if (force || previousValue !== newValue) {
+                this.gridOptions[key] = newValue;
                 const event: PropertyChangedEvent = {
                     type: key,
-                    currentValue: value,
-                    previousValue: previousValue
+                    currentValue: newValue,
+                    previousValue: previousValue,
+                    ...eventParams
                 };
                 this.propertyEventService.dispatchEvent(event);
             }
-
-        } else {
-            doOnce(() => {
-                console.warn(`You tried to set the property "${key}" on GridOptions but this is not a valid property name.`)
-            }, key)
         }
-
     }
 
     addEventListener(key: keyof GridOptions, listener: PropertyChangedListener): void {

--- a/community-modules/core/src/ts/gridOptionsWrapper.ts
+++ b/community-modules/core/src/ts/gridOptionsWrapper.ts
@@ -43,22 +43,6 @@ export interface PropertyChangedEvent extends AgEvent {
 export class GridOptionsWrapper {
     private static MIN_COL_WIDTH = 10;
 
-    public static PROP_GROUP_DISPLAY_TYPE: 'groupDisplayType' = 'groupDisplayType';
-    public static PROP_GROUP_REMOVE_SINGLE_CHILDREN: 'groupRemoveSingleChildren' = 'groupRemoveSingleChildren';
-    public static PROP_GROUP_REMOVE_LOWEST_SINGLE_CHILDREN: 'groupRemoveLowestSingleChildren' = 'groupRemoveLowestSingleChildren';
-
-    public static PROP_HEADER_HEIGHT: 'headerHeight' = 'headerHeight';
-    public static PROP_PIVOT_HEADER_HEIGHT: 'pivotHeaderHeight' = 'pivotHeaderHeight';
-    public static PROP_GROUP_HEADER_HEIGHT: 'groupHeaderHeight' = 'groupHeaderHeight';
-    public static PROP_PIVOT_GROUP_HEADER_HEIGHT: 'pivotGroupHeaderHeight' = 'pivotGroupHeaderHeight';
-    public static PROP_FLOATING_FILTERS_HEIGHT: 'floatingFiltersHeight' = 'floatingFiltersHeight';
-
-    public static PROP_DOM_LAYOUT: 'domLayout' = 'domLayout';
-    public static PROP_ROW_CLASS: 'rowClass' = 'rowClass';
-
-    public static PROP_AUTO_GROUP_COLUMN_DEF: 'autoGroupColumnDef' = 'autoGroupColumnDef';
-    public static PROP_DEFAULT_COL_DEF: 'defaultColDef' = 'defaultColDef';
-
     @Autowired('gridOptions') private readonly gridOptions: GridOptions;
     @Autowired('gridOptionsService') private readonly gridOptionsService: GridOptionsService;
     @Autowired('eventService') private readonly eventService: EventService;

--- a/community-modules/core/src/ts/gridOptionsWrapper.ts
+++ b/community-modules/core/src/ts/gridOptionsWrapper.ts
@@ -349,7 +349,7 @@ export class GridOptionsWrapper {
     public getInitialGroupOrderComparator() {
         const { initialGroupOrderComparator, defaultGroupOrderComparator } = this.gridOptions;
         if (initialGroupOrderComparator) {
-            return this.gridOptionsService.mergeGridCommonParams(initialGroupOrderComparator);
+            return this.gridOptionsService.getCallback('initialGroupOrderComparator');
         }
         // this is the deprecated way, so provide a proxy to make it compatible
         if (defaultGroupOrderComparator) {
@@ -360,7 +360,7 @@ export class GridOptionsWrapper {
     public getIsFullWidthCellFunc() {
         const { isFullWidthRow, isFullWidthCell } = this.gridOptions;
         if (isFullWidthRow) {
-            return this.gridOptionsService.mergeGridCommonParams(isFullWidthRow);
+            return this.gridOptionsService.getCallback('isFullWidthRow');
         }
         // this is the deprecated way, so provide a proxy to make it compatible
         if (isFullWidthCell) {
@@ -399,7 +399,7 @@ export class GridOptionsWrapper {
         const userValue = this.gridOptions.groupAggFiltering;
 
         if (typeof userValue === 'function') {
-            return this.gridOptionsService.mergeGridCommonParams(userValue);
+            this.gridOptionsService.getCallback('groupAggFiltering' as any)
         }
 
         if (isTrue(userValue)) {
@@ -443,7 +443,7 @@ export class GridOptionsWrapper {
 
         const { getGroupRowAgg, groupRowAggNodes } = this.gridOptions;
         if (getGroupRowAgg) {
-            return this.gridOptionsService.mergeGridCommonParams(getGroupRowAgg);
+            return this.gridOptionsService.getCallback('getGroupRowAgg');
         }
         // this is the deprecated way, so provide a proxy to make it compatible
         if (groupRowAggNodes) {
@@ -454,7 +454,7 @@ export class GridOptionsWrapper {
     public getRowIdFunc() {
         const { getRowId, getRowNodeId } = this.gridOptions;
         if (getRowId) {
-            return this.gridOptionsService.mergeGridCommonParams(getRowId);
+            return this.gridOptionsService.getCallback('getRowId');
         }
         // this is the deprecated way, so provide a proxy to make it compatible
         if (getRowNodeId) {
@@ -524,7 +524,7 @@ export class GridOptionsWrapper {
     public getPostSortFunc() {
         const { postSortRows, postSort } = this.gridOptions;
         if (postSortRows) {
-            return this.gridOptionsService.mergeGridCommonParams(postSortRows);
+            return this.gridOptionsService.getCallback('postSortRows');
         }
         // this is the deprecated way, so provide a proxy to make it compatible
         if (postSort) {
@@ -934,7 +934,7 @@ export class GridOptionsWrapper {
                 data: rowNode.data
             };
 
-            const height = this.gridOptionsService.mergeGridCommonParams(this.gridOptions.getRowHeight)!(params);
+            const height = this.gridOptionsService.getCallback('getRowHeight')!(params);
 
             if (this.isNumeric(height)) {
                 if (height === 0) {

--- a/community-modules/core/src/ts/headerRendering/gridHeaderCtrl.ts
+++ b/community-modules/core/src/ts/headerRendering/gridHeaderCtrl.ts
@@ -52,11 +52,11 @@ export class GridHeaderCtrl extends BeanStub {
         const listener = this.setHeaderHeight.bind(this);
         listener();
 
-        this.addManagedListener(this.gridOptionsWrapper, GridOptionsWrapper.PROP_HEADER_HEIGHT, listener);
-        this.addManagedListener(this.gridOptionsWrapper, GridOptionsWrapper.PROP_PIVOT_HEADER_HEIGHT, listener);
-        this.addManagedListener(this.gridOptionsWrapper, GridOptionsWrapper.PROP_GROUP_HEADER_HEIGHT, listener);
-        this.addManagedListener(this.gridOptionsWrapper, GridOptionsWrapper.PROP_PIVOT_GROUP_HEADER_HEIGHT, listener);
-        this.addManagedListener(this.gridOptionsWrapper, GridOptionsWrapper.PROP_FLOATING_FILTERS_HEIGHT, listener);
+        this.addManagedPropertyListener('headerHeight', listener);
+        this.addManagedPropertyListener('pivotHeaderHeight', listener);
+        this.addManagedPropertyListener('groupHeaderHeight', listener);
+        this.addManagedPropertyListener('pivotGroupHeaderHeight', listener);
+        this.addManagedPropertyListener('floatingFiltersHeight', listener);
 
         this.addManagedListener(this.eventService, Events.EVENT_DISPLAYED_COLUMNS_CHANGED, listener);
         this.addManagedListener(this.eventService, Events.EVENT_COLUMN_HEADER_HEIGHT_CHANGED, listener);

--- a/community-modules/core/src/ts/headerRendering/row/headerRowCtrl.ts
+++ b/community-modules/core/src/ts/headerRendering/row/headerRowCtrl.ts
@@ -72,20 +72,17 @@ export class HeaderRowCtrl extends BeanStub {
 
     private addEventListeners(): void {
         this.addManagedListener(this.eventService, Events.EVENT_COLUMN_RESIZED, this.onColumnResized.bind(this));
+        this.addManagedListener(this.eventService, Events.EVENT_DISPLAYED_COLUMNS_CHANGED, this.onDisplayedColumnsChanged.bind(this));
+        this.addManagedListener(this.eventService, Events.EVENT_VIRTUAL_COLUMNS_CHANGED, this.onVirtualColumnsChanged.bind(this));
+        this.addManagedListener(this.eventService, Events.EVENT_COLUMN_HEADER_HEIGHT_CHANGED, this.onRowHeightChanged.bind(this));
 
         // when print layout changes, it changes what columns are in what section
-        this.addManagedListener(this.gridOptionsWrapper, GridOptionsWrapper.PROP_DOM_LAYOUT, this.onDisplayedColumnsChanged.bind(this));
-
-        this.addManagedListener(this.eventService, Events.EVENT_DISPLAYED_COLUMNS_CHANGED, this.onDisplayedColumnsChanged.bind(this));
-
-        this.addManagedListener(this.eventService, Events.EVENT_VIRTUAL_COLUMNS_CHANGED, this.onVirtualColumnsChanged.bind(this));
-
-        this.addManagedListener(this.eventService, Events.EVENT_COLUMN_HEADER_HEIGHT_CHANGED, this.onRowHeightChanged.bind(this));
-        this.addManagedListener(this.gridOptionsWrapper, GridOptionsWrapper.PROP_HEADER_HEIGHT, this.onRowHeightChanged.bind(this));
-        this.addManagedListener(this.gridOptionsWrapper, GridOptionsWrapper.PROP_PIVOT_HEADER_HEIGHT, this.onRowHeightChanged.bind(this));
-        this.addManagedListener(this.gridOptionsWrapper, GridOptionsWrapper.PROP_GROUP_HEADER_HEIGHT, this.onRowHeightChanged.bind(this));
-        this.addManagedListener(this.gridOptionsWrapper, GridOptionsWrapper.PROP_PIVOT_GROUP_HEADER_HEIGHT, this.onRowHeightChanged.bind(this));
-        this.addManagedListener(this.gridOptionsWrapper, GridOptionsWrapper.PROP_FLOATING_FILTERS_HEIGHT, this.onRowHeightChanged.bind(this));
+        this.addManagedPropertyListener('domLayout', this.onDisplayedColumnsChanged.bind(this));
+        this.addManagedPropertyListener('headerHeight', this.onRowHeightChanged.bind(this));
+        this.addManagedPropertyListener('pivotHeaderHeight', this.onRowHeightChanged.bind(this));
+        this.addManagedPropertyListener('groupHeaderHeight', this.onRowHeightChanged.bind(this));
+        this.addManagedPropertyListener('pivotGroupHeaderHeight', this.onRowHeightChanged.bind(this));
+        this.addManagedPropertyListener('floatingFiltersHeight', this.onRowHeightChanged.bind(this));
     }
 
     public getHeaderCellCtrl(column: ColumnGroup): HeaderGroupCellCtrl | undefined;

--- a/community-modules/core/src/ts/pagination/paginationProxy.ts
+++ b/community-modules/core/src/ts/pagination/paginationProxy.ts
@@ -35,7 +35,7 @@ export class PaginationProxy extends BeanStub {
         this.paginateChildRows = this.isPaginateChildRows();
 
         this.addManagedListener(this.eventService, Events.EVENT_MODEL_UPDATED, this.onModelUpdated.bind(this));
-        this.addManagedListener(this.gridOptionsWrapper, 'paginationPageSize', this.onPaginationPageSizeChanged.bind(this));
+        this.addManagedPropertyListener('paginationPageSize', this.onPaginationPageSizeChanged.bind(this));
 
         this.onModelUpdated();
     }

--- a/community-modules/core/src/ts/rendering/features/setLeftFeature.ts
+++ b/community-modules/core/src/ts/rendering/features/setLeftFeature.ts
@@ -55,7 +55,7 @@ export class SetLeftFeature extends BeanStub {
         this.addManagedListener(this.eventService, Events.EVENT_DISPLAYED_COLUMNS_WIDTH_CHANGED, this.onLeftChanged.bind(this));
 
         // setting left has a dependency on print layout
-        this.addManagedListener(this.beans.gridOptionsWrapper, GridOptionsWrapper.PROP_DOM_LAYOUT, this.onLeftChanged.bind(this));
+        this.addManagedPropertyListener('domLayout', this.onLeftChanged.bind(this));
     }
 
     private setLeftFirstTime(): void {

--- a/community-modules/core/src/ts/rendering/row/rowDragComp.ts
+++ b/community-modules/core/src/ts/rendering/row/rowDragComp.ts
@@ -187,7 +187,7 @@ class NonManagedVisibilityStrategy extends VisibilityStrategy {
 
     @PostConstruct
     private postConstruct(): void {
-        this.addManagedListener(this.beans.gridOptionsWrapper, 'suppressRowDrag', this.onSuppressRowDrag.bind(this));
+        this.addManagedPropertyListener('suppressRowDrag', this.onSuppressRowDrag.bind(this));
 
         // in case data changes, then we need to update visibility of drag item
         this.addManagedListener(this.rowNode, RowNode.EVENT_DATA_CHANGED, this.workOutVisibility.bind(this));
@@ -232,7 +232,7 @@ class ManagedVisibilityStrategy extends VisibilityStrategy {
         this.addManagedListener(this.rowNode, RowNode.EVENT_DATA_CHANGED, this.workOutVisibility.bind(this));
         this.addManagedListener(this.rowNode, RowNode.EVENT_CELL_CHANGED, this.workOutVisibility.bind(this));
 
-        this.addManagedListener(this.beans.gridOptionsWrapper, 'suppressRowDrag', this.onSuppressRowDrag.bind(this));
+        this.addManagedPropertyListener('suppressRowDrag', this.onSuppressRowDrag.bind(this));
 
         this.workOutVisibility();
     }

--- a/community-modules/core/src/ts/rendering/rowRenderer.ts
+++ b/community-modules/core/src/ts/rendering/rowRenderer.ts
@@ -134,8 +134,9 @@ export class RowRenderer extends BeanStub {
         this.addManagedListener(this.eventService, Events.EVENT_DISPLAYED_COLUMNS_CHANGED, this.onDisplayedColumnsChanged.bind(this));
         this.addManagedListener(this.eventService, Events.EVENT_BODY_SCROLL, this.redrawAfterScroll.bind(this));
         this.addManagedListener(this.eventService, Events.EVENT_BODY_HEIGHT_CHANGED, this.redrawAfterScroll.bind(this));
-        this.addManagedListener(this.gridOptionsWrapper, GridOptionsWrapper.PROP_DOM_LAYOUT, this.onDomLayoutChanged.bind(this));
-        this.addManagedListener(this.gridOptionsWrapper, GridOptionsWrapper.PROP_ROW_CLASS, this.redrawRows.bind(this));
+
+        this.addManagedPropertyListener('domLayout', this.onDomLayoutChanged.bind(this));
+        this.addManagedPropertyListener('rowClass', this.redrawRows.bind(this));
 
         if (this.gridOptionsService.is('groupRowsSticky')) {
             if (this.rowModel.getType() != 'clientSide') {

--- a/community-modules/core/src/ts/styling/layoutFeature.ts
+++ b/community-modules/core/src/ts/styling/layoutFeature.ts
@@ -31,7 +31,7 @@ export class LayoutFeature extends BeanStub {
 
     @PostConstruct
     private postConstruct(): void {
-        this.addManagedListener(this.gridOptionsWrapper, GridOptionsWrapper.PROP_DOM_LAYOUT, this.updateLayoutClasses.bind(this));
+        this.addManagedPropertyListener('domLayout', this.updateLayoutClasses.bind(this));
         this.updateLayoutClasses();
     }
 

--- a/enterprise-modules/column-tool-panel/src/columnToolPanel/toolPanelColumnComp.ts
+++ b/enterprise-modules/column-tool-panel/src/columnToolPanel/toolPanelColumnComp.ts
@@ -84,7 +84,7 @@ export class ToolPanelColumnComp extends Component {
         this.addManagedListener(this.focusWrapper, 'keydown', this.handleKeyDown.bind(this));
         this.addManagedListener(this.focusWrapper, 'contextmenu', this.onContextMenu.bind(this));
 
-        this.addManagedListener(this.gridOptionsWrapper, 'functionsReadOnly', this.onColumnStateChanged.bind(this));
+        this.addManagedPropertyListener('functionsReadOnly', this.onColumnStateChanged.bind(this));
 
         this.addManagedListener(this.cbSelect, AgCheckbox.EVENT_CHANGED, this.onCheckboxChanged.bind(this));
         this.addManagedListener(this.eLabel, 'click', this.onLabelClicked.bind(this));

--- a/enterprise-modules/row-grouping/src/rowGrouping/columnDropZones/baseDropZonePanel.ts
+++ b/enterprise-modules/row-grouping/src/rowGrouping/columnDropZones/baseDropZonePanel.ts
@@ -127,7 +127,7 @@ export abstract class BaseDropZonePanel extends Component {
         ));
 
         this.addManagedListener(this.beans.eventService, Events.EVENT_NEW_COLUMNS_LOADED, this.refreshGui.bind(this));
-        this.addManagedListener(this.beans.gridOptionsWrapper, 'functionsReadOnly', this.refreshGui.bind(this));
+        this.addManagedPropertyListener('functionsReadOnly', this.refreshGui.bind(this));
 
         this.setupDropTarget();
 

--- a/enterprise-modules/row-grouping/src/rowGrouping/columnDropZones/gridHeaderDropZones.ts
+++ b/enterprise-modules/row-grouping/src/rowGrouping/columnDropZones/gridHeaderDropZones.ts
@@ -26,7 +26,7 @@ export class GridHeaderDropZones extends Component {
 
         this.addManagedListener(this.eventService, Events.EVENT_COLUMN_ROW_GROUP_CHANGED, this.onRowGroupChanged.bind(this));
         this.addManagedListener(this.eventService, Events.EVENT_NEW_COLUMNS_LOADED, this.onRowGroupChanged.bind(this));
-        this.addManagedListener(this.gridOptionsWrapper, 'rowGroupPanelShow', this.onRowGroupChanged.bind(this));
+        this.addManagedPropertyListener('rowGroupPanelShow', this.onRowGroupChanged.bind(this));
 
         this.onRowGroupChanged();
     }

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/grid-api.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/grid-api.AUTO.json
@@ -16,6 +16,10 @@
     "description": "/** Used internally by grid. Not intended to be used by the client. Interface may change between releases. */",
     "type": { "arguments": {}, "returnType": "Context" }
   },
+  "___setProperty": {
+    "description": "/** Used internally by grid. Not intended to be used by the client. Interface may change between releases\n     */",
+    "type": { "arguments": { "propertyName": "K", "value": "GridOptions[K]" } }
+  },
   "addDetailGridInfo": {
     "description": "/** Register a detail grid with the master grid when it is created. */",
     "type": {
@@ -506,9 +510,7 @@
   },
   "setDomLayout": {
     "description": "/** Switch between layout options: `normal`, `autoHeight`, `print`.\n     * Defaults to `normal` if no domLayout provided.\n     */",
-    "type": {
-      "arguments": { "domLayout?": "'normal' | 'autoHeight' | 'print'" }
-    }
+    "type": { "arguments": { "domLayout?": "DomLayoutType" } }
   },
   "setEnableCellTextSelection": {
     "description": "/** Sets the `enableCellTextSelection` property. */",
@@ -534,6 +536,7 @@
     "description": "/** Sets the height in pixels for the row containing header column groups when in pivot mode. */",
     "type": { "arguments": { "headerHeight?": "number" } }
   },
+  "setPivotMode": { "type": { "arguments": { "pivotMode": "boolean" } } },
   "setIsExternalFilterPresent": {
     "type": {
       "arguments": { "isExternalFilterPresentFunc": "() => boolean" },

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/interfaces.AUTO.json
@@ -6243,7 +6243,7 @@
   },
   "PropertyChangedListener": {
     "meta": { "isTypeAlias": true },
-    "type": "(event?: PropertyChangedEvent) => void"
+    "type": "(event: PropertyChangedEvent) => void"
   },
   "IAbstractHeaderCellComp": { "meta": {}, "type": {} },
   "IHeaderCellComp": {


### PR DESCRIPTION
With the new GridOptionsService we have an opportunity to update how ComponentUtils works to lay a solid foundation for making as many of the Grid properties reactive as we can. As such our aims include:

1. Ensure that a `PropertyChangedEvent` is fired for every changed grid option
2. Avoid bugs due to events not firing due to updated order breaking change detection
3. Remove as much custom handling from ComponentUtils as possible

I believe the following changes meet these requirements. There could be some followup items such as:

- removing GridApi set methods that are solely for component utils to be able to update grid options. If they are not triggering reactive behaviour then maybe JS users can just update their GridOptions config option and have the grid use the new values. 
- Make the quickFilter listen to propertyChanged event instead of having the special case handling because of a GridApi misnaming. 