### PR TITLE
AG-7656 - Refactor cursor style handling

### DIFF
--- a/charts-packages/ag-charts-community/src/chart/cartesianChart.ts
+++ b/charts-packages/ag-charts-community/src/chart/cartesianChart.ts
@@ -24,7 +24,7 @@ export class CartesianChart extends Chart {
         this.navigator.enabled = false;
     }
 
-    readonly navigator = new Navigator(this, this.interactionManager);
+    readonly navigator = new Navigator(this, this.interactionManager, this.cursorManager);
 
     async performLayout() {
         this.scene.root!.visible = true;

--- a/charts-packages/ag-charts-community/src/chart/chart.ts
+++ b/charts-packages/ag-charts-community/src/chart/chart.ts
@@ -307,7 +307,7 @@ export abstract class Chart extends Observable implements AgChartInstance {
         if (this.tooltip.enabled) {
             this.tooltip.toggle(visible);
         }
-        if (!visible && this.lastPick) {
+        if (!visible && this.lastPick?.datum?.datum != null) {
             this.changeHighlightDatum();
         }
         if (!visible && this.lastInteractionEvent) {
@@ -874,7 +874,9 @@ export abstract class Chart extends Observable implements AgChartInstance {
     }
 
     private disablePointer({ updateProcessing = true } = {}) {
-        this.changeHighlightDatum(undefined, { updateProcessing });
+        if (this.highlightedDatum?.datum?.datum != null) {
+            this.changeHighlightDatum(undefined, { updateProcessing });
+        }
         this.togglePointer(false);
     }
 

--- a/charts-packages/ag-charts-community/src/chart/interaction/cursorManager.ts
+++ b/charts-packages/ag-charts-community/src/chart/interaction/cursorManager.ts
@@ -1,0 +1,38 @@
+interface CursorState {
+    style: string;
+}
+
+/**
+ * Manages the cursor styling for an element. Tracks the requested styling from distinct
+ * dependents and handles conflicting styling requests.
+ */
+export class CursorManager {
+    private readonly states: Record<string, CursorState> = {};
+    private readonly element: HTMLElement;
+
+    public constructor(element: HTMLElement) {
+        this.element = element;
+    }
+
+    public updateCursor(callerId: string, style?: string) {
+        delete this.states[callerId];
+
+        if (style != null) {
+            this.states[callerId] = { style };
+        }
+
+        this.applyStates();
+    }
+
+    private applyStates() {
+        let styleToApply = 'default';
+
+        // Last added entry wins.
+        Object.entries(this.states)
+            .reverse()
+            .slice(0, 1)
+            .forEach(([_, { style }]) => (styleToApply = style));
+
+        this.element.style.cursor = styleToApply;
+    }
+}

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/doc-interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/doc-interfaces.AUTO.json
@@ -4436,6 +4436,9 @@
   "LabelTranslationDirection": {},
   "CrossLineTranslationDirection": {},
   "CrossLinesRangeConfig": {},
+  "CursorState": {
+    "style": { "type": { "returnType": "string", "optional": false } }
+  },
   "InteractionTypes": {},
   "Listener": { "meta": { "typeParams": ["T extends InteractionTypes"] } },
   "SUPPORTED_EVENTS": {},

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
@@ -2944,6 +2944,7 @@
     "meta": { "isTypeAlias": true },
     "type": "Record<string, { vertical: [ Date, Date ]; horizontal: [ number, number ]; }>"
   },
+  "CursorState": { "meta": {}, "type": { "style": "string" } },
   "InteractionTypes": {
     "meta": { "isTypeAlias": true },
     "type": "'click' | 'hover' | 'drag-start' | 'drag' | 'drag-end' | 'leave' | 'page-left'"
@@ -2964,7 +2965,7 @@
       "isTypeAlias": true,
       "typeParams": ["T extends InteractionTypes"]
     },
-    "type": "{ type: T; offsetX: number; offsetY: number; pageX: number; pageY: number; sourceEvent: Event; } & (T extends 'drag' ? { startX: number; startY: number; } : {})"
+    "type": "{ type: T; offsetX: number; offsetY: number; pageX: number; pageY: number; sourceEvent: Event; consume(): void; } & (T extends 'drag' ? { startX: number; startY: number; } : {})"
   },
   "Layers": {
     "meta": { "isEnum": true },


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-7656

Attempts to consolidate `element.style.cursor` handling to better separate cursor styling logic, state and conflict resolution from various parts of the code base into `CursorManager`.

Bonus:
- Moves all legend-related `InteractionEvent` handling to `legend.ts`.
- Adds `InteractionEvent.consume()` to allow mutually-exclusive event processing without tight coupling between handlers.
- Removes some redundant code from `Chart`.