### PR TITLE
Ag 7772/truncated legend item tooltip

### DIFF
--- a/charts-packages/ag-charts-community/src/chart/legend.ts
+++ b/charts-packages/ag-charts-community/src/chart/legend.ts
@@ -177,6 +177,8 @@ export class Legend {
     readonly item = new LegendItem();
     readonly listeners = new LegendListeners();
 
+    private readonly truncatedItems: Set<string> = new Set();
+
     set translationX(value: number) {
         this.group.translationX = value;
     }
@@ -404,8 +406,12 @@ export class Legend {
                 addEllipsis = true;
             }
 
+            const id = datum.itemId || datum.id;
             if (addEllipsis) {
                 text += ellipsis;
+                this.truncatedItems.add(id);
+            } else {
+                this.truncatedItems.delete(id);
             }
 
             markerLabel.text = text;

--- a/charts-packages/ag-charts-community/src/chart/legend.ts
+++ b/charts-packages/ag-charts-community/src/chart/legend.ts
@@ -247,6 +247,7 @@ export class Legend {
     constructor(
         private readonly chart: {
             readonly series: Series<any>[];
+            readonly element: HTMLElement;
             togglePointer(visible: boolean): void;
             update(
                 type: ChartUpdateType,
@@ -706,6 +707,12 @@ export class Legend {
             this.cursorManager.updateCursor(this.id);
             this.highlightManager.updateHighlight(this.id);
             return;
+        }
+
+        if (datum && this.truncatedItems.has(datum.itemId || datum.id)) {
+            this.chart.element.title = datum.label.text;
+        } else {
+            this.chart.element.title = '';
         }
 
         if (toggleSeriesVisible || listeners.legendItemClick !== NO_OP_LISTENER) {


### PR DESCRIPTION
PR for https://ag-grid.atlassian.net/browse/AG-7772

For now adding a tooltip for truncated legend items using the chart element title property to fix regression
