### PR TITLE
AG-7578 - Add chart data panel customisation

### DIFF
--- a/community-modules/core/src/ts/interfaces/iChartOptions.ts
+++ b/community-modules/core/src/ts/interfaces/iChartOptions.ts
@@ -55,16 +55,23 @@ export interface ChartSettingsPanel {
 
 export type ChartFormatPanelGroup = 'chart' | 'legend' | 'axis' | 'series' | 'navigator';
 
-export interface ChartFormatPanelGroupDef {
-    /** The format panel group type */
-    type: ChartFormatPanelGroup,
-    /** Whether the format panel group is open by default. If not specified, it is closed */
+export type ChartDataPanelGroup = 'categories' | 'series' | 'seriesChartType';
+
+export interface ChartPanelGroupDef<GroupType> {
+    /** The panel group type */
+    type: GroupType,
+    /** Whether the panel group is open by default. If not specified, it is closed */
     isOpen?: boolean
 }
 
 export interface ChartFormatPanel {
     /** The format panel group configurations, their order and whether they are shown. If not specified shows all groups */
-    groups?: ChartFormatPanelGroupDef[];
+    groups?: ChartPanelGroupDef<ChartFormatPanelGroup>[];
+}
+
+export interface ChartDataPanel {
+    /** The data panel group configurations, their order and whether they are shown. If not specified shows all groups */
+    groups?: ChartPanelGroupDef<ChartDataPanelGroup>[];
 }
 
 export interface ChartToolPanelsDef {
@@ -72,6 +79,8 @@ export interface ChartToolPanelsDef {
     settingsPanel?: ChartSettingsPanel,
     /** Customisations for the format panel */
     formatPanel?: ChartFormatPanel,
+    /** Customisations for the data panel */
+    dataPanel?: ChartDataPanel,
     /** The ordered list of panels to show in the chart tool panels. If none specified, all panels are shown */
     panels?: ChartToolPanelName[],
     /** The panel to open by default when the chart loads. If none specified, the tool panel is hidden by default and the first panel is open when triggered. */

--- a/enterprise-modules/charts/src/charts/chartComp/menu/format/formatPanel.ts
+++ b/enterprise-modules/charts/src/charts/chartComp/menu/format/formatPanel.ts
@@ -2,10 +2,10 @@ import {
     _,
     ChartFormatPanel,
     ChartFormatPanelGroup,
-    ChartFormatPanelGroupDef,
     ChartType,
     Component,
-    PostConstruct
+    PostConstruct,
+    ChartPanelGroupDef
 } from "@ag-grid-community/core";
 import { ChartController } from "../../chartController";
 import { LegendPanel } from "./legend/legendPanel";
@@ -68,7 +68,7 @@ export class FormatPanel extends Component {
 
         this.destroyPanels();
 
-        this.getFormatPanelDef().groups?.forEach((groupDef: ChartFormatPanelGroupDef) => {
+        this.getFormatPanelDef().groups?.forEach((groupDef: ChartPanelGroupDef<ChartFormatPanelGroup>) => {
             const group = groupDef.type;
 
             // ensure the group should be displayed for the current series type

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/doc-interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/doc-interfaces.AUTO.json
@@ -16408,20 +16408,34 @@
     }
   },
   "ChartFormatPanelGroup": {},
-  "ChartFormatPanelGroupDef": {
+  "ChartDataPanelGroup": {},
+  "ChartPanelGroupDef": {
     "type": {
-      "description": "/** The format panel group type */",
-      "type": { "returnType": "ChartFormatPanelGroup", "optional": false }
+      "description": "/** The panel group type */",
+      "type": { "returnType": "GroupType", "optional": false }
     },
     "isOpen": {
-      "description": "/** Whether the format panel group is open by default. If not specified, it is closed */",
+      "description": "/** Whether the panel group is open by default. If not specified, it is closed */",
       "type": { "returnType": "boolean", "optional": true }
-    }
+    },
+    "meta": { "typeParams": ["GroupType"] }
   },
   "ChartFormatPanel": {
     "groups": {
       "description": "/** The format panel group configurations, their order and whether they are shown. If not specified shows all groups */",
-      "type": { "returnType": "ChartFormatPanelGroupDef[]", "optional": true }
+      "type": {
+        "returnType": "ChartPanelGroupDef<ChartFormatPanelGroup>[]",
+        "optional": true
+      }
+    }
+  },
+  "ChartDataPanel": {
+    "groups": {
+      "description": "/** The data panel group configurations, their order and whether they are shown. If not specified shows all groups */",
+      "type": {
+        "returnType": "ChartPanelGroupDef<ChartDataPanelGroup>[]",
+        "optional": true
+      }
     }
   },
   "ChartToolPanelsDef": {
@@ -16432,6 +16446,10 @@
     "formatPanel": {
       "description": "/** Customisations for the format panel */",
       "type": { "returnType": "ChartFormatPanel", "optional": true }
+    },
+    "dataPanel": {
+      "description": "/** Customisations for the data panel */",
+      "type": { "returnType": "ChartDataPanel", "optional": true }
     },
     "panels": {
       "description": "/** The ordered list of panels to show in the chart tool panels. If none specified, all panels are shown */",

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/interfaces.AUTO.json
@@ -9599,19 +9599,30 @@
     "meta": { "isTypeAlias": true },
     "type": "'chart' | 'legend' | 'axis' | 'series' | 'navigator'"
   },
-  "ChartFormatPanelGroupDef": {
-    "meta": {},
-    "type": { "type": "ChartFormatPanelGroup", "isOpen?": "boolean" },
+  "ChartDataPanelGroup": {
+    "meta": { "isTypeAlias": true },
+    "type": "'categories' | 'series' | 'seriesChartType'"
+  },
+  "ChartPanelGroupDef": {
+    "meta": { "typeParams": ["GroupType"] },
+    "type": { "type": "GroupType", "isOpen?": "boolean" },
     "docs": {
-      "type": "/** The format panel group type */",
-      "isOpen?": "/** Whether the format panel group is open by default. If not specified, it is closed */"
+      "type": "/** The panel group type */",
+      "isOpen?": "/** Whether the panel group is open by default. If not specified, it is closed */"
     }
   },
   "ChartFormatPanel": {
     "meta": {},
-    "type": { "groups?": "ChartFormatPanelGroupDef[]" },
+    "type": { "groups?": "ChartPanelGroupDef<ChartFormatPanelGroup>[]" },
     "docs": {
       "groups?": "/** The format panel group configurations, their order and whether they are shown. If not specified shows all groups */"
+    }
+  },
+  "ChartDataPanel": {
+    "meta": {},
+    "type": { "groups?": "ChartPanelGroupDef<ChartDataPanelGroup>[]" },
+    "docs": {
+      "groups?": "/** The data panel group configurations, their order and whether they are shown. If not specified shows all groups */"
     }
   },
   "ChartToolPanelsDef": {
@@ -9619,12 +9630,14 @@
     "type": {
       "settingsPanel?": "ChartSettingsPanel",
       "formatPanel?": "ChartFormatPanel",
+      "dataPanel?": "ChartDataPanel",
       "panels?": "ChartToolPanelName[]",
       "defaultToolPanel?": "ChartToolPanelName"
     },
     "docs": {
       "settingsPanel?": "/** Customisations for the settings panel */",
       "formatPanel?": "/** Customisations for the format panel */",
+      "dataPanel?": "/** Customisations for the data panel */",
       "panels?": "/** The ordered list of panels to show in the chart tool panels. If none specified, all panels are shown */",
       "defaultToolPanel?": "/** The panel to open by default when the chart loads. If none specified, the tool panel is hidden by default and the first panel is open when triggered. */"
     }

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/integrated-charts-toolbar/examples/customise-data-groups/data.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/integrated-charts-toolbar/examples/customise-data-groups/data.ts
@@ -1,0 +1,33 @@
+export function getData(): any[] {
+    var countries = [
+        'Ireland',
+        'Spain',
+        'United Kingdom',
+        'France',
+        'Germany',
+        'Luxembourg',
+        'Sweden',
+        'Norway',
+        'Italy',
+        'Greece',
+        'Iceland',
+        'Portugal',
+        'Malta',
+        'Brazil',
+        'Argentina',
+        'Colombia',
+        'Peru',
+        'Venezuela',
+        'Uruguay',
+        'Belgium',
+    ]
+
+    return countries.map(function (country, index) {
+        return {
+            country: country,
+            gold: Math.floor(((index + 1 / 7) * 333) % 100),
+            silver: Math.floor(((index + 1 / 3) * 555) % 100),
+            bronze: Math.floor(((index + 1 / 7.3) * 777) % 100),
+        }
+    })
+}

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/integrated-charts-toolbar/examples/customise-data-groups/index.html
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/integrated-charts-toolbar/examples/customise-data-groups/index.html
@@ -1,0 +1,1 @@
+<div id="myGrid" style="height: 100%;" class="ag-theme-alpine"></div>

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/integrated-charts-toolbar/examples/customise-data-groups/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/integrated-charts-toolbar/examples/customise-data-groups/main.ts
@@ -1,0 +1,81 @@
+import { ColDef, CreateRangeChartParams, FirstDataRenderedEvent, Grid, GridOptions } from '@ag-grid-community/core';
+import { getData } from "./data";
+
+const columnDefs: ColDef[] = [
+  { field: 'country', width: 150, chartDataType: 'category' },
+  { field: 'gold', chartDataType: 'series' },
+  { field: 'silver', chartDataType: 'series' },
+  { field: 'bronze', chartDataType: 'series' },
+  {
+    headerName: 'A',
+    valueGetter: 'Math.floor(Math.random()*1000)',
+    chartDataType: 'series',
+  },
+  {
+    headerName: 'B',
+    valueGetter: 'Math.floor(Math.random()*1000)',
+    chartDataType: 'series',
+  },
+  {
+    headerName: 'C',
+    valueGetter: 'Math.floor(Math.random()*1000)',
+    chartDataType: 'series',
+  },
+  {
+    headerName: 'D',
+    valueGetter: 'Math.floor(Math.random()*1000)',
+    chartDataType: 'series',
+  },
+]
+
+const gridOptions: GridOptions = {
+  defaultColDef: {
+    editable: true,
+    sortable: true,
+    flex: 1,
+    minWidth: 100,
+    filter: true,
+    resizable: true,
+  },
+  columnDefs: columnDefs,
+  rowData: getData(),
+  popupParent: document.body,
+  enableRangeSelection: true,
+  onFirstDataRendered: onFirstDataRendered,
+  enableCharts: true,
+  chartToolPanelsDef: {
+    defaultToolPanel: 'data',
+    dataPanel: {
+      groups: [
+        { type: 'seriesChartType', isOpen: true },
+        { type: 'series', isOpen: false }
+      ]
+    }
+  }
+}
+
+function onFirstDataRendered(params: FirstDataRenderedEvent) {
+  var createRangeChartParams: CreateRangeChartParams = {
+    cellRange: {
+      rowStartIndex: 0,
+      rowEndIndex: 4,
+      columns: ['country', 'gold', 'silver', 'bronze'],
+    },
+    chartType: 'groupedColumn',
+    chartThemeOverrides: {
+      column: {
+        legend: {
+          position: 'bottom'
+        }
+      }
+    }
+  }
+
+  params.api.createRangeChart(createRangeChartParams)
+}
+
+// setup the grid after the page has finished loading
+document.addEventListener('DOMContentLoaded', function () {
+  var gridDiv = document.querySelector<HTMLElement>('#myGrid')!
+  new Grid(gridDiv, gridOptions)
+})

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/integrated-charts-toolbar/index.md
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/integrated-charts-toolbar/index.md
@@ -164,6 +164,37 @@ The example below shows a reordering of chart groups with some chart groups and 
 
 <grid-example title='Customising settings panel chart groups' name='customise-chart-groups' type='generated' options='{ "enterprise": true, "modules": ["clientside", "menu", "charts"] }'></grid-example>
 
+### Customising data panel groups
+
+The groups shown on the data panel can be customised using the `chartToolPanelsDef.dataPanel.groups` grid option. The list specified also indicates the order the groups are shown and whether they are open by default. If `chartToolPanelsDef.dataPanel.groups` is not specified, all groups are shown and are open by default.
+
+The default list and order of data groups are as follows:
+
+<snippet>
+const gridOptions = {
+    chartToolPanelsDef: {
+        dataPanel: {
+            groups: [
+                { type: 'categories', isOpen: true },
+                { type: 'series', isOpen: true },
+                { type: 'seriesChartType', isOpen: true }
+            ]
+        }
+    }
+}
+</snippet>
+
+[[note]]
+| The `seriesChartType` group is only shown for [Combination Charts](/charts-combination-series/).
+
+The following example shows the data panel with:
+
+* `series` group closed by default
+* `categories` not shown
+* `seriesChartType` group shown above `series` and open by default, but only shown if a combination chart is chosen in the settings panel
+
+<grid-example title='Customising data panel groups' name='customise-data-groups' type='generated' options='{ "enterprise": true, "modules": ["clientside", "menu", "charts"] }'></grid-example>
+
 ### Customising format panel groups
 
 The groups shown on the format panel can be customised using the `chartToolPanelsDef.formatPanel.groups` grid option. The list specified also indicates the order the groups are shown and whether they are open by default. If `chartToolPanelsDef.formatPanel.groups` is not specified, all groups are shown and are closed by default.


### PR DESCRIPTION
## Changes

* Add chart data panel customisation using `chartToolPanelsDef.dataPanel.groups` grid options
* Add docs

## Grid options update

```
const gridOptions = {
    chartToolPanelsDef: {
        dataPanel: {
            groups: [
                { type: 'categories', isOpen: true },
                { type: 'series', isOpen: true },
                { type: 'seriesChartType', isOpen: true }
            ]
        }
    }
}
```