### PR TITLE
AG-7596 - Increase Chart Tool Panels click area and increase chart padding

### DIFF
--- a/community-modules/styles/src/internal/base/parts/_charts.scss
+++ b/community-modules/styles/src/internal/base/parts/_charts.scss
@@ -233,11 +233,11 @@
         flex-direction: row;
         overflow: auto;
         top: 5px;
-        gap: 7px;
+        gap: calc(var(--ag-grid-size) * 3 - 8px);
         width: auto;
 
         @include ag.unthemed-rtl((
-            right: 10px,
+            right: calc(var(--ag-cell-horizontal-padding) + var(--ag-grid-size) - 4px),
             justify-content: right
         ));
     }
@@ -249,7 +249,8 @@
     .ag-chart-tool-panel-button-enable {
         .ag-chart-menu-close {
             position: absolute;
-            top: 45%;
+            top: 50%;
+            transform: translateY(-50%);
             padding: 0;
             display: block;
             cursor: pointer;
@@ -258,7 +259,16 @@
             @include ag.unthemed-rtl((right: 0px));
 
             .ag-icon {
-                padding: 9px 0 9px 0;
+                padding: 10px 2px;
+            }
+
+            &:before {
+                content: "";
+                position: absolute;
+                top: -40px;
+                bottom: -40px;
+                @include ag.unthemed-rtl((right: 0px));
+                @include ag.unthemed-rtl((left: -10px));
             }
         }
 

--- a/community-modules/styles/src/internal/themes/alpine/_index.scss
+++ b/community-modules/styles/src/internal/themes/alpine/_index.scss
@@ -200,14 +200,15 @@
         background: var(--ag-background-color);
     }
 
+    .ag-chart-menu-close:hover .ag-icon {
+        border-color: var(--ag-border-color);
+        background: var(--ag-header-background-color);
+    }
+
     .ag-chart-menu-close .ag-icon {
         background: none;
         border: 1px solid var(--ag-secondary-border-color);
         border-right: none;
-    }
-
-    .ag-chart-menu-close .ag-icon:hover {
-        background: var(--ag-header-background-color);
     }
 
     .ag-chart-settings-card-item.ag-not-selected:hover {

--- a/community-modules/styles/src/internal/themes/balham/_index.scss
+++ b/community-modules/styles/src/internal/themes/balham/_index.scss
@@ -130,14 +130,15 @@
         background: var(--ag-background-color);
     }
 
+    .ag-chart-menu-close:hover .ag-icon {
+        border-color: var(--ag-border-color);
+        background: var(--ag-header-background-color);
+    }
+
     .ag-chart-menu-close .ag-icon {
         background: none;
         border: 1px solid var(--ag-secondary-border-color);
         border-right: none;
-    }
-
-    .ag-chart-menu-close .ag-icon:hover {
-        background: var(--ag-header-background-color);
     }
 }
 

--- a/community-modules/styles/src/internal/themes/material/_index.scss
+++ b/community-modules/styles/src/internal/themes/material/_index.scss
@@ -117,12 +117,12 @@
         background: var(--ag-background-color);
     }
 
-    .ag-chart-menu-close .ag-icon {
-        background: none;
+    .ag-chart-menu-close:hover .ag-icon {
+        background: var(--ag-subheader-background-color);
     }
 
-    .ag-chart-menu-close .ag-icon:hover {
-        background: var(--ag-subheader-background-color);
+    .ag-chart-menu-close .ag-icon {
+        background: none;
     }
 
     @include ag.text-input {

--- a/enterprise-modules/charts/src/charts/chartComp/chartProxies/chartTheme.ts
+++ b/enterprise-modules/charts/src/charts/chartComp/chartProxies/chartTheme.ts
@@ -140,26 +140,12 @@ const STATIC_INBUILT_STOCK_THEME_AXES_OVERRIDES = ALL_AXIS_TYPES.reduce(
     (r, n) => ({ ...r, [n]: { title: { _enabledFromTheme: true } } }),
     {}
 );
-const STATIC_INBUILT_STOCK_THEME_OVERRIDES: AgChartThemeOverrides = {
-    common: {
-        axes: STATIC_INBUILT_STOCK_THEME_AXES_OVERRIDES,
-    },
-    pie: {
-        series: {
-            title: { _enabledFromTheme: true },
-            calloutLabel: { _enabledFromTheme: true },
-            sectorLabel: {
-                enabled: false,
-                _enabledFromTheme: true,
-            },
-        } as any,
-    },
-};
 
 function inbuiltStockThemeOverrides(params: ChartProxyParams) {
     const extraPadding = params.getExtraPaddingRequired();
     return {
         common: {
+            axes: STATIC_INBUILT_STOCK_THEME_AXES_OVERRIDES,
             padding: {
                 top: 20 + (extraPadding.top ?? 0),
                 right: 20 + (extraPadding.right ?? 0),
@@ -167,7 +153,16 @@ function inbuiltStockThemeOverrides(params: ChartProxyParams) {
                 left: 20 + (extraPadding.left ?? 0),
             },
         },
-        ...STATIC_INBUILT_STOCK_THEME_OVERRIDES,
+        pie: {
+            series: {
+                title: { _enabledFromTheme: true },
+                calloutLabel: { _enabledFromTheme: true },
+                sectorLabel: {
+                    enabled: false,
+                    _enabledFromTheme: true,
+                },
+            } as any,
+        },
     };
 }
 

--- a/enterprise-modules/charts/src/charts/chartComp/menu/chartMenu.ts
+++ b/enterprise-modules/charts/src/charts/chartComp/menu/chartMenu.ts
@@ -98,11 +98,22 @@ export class ChartMenu extends Component {
         const rightItems: ChartMenuOptions[] = ['chartSettings', 'chartData', 'chartFormat'];
 
         const result: AgChartPaddingOptions = {};
+        const extraPadding = 10;
         if (topItems.some(v => this.chartToolbarOptions.includes(v))) {
-            result.top = 10;
+            const isRtl = this.gridOptionsService.is('enableRtl');
+            if (isRtl) {
+                result.top = extraPadding + 10; // More padding to account for the flip of the y axis
+            } else {
+                result.top = extraPadding;
+            }
         }
         if (rightItems.some(v => this.chartToolbarOptions.includes(v))) {
-            result.right = 15;
+            const isRtl = this.gridOptionsService.is('enableRtl');
+            if (isRtl) {
+                result.left = extraPadding;
+            } else {
+                result.right = extraPadding;
+            }
         }
 
         return result;

--- a/grid-packages/ag-grid-docs/documentation/customise.js
+++ b/grid-packages/ag-grid-docs/documentation/customise.js
@@ -132,7 +132,7 @@ const fixFileLoadingIssue = () => {
 const jsxErrorProcessingIssue = () => {
     // Prevents Gatsby from dying when an JSX error is introduced
 
-    return applyCustomisation('gatsby-cli', '3.14.2', {
+    return applyCustomisation('gatsby-cli', '3.15.0', {
             name: 'JSX Error Processing Issue',
             apply: () => updateFileContents(
                 './node_modules/gatsby-cli/lib/structured-errors/construct-error.js',

--- a/scripts/release/createAndDeployDocsToS3.sh
+++ b/scripts/release/createAndDeployDocsToS3.sh
@@ -2,11 +2,11 @@
 
 TARGET_DIRECTORY=$1
 
-#cd grid-packages/ag-grid-docs
-#npx gulp release-archive
+cd grid-packages/ag-grid-docs
+npx gulp release-archive
 
-#cd ../../
-#node scripts/release/patchDocs.js
+cd ../../
+node scripts/release/patchDocs.js
 
 cd grid-packages/ag-grid-docs
 

--- a/scripts/release/createAndDeployDocsToS3.sh
+++ b/scripts/release/createAndDeployDocsToS3.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+TARGET_DIRECTORY=$1
+
+ZIP_PREFIX=`date +%Y%m%d`
+
+cd grid-packages/ag-grid-docs
+npx gulp release-archive
+
+cd ../../
+node scripts/release/patchDocs.js
+
+cd grid-packages/ag-grid-docs
+
+s3 cp dist s3://testing.ag-grid.com/$TARGET_DIRECTORY --recursive

--- a/scripts/release/createAndDeployDocsToS3.sh
+++ b/scripts/release/createAndDeployDocsToS3.sh
@@ -8,6 +8,6 @@ TARGET_DIRECTORY=$1
 #cd ../../
 #node scripts/release/patchDocs.js
 
-#cd grid-packages/ag-grid-docs
+cd grid-packages/ag-grid-docs
 
 aws s3 cp dist s3://testing.ag-grid.com/$TARGET_DIRECTORY --recursive

--- a/scripts/release/createAndDeployDocsToS3.sh
+++ b/scripts/release/createAndDeployDocsToS3.sh
@@ -2,14 +2,12 @@
 
 TARGET_DIRECTORY=$1
 
-ZIP_PREFIX=`date +%Y%m%d`
+#cd grid-packages/ag-grid-docs
+#npx gulp release-archive
 
-cd grid-packages/ag-grid-docs
-npx gulp release-archive
+#cd ../../
+#node scripts/release/patchDocs.js
 
-cd ../../
-node scripts/release/patchDocs.js
+#cd grid-packages/ag-grid-docs
 
-cd grid-packages/ag-grid-docs
-
-s3 cp dist s3://testing.ag-grid.com/$TARGET_DIRECTORY --recursive
+aws s3 cp dist s3://testing.ag-grid.com/$TARGET_DIRECTORY --recursive


### PR DESCRIPTION
## Changes

* Fix bug with integrated charts padding being overwritten
* Add integrated chart padding based on RTL
* Style chart tool panel button to make click target larger and more obvious
  * For `alpine`, `alpine-dark`, `balham`, `balham-dark` and `material` grid themes

## Screenshots

Closed
| Before | After |
| - | - |
| ![Screenshot 2022-12-07 at 3 29 32 pm](https://user-images.githubusercontent.com/79451/206221094-2b269f16-0119-40ca-a4f4-ea549d995516.png) | ![Screenshot 2022-12-07 at 3 22 19 pm](https://user-images.githubusercontent.com/79451/206220368-17c97e0c-0aaa-42f1-9fc9-c1d6202f674c.png) |

Open
| Before | After |
| - | - |
| ![Screenshot 2022-12-07 at 3 29 38 pm](https://user-images.githubusercontent.com/79451/206221342-a06d4d86-1923-405c-ac8f-9f74a6bec4fe.png) | ![Screenshot 2022-12-07 at 3 22 26 pm](https://user-images.githubusercontent.com/79451/206220436-feda9798-bc57-4112-aa2d-311a91d19abc.png) |

Increased click area (in red)
![Screenshot 2022-12-07 at 3 22 52 pm](https://user-images.githubusercontent.com/79451/206220532-05157cb2-36d4-43ea-a251-259422838916.png)

