### PR TITLE
RTI-1226 - Show legend if dimensions configured via `maxWidth` or `ma…

### DIFF
--- a/charts-packages/ag-charts-community/src/chart/gridLayout.ts
+++ b/charts-packages/ag-charts-community/src/chart/gridLayout.ts
@@ -151,7 +151,7 @@ function calculatePage(
         }
 
         const sumPrimary = maxPrimaryValues.reduce((sum, next) => sum + next, 0);
-        if (sumPrimary > primary.max && returnResult) {
+        if (sumPrimary > primary.max && !forceResult) {
             // Breached max main dimension size.
             if (maxPrimaryValues.length < primaryCount) {
                 // Feedback as guess for next iteration if we're on the first round still.

--- a/charts-packages/ag-charts-community/src/chart/legend.ts
+++ b/charts-packages/ag-charts-community/src/chart/legend.ts
@@ -635,6 +635,9 @@ export class Legend {
             this.paginationTrackingIndex = Math.floor((startIndex + endIndex) / 2);
         }
 
+        this.pagination.update();
+        this.pagination.updateMarkers();
+
         this.updatePositions(pageNumber);
         this.chart.update(ChartUpdateType.SCENE_RENDER);
     }


### PR DESCRIPTION
PR for https://ag-grid.atlassian.net/browse/RTI-1226

Display at least one item in the primary dimension when primary dimension has been constrained via `maxWidth` or `maxHeight`
Update pagination component when `currentPage` changes
