### PR TITLE
AG-7775 Simplify Array utilities

### DIFF
--- a/charts-packages/ag-charts-community/src/chart/axis/groupedCategoryAxis.ts
+++ b/charts-packages/ag-charts-community/src/chart/axis/groupedCategoryAxis.ts
@@ -9,7 +9,6 @@ import { ticksToTree, TreeLayout, treeLayout } from '../../layout/tree';
 import { AxisLabel, AxisLine } from '../../axis';
 import { ChartAxis, ChartAxisDirection } from '../chartAxis';
 import { extent } from '../../util/array';
-import { isContinuous } from '../../util/value';
 import { Point } from '../../scene/point';
 import { BOOLEAN, OPT_COLOR_STRING, Validate } from '../../util/validation';
 
@@ -146,7 +145,7 @@ export class GroupedCategoryAxis extends ChartAxis<BandScale<string | number>> {
 
         const domain = new Array<any>().concat(...domains);
 
-        const values = extent(domain, isContinuous) || domain;
+        const values = extent(domain) || domain;
 
         this.dataDomain = this.normaliseDataDomain(values);
     }

--- a/charts-packages/ag-charts-community/src/chart/axis/numberAxis.ts
+++ b/charts-packages/ag-charts-community/src/chart/axis/numberAxis.ts
@@ -1,7 +1,6 @@
 import { LinearScale } from '../../scale/linearScale';
 import { LogScale } from '../../scale/logScale';
 import { extent } from '../../util/array';
-import { isContinuous } from '../../util/value';
 import { ChartAxis } from '../chartAxis';
 import { doOnce } from '../../util/function';
 import { predicateWithMessage, Validate, GREATER_THAN, AND, LESS_THAN } from '../../util/validation';
@@ -37,7 +36,7 @@ export class NumberAxis extends ChartAxis<LinearScale | LogScale, number> {
         const { min, max } = this;
 
         if (d.length > 2) {
-            d = extent(d, isContinuous, Number) || [NaN, NaN];
+            d = extent(d) || [NaN, NaN];
         }
         if (!isNaN(min)) {
             d = [min, d[1]];

--- a/charts-packages/ag-charts-community/src/chart/axis/timeAxis.ts
+++ b/charts-packages/ag-charts-community/src/chart/axis/timeAxis.ts
@@ -1,7 +1,6 @@
 import { Validate, AND, LESS_THAN, GREATER_THAN, OPT_DATE_OR_DATETIME_MS } from '../../util/validation';
 import { TimeScale } from '../../scale/timeScale';
 import { extent } from '../../util/array';
-import { isContinuous } from '../../util/value';
 import { ChartAxis } from '../chartAxis';
 
 export class TimeAxis extends ChartAxis<TimeScale> {
@@ -40,7 +39,9 @@ export class TimeAxis extends ChartAxis<TimeScale> {
         }
 
         if (d.length > 2) {
-            d = (extent(d, isContinuous, Number) || [0, 1000]).map((x) => new Date(x));
+            d = ((extent(d.map((x) => (x instanceof Date ? x.getTime() : x))) || [0, 1000]) as [any, any]).map(
+                (x) => new Date(x)
+            );
         }
         if (min instanceof Date) {
             d = [min, d[1]];

--- a/charts-packages/ag-charts-community/src/chart/axis/timeAxis.ts
+++ b/charts-packages/ag-charts-community/src/chart/axis/timeAxis.ts
@@ -39,9 +39,7 @@ export class TimeAxis extends ChartAxis<TimeScale> {
         }
 
         if (d.length > 2) {
-            d = ((extent(d.map((x) => (x instanceof Date ? x.getTime() : x))) || [0, 1000]) as [any, any]).map(
-                (x) => new Date(x)
-            );
+            d = (extent(d) || [0, 1000]).map((x) => new Date(x));
         }
         if (min instanceof Date) {
             d = [min, d[1]];

--- a/charts-packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
@@ -308,7 +308,7 @@ export class AreaSeries extends CartesianSeries<AreaSeriesNodeDataContext> {
         this.yData = yData;
         this.xData = xData;
 
-        this.xDomain = isContinuousX ? this.fixNumericExtent(extent(xValues, isContinuous), xAxis) : xValues;
+        this.xDomain = isContinuousX ? this.fixNumericExtent(extent(xValues), xAxis) : xValues;
 
         // xData: ['Jan', 'Feb', undefined]
         //

--- a/charts-packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
@@ -15,7 +15,7 @@ import { extent, findMinMax } from '../../../util/array';
 import { equal } from '../../../util/equal';
 import { Scale } from '../../../scale/scale';
 import { sanitizeHtml } from '../../../util/sanitize';
-import { checkDatum, isContinuous, isNumber } from '../../../util/value';
+import { checkDatum, isNumber } from '../../../util/value';
 import { ContinuousScale } from '../../../scale/continuousScale';
 import { Point } from '../../../scene/point';
 import {
@@ -442,7 +442,7 @@ export class BarSeries extends CartesianSeries<SeriesNodeDataContext<BarNodeDatu
             }
             // The last node will be clipped if the scale is not a band scale
             // Extend the domain by the smallest data interval so that the last band is not clipped
-            const xDomain = extent(this.xData, isContinuous, Number) || [NaN, NaN];
+            const xDomain = extent(this.xData) || [NaN, NaN];
             if (flipXY) {
                 xDomain[0] = xDomain[0] - (this.smallestDataInterval?.x ?? 0);
             } else {

--- a/charts-packages/ag-charts-community/src/chart/series/cartesian/histogramSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/cartesian/histogramSeries.ts
@@ -13,7 +13,6 @@ import { toTooltipHtml } from '../../tooltip/tooltip';
 import { extent } from '../../../util/array';
 import ticks, { tickStep } from '../../../util/ticks';
 import { sanitizeHtml } from '../../../util/sanitize';
-import { isContinuous } from '../../../util/value';
 import {
     BOOLEAN,
     NUMBER,
@@ -231,7 +230,7 @@ export class HistogramSeries extends CartesianSeries<SeriesNodeDataContext<Histo
         }
 
         const xData = this.data.map((datum) => datum[this.xKey]);
-        const xDomain = this.fixNumericExtent(extent(xData, isContinuous));
+        const xDomain = this.fixNumericExtent(extent(xData));
 
         if (this.binCount === undefined) {
             if (bins) {
@@ -342,7 +341,7 @@ export class HistogramSeries extends CartesianSeries<SeriesNodeDataContext<Histo
         this.binnedData = this.placeDataInBins(xKey && data ? data : []);
 
         const yData = this.binnedData.map((b) => b.getY(this.areaPlot));
-        const yMinMax = extent(yData, isContinuous);
+        const yMinMax = extent(yData);
 
         this.yDomain = this.fixNumericExtent([0, yMinMax ? yMinMax[1] : 1]);
 

--- a/charts-packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
@@ -14,7 +14,7 @@ import { toTooltipHtml } from '../../tooltip/tooltip';
 import { interpolate } from '../../../util/string';
 import { Label } from '../../label';
 import { sanitizeHtml } from '../../../util/sanitize';
-import { checkDatum, isContinuous } from '../../../util/value';
+import { checkDatum } from '../../../util/value';
 import { Marker } from '../../marker/marker';
 import {
     NUMBER,
@@ -187,8 +187,8 @@ export class LineSeries extends CartesianSeries<LineContext> {
             });
         }
 
-        this.xDomain = isContinuousX ? this.fixNumericExtent(extent(xData, isContinuous), xAxis) : xData;
-        this.yDomain = isContinuousY ? this.fixNumericExtent(extent(yData, isContinuous), yAxis) : yData;
+        this.xDomain = isContinuousX ? this.fixNumericExtent(extent(xData), xAxis) : xData;
+        this.yDomain = isContinuousY ? this.fixNumericExtent(extent(yData), yAxis) : yData;
     }
 
     async createNodeData() {

--- a/charts-packages/ag-charts-community/src/chart/series/cartesian/scatterSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/cartesian/scatterSeries.ts
@@ -15,7 +15,7 @@ import { Text } from '../../../scene/shape/text';
 import { HdpiCanvas } from '../../../canvas/hdpiCanvas';
 import { Marker } from '../../marker/marker';
 import { MeasuredLabel, PointLabelDatum } from '../../../util/labelPlacement';
-import { checkDatum, isContinuous } from '../../../util/value';
+import { checkDatum } from '../../../util/value';
 import { OPT_FUNCTION, OPT_STRING, STRING, Validate } from '../../../util/validation';
 import {
     AgScatterSeriesTooltipRendererParams,
@@ -151,14 +151,14 @@ export class ScatterSeries extends CartesianSeries<SeriesNodeDataContext<Scatter
 
         this.sizeData = sizeKey ? this.validData.map((d) => d[sizeKey]) : [];
 
-        this.sizeScale.domain = marker.domain ? marker.domain : extent(this.sizeData, isContinuous) || [1, 1];
+        this.sizeScale.domain = marker.domain ? marker.domain : extent(this.sizeData) || [1, 1];
         if (xAxis.scale instanceof ContinuousScale) {
-            this.xDomain = this.fixNumericExtent(extent(this.xData, isContinuous), xAxis);
+            this.xDomain = this.fixNumericExtent(extent(this.xData), xAxis);
         } else {
             this.xDomain = this.xData;
         }
         if (yAxis.scale instanceof ContinuousScale) {
-            this.yDomain = this.fixNumericExtent(extent(this.yData, isContinuous), yAxis);
+            this.yDomain = this.fixNumericExtent(extent(this.yData), yAxis);
         } else {
             this.yDomain = this.yData;
         }

--- a/charts-packages/ag-charts-community/src/layout/tree.ts
+++ b/charts-packages/ag-charts-community/src/layout/tree.ts
@@ -1,5 +1,3 @@
-import { find } from '../util/array';
-
 interface Tick {
     labels: string[];
 }
@@ -90,7 +88,7 @@ function insertTick(root: TreeNode, tick: Tick) {
 
     pathParts.forEach((pathPart, partIndex) => {
         const children = root.children;
-        const existingNode = find(children, (child) => child.label === pathPart);
+        const existingNode = children.find((child) => child.label === pathPart);
         const isNotLeaf = partIndex !== lastPartIndex;
         if (existingNode && isNotLeaf) {
             // the isNotLeaf check is to allow duplicate leafs

--- a/charts-packages/ag-charts-community/src/util/array.test.ts
+++ b/charts-packages/ag-charts-community/src/util/array.test.ts
@@ -1,50 +1,49 @@
 import { describe, expect, test } from '@jest/globals';
 import { extent } from './array';
-import { isContinuous } from './value';
 
 describe('extent with isContinuous', () => {
     test('returns lowest and highest numbers from list of numbers', () => {
         {
-            const result = extent([3, 7, 1, 2, 9, -2], isContinuous);
+            const result = extent([3, 7, 1, 2, 9, -2]);
             expect(result![0]).toBe(-2);
             expect(result![1]).toBe(9);
         }
         {
-            const result = extent([0, 13, 10, 19], isContinuous);
+            const result = extent([0, 13, 10, 19]);
             expect(result![0]).toBe(0);
             expect(result![1]).toBe(19);
         }
         {
-            const result = extent([null, 0, 13, 10, 19], isContinuous);
+            const result = extent([null as any, 0, 13, 10, 19]);
             expect(result![0]).toBe(0);
             expect(result![1]).toBe(19);
         }
     });
 
     test('returns undefined for list of invalid values', () => {
-        const result = extent([NaN, null, undefined], isContinuous);
+        const result = extent([NaN, null, undefined] as any[]);
         expect(result).toBe(undefined);
     });
 
     test('returns undefined for empty list', () => {
-        const result = extent([], isContinuous);
+        const result = extent([]);
         expect(result).toBe(undefined);
     });
 
     test('returns same lowest and highest number for single number', () => {
-        const result = extent([5], isContinuous);
+        const result = extent([5]);
         expect(result![0]).toBe(5);
         expect(result![1]).toBe(5);
     });
 
     test('returns valid lowest and highest number from mixed values', () => {
-        const result = extent([undefined, 4, 3, 7, null, {}, 1, 5], isContinuous);
+        const result = extent([undefined, 4, 3, 7, null, {}, 1, 5] as any);
         expect(result![0]).toBe(1);
         expect(result![1]).toBe(7);
     });
 
     test('does not coerce objects', () => {
-        const result = extent([{ toString: () => '2' }, { toString: () => '1' }], isContinuous);
+        const result = extent([{ toString: () => '2' }, { toString: () => '1' }] as any);
         expect(result).toBe(undefined);
     });
 
@@ -52,7 +51,9 @@ describe('extent with isContinuous', () => {
         const earliest = 5270400000;
         const latest = 1568332800000;
 
-        const result = extent([new Date(earliest), new Date(latest), new Date(1985, 5, 5)], isContinuous, (x) => +x);
+        const result = extent(
+            [new Date(earliest), new Date(latest), new Date(1985, 5, 5)].map((d) => d.getTime())
+        )!.map((x) => Number(x));
 
         expect(result![0]).toBe(earliest);
         expect(result![1]).toBe(latest);
@@ -63,10 +64,10 @@ describe('extent with isContinuous', () => {
         const latest = 1568468277000;
 
         const result = extent(
-            [new Date(2019, 7, 20), new Date(earliest), latest, new Date(1985, 5, 5)],
-            isContinuous,
-            (x) => +x
-        );
+            [new Date(2019, 7, 20), new Date(earliest), latest, new Date(1985, 5, 5)].map((d) =>
+                d instanceof Date ? d.getTime() : d
+            )
+        )!.map((x) => Number(x));
 
         expect(result![0]).toBe(earliest);
         expect(result![1]).toBe(latest);

--- a/charts-packages/ag-charts-community/src/util/array.test.ts
+++ b/charts-packages/ag-charts-community/src/util/array.test.ts
@@ -63,11 +63,9 @@ describe('extent with isContinuous', () => {
         const earliest = 5270400000;
         const latest = 1568468277000;
 
-        const result = extent(
-            [new Date(2019, 7, 20), new Date(earliest), latest, new Date(1985, 5, 5)].map((d) =>
-                d instanceof Date ? d.getTime() : d
-            )
-        )!.map((x) => Number(x));
+        const result = extent([new Date(2019, 7, 20), new Date(earliest), latest, new Date(1985, 5, 5)])!.map((x) =>
+            Number(x)
+        );
 
         expect(result![0]).toBe(earliest);
         expect(result![1]).toBe(latest);

--- a/charts-packages/ag-charts-community/src/util/array.ts
+++ b/charts-packages/ag-charts-community/src/util/array.ts
@@ -1,4 +1,4 @@
-export function extent(values: number[]): [number, number] | undefined {
+export function extent(values: Array<number | Date>): [number, number] | undefined {
     const { length } = values;
     if (length === 0) {
         return undefined;
@@ -9,8 +9,8 @@ export function extent(values: number[]): [number, number] | undefined {
 
     for (let i = 0; i < length; i++) {
         let v = values[i];
-        if ((v as any) instanceof Date) {
-            v = (v as any).getTime();
+        if (v instanceof Date) {
+            v = v.getTime();
         }
         if (typeof v !== 'number') {
             continue;

--- a/charts-packages/ag-charts-community/src/util/array.ts
+++ b/charts-packages/ag-charts-community/src/util/array.ts
@@ -1,21 +1,18 @@
-export function extent<T>(values: T[], predicate: (value: T) => boolean): [T, T] | undefined;
-export function extent<T, K>(values: T[], predicate: (value: T) => boolean, map: (value: T) => K): [K, K] | undefined;
-export function extent<T, K>(
-    values: T[],
-    predicate: (value: T) => boolean,
-    map?: (value: T) => K
-): [T | K, T | K] | undefined {
+export function extent(values: number[]): [number, number] | undefined {
     const { length } = values;
     if (length === 0) {
         return undefined;
     }
 
-    let min = Infinity as any;
-    let max = -Infinity as any;
+    let min = Infinity;
+    let max = -Infinity;
 
     for (let i = 0; i < length; i++) {
-        const v = values[i];
-        if (!predicate(v)) {
+        let v = values[i];
+        if ((v as any) instanceof Date) {
+            v = (v as any).getTime();
+        }
+        if (typeof v !== 'number') {
             continue;
         }
         if (v < min) {
@@ -25,14 +22,11 @@ export function extent<T, K>(
             max = v;
         }
     }
-    const extent = [min, max];
+    const extent = [min, max] as [number, number];
     if (extent.some((v) => !isFinite(v))) {
         return undefined;
     }
-    if (map) {
-        return extent.map(map) as [K, K];
-    }
-    return extent as [T, T];
+    return extent;
 }
 
 /**

--- a/charts-packages/ag-charts-community/src/util/array.ts
+++ b/charts-packages/ag-charts-community/src/util/array.ts
@@ -1,26 +1,3 @@
-// Custom `Array.find` implementation for legacy browsers.
-export function find<T>(arr: T[], predicate: (item: T, index: number, arr: T[]) => boolean): T | undefined {
-    for (let i = 0; i < arr.length; i++) {
-        const value = arr[i];
-        if (predicate(value, i, arr)) {
-            return value;
-        }
-    }
-}
-
-export function findIndex<T>(arr: T[], predicate: (item: T, index: number, arr: T[]) => boolean): number {
-    for (let i = 0; i < arr.length; i++) {
-        if (predicate(arr[i], i, arr)) {
-            return i;
-        }
-    }
-    return -1;
-}
-
-function identity<T>(value: T): T {
-    return value;
-}
-
 export function extent<T>(values: T[], predicate: (value: T) => boolean): [T, T] | undefined;
 export function extent<T, K>(values: T[], predicate: (value: T) => boolean, map: (value: T) => K): [K, K] | undefined;
 export function extent<T, K>(
@@ -28,34 +5,34 @@ export function extent<T, K>(
     predicate: (value: T) => boolean,
     map?: (value: T) => K
 ): [T | K, T | K] | undefined {
-    const transform = map || identity;
-    const n = values.length;
-    let i = -1;
-    let value;
-    let min;
-    let max;
-
-    while (++i < n) {
-        // Find the first value.
-        value = values[i];
-        if (predicate(value)) {
-            min = max = value;
-            while (++i < n) {
-                // Compare the remaining values.
-                value = values[i];
-                if (predicate(value)) {
-                    if (min > value) {
-                        min = value;
-                    }
-                    if (max < value) {
-                        max = value;
-                    }
-                }
-            }
-        }
+    const { length } = values;
+    if (length === 0) {
+        return undefined;
     }
 
-    return min === undefined || max === undefined ? undefined : [transform(min), transform(max)];
+    let min = Infinity as any;
+    let max = -Infinity as any;
+
+    for (let i = 0; i < length; i++) {
+        const v = values[i];
+        if (!predicate(v)) {
+            continue;
+        }
+        if (v < min) {
+            min = v;
+        }
+        if (v > max) {
+            max = v;
+        }
+    }
+    const extent = [min, max];
+    if (extent.some((v) => !isFinite(v))) {
+        return undefined;
+    }
+    if (map) {
+        return extent.map(map) as [K, K];
+    }
+    return extent as [T, T];
 }
 
 /**
@@ -75,17 +52,4 @@ export function findMinMax(values: number[]): { min?: number; max?: number } {
     }
 
     return { min, max };
-}
-
-export function copy(array: any[], start: number = 0, count: number = array.length): any[] {
-    const result = [];
-    let n = array.length;
-
-    if (n) {
-        for (let i = 0; i < count; i++) {
-            result.push(array[(start + i) % n]);
-        }
-    }
-
-    return result;
 }

--- a/enterprise-modules/sparklines/src/sparkline/area/areaSparkline.ts
+++ b/enterprise-modules/sparklines/src/sparkline/area/areaSparkline.ts
@@ -105,7 +105,7 @@ export class AreaSparkline extends Sparkline {
 
     protected updateYScaleDomain(): void {
         const { yData, yScale } = this;
-        const yMinMax = extent(yData);
+        const yMinMax = extent(yData as number[]);
 
         let yMin = 0;
         let yMax = 1;

--- a/enterprise-modules/sparklines/src/sparkline/area/areaSparkline.ts
+++ b/enterprise-modules/sparklines/src/sparkline/area/areaSparkline.ts
@@ -6,7 +6,7 @@ import { toTooltipHtml } from '../tooltip/sparklineTooltip';
 import { getMarker } from '../marker/markerFactory';
 import { getLineDash } from '../../util/lineDash';
 
-const { extent, isNumber } = _Util;
+const { extent } = _Util;
 const { BandScale } = _Scale;
 
 interface AreaNodeDatum extends SeriesNodeDatum { }
@@ -105,7 +105,7 @@ export class AreaSparkline extends Sparkline {
 
     protected updateYScaleDomain(): void {
         const { yData, yScale } = this;
-        const yMinMax = extent(yData, isNumber);
+        const yMinMax = extent(yData);
 
         let yMin = 0;
         let yMax = 1;

--- a/enterprise-modules/sparklines/src/sparkline/bar-column/barColumnSparkline.ts
+++ b/enterprise-modules/sparklines/src/sparkline/bar-column/barColumnSparkline.ts
@@ -137,7 +137,7 @@ export abstract class BarColumnSparkline extends Sparkline {
     protected updateYScaleDomain(): void {
         const { yScale, yData, valueAxisDomain } = this;
 
-        const yMinMax = extent(yData);
+        const yMinMax = extent(yData as number[]);
 
         let yMin = 0;
         let yMax = 1;

--- a/enterprise-modules/sparklines/src/sparkline/bar-column/barColumnSparkline.ts
+++ b/enterprise-modules/sparklines/src/sparkline/bar-column/barColumnSparkline.ts
@@ -5,7 +5,7 @@ import { SeriesNodeDatum, Sparkline } from '../sparkline';
 import { toTooltipHtml } from '../tooltip/sparklineTooltip';
 import { Label } from '../label/label';
 
-const { extent, isNumber } = _Util;
+const { extent } = _Util;
 
 export interface RectNodeDatum extends SeriesNodeDatum {
     readonly x: number;
@@ -137,7 +137,7 @@ export abstract class BarColumnSparkline extends Sparkline {
     protected updateYScaleDomain(): void {
         const { yScale, yData, valueAxisDomain } = this;
 
-        const yMinMax = extent(yData, isNumber);
+        const yMinMax = extent(yData);
 
         let yMin = 0;
         let yMax = 1;

--- a/enterprise-modules/sparklines/src/sparkline/line/lineSparkline.ts
+++ b/enterprise-modules/sparklines/src/sparkline/line/lineSparkline.ts
@@ -100,7 +100,7 @@ export class LineSparkline extends Sparkline {
     protected updateYScaleDomain(): void {
         const { yData, yScale } = this;
 
-        const yMinMax = extent(yData);
+        const yMinMax = extent(yData as number[]);
 
         let yMin = 0;
         let yMax = 1;

--- a/enterprise-modules/sparklines/src/sparkline/line/lineSparkline.ts
+++ b/enterprise-modules/sparklines/src/sparkline/line/lineSparkline.ts
@@ -6,7 +6,7 @@ import { toTooltipHtml } from '../tooltip/sparklineTooltip';
 import { getMarker } from '../marker/markerFactory';
 import { getLineDash } from '../../util/lineDash';
 
-const { extent, isNumber } = _Util;
+const { extent } = _Util;
 const { BandScale } = _Scale;
 
 interface LineNodeDatum extends SeriesNodeDatum {
@@ -100,7 +100,7 @@ export class LineSparkline extends Sparkline {
     protected updateYScaleDomain(): void {
         const { yData, yScale } = this;
 
-        const yMinMax = extent(yData, isNumber);
+        const yMinMax = extent(yData);
 
         let yMin = 0;
         let yMax = 1;

--- a/enterprise-modules/sparklines/src/sparkline/sparkline.ts
+++ b/enterprise-modules/sparklines/src/sparkline/sparkline.ts
@@ -4,7 +4,7 @@ import { _Scale, _Scene, _Util } from 'ag-charts-community';
 import { defaultTooltipCss } from './tooltip/defaultTooltipCss';
 import { SparklineTooltip } from './tooltip/sparklineTooltip';
 
-const { extent, isNumber, isContinuous, isString, isStringObject, isDate, createId, Padding } = _Util;
+const { extent, isNumber, isString, isStringObject, isDate, createId, Padding } = _Util;
 const { LinearScale, BandScale, TimeScale } = _Scale;
 
 export interface SeriesNodeDatum {
@@ -213,10 +213,8 @@ export abstract class Sparkline {
         const { xData, xScale } = this;
 
         let xMinMax;
-        if (xScale instanceof LinearScale) {
-            xMinMax = extent(xData, isNumber);
-        } else if (xScale instanceof TimeScale) {
-            xMinMax = extent(xData, isContinuous);
+        if (xScale instanceof LinearScale || xScale instanceof TimeScale) {
+            xMinMax = extent(xData);
         }
 
         this.xScale.domain = xMinMax ? xMinMax.slice() : xData;


### PR DESCRIPTION
- Remove unnecessary Array utilities.
- Accept numbers and dates for `extent` utility.
- Make `extent` always return numbers.