### PR TITLE
AG-7762 - Force legend grid layout if maxWidth or maxHeight is config…

### DIFF
--- a/charts-packages/ag-charts-community/src/chart/legend.ts
+++ b/charts-packages/ag-charts-community/src/chart/legend.ts
@@ -467,6 +467,8 @@ export class Legend {
             return width === paginationBBox.width && height === paginationBBox.height;
         };
 
+        const forceResult = this.maxWidth !== undefined || this.maxHeight !== undefined;
+
         do {
             if (count++ > 10) {
                 console.warn('AG Charts - unable to find stable legend layout.');
@@ -484,6 +486,7 @@ export class Legend {
                 maxWidth,
                 itemPaddingY,
                 itemPaddingX,
+                forceResult,
             });
 
             if (layout) {


### PR DESCRIPTION
PR for https://ag-grid.atlassian.net/browse/AG-7762

If maxWidth/maxHeight is larger than chart width/height, the legend still gets displayed
For consistency, we are forcing legend grid layout to display at least one row or column of legend items if the maxWidth/maxHeight is smaller than chart width.height