### PR TITLE
AG-6834 - Add `axis.label.minGap` option to prevent eager axis label …

### DIFF
--- a/charts-packages/ag-charts-community/src/chart/agChartOptions.ts
+++ b/charts-packages/ag-charts-community/src/chart/agChartOptions.ts
@@ -591,6 +591,8 @@ export interface AgAxisLabelOptions {
     autoRotateAngle?: number;
     /** Avoid axis label collision by automatically reducing the number of ticks displayed. If set to `false`, axis labels may collide. */
     avoidCollision?: boolean;
+    /** Minimum gap in pixels between the axis labels before being removed to avoid collisions. */
+    minGap?: PixelSize;
     // mirrored?: boolean;
     // parallel?: boolean;
     /** Format string used when rendering labels for time axes. */

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/doc-interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/doc-interfaces.AUTO.json
@@ -1695,6 +1695,10 @@
       "description": "/** Avoid axis label collision by automatically reducing the number of ticks displayed. If set to `false`, axis labels may collide. */",
       "type": { "returnType": "boolean", "optional": true }
     },
+    "minGap": {
+      "description": "/** Minimum gap in pixels between the axis labels before being removed to avoid collisions. */",
+      "type": { "returnType": "PixelSize", "optional": true }
+    },
     "format": {
       "description": "/** Format string used when rendering labels for time axes. */",
       "type": { "returnType": "string", "optional": true }

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
@@ -1092,6 +1092,7 @@
       "autoRotate?": "boolean",
       "autoRotateAngle?": "number",
       "avoidCollision?": "boolean",
+      "minGap?": "PixelSize",
       "format?": "string",
       "formatter?": "(params: AgAxisLabelFormatterParams) => string | undefined"
     },
@@ -1106,6 +1107,7 @@
       "autoRotate?": "/** If specified and axis labels may collide, they are rotated so that they are positioned at the supplied angle. This is enabled by default for category. If the `rotation` property is specified, it takes precedence. */",
       "autoRotateAngle?": "/** If autoRotate is enabled, specifies the rotation angle to use when autoRotate is activated. Defaults to an angle of 335 degrees if unspecified. */",
       "avoidCollision?": "/** Avoid axis label collision by automatically reducing the number of ticks displayed. If set to `false`, axis labels may collide. */",
+      "minGap?": "/** Minimum gap in pixels between the axis labels before being removed to avoid collisions. */",
       "format?": "/** Format string used when rendering labels for time axes. */",
       "formatter?": "/** Function used to render axis labels. If `value` is a number, `fractionDigits` will also be provided, which indicates the number of fractional digits used in the step between ticks; for example, a tick step of `0.0005` would have `fractionDigits` set to `4` */"
     }


### PR DESCRIPTION
PR for https://ag-grid.atlassian.net/browse/AG-6834

Added `axis.label.minGap` property to allow configuration of gap between axis labels when deciding whether tick count should be reduced