### PR TITLE
AG-7585 Treemap API improvements & docs

### DIFF
--- a/charts-packages/ag-charts-community/src/chart/agChartOptions.ts
+++ b/charts-packages/ag-charts-community/src/chart/agChartOptions.ts
@@ -711,6 +711,11 @@ export interface AgSeriesHighlightMarkerStyle {
     strokeWidth?: PixelSize;
 }
 
+export interface AgSeriesHighlightTextStyle {
+    /** The colour of an item's text when tapped or hovered over. Use `undefined` for no highlight. */
+    color?: CssColor;
+}
+
 export interface AgSeriesHighlightSeriesStyle {
     enabled?: boolean;
     /** The opacity of the whole series (area line, area fill, labels and markers, if any) when another chart series or another stack level in the same area series is highlighted by hovering a data point or a legend item. Use `undefined` or `1` for no dimming. */
@@ -724,6 +729,8 @@ export interface AgSeriesHighlightStyle {
     item?: AgSeriesHighlightMarkerStyle;
     /** Highlight style used for whole series when one of its markers is tapped or hovered over. */
     series?: AgSeriesHighlightSeriesStyle;
+    /** Highlight style used for a text when item is tapped or hovered over. */
+    text?: AgSeriesHighlightTextStyle;
 }
 
 export interface AgSeriesNodeClickParams<DatumType> {
@@ -1478,6 +1485,8 @@ export interface AgTreemapSeriesLabelsOptions {
     value?: {
         /** A property to be used as a key to retrieve a value from datum. */
         key?: string;
+        /** A name of a datum value. */
+        name?: string;
         /** A function to generate a value label from datum. */
         formatter?: (params: { datum: any }) => string | undefined;
         /** The label's font and color style. */
@@ -1520,6 +1529,12 @@ export interface AgTreemapSeriesOptions<DatumType = any> extends AgBaseSeriesOpt
     nodePadding?: PixelSize;
     /** Whether or not to use gradients for treemap tiles. */
     gradient?: boolean;
+    /** Configuration for the shadow used behind the treemap tiles. */
+    tileShadow?: AgDropShadowOptions;
+    /** Configuration for the shadow used behind the treemap labels. */
+    labelShadow?: AgDropShadowOptions;
+    /** Determines whether the groups will be highlighted by cursor. */
+    highlightGroups?: boolean;
     /** A callback function for adjusting the styles of a particular treemap tile based on the input parameters */
     formatter?: (params: AgTreemapSeriesFormatterParams<DataValue>) => AgTreemapSeriesFormat;
     /** A map of event names to event listeners. */

--- a/charts-packages/ag-charts-community/src/chart/agChartOptions.ts
+++ b/charts-packages/ag-charts-community/src/chart/agChartOptions.ts
@@ -711,11 +711,6 @@ export interface AgSeriesHighlightMarkerStyle {
     strokeWidth?: PixelSize;
 }
 
-export interface AgSeriesHighlightTextStyle {
-    /** The colour of an item's text when tapped or hovered over. Use `undefined` for no highlight. */
-    color?: CssColor;
-}
-
 export interface AgSeriesHighlightSeriesStyle {
     enabled?: boolean;
     /** The opacity of the whole series (area line, area fill, labels and markers, if any) when another chart series or another stack level in the same area series is highlighted by hovering a data point or a legend item. Use `undefined` or `1` for no dimming. */
@@ -729,8 +724,6 @@ export interface AgSeriesHighlightStyle {
     item?: AgSeriesHighlightMarkerStyle;
     /** Highlight style used for whole series when one of its markers is tapped or hovered over. */
     series?: AgSeriesHighlightSeriesStyle;
-    /** Highlight style used for a text when item is tapped or hovered over. */
-    text?: AgSeriesHighlightTextStyle;
 }
 
 export interface AgSeriesNodeClickParams<DatumType> {
@@ -1494,6 +1487,16 @@ export interface AgTreemapSeriesLabelsOptions {
     };
 }
 
+export interface AgTreemapSeriesHighlightTextStyle {
+    /** The colour of an item's text when tapped or hovered over. Use `undefined` for no highlight. */
+    color?: CssColor;
+}
+
+export interface AgTreemapSeriesHighlightStyle extends AgSeriesHighlightStyle {
+    /** Highlight style used for a text when item is tapped or hovered over. */
+    text?: AgTreemapSeriesHighlightTextStyle;
+}
+
 /** Configuration for the treemap series. */
 export interface AgTreemapSeriesOptions<DatumType = any> extends AgBaseSeriesOptions<DatumType> {
     type?: 'treemap';
@@ -1535,6 +1538,8 @@ export interface AgTreemapSeriesOptions<DatumType = any> extends AgBaseSeriesOpt
     labelShadow?: AgDropShadowOptions;
     /** Determines whether the groups will be highlighted by cursor. */
     highlightGroups?: boolean;
+    /** Configuration for treemap tiles when they are hovered over. */
+    highlightStyle?: AgTreemapSeriesHighlightStyle;
     /** A callback function for adjusting the styles of a particular treemap tile based on the input parameters */
     formatter?: (params: AgTreemapSeriesFormatterParams<DataValue>) => AgTreemapSeriesFormat;
     /** A map of event names to event listeners. */

--- a/charts-packages/ag-charts-community/src/chart/agChartOptions.ts
+++ b/charts-packages/ag-charts-community/src/chart/agChartOptions.ts
@@ -1442,13 +1442,23 @@ export interface AgTreemapSeriesLabelOptions extends AgChartLabelOptions {
 }
 
 export interface AgTreemapSeriesTooltipRendererParams<DatumType> {
+    /** Datum from the series data that the treemap tile is being rendered for. */
     datum: DatumType;
+    /** The parent of the datum from the treemap data. */
+    parent?: DataValue;
+    /** The depth of the datum in the hierarchy. */
+    depth: number;
+    /** sizeKey as specified on series options. */
     sizeKey?: string;
+    /** labelKey as specified on series options. */
     labelKey?: string;
-    valueKey?: string;
+    /** colorKey as specified on series options. */
     colorKey?: string;
+    /** The computed fill colour of the treemap tile. */
     color?: string;
+    /** The title of the treemap tile */
     title?: string;
+    /** The ID of the series. */
     seriesId: string;
 }
 
@@ -1518,8 +1528,10 @@ export interface AgTreemapSeriesOptions<DatumType = any> extends AgBaseSeriesOpt
 
 /** The parameters of the treemap series formatter function */
 export interface AgTreemapSeriesFormatterParams<DataValue = any> {
-    /** Datum from the series data array that the treemap tile is being rendered for. */
+    /** Datum from the series data that the treemap tile is being rendered for. */
     readonly datum: DataValue;
+    /** The parent of the datum from the treemap data. */
+    readonly parent?: DataValue;
     /** The depth of the datum in the hierarchy. */
     readonly depth: number;
     /** labelKey as specified on series options. */

--- a/charts-packages/ag-charts-community/src/chart/mapping/__snapshots__/prepare.test.ts.snap
+++ b/charts-packages/ag-charts-community/src/chart/mapping/__snapshots__/prepare.test.ts.snap
@@ -180,6 +180,9 @@ Object {
         "series": Object {
           "dimOpacity": 1,
         },
+        "text": Object {
+          "color": "black",
+        },
       },
       "label": Object {
         "color": "rgb(70, 70, 70)",
@@ -233,6 +236,9 @@ Object {
         "series": Object {
           "dimOpacity": 1,
         },
+        "text": Object {
+          "color": "black",
+        },
       },
       "label": Object {
         "color": "rgb(70, 70, 70)",
@@ -285,6 +291,9 @@ Object {
         },
         "series": Object {
           "dimOpacity": 1,
+        },
+        "text": Object {
+          "color": "black",
         },
       },
       "label": Object {
@@ -607,6 +616,9 @@ Object {
         "series": Object {
           "dimOpacity": 1,
         },
+        "text": Object {
+          "color": "black",
+        },
       },
       "label": Object {
         "color": "rgb(70, 70, 70)",
@@ -669,6 +681,9 @@ Object {
         },
         "series": Object {
           "dimOpacity": 1,
+        },
+        "text": Object {
+          "color": "black",
         },
       },
       "label": Object {
@@ -939,6 +954,9 @@ Object {
           "dimOpacity": 0.2,
           "strokeWidth": 3,
         },
+        "text": Object {
+          "color": "black",
+        },
       },
       "label": Object {
         "color": "rgb(70, 70, 70)",
@@ -992,6 +1010,9 @@ Object {
         "series": Object {
           "dimOpacity": 0.2,
           "strokeWidth": 3,
+        },
+        "text": Object {
+          "color": "black",
         },
       },
       "label": Object {
@@ -1047,6 +1068,9 @@ Object {
           "dimOpacity": 0.2,
           "strokeWidth": 3,
         },
+        "text": Object {
+          "color": "black",
+        },
       },
       "label": Object {
         "color": "rgb(70, 70, 70)",
@@ -1100,6 +1124,9 @@ Object {
         "series": Object {
           "dimOpacity": 0.2,
           "strokeWidth": 3,
+        },
+        "text": Object {
+          "color": "black",
         },
       },
       "label": Object {
@@ -1155,6 +1182,9 @@ Object {
           "dimOpacity": 0.2,
           "strokeWidth": 3,
         },
+        "text": Object {
+          "color": "black",
+        },
       },
       "label": Object {
         "color": "rgb(70, 70, 70)",
@@ -1209,6 +1239,9 @@ Object {
           "dimOpacity": 0.2,
           "strokeWidth": 3,
         },
+        "text": Object {
+          "color": "black",
+        },
       },
       "label": Object {
         "color": "rgb(70, 70, 70)",
@@ -1262,6 +1295,9 @@ Object {
         "series": Object {
           "dimOpacity": 0.2,
           "strokeWidth": 3,
+        },
+        "text": Object {
+          "color": "black",
         },
       },
       "label": Object {
@@ -1551,6 +1587,9 @@ Object {
         "series": Object {
           "dimOpacity": 1,
         },
+        "text": Object {
+          "color": "black",
+        },
       },
       "label": Object {
         "color": "rgb(70, 70, 70)",
@@ -1833,6 +1872,9 @@ Object {
         "series": Object {
           "dimOpacity": 1,
         },
+        "text": Object {
+          "color": "black",
+        },
       },
       "label": Object {
         "color": "rgb(70, 70, 70)",
@@ -2066,6 +2108,9 @@ Object {
         "series": Object {
           "dimOpacity": 1,
         },
+        "text": Object {
+          "color": "black",
+        },
       },
       "label": Object {
         "color": "rgb(70, 70, 70)",
@@ -2118,6 +2163,9 @@ Object {
         },
         "series": Object {
           "dimOpacity": 1,
+        },
+        "text": Object {
+          "color": "black",
         },
       },
       "label": Object {
@@ -2172,6 +2220,9 @@ Object {
         "series": Object {
           "dimOpacity": 1,
         },
+        "text": Object {
+          "color": "black",
+        },
       },
       "label": Object {
         "color": "rgb(70, 70, 70)",
@@ -2224,6 +2275,9 @@ Object {
         },
         "series": Object {
           "dimOpacity": 1,
+        },
+        "text": Object {
+          "color": "black",
         },
       },
       "label": Object {
@@ -2499,6 +2553,9 @@ Object {
           "dimOpacity": 0.1,
           "strokeWidth": 3,
         },
+        "text": Object {
+          "color": "black",
+        },
       },
       "label": Object {
         "color": "rgb(70, 70, 70)",
@@ -2568,6 +2625,9 @@ Object {
         "series": Object {
           "dimOpacity": 0.1,
           "strokeWidth": 3,
+        },
+        "text": Object {
+          "color": "black",
         },
       },
       "label": Object {
@@ -2639,6 +2699,9 @@ Object {
           "dimOpacity": 0.1,
           "strokeWidth": 3,
         },
+        "text": Object {
+          "color": "black",
+        },
       },
       "label": Object {
         "color": "rgb(70, 70, 70)",
@@ -2709,6 +2772,9 @@ Object {
           "dimOpacity": 0.1,
           "strokeWidth": 3,
         },
+        "text": Object {
+          "color": "black",
+        },
       },
       "label": Object {
         "color": "rgb(70, 70, 70)",
@@ -2778,6 +2844,9 @@ Object {
         "series": Object {
           "dimOpacity": 0.1,
           "strokeWidth": 3,
+        },
+        "text": Object {
+          "color": "black",
         },
       },
       "label": Object {
@@ -3068,6 +3137,9 @@ Object {
         "series": Object {
           "dimOpacity": 1,
         },
+        "text": Object {
+          "color": "black",
+        },
       },
       "label": Object {
         "color": "rgb(70, 70, 70)",
@@ -3324,6 +3396,9 @@ Object {
         "series": Object {
           "dimOpacity": 1,
         },
+        "text": Object {
+          "color": "black",
+        },
       },
       "label": Object {
         "color": "white",
@@ -3561,6 +3636,9 @@ Object {
         },
         "series": Object {
           "dimOpacity": 1,
+        },
+        "text": Object {
+          "color": "black",
         },
       },
       "label": Object {
@@ -3800,6 +3878,9 @@ Object {
         },
         "series": Object {
           "dimOpacity": 1,
+        },
+        "text": Object {
+          "color": "black",
         },
       },
       "label": Object {
@@ -4042,6 +4123,9 @@ Object {
         },
         "series": Object {
           "dimOpacity": 0.3,
+        },
+        "text": Object {
+          "color": "black",
         },
       },
       "label": Object {
@@ -4323,6 +4407,9 @@ Object {
         "series": Object {
           "dimOpacity": 0.2,
           "strokeWidth": 1,
+        },
+        "text": Object {
+          "color": "black",
         },
       },
       "label": Object {
@@ -4611,6 +4698,9 @@ Object {
         },
         "series": Object {
           "dimOpacity": 1,
+        },
+        "text": Object {
+          "color": "black",
         },
       },
       "label": Object {
@@ -4913,6 +5003,9 @@ Object {
         "series": Object {
           "dimOpacity": 1,
         },
+        "text": Object {
+          "color": "black",
+        },
       },
       "label": Object {
         "color": "rgb(70, 70, 70)",
@@ -5149,6 +5242,9 @@ Object {
           "dimOpacity": 0.2,
           "strokeWidth": 4,
         },
+        "text": Object {
+          "color": "black",
+        },
       },
       "label": Object {
         "color": "rgb(70, 70, 70)",
@@ -5202,6 +5298,9 @@ Object {
         "series": Object {
           "dimOpacity": 0.2,
           "strokeWidth": 4,
+        },
+        "text": Object {
+          "color": "black",
         },
       },
       "label": Object {
@@ -5257,6 +5356,9 @@ Object {
           "dimOpacity": 0.2,
           "strokeWidth": 4,
         },
+        "text": Object {
+          "color": "black",
+        },
       },
       "label": Object {
         "color": "rgb(70, 70, 70)",
@@ -5310,6 +5412,9 @@ Object {
         "series": Object {
           "dimOpacity": 0.2,
           "strokeWidth": 4,
+        },
+        "text": Object {
+          "color": "black",
         },
       },
       "label": Object {
@@ -5365,6 +5470,9 @@ Object {
           "dimOpacity": 0.2,
           "strokeWidth": 4,
         },
+        "text": Object {
+          "color": "black",
+        },
       },
       "label": Object {
         "color": "rgb(70, 70, 70)",
@@ -5418,6 +5526,9 @@ Object {
         "series": Object {
           "dimOpacity": 0.2,
           "strokeWidth": 4,
+        },
+        "text": Object {
+          "color": "black",
         },
       },
       "label": Object {
@@ -5473,6 +5584,9 @@ Object {
           "dimOpacity": 0.2,
           "strokeWidth": 4,
         },
+        "text": Object {
+          "color": "black",
+        },
       },
       "label": Object {
         "color": "rgb(70, 70, 70)",
@@ -5526,6 +5640,9 @@ Object {
         "series": Object {
           "dimOpacity": 0.2,
           "strokeWidth": 4,
+        },
+        "text": Object {
+          "color": "black",
         },
       },
       "label": Object {
@@ -5581,6 +5698,9 @@ Object {
           "dimOpacity": 0.2,
           "strokeWidth": 4,
         },
+        "text": Object {
+          "color": "black",
+        },
       },
       "label": Object {
         "color": "rgb(70, 70, 70)",
@@ -5634,6 +5754,9 @@ Object {
         "series": Object {
           "dimOpacity": 0.2,
           "strokeWidth": 4,
+        },
+        "text": Object {
+          "color": "black",
         },
       },
       "label": Object {
@@ -5689,6 +5812,9 @@ Object {
           "dimOpacity": 0.2,
           "strokeWidth": 4,
         },
+        "text": Object {
+          "color": "black",
+        },
       },
       "label": Object {
         "color": "rgb(70, 70, 70)",
@@ -5742,6 +5868,9 @@ Object {
         "series": Object {
           "dimOpacity": 0.2,
           "strokeWidth": 4,
+        },
+        "text": Object {
+          "color": "black",
         },
       },
       "label": Object {
@@ -5797,6 +5926,9 @@ Object {
           "dimOpacity": 0.2,
           "strokeWidth": 4,
         },
+        "text": Object {
+          "color": "black",
+        },
       },
       "label": Object {
         "color": "rgb(70, 70, 70)",
@@ -5850,6 +5982,9 @@ Object {
         "series": Object {
           "dimOpacity": 0.2,
           "strokeWidth": 4,
+        },
+        "text": Object {
+          "color": "black",
         },
       },
       "label": Object {
@@ -5905,6 +6040,9 @@ Object {
           "dimOpacity": 0.2,
           "strokeWidth": 4,
         },
+        "text": Object {
+          "color": "black",
+        },
       },
       "label": Object {
         "color": "rgb(70, 70, 70)",
@@ -5958,6 +6096,9 @@ Object {
         "series": Object {
           "dimOpacity": 0.2,
           "strokeWidth": 4,
+        },
+        "text": Object {
+          "color": "black",
         },
       },
       "label": Object {
@@ -6255,6 +6396,9 @@ Object {
         "series": Object {
           "dimOpacity": 1,
         },
+        "text": Object {
+          "color": "black",
+        },
       },
       "label": Object {
         "color": "rgb(70, 70, 70)",
@@ -6382,6 +6526,7 @@ Object {
       "groupFill": "#272931",
       "groupStroke": "black",
       "groupStrokeWidth": 1,
+      "highlightGroups": true,
       "highlightStyle": Object {
         "item": Object {
           "fill": "yellow",
@@ -6390,8 +6535,18 @@ Object {
         "series": Object {
           "dimOpacity": 1,
         },
+        "text": Object {
+          "color": "black",
+        },
       },
       "labelKey": "name",
+      "labelShadow": Object {
+        "blur": 5,
+        "color": "rgba(0, 0, 0, 0.4)",
+        "enabled": true,
+        "xOffset": 1.5,
+        "yOffset": 1.5,
+      },
       "labels": Object {
         "large": Object {
           "color": "white",
@@ -6440,6 +6595,13 @@ Object {
         "fontStyle": undefined,
         "fontWeight": undefined,
         "padding": 13,
+      },
+      "tileShadow": Object {
+        "blur": 5,
+        "color": "rgba(0, 0, 0, 0.5)",
+        "enabled": false,
+        "xOffset": 3,
+        "yOffset": 3,
       },
       "tileStroke": "black",
       "tileStrokeWidth": 1,
@@ -6666,6 +6828,9 @@ Object {
         "series": Object {
           "dimOpacity": 0.3,
           "strokeWidth": 4,
+        },
+        "text": Object {
+          "color": "black",
         },
       },
       "label": Object {
@@ -6966,6 +7131,9 @@ Object {
           "dimOpacity": 0.2,
           "strokeWidth": 1,
         },
+        "text": Object {
+          "color": "black",
+        },
       },
       "label": Object {
         "color": "rgb(70, 70, 70)",
@@ -7255,6 +7423,9 @@ Object {
         },
         "series": Object {
           "dimOpacity": 0.3,
+        },
+        "text": Object {
+          "color": "black",
         },
       },
       "label": Object {
@@ -7554,6 +7725,9 @@ Object {
         "series": Object {
           "dimOpacity": 1,
         },
+        "text": Object {
+          "color": "black",
+        },
       },
       "label": Object {
         "color": "rgb(70, 70, 70)",
@@ -7619,6 +7793,9 @@ Object {
         },
         "series": Object {
           "dimOpacity": 1,
+        },
+        "text": Object {
+          "color": "black",
         },
       },
       "label": Object {
@@ -7686,6 +7863,9 @@ Object {
         "series": Object {
           "dimOpacity": 1,
         },
+        "text": Object {
+          "color": "black",
+        },
       },
       "label": Object {
         "color": "rgb(70, 70, 70)",
@@ -7751,6 +7931,9 @@ Object {
         },
         "series": Object {
           "dimOpacity": 1,
+        },
+        "text": Object {
+          "color": "black",
         },
       },
       "label": Object {
@@ -8016,6 +8199,9 @@ Object {
         "series": Object {
           "dimOpacity": 1,
         },
+        "text": Object {
+          "color": "black",
+        },
       },
       "label": Object {
         "color": "#eeeeee",
@@ -8169,6 +8355,9 @@ Object {
         },
         "series": Object {
           "dimOpacity": 1,
+        },
+        "text": Object {
+          "color": "black",
         },
       },
       "innerLabels": Array [
@@ -8450,6 +8639,9 @@ Object {
         "series": Object {
           "dimOpacity": 1,
         },
+        "text": Object {
+          "color": "black",
+        },
       },
       "label": Object {
         "color": "rgb(70, 70, 70)",
@@ -8686,6 +8878,9 @@ Object {
           "dimOpacity": 0.2,
           "strokeWidth": 3,
         },
+        "text": Object {
+          "color": "black",
+        },
       },
       "label": Object {
         "color": "rgb(70, 70, 70)",
@@ -8739,6 +8934,9 @@ Object {
         "series": Object {
           "dimOpacity": 0.2,
           "strokeWidth": 3,
+        },
+        "text": Object {
+          "color": "black",
         },
       },
       "label": Object {
@@ -8905,6 +9103,9 @@ Object {
         },
         "series": Object {
           "dimOpacity": 1,
+        },
+        "text": Object {
+          "color": "black",
         },
       },
       "innerRadiusOffset": 0,
@@ -9160,6 +9361,9 @@ Object {
         "series": Object {
           "dimOpacity": 1,
         },
+        "text": Object {
+          "color": "black",
+        },
       },
       "label": Object {
         "color": "rgb(70, 70, 70)",
@@ -9402,6 +9606,9 @@ Object {
         },
         "series": Object {
           "dimOpacity": 0.2,
+        },
+        "text": Object {
+          "color": "black",
         },
       },
       "label": Object {
@@ -9710,6 +9917,9 @@ Object {
           "dimOpacity": 0.3,
           "strokeWidth": 1,
         },
+        "text": Object {
+          "color": "black",
+        },
       },
       "label": Object {
         "color": "rgb(70, 70, 70)",
@@ -9990,6 +10200,9 @@ Object {
         "series": Object {
           "dimOpacity": 0.3,
           "strokeWidth": 1,
+        },
+        "text": Object {
+          "color": "black",
         },
       },
       "label": Object {
@@ -10297,6 +10510,9 @@ Object {
         },
         "series": Object {
           "dimOpacity": 1,
+        },
+        "text": Object {
+          "color": "black",
         },
       },
       "label": Object {

--- a/charts-packages/ag-charts-community/src/chart/series/hierarchy/treemapSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/hierarchy/treemapSeries.ts
@@ -1,7 +1,7 @@
 import { Selection } from '../../../scene/selection';
 import { HdpiCanvas } from '../../../canvas/hdpiCanvas';
 import { Label } from '../../label';
-import { SeriesNodeDatum, SeriesTooltip, SeriesNodeClickEvent } from '../series';
+import { SeriesNodeDatum, SeriesTooltip, SeriesNodeClickEvent, HighlightStyle } from '../series';
 import { HierarchySeries } from './hierarchySeries';
 import { toTooltipHtml } from '../../tooltip/tooltip';
 import { Group } from '../../../scene/group';
@@ -104,6 +104,15 @@ enum TextNodeTag {
 
 function getTextSize(text: string, style: Label) {
     return HdpiCanvas.getTextSize(text, [style.fontWeight, `${style.fontSize}px`, style.fontFamily].join(' '));
+}
+
+class TreemapTextHighlightStyle {
+    @Validate(OPT_COLOR_STRING)
+    color?: string = 'black';
+}
+
+export class TreemapHighlightStyle extends HighlightStyle {
+    readonly text = new TreemapTextHighlightStyle();
 }
 
 export class TreemapSeries extends HierarchySeries<TreemapNodeDatum> {
@@ -216,6 +225,8 @@ export class TreemapSeries extends HierarchySeries<TreemapNodeDatum> {
     labelShadow = new DropShadow();
 
     readonly tooltip = new TreemapSeriesTooltip();
+
+    readonly highlightStyle = new TreemapHighlightStyle();
 
     private getNodePaddingTop(nodeDatum: TreemapNodeDatum, bbox: BBox) {
         const { title, subtitle, nodePadding } = this;

--- a/charts-packages/ag-charts-community/src/chart/series/hierarchy/treemapSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/hierarchy/treemapSeries.ts
@@ -756,6 +756,8 @@ export class TreemapSeries extends HierarchySeries<TreemapNodeDatum> {
             return toTooltipHtml(
                 tooltipRenderer({
                     datum: nodeDatum.datum,
+                    parent: nodeDatum.parent?.datum,
+                    depth: nodeDatum.depth,
                     sizeKey,
                     labelKey,
                     colorKey,

--- a/charts-packages/ag-charts-community/src/chart/series/series.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/series.ts
@@ -95,9 +95,15 @@ class SeriesHighlightStyle {
     enabled?: boolean = undefined;
 }
 
+class TextHighlightStyle {
+    @Validate(OPT_COLOR_STRING)
+    color?: string = 'black';
+}
+
 export class HighlightStyle {
     readonly item = new SeriesItemHighlightStyle();
     readonly series = new SeriesHighlightStyle();
+    readonly text = new TextHighlightStyle();
 }
 
 export class SeriesTooltip {

--- a/charts-packages/ag-charts-community/src/chart/themes/chartTheme.ts
+++ b/charts-packages/ag-charts-community/src/chart/themes/chartTheme.ts
@@ -132,6 +132,9 @@ export class ChartTheme {
                 series: {
                     dimOpacity: 1,
                 },
+                text: {
+                    color: 'black',
+                },
             },
         };
     }
@@ -521,6 +524,21 @@ export class ChartTheme {
                 tileStroke: 'black',
                 tileStrokeWidth: 1,
                 gradient: true,
+                tileShadow: {
+                    enabled: false,
+                    color: 'rgba(0, 0, 0, 0.5)',
+                    xOffset: 3,
+                    yOffset: 3,
+                    blur: 5,
+                },
+                labelShadow: {
+                    enabled: true,
+                    color: 'rgba(0, 0, 0, 0.4)',
+                    xOffset: 1.5,
+                    yOffset: 1.5,
+                    blur: 5,
+                },
+                highlightGroups: true,
                 nodePadding: 2,
                 title: {
                     enabled: true,

--- a/charts-packages/ag-charts-community/tools/dev-server/tsconfig.json
+++ b/charts-packages/ag-charts-community/tools/dev-server/tsconfig.json
@@ -5,6 +5,7 @@
         "checkJs": true,
         "lib": ["DOM", "ESNext"],
         "noEmit": true,
+        "baseUrl": "./",
         "paths": {
             "ag-charts-community": ["../../src/main.ts"]
         },

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/doc-interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/doc-interfaces.AUTO.json
@@ -1985,12 +1985,6 @@
       "type": { "returnType": "PixelSize", "optional": true }
     }
   },
-  "AgSeriesHighlightTextStyle": {
-    "color": {
-      "description": "/** The colour of an item's text when tapped or hovered over. Use `undefined` for no highlight. */",
-      "type": { "returnType": "CssColor", "optional": true }
-    }
-  },
   "AgSeriesHighlightSeriesStyle": {
     "enabled": { "type": { "returnType": "boolean", "optional": true } },
     "dimOpacity": {
@@ -2010,10 +2004,6 @@
     "series": {
       "description": "/** Highlight style used for whole series when one of its markers is tapped or hovered over. */",
       "type": { "returnType": "AgSeriesHighlightSeriesStyle", "optional": true }
-    },
-    "text": {
-      "description": "/** Highlight style used for a text when item is tapped or hovered over. */",
-      "type": { "returnType": "AgSeriesHighlightTextStyle", "optional": true }
     }
   },
   "AgSeriesNodeClickParams": {
@@ -3943,6 +3933,29 @@
       }
     }
   },
+  "AgTreemapSeriesHighlightTextStyle": {
+    "color": {
+      "description": "/** The colour of an item's text when tapped or hovered over. Use `undefined` for no highlight. */",
+      "type": { "returnType": "CssColor", "optional": true }
+    }
+  },
+  "AgTreemapSeriesHighlightStyle": {
+    "text": {
+      "description": "/** Highlight style used for a text when item is tapped or hovered over. */",
+      "type": {
+        "returnType": "AgTreemapSeriesHighlightTextStyle",
+        "optional": true
+      }
+    },
+    "item": {
+      "description": "/** Highlight style used for an individual marker when tapped or hovered over. */",
+      "type": { "returnType": "AgSeriesHighlightMarkerStyle", "optional": true }
+    },
+    "series": {
+      "description": "/** Highlight style used for whole series when one of its markers is tapped or hovered over. */",
+      "type": { "returnType": "AgSeriesHighlightSeriesStyle", "optional": true }
+    }
+  },
   "AgTreemapSeriesOptions": {
     "type": { "type": { "returnType": "'treemap'", "optional": true } },
     "title": {
@@ -4024,6 +4037,13 @@
       "description": "/** Determines whether the groups will be highlighted by cursor. */",
       "type": { "returnType": "boolean", "optional": true }
     },
+    "highlightStyle": {
+      "description": "/** Configuration for treemap tiles when they are hovered over. */",
+      "type": {
+        "returnType": "AgTreemapSeriesHighlightStyle",
+        "optional": true
+      }
+    },
     "formatter": {
       "description": "/** A callback function for adjusting the styles of a particular treemap tile based on the input parameters */",
       "type": {
@@ -4056,10 +4076,6 @@
     "cursor": {
       "description": "/** The cursor to use for hovered area markers. This config is identical to the CSS `cursor` property. */",
       "type": { "returnType": "string", "optional": true }
-    },
-    "highlightStyle": {
-      "description": "/** Configuration for series markers and series line highlighting when a marker / data point or a legend item is hovered over. */",
-      "type": { "returnType": "AgSeriesHighlightStyle", "optional": true }
     }
   },
   "AgTreemapSeriesFormatterParams": {

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/doc-interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/doc-interfaces.AUTO.json
@@ -1985,6 +1985,12 @@
       "type": { "returnType": "PixelSize", "optional": true }
     }
   },
+  "AgSeriesHighlightTextStyle": {
+    "color": {
+      "description": "/** The colour of an item's text when tapped or hovered over. Use `undefined` for no highlight. */",
+      "type": { "returnType": "CssColor", "optional": true }
+    }
+  },
   "AgSeriesHighlightSeriesStyle": {
     "enabled": { "type": { "returnType": "boolean", "optional": true } },
     "dimOpacity": {
@@ -2004,6 +2010,10 @@
     "series": {
       "description": "/** Highlight style used for whole series when one of its markers is tapped or hovered over. */",
       "type": { "returnType": "AgSeriesHighlightSeriesStyle", "optional": true }
+    },
+    "text": {
+      "description": "/** Highlight style used for a text when item is tapped or hovered over. */",
+      "type": { "returnType": "AgSeriesHighlightTextStyle", "optional": true }
     }
   },
   "AgSeriesNodeClickParams": {
@@ -3928,7 +3938,7 @@
     "value": {
       "description": "/** The configuration for the cell value label. */",
       "type": {
-        "returnType": "{\n        /** A property to be used as a key to retrieve a value from datum. */\n        key?: string;\n        /** A function to generate a value label from datum. */\n        formatter?: (params: { datum: any }) => string | undefined;\n        /** The label's font and color style. */\n        style?: AgChartLabelOptions;\n    }",
+        "returnType": "{\n        /** A property to be used as a key to retrieve a value from datum. */\n        key?: string;\n        /** A name of a datum value. */\n        name?: string;\n        /** A function to generate a value label from datum. */\n        formatter?: (params: { datum: any }) => string | undefined;\n        /** The label's font and color style. */\n        style?: AgChartLabelOptions;\n    }",
         "optional": true
       }
     }
@@ -4000,6 +4010,18 @@
     },
     "gradient": {
       "description": "/** Whether or not to use gradients for treemap tiles. */",
+      "type": { "returnType": "boolean", "optional": true }
+    },
+    "tileShadow": {
+      "description": "/** Configuration for the shadow used behind the treemap tiles. */",
+      "type": { "returnType": "AgDropShadowOptions", "optional": true }
+    },
+    "labelShadow": {
+      "description": "/** Configuration for the shadow used behind the treemap labels. */",
+      "type": { "returnType": "AgDropShadowOptions", "optional": true }
+    },
+    "highlightGroups": {
+      "description": "/** Determines whether the groups will be highlighted by cursor. */",
       "type": { "returnType": "boolean", "optional": true }
     },
     "formatter": {

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/doc-interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/doc-interfaces.AUTO.json
@@ -3857,14 +3857,42 @@
     }
   },
   "AgTreemapSeriesTooltipRendererParams": {
-    "datum": { "type": { "returnType": "DatumType", "optional": false } },
-    "sizeKey": { "type": { "returnType": "string", "optional": true } },
-    "labelKey": { "type": { "returnType": "string", "optional": true } },
-    "valueKey": { "type": { "returnType": "string", "optional": true } },
-    "colorKey": { "type": { "returnType": "string", "optional": true } },
-    "color": { "type": { "returnType": "string", "optional": true } },
-    "title": { "type": { "returnType": "string", "optional": true } },
-    "seriesId": { "type": { "returnType": "string", "optional": false } },
+    "datum": {
+      "description": "/** Datum from the series data that the treemap tile is being rendered for. */",
+      "type": { "returnType": "DatumType", "optional": false }
+    },
+    "parent": {
+      "description": "/** The parent of the datum from the treemap data. */",
+      "type": { "returnType": "DataValue", "optional": true }
+    },
+    "depth": {
+      "description": "/** The depth of the datum in the hierarchy. */",
+      "type": { "returnType": "number", "optional": false }
+    },
+    "sizeKey": {
+      "description": "/** sizeKey as specified on series options. */",
+      "type": { "returnType": "string", "optional": true }
+    },
+    "labelKey": {
+      "description": "/** labelKey as specified on series options. */",
+      "type": { "returnType": "string", "optional": true }
+    },
+    "colorKey": {
+      "description": "/** colorKey as specified on series options. */",
+      "type": { "returnType": "string", "optional": true }
+    },
+    "color": {
+      "description": "/** The computed fill colour of the treemap tile. */",
+      "type": { "returnType": "string", "optional": true }
+    },
+    "title": {
+      "description": "/** The title of the treemap tile */",
+      "type": { "returnType": "string", "optional": true }
+    },
+    "seriesId": {
+      "description": "/** The ID of the series. */",
+      "type": { "returnType": "string", "optional": false }
+    },
     "meta": { "typeParams": ["DatumType"] }
   },
   "AgTreemapSeriesTooltip": {
@@ -4014,8 +4042,12 @@
   },
   "AgTreemapSeriesFormatterParams": {
     "datum": {
-      "description": "/** Datum from the series data array that the treemap tile is being rendered for. */",
+      "description": "/** Datum from the series data that the treemap tile is being rendered for. */",
       "type": { "returnType": "DataValue", "optional": false }
+    },
+    "parent": {
+      "description": "/** The parent of the datum from the treemap data. */",
+      "type": { "returnType": "DataValue", "optional": true }
     },
     "depth": {
       "description": "/** The depth of the datum in the hierarchy. */",

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
@@ -1295,6 +1295,13 @@
       "strokeWidth?": "/** The stroke width of a marker when tapped or hovered over. Use `undefined` for no highlight. */"
     }
   },
+  "AgSeriesHighlightTextStyle": {
+    "meta": {},
+    "type": { "color?": "CssColor" },
+    "docs": {
+      "color?": "/** The colour of an item's text when tapped or hovered over. Use `undefined` for no highlight. */"
+    }
+  },
   "AgSeriesHighlightSeriesStyle": {
     "meta": {},
     "type": {
@@ -1311,11 +1318,13 @@
     "meta": {},
     "type": {
       "item?": "AgSeriesHighlightMarkerStyle",
-      "series?": "AgSeriesHighlightSeriesStyle"
+      "series?": "AgSeriesHighlightSeriesStyle",
+      "text?": "AgSeriesHighlightTextStyle"
     },
     "docs": {
       "item?": "/** Highlight style used for an individual marker when tapped or hovered over. */",
-      "series?": "/** Highlight style used for whole series when one of its markers is tapped or hovered over. */"
+      "series?": "/** Highlight style used for whole series when one of its markers is tapped or hovered over. */",
+      "text?": "/** Highlight style used for a text when item is tapped or hovered over. */"
     }
   },
   "AgSeriesNodeClickParams": {
@@ -2550,7 +2559,7 @@
       "large?": "AgChartLabelOptions",
       "medium?": "AgChartLabelOptions",
       "small?": "AgChartLabelOptions",
-      "value?": "{ key?: string; formatter?: (params: { datum: any; }) => string | undefined; style?: AgChartLabelOptions; }"
+      "value?": "{ key?: string; name?: string; formatter?: (params: { datum: any; }) => string | undefined; style?: AgChartLabelOptions; }"
     },
     "docs": {
       "large?": "/** The label configuration for the large leaf tiles. */",
@@ -2582,6 +2591,9 @@
       "tooltip?": "AgTreemapSeriesTooltip<DatumType>",
       "nodePadding?": "PixelSize",
       "gradient?": "boolean",
+      "tileShadow?": "AgDropShadowOptions",
+      "labelShadow?": "AgDropShadowOptions",
+      "highlightGroups?": "boolean",
       "formatter?": "(params: AgTreemapSeriesFormatterParams<DataValue>) => AgTreemapSeriesFormat",
       "listeners?": "AgSeriesListeners<DatumType>",
       "id?": "string",
@@ -2608,6 +2620,9 @@
       "tooltip?": "/** Series-specific tooltip configuration. */",
       "nodePadding?": "/** The amount of padding in pixels inside of each treemap tile. Increasing `nodePadding` will reserve more space for parent labels. */",
       "gradient?": "/** Whether or not to use gradients for treemap tiles. */",
+      "tileShadow?": "/** Configuration for the shadow used behind the treemap tiles. */",
+      "labelShadow?": "/** Configuration for the shadow used behind the treemap labels. */",
+      "highlightGroups?": "/** Determines whether the groups will be highlighted by cursor. */",
       "formatter?": "/** A callback function for adjusting the styles of a particular treemap tile based on the input parameters */",
       "listeners?": "/** A map of event names to event listeners. */",
       "id?": "/** Primary identifier for the series. This is provided as `seriesId` in user callbacks to differentiate multiple\n     * series. Auto-generated ids are subject to future change without warning, if your callbacks need to vary behaviour\n     * by series please supply your own unique `id` value.\n     *\n     * Default: auto-generated value\n     */",

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
@@ -2512,13 +2512,25 @@
     "meta": { "typeParams": ["DatumType"] },
     "type": {
       "datum": "DatumType",
+      "parent?": "DataValue",
+      "depth": "number",
       "sizeKey?": "string",
       "labelKey?": "string",
-      "valueKey?": "string",
       "colorKey?": "string",
       "color?": "string",
       "title?": "string",
       "seriesId": "string"
+    },
+    "docs": {
+      "datum": "/** Datum from the series data that the treemap tile is being rendered for. */",
+      "parent?": "/** The parent of the datum from the treemap data. */",
+      "depth": "/** The depth of the datum in the hierarchy. */",
+      "sizeKey?": "/** sizeKey as specified on series options. */",
+      "labelKey?": "/** labelKey as specified on series options. */",
+      "colorKey?": "/** colorKey as specified on series options. */",
+      "color?": "/** The computed fill colour of the treemap tile. */",
+      "title?": "/** The title of the treemap tile */",
+      "seriesId": "/** The ID of the series. */"
     }
   },
   "AgTreemapSeriesTooltip": {
@@ -2613,6 +2625,7 @@
     },
     "type": {
       "datum": "DataValue",
+      "parent?": "DataValue",
       "depth": "number",
       "labelKey": "string",
       "sizeKey?": "string",
@@ -2627,7 +2640,8 @@
       "seriesId": "string"
     },
     "docs": {
-      "datum": "/** Datum from the series data array that the treemap tile is being rendered for. */",
+      "datum": "/** Datum from the series data that the treemap tile is being rendered for. */",
+      "parent?": "/** The parent of the datum from the treemap data. */",
       "depth": "/** The depth of the datum in the hierarchy. */",
       "labelKey": "/** labelKey as specified on series options. */",
       "sizeKey?": "/** sizeKey as specified on series options. */",

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
@@ -1295,13 +1295,6 @@
       "strokeWidth?": "/** The stroke width of a marker when tapped or hovered over. Use `undefined` for no highlight. */"
     }
   },
-  "AgSeriesHighlightTextStyle": {
-    "meta": {},
-    "type": { "color?": "CssColor" },
-    "docs": {
-      "color?": "/** The colour of an item's text when tapped or hovered over. Use `undefined` for no highlight. */"
-    }
-  },
   "AgSeriesHighlightSeriesStyle": {
     "meta": {},
     "type": {
@@ -1318,13 +1311,11 @@
     "meta": {},
     "type": {
       "item?": "AgSeriesHighlightMarkerStyle",
-      "series?": "AgSeriesHighlightSeriesStyle",
-      "text?": "AgSeriesHighlightTextStyle"
+      "series?": "AgSeriesHighlightSeriesStyle"
     },
     "docs": {
       "item?": "/** Highlight style used for an individual marker when tapped or hovered over. */",
-      "series?": "/** Highlight style used for whole series when one of its markers is tapped or hovered over. */",
-      "text?": "/** Highlight style used for a text when item is tapped or hovered over. */"
+      "series?": "/** Highlight style used for whole series when one of its markers is tapped or hovered over. */"
     }
   },
   "AgSeriesNodeClickParams": {
@@ -2568,6 +2559,26 @@
       "value?": "/** The configuration for the cell value label. */"
     }
   },
+  "AgTreemapSeriesHighlightTextStyle": {
+    "meta": {},
+    "type": { "color?": "CssColor" },
+    "docs": {
+      "color?": "/** The colour of an item's text when tapped or hovered over. Use `undefined` for no highlight. */"
+    }
+  },
+  "AgTreemapSeriesHighlightStyle": {
+    "meta": {},
+    "type": {
+      "text?": "AgTreemapSeriesHighlightTextStyle",
+      "item?": "AgSeriesHighlightMarkerStyle",
+      "series?": "AgSeriesHighlightSeriesStyle"
+    },
+    "docs": {
+      "text?": "/** Highlight style used for a text when item is tapped or hovered over. */",
+      "item?": "/** Highlight style used for an individual marker when tapped or hovered over. */",
+      "series?": "/** Highlight style used for whole series when one of its markers is tapped or hovered over. */"
+    }
+  },
   "AgTreemapSeriesOptions": {
     "meta": {
       "typeParams": ["DatumType = any"],
@@ -2594,14 +2605,14 @@
       "tileShadow?": "AgDropShadowOptions",
       "labelShadow?": "AgDropShadowOptions",
       "highlightGroups?": "boolean",
+      "highlightStyle?": "AgTreemapSeriesHighlightStyle",
       "formatter?": "(params: AgTreemapSeriesFormatterParams<DataValue>) => AgTreemapSeriesFormat",
       "listeners?": "AgSeriesListeners<DatumType>",
       "id?": "string",
       "data?": "DatumType[]",
       "visible?": "boolean",
       "showInLegend?": "boolean",
-      "cursor?": "string",
-      "highlightStyle?": "AgSeriesHighlightStyle"
+      "cursor?": "string"
     },
     "docs": {
       "title?": "/** The label configuration for the top-level tiles. */",
@@ -2623,14 +2634,14 @@
       "tileShadow?": "/** Configuration for the shadow used behind the treemap tiles. */",
       "labelShadow?": "/** Configuration for the shadow used behind the treemap labels. */",
       "highlightGroups?": "/** Determines whether the groups will be highlighted by cursor. */",
+      "highlightStyle?": "/** Configuration for treemap tiles when they are hovered over. */",
       "formatter?": "/** A callback function for adjusting the styles of a particular treemap tile based on the input parameters */",
       "listeners?": "/** A map of event names to event listeners. */",
       "id?": "/** Primary identifier for the series. This is provided as `seriesId` in user callbacks to differentiate multiple\n     * series. Auto-generated ids are subject to future change without warning, if your callbacks need to vary behaviour\n     * by series please supply your own unique `id` value.\n     *\n     * Default: auto-generated value\n     */",
       "data?": "/** The data to use when rendering the series. If this is not supplied, data must be set on the chart instead. */",
       "visible?": "/** Whether or not to display the series. */",
       "showInLegend?": "/** Whether or not to include the series in the legend. */",
-      "cursor?": "/** The cursor to use for hovered area markers. This config is identical to the CSS `cursor` property. */",
-      "highlightStyle?": "/** Configuration for series markers and series line highlighting when a marker / data point or a legend item is hovered over. */"
+      "cursor?": "/** The cursor to use for hovered area markers. This config is identical to the CSS `cursor` property. */"
     }
   },
   "AgTreemapSeriesFormatterParams": {

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-overview/examples/market-index-treemap/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-overview/examples/market-index-treemap/main.ts
@@ -33,24 +33,22 @@ const options: AgChartOptions = {
 }
 
 function tooltipRenderer(params: AgTreemapSeriesTooltipRendererParams<any>) {
-  const { datum } = params
-  const customRootText = 'Custom Root Text'
-  const title = datum.parent
-    ? datum.parent.depth
-      ? datum.parent.datum[params.labelKey!]
-      : customRootText
+  const { color, parent, depth, labelKey, colorKey } = params
+  const customRootText = 'All industries'
+  const title = depth > 1
+    ? parent[labelKey!]
     : customRootText
   let content = '<div>'
   let ellipsis = false
 
-  if (datum.parent) {
+  if (parent) {
     const maxCount = 5
-    ellipsis = datum.parent.children!.length > maxCount
-    datum.parent.children!.slice(0, maxCount).forEach((child: any) => {
-      content += `<div style="font-weight: bold; color: white; background-color: ${child.fill
-        }; padding: 5px;"><strong>${child.datum.name || child.label
+    ellipsis = parent.children!.length > maxCount
+    parent.children!.slice(0, maxCount).forEach((child: any) => {
+      content += `<div style="font-weight: bold; color: white; background-color: ${color
+        }; padding: 5px;"><strong>${child[labelKey!]
         }</strong>: ${String(
-          isFinite(child.colorValue) ? child.colorValue.toFixed(2) : ''
+          isFinite(child[colorKey!]) ? child[colorKey!].toFixed(2) : ''
         )}%</div>`
     })
   }

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-treemap-series/examples/custom-colors/data.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-treemap-series/examples/custom-colors/data.ts
@@ -1,0 +1,53 @@
+export function getData() {
+    return {
+        name: 'Products',
+        children: [
+            {
+                name: 'Foodstuffs',
+                children: [
+                    {
+                        name: 'Buckwheat Honey',
+                        exports: 25000,
+                    },
+                    {
+                        name: 'Doughnut Holes',
+                        exports: 8000,
+                    },
+                    {
+                        name: 'Fly Agarics',
+                        exports: 5000,
+                    },
+                    {
+                        name: 'Pumpkins',
+                        exports: 12000,
+                    },
+                    {
+                        name: 'Sunflowers',
+                        exports: 10000,
+                    },
+                ],
+            },
+            {
+                name: 'Instruments',
+                children: [
+                    {
+                        name: 'Air Fresheners',
+                        exports: 2000,
+                    },
+                    {
+                        name: 'Clock Hands',
+                        exports: 8000,
+                    },
+                    {
+                        name: 'Digging Sticks',
+                        exports: 5000,
+                    },
+                    {
+                        name: 'Logarithmic Rulers',
+                        exports: 2000,
+                    },
+                ],
+            },
+        ],
+    };
+}

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-treemap-series/examples/custom-colors/index.html
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-treemap-series/examples/custom-colors/index.html
@@ -1,0 +1,1 @@
+<div id="myChart" style="height: 100%;"></div>

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-treemap-series/examples/custom-colors/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-treemap-series/examples/custom-colors/main.ts
@@ -37,17 +37,13 @@ const options: agCharts.AgChartOptions = {
                     color: undefined,
                 },
             },
-            formatter: ({ datum, depth, parent, highlighted }) => {
+            formatter: ({ depth, parent, highlighted }) => {
                 if (depth < 2) {
                     return {};
                 }
 
+                const fill = parent.name === 'Foodstuffs' ? 'rgb(64, 172, 64)' : 'rgb(32, 96, 224)';
                 const stroke = highlighted ? 'black' : 'white';
-                const mainColor = parent.name === 'Foodstuffs' ? [224, 64, 32] : [32, 92, 224];
-                const siblings = parent.children.sort((a, b) => b.exports - a.exports);
-                const lightness = siblings.indexOf(datum) / siblings.length;
-                const color = mainColor.map((v) => v * (1 - 0.5 * lightness));
-                const fill = `rgb(${color.join(',')})`;
                 return { fill, stroke };
             },
         } as agCharts.AgTreemapSeriesOptions,

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-treemap-series/examples/custom-colors/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-treemap-series/examples/custom-colors/main.ts
@@ -1,0 +1,63 @@
+import * as agCharts from 'ag-charts-community';
+import { getData } from './data';
+
+const options: agCharts.AgChartOptions = {
+    type: 'hierarchy',
+    container: document.getElementById('myChart'),
+    data: getData(),
+    series: [
+        {
+            type: 'treemap',
+            labelKey: 'name',
+            gradient: false,
+            nodePadding: 2,
+            sizeKey: 'exports',
+            tileStroke: 'white',
+            tileStrokeWidth: 1,
+            labelShadow: {
+                enabled: false,
+            },
+            groupFill: 'transparent',
+            title: {
+                color: 'black',
+            },
+            subtitle: {
+                color: 'black',
+            },
+            labels: {
+                value: {
+                    name: 'Exports',
+                    formatter: (params) => `$${params.datum.exports}M`,
+                },
+            },
+            groupStrokeWidth: 0,
+            highlightGroups: false,
+            highlightStyle: {
+                text: {
+                    color: undefined,
+                },
+            },
+            formatter: ({ datum, depth, parent, highlighted }) => {
+                if (depth < 2) {
+                    return {};
+                }
+
+                const stroke = highlighted ? 'black' : 'white';
+                const mainColor = parent.name === 'Foodstuffs' ? [224, 64, 32] : [32, 92, 224];
+                const siblings = parent.children.sort((a, b) => b.exports - a.exports);
+                const lightness = siblings.indexOf(datum) / siblings.length;
+                const color = mainColor.map((v) => v * (1 - 0.5 * lightness));
+                const fill = `rgb(${color.join(',')})`;
+                return { fill, stroke };
+            },
+        } as agCharts.AgTreemapSeriesOptions,
+    ],
+    title: {
+        text: 'Exports of Krakozhia in 2022',
+    },
+    subtitle: {
+        text: 'in millions US dollars',
+    },
+}
+
+agCharts.AgChart.create(options);

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-treemap-series/index.md
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-treemap-series/index.md
@@ -100,6 +100,155 @@ series: [{
 
 <chart-example title='Organizational Chart' name='org-chart' type='generated'></chart-example>
 
+## Understanding the Treemap colours
+
+There are several ways to customise the colours of treemap tiles.
+
+### Storing the colour values in the data
+
+If treemap data nodes have fill colours assigned to them,
+the property containing the colour should be specified in `colorKey`.
+
+```js
+series: [{
+    type: 'treemap',
+    colorKey: 'color',
+    data: [{
+        children: [
+            { color: 'red' },
+            { color: '#fa5310' },
+        ],
+    }],
+}]
+```
+
+### Using the color scale
+
+`colorKey` can also specify a property containing a numeric value.
+In this case the `colorDomain` and `colorRange` should be provided.
+
+```js
+series: [{
+    type: 'treemap',
+    colorKey: 'color',
+    colorDomain: [0, 10, 20],
+    colorRange: ['red', 'yellow', 'green'],
+    data: [{
+        children: [
+            { color: 5 },
+            { color: 8 },
+            { color: 12 },
+        ],
+    }],
+}]
+```
+
+### Groups colours
+
+The groups can be coloured in 2 ways:
+- A static colour value can be specified in `groupFill` property.
+- If `groupFill` can be set to `undefined`, the group colour behaviour will match the one for tiles.
+
+```js
+series: [{
+    type: 'treemap',
+    colorKey: 'color',
+    groupFill: 'black',
+    ...
+    groupFill: undefined,
+    data: [{
+        color: 'black',
+        children: [
+            { color: 'white' },
+            { color: 'red' },
+            { color: 'white' },
+        ],
+    }],
+}]
+```
+
+### Strokes
+
+There are several properties to control the tiles' and groups' stroke colors and widths.
+
+```js
+series: [{
+    type: 'treemap',
+    tileStroke: 'black',
+    tileStrokeWidth: 2,
+    groupStroke: 'transparent',
+    groupStrokeWidth: 0,
+}]
+```
+
+### Labels colours and font styles
+
+Since tiles can have different sizes depending on layout,
+there is `large`, `medium` and `small` label configuration to match a specific size.
+Tiles can also have separate `value` labels.
+The styles for all of them can be specified like:
+
+```js
+series: [{
+    type: 'treemap',
+    labels: {
+        large: {
+            color: 'black',
+            fontWeight: 'bold',
+        },
+        medium: {
+            color: 'black',
+        },
+        small: {
+            color: 'gray',
+            fontSize: 8,
+        },
+        value: {
+            formatter: ({ datum }) => `${datum.size * 100}%`,
+            style: {
+                color: 'orange',
+            },
+        },
+    },
+}]
+```
+
+In addition the groups' titles can have their own styles:
+
+```js
+series: [{
+    type: 'treemap',
+    title: {
+        color: 'black',
+        fontWeight: 'bold',
+    },
+    subtitle: {
+        color: 'black',
+        fontSize: 8,
+    },
+}]
+```
+
+### Overriding the styles for particular tiles
+
+Use `formatter` function to change a colour for specific tiles.
+
+```js
+series: [{
+    formatter: ({ datum, depth, labelKey, highlighted }) => {
+        if (datum[labelKey] === 'Joel Cooper') {
+            return { fill: highlighted ? 'white' : 'orchid' };
+        }
+    },
+}]
+```
+
+Please see the API reference for more information.
+
+## Complex Colouring Chart Example
+
+<chart-example title='Complex Colouring Chart' name='custom-colors' type='generated'></chart-example>
+
 ## API Reference
 
 <interface-documentation interfaceName='AgTreemapSeriesOptions' overridesrc="charts-api/api.json" config='{ "showSnippets": false, "lookupRoot": "charts-api" }'></interface-documentation>


### PR DESCRIPTION
- Untie tile and tooltip label text from colorKey.
- Ability to get depth and parent in formatter and tooltip renderer.
- Separate tile and text shadows.
- Highlight text colour (can be used in all types).
- Ability to prevent groups highlighting.
- Fixed not displaying formatted fill in the tooltip.
- API docs update and complex colouring example.