### PR TITLE
AG-7583- Allow disabling series toggling when legend item is clicked

### DIFF
--- a/charts-packages/ag-charts-community/src/chart/agChartOptions.ts
+++ b/charts-packages/ag-charts-community/src/chart/agChartOptions.ts
@@ -378,6 +378,8 @@ export interface AgChartLegendOptions {
     item?: AgChartLegendItemOptions;
     /** Reverse the display order of legend items if `true`. */
     reverseOrder?: boolean;
+    /** Set to `false` to turn off toggling of the series visibility in the chart when the legend item is clicked. */
+    seriesToggleEnabled?: boolean;
     /** Optional callbacks for specific legend-related events. */
     listeners?: AgChartLegendListeners;
     pagination?: AgChartLegendPaginationOptions;

--- a/charts-packages/ag-charts-community/src/chart/legend.ts
+++ b/charts-packages/ag-charts-community/src/chart/legend.ts
@@ -237,6 +237,9 @@ export class Legend {
     @Validate(OPT_ORIENTATION)
     orientation?: AgChartOrientation;
 
+    @Validate(BOOLEAN)
+    seriesToggleEnabled: boolean = true;
+
     constructor(
         private readonly chart: {
             readonly series: Series<any>[];
@@ -582,6 +585,7 @@ export class Legend {
             listeners: { legendItemClick },
             chart,
             highlightManager,
+            seriesToggleEnabled,
         } = this;
         const datum = this.getDatumForPoint(event.offsetX, event.offsetY);
         if (!datum) {
@@ -596,7 +600,10 @@ export class Legend {
         event.consume();
 
         const newEnabled = !enabled;
-        series.toggleSeriesItem(itemId, newEnabled);
+        if (seriesToggleEnabled) {
+            series.toggleSeriesItem(itemId, newEnabled);
+        }
+
         if (!newEnabled) {
             chart.togglePointer(false);
             highlightManager.updateHighlight(this.id);
@@ -614,7 +621,7 @@ export class Legend {
     }
 
     private handleLegendMouseMove(event: InteractionEvent<'hover'>) {
-        const { enabled } = this;
+        const { enabled, seriesToggleEnabled, listeners } = this;
         if (!enabled) {
             return;
         }
@@ -641,7 +648,9 @@ export class Legend {
             return;
         }
 
-        this.cursorManager.updateCursor(this.id, 'pointer');
+        if (seriesToggleEnabled || listeners.legendItemClick !== NO_OP_LISTENER) {
+            this.cursorManager.updateCursor(this.id, 'pointer');
+        }
 
         const series = datum ? this.chart.series.find((series) => series.id === datum?.id) : undefined;
         if (datum?.enabled && series) {

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/doc-interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/doc-interfaces.AUTO.json
@@ -1315,6 +1315,10 @@
       "description": "/** Reverse the display order of legend items if `true`. */",
       "type": { "returnType": "boolean", "optional": true }
     },
+    "seriesToggleEnabled": {
+      "description": "/** Set to `false` to turn off toggling of the series visibility in the chart when the legend item is clicked. */",
+      "type": { "returnType": "boolean", "optional": true }
+    },
     "listeners": {
       "description": "/** Optional callbacks for specific legend-related events. */",
       "type": { "returnType": "AgChartLegendListeners", "optional": true }

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
@@ -818,6 +818,7 @@
       "spacing?": "PixelSize",
       "item?": "AgChartLegendItemOptions",
       "reverseOrder?": "boolean",
+      "seriesToggleEnabled?": "boolean",
       "listeners?": "AgChartLegendListeners",
       "pagination?": "AgChartLegendPaginationOptions"
     },
@@ -830,6 +831,7 @@
       "spacing?": "/** The spacing in pixels to use outside the legend. */",
       "item?": "/** Configuration for the legend items that consist of a marker and a label. */",
       "reverseOrder?": "/** Reverse the display order of legend items if `true`. */",
+      "seriesToggleEnabled?": "/** Set to `false` to turn off toggling of the series visibility in the chart when the legend item is clicked. */",
       "listeners?": "/** Optional callbacks for specific legend-related events. */"
     }
   },


### PR DESCRIPTION
PR for https://ag-grid.atlassian.net/browse/AG-7583 & https://ag-grid.atlassian.net/browse/AG-6424.

Added `legend.seriesToggleEnabled` property to disable toggling the visibility of the series when the legend items are clicked.
`legend.listeners.legendItemClick` callback function will still invoked. 
If there is no `legend.listeners.legendItemClick`, and `legend.seriesToggleEnabled` is set to false, the cursor will not be changed to a pointer. Even if there is series highlighting on legend item hover.
