### PR TITLE
Update dom.ts fixes function "addStylesToElement"

### DIFF
--- a/community-modules/core/src/ts/utils/dom.ts
+++ b/community-modules/core/src/ts/utils/dom.ts
@@ -367,8 +367,10 @@ export function addStylesToElement(eElement: any, styles: any) {
         if (!key || !key.length) { return; }
         // changes the key from camelCase into a hyphenated-string
         const parsedKey = key.replace(/[A-Z]/g, s => `-${s.toLocaleLowerCase()}`);
-        const value = styles[key].replace(/\s*!important/g, '');
-        const priority = value.length != styles[key].length ? 'important' : undefined;
+        // value for this key could be something that is not implementing ".replace"
+        const sanatizedValue = styles[key]?.toString() ?? ''; 
+        const value = sanatizedValue.replace(/\s*!important/g, '');
+        const priority = value.length != sanatizedValue.length ? 'important' : undefined;
 
         eElement.style.setProperty(parsedKey, value, priority);
     });


### PR DESCRIPTION
Currently if an object containing some of it's properties with ie: null | undefined the function throws an Error when calling ".replace()"