### PR TITLE
AG-6986 Fix API explorer warnings

### DIFF
--- a/grid-packages/ag-grid-docs/documentation/src/components/charts-api-explorer/Options.tsx
+++ b/grid-packages/ag-grid-docs/documentation/src/components/charts-api-explorer/Options.tsx
@@ -237,8 +237,6 @@ const Search = ({ value, onChange }) => {
     );
 };
 
-const CACHED_MODELS: Record<string, JsonModel> = {};
-
 /**
  * This displays the list of options in the Standalone Charts API Explorer.
  */
@@ -268,25 +266,22 @@ export const Options = ({ chartType, axisType, updateOption }) => {
     const isSearching = getTrimmedSearchText() !== '';
 
     const optionsType = chartType === 'pie' ? 'AgPolarChartOptions' : 'AgCartesianChartOptions';
-    if (CACHED_MODELS[chartType] == null) {
-        const { interfaceLookup, codeLookup } = loadLookups('charts-api', 'charts-api/api.json');
-        const model = CACHED_MODELS[chartType] = buildModel(optionsType, interfaceLookup, codeLookup);
-        const seriesModelDesc = model.properties['series']?.desc;
-        if (seriesModelDesc.type === 'array' && seriesModelDesc.elements.type === 'union') {
-            seriesModelDesc.elements.options = seriesModelDesc.elements.options.filter(
-                (o) => o.type === 'nested-object' && o.model.properties['type'].desc.tsType.indexOf(chartType) >= 0
-            );
-        }
-    
-        const axesModelDesc = model.properties['axes']?.desc;
-        if (axesModelDesc?.type === 'array' && axesModelDesc.elements.type === 'union') {
-            axesModelDesc.elements.options = axesModelDesc.elements.options.filter(
-                (o) => o.type === 'nested-object' && o.model.properties['type'].desc.tsType.indexOf(axisType) >= 0
-            );
-        }
+    const { interfaceLookup, codeLookup } = loadLookups('charts-api', 'charts-api/api.json');
+    const model = buildModel(optionsType, interfaceLookup, codeLookup);
+    const seriesModelDesc = model.properties['series']?.desc;
+    if (seriesModelDesc.type === 'array' && seriesModelDesc.elements.type === 'union') {
+        seriesModelDesc.elements.options = seriesModelDesc.elements.options.filter(
+            (o) => o.type === 'nested-object' && o.model.properties['type'].desc.tsType.indexOf(chartType) >= 0
+        );
     }
 
-    const model = CACHED_MODELS[chartType];
+    const axesModelDesc = model.properties['axes']?.desc;
+    if (axesModelDesc?.type === 'array' && axesModelDesc.elements.type === 'union') {
+        axesModelDesc.elements.options = axesModelDesc.elements.options.filter(
+            (o) => o.type === 'nested-object' && o.model.properties['type'].desc.tsType.indexOf(axisType) >= 0
+        );
+    }
+
     const context = {
         chartType,
         childMatchesSearch,

--- a/grid-packages/ag-grid-docs/documentation/src/components/example-runner/CodeViewer.jsx
+++ b/grid-packages/ag-grid-docs/documentation/src/components/example-runner/CodeViewer.jsx
@@ -13,8 +13,12 @@ const CodeViewer = ({ isActive, exampleInfo }) => {
     const [files, setFiles] = useState(null);
     const [activeFile, setActiveFile] = useState(null);
 
+    let unmount = false;
+    const didUnmount = () => unmount;
+
     useEffect(() => {
-        updateFiles(exampleInfo, setFiles, setActiveFile);
+        updateFiles(exampleInfo, setFiles, setActiveFile, didUnmount);
+        return () => unmount = true;
     }, [exampleInfo]);
 
     const keys = files ? Object.keys(files).sort() : [];
@@ -38,12 +42,14 @@ const CodeViewer = ({ isActive, exampleInfo }) => {
     </div>;
 };
 
-const updateFiles = (exampleInfo, setFiles, setActiveFile) => {
+const updateFiles = (exampleInfo, setFiles, setActiveFile, didUnmount) => {
     if (isServerSideRendering()) { return; }
 
     const { framework, internalFramework } = exampleInfo;
 
     getExampleFiles(exampleInfo).then(files => {
+        if (didUnmount()) { return; }
+
         setFiles(files);
 
         const entryFile = getEntryFile(framework, internalFramework);


### PR DESCRIPTION
1. Fix setting component state after unmounting.
`Can't perform a React state update on an unmounted component`
2. Fix warning when switching chart type.
`React has detected a change in the order of Hooks called by Options`
This is due Gatsby using `useContext` inside `useStaticQuery`. React doesn't recommend having hooks inside conditions.