### PR TITLE
AG-7407 - Hide axes, crossLines, series and legend based on bounds ca…

### DIFF
--- a/charts-packages/ag-charts-community/src/scene/group.ts
+++ b/charts-packages/ag-charts-community/src/scene/group.ts
@@ -65,7 +65,8 @@ export class Group extends Node {
         if (scene && this.opts?.layer) {
             const { zIndex, zIndexSubOrder, name } = this.opts || {};
             const getComputedOpacity = () => this.getComputedOpacity();
-            this.layer = scene.addLayer({ zIndex, zIndexSubOrder, name, getComputedOpacity });
+            const getVisibility = () => this.getVisibility();
+            this.layer = scene.addLayer({ zIndex, zIndexSubOrder, name, getComputedOpacity, getVisibility });
         }
     }
 
@@ -78,6 +79,18 @@ export class Group extends Node {
             }
         } while ((node = node.parent));
         return opacity;
+    }
+
+    protected getVisibility() {
+        let node: Node | undefined = this;
+        let visible = this.visible;
+        while ((node = node.parent)) {
+            if (node.visible) {
+                continue;
+            }
+            visible = node.visible;
+        }
+        return visible;
     }
 
     protected visibilityChanged() {

--- a/charts-packages/ag-charts-community/src/scene/scene.ts
+++ b/charts-packages/ag-charts-community/src/scene/scene.ts
@@ -25,6 +25,7 @@ interface SceneLayer {
     zIndexSubOrder?: [string, number];
     canvas: HdpiOffscreenCanvas | HdpiCanvas;
     getComputedOpacity: () => number;
+    getVisibility: () => boolean;
 }
 
 export class Scene {
@@ -113,6 +114,7 @@ export class Scene {
         zIndexSubOrder?: [string, number];
         name?: string;
         getComputedOpacity: () => number;
+        getVisibility: () => boolean;
     }): HdpiCanvas | HdpiOffscreenCanvas | undefined {
         const { mode } = this.opts;
         const layeredModes = ['composite', 'dom-composite', 'adv-composite'];
@@ -120,7 +122,7 @@ export class Scene {
             return undefined;
         }
 
-        const { zIndex = this._nextZIndex++, name, zIndexSubOrder, getComputedOpacity } = opts;
+        const { zIndex = this._nextZIndex++, name, zIndexSubOrder, getComputedOpacity, getVisibility } = opts;
         const { width, height, overrideDevicePixelRatio } = this;
         const domLayer = mode === 'dom-composite';
         const advLayer = mode === 'adv-composite';
@@ -147,6 +149,7 @@ export class Scene {
             zIndexSubOrder,
             canvas,
             getComputedOpacity,
+            getVisibility,
         };
 
         if (zIndex >= this._nextZIndex) {
@@ -347,8 +350,8 @@ export class Scene {
         if (mode !== 'dom-composite' && layers.length > 0 && canvasCleared) {
             ctx.save();
             ctx.setTransform(1 / canvas.pixelRatio, 0, 0, 1 / canvas.pixelRatio, 0, 0);
-            layers.forEach(({ canvas: { imageSource, enabled }, getComputedOpacity }) => {
-                if (!enabled) {
+            layers.forEach(({ canvas: { imageSource, enabled }, getComputedOpacity, getVisibility }) => {
+                if (!enabled || !getVisibility()) {
                     return;
                 }
 

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/doc-interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/doc-interfaces.AUTO.json
@@ -4867,6 +4867,9 @@
     },
     "getComputedOpacity": {
       "type": { "arguments": {}, "returnType": "number", "optional": false }
+    },
+    "getVisibility": {
+      "type": { "arguments": {}, "returnType": "boolean", "optional": false }
     }
   },
   "ValueFn": { "meta": { "typeParams": ["P", "GDatum", "PDatum"] } },

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
@@ -3428,7 +3428,8 @@
       "zIndex": "number",
       "zIndexSubOrder?": "[ string, number ]",
       "canvas": "HdpiOffscreenCanvas | HdpiCanvas",
-      "getComputedOpacity": "() => number"
+      "getComputedOpacity": "() => number",
+      "getVisibility": "() => boolean"
     }
   },
   "ValueFn": {


### PR DESCRIPTION
PR for: https://ag-grid.atlassian.net/browse/AG-7407

When the crossLinePadding exceeds available boundary, prioritise axes, remove crossLines.
If axisWidths exceed available chart space, remove axes, series and crossLines.

This is done by toggling the relevant group visibility.

Layers should honour group visibility based on parent nodes' visible flag.

TODO: should  navigator also be hidden?
Look into why legend recreates groups on performLayout