### PR TITLE
AG-7751 - Track current legend page on chart resize.

### DIFF
--- a/charts-packages/ag-charts-community/src/chart/pagination/pagination.ts
+++ b/charts-packages/ag-charts-community/src/chart/pagination/pagination.ts
@@ -94,8 +94,6 @@ export class Pagination {
     readonly highlightStyle = new PaginationMarkerStyle();
     readonly label = new PaginationLabel();
 
-    private currentPage: number = 0;
-
     constructor(
         private readonly chartUpdateCallback: (type: ChartUpdateType) => void,
         private readonly pageUpdateCallback: (newPage: number) => void,
@@ -126,12 +124,22 @@ export class Pagination {
     set totalPages(value: number) {
         if (this._totalPages !== value) {
             this._totalPages = value;
-            this.setCurrentPage(0);
             this.update();
         }
     }
     get totalPages() {
         return this._totalPages;
+    }
+
+    private _currentPage: number = 0;
+    set currentPage(value: number) {
+        if (this._currentPage !== value) {
+            this._currentPage = value;
+            this.update();
+        }
+    }
+    get currentPage() {
+        return this._currentPage;
     }
 
     private _visible: boolean = true;
@@ -339,18 +347,6 @@ export class Pagination {
 
     private decrementPage() {
         this.currentPage = Math.max(this.currentPage - 1, 0);
-    }
-
-    getCurrentPage() {
-        return this.currentPage;
-    }
-
-    setCurrentPage(page: number) {
-        if (this.currentPage === page) {
-            return;
-        }
-
-        this.currentPage = page;
     }
 
     onMarkerShapeChange() {


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-7751

Attempts to maintain state of the current legend page in resize scenarios (most commonly, in Integrated Charts when opening and closing the side-panel)

![chrome-capture-2023-0-6](https://user-images.githubusercontent.com/17544187/211014790-57d7863d-be01-4c83-9a6e-43a1e564d357.gif)
