### PR TITLE
AG-7783 - Switch Legend to use HTML tooltips

### DIFF
--- a/charts-packages/ag-charts-community/src/chart/interaction/tooltipManager.ts
+++ b/charts-packages/ag-charts-community/src/chart/interaction/tooltipManager.ts
@@ -1,0 +1,63 @@
+import { Tooltip, TooltipMeta } from '../tooltip/tooltip';
+
+interface TooltipState {
+    content: string;
+    meta: TooltipMeta;
+}
+
+/**
+ * Manages the tooltip HTML an element. Tracks the requested HTML from distinct dependents and
+ * handles conflicting tooltip requests.
+ */
+export class TooltipManager {
+    private readonly states: Record<string, TooltipState> = {};
+    private readonly tooltip: Tooltip;
+    private appliedState?: TooltipState;
+
+    public constructor(tooltip: Tooltip) {
+        this.tooltip = tooltip;
+    }
+
+    public updateTooltip(callerId: string, meta?: TooltipMeta, content?: string) {
+        if (content == null) {
+            content = this.states[callerId]?.content;
+        }
+
+        delete this.states[callerId];
+
+        if (meta != null && content != null) {
+            this.states[callerId] = { content, meta };
+        }
+
+        this.applyStates();
+    }
+
+    private applyStates() {
+        let contentToApply: string | undefined = undefined;
+        let metaToApply: TooltipMeta | undefined = undefined;
+
+        // Last added entry wins.
+        Object.entries(this.states)
+            .reverse()
+            .slice(0, 1)
+            .forEach(([_, { content, meta }]) => {
+                contentToApply = content;
+                metaToApply = meta;
+            });
+
+        if (metaToApply === undefined || contentToApply === undefined) {
+            this.appliedState = undefined;
+            this.tooltip.toggle(false);
+            return;
+        }
+
+        if (this.appliedState?.content === contentToApply) {
+            const renderInstantly = this.tooltip.isVisible();
+            this.tooltip.show(metaToApply, undefined, renderInstantly);
+        } else {
+            this.tooltip.show(metaToApply, contentToApply);
+        }
+
+        this.appliedState = { content: contentToApply, meta: metaToApply };
+    }
+}

--- a/charts-packages/ag-charts-community/src/chart/tooltip/tooltip.ts
+++ b/charts-packages/ag-charts-community/src/chart/tooltip/tooltip.ts
@@ -1,6 +1,7 @@
 import { BBox } from '../../scene/bbox';
 import { Validate, BOOLEAN, NUMBER, OPT_STRING } from '../../util/validation';
 import { AgTooltipRendererResult } from '../agChartOptions';
+import { InteractionEvent } from '../interaction/interactionManager';
 
 export const DEFAULT_TOOLTIP_CLASS = 'ag-chart-tooltip';
 
@@ -107,7 +108,7 @@ export interface TooltipMeta {
     pageY: number;
     offsetX: number;
     offsetY: number;
-    event: Event;
+    event: Event | InteractionEvent<any>;
 }
 
 export function toTooltipHtml(input: string | AgTooltipRendererResult, defaults?: AgTooltipRendererResult): string {
@@ -207,7 +208,7 @@ export class Tooltip {
         return !element.classList.contains(DEFAULT_TOOLTIP_CLASS + '-hidden');
     }
 
-    updateClass(visible?: boolean, constrained?: boolean) {
+    private updateClass(visible?: boolean, constrained?: boolean) {
         const { element, class: newClass, lastClass } = this;
 
         const wasVisible = !element.classList.contains(`${DEFAULT_TOOLTIP_CLASS}-hidden`);

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/doc-interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/doc-interfaces.AUTO.json
@@ -4633,6 +4633,10 @@
     "offsetY": { "type": { "returnType": "number", "optional": false } }
   },
   "SupportedEvent": {},
+  "TooltipState": {
+    "content": { "type": { "returnType": "string", "optional": false } },
+    "meta": { "type": { "returnType": "TooltipMeta", "optional": false } }
+  },
   "Layers": {},
   "LegendDatum": {
     "id": { "type": { "returnType": "string", "optional": false } },
@@ -5006,7 +5010,12 @@
     "pageY": { "type": { "returnType": "number", "optional": false } },
     "offsetX": { "type": { "returnType": "number", "optional": false } },
     "offsetY": { "type": { "returnType": "number", "optional": false } },
-    "event": { "type": { "returnType": "Event", "optional": false } }
+    "event": {
+      "type": {
+        "returnType": "Event | InteractionEvent<any>",
+        "optional": false
+      }
+    }
   },
   "Tick": {
     "labels": { "type": { "returnType": "string[]", "optional": false } }

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
@@ -3113,6 +3113,10 @@
     "meta": { "isTypeAlias": true },
     "type": "MouseEvent | TouchEvent | Event"
   },
+  "TooltipState": {
+    "meta": {},
+    "type": { "content": "string", "meta": "TooltipMeta" }
+  },
   "Layers": {
     "meta": { "isEnum": true },
     "type": [
@@ -3514,7 +3518,7 @@
       "pageY": "number",
       "offsetX": "number",
       "offsetY": "number",
-      "event": "Event"
+      "event": "Event | InteractionEvent<any>"
     }
   },
   "Tick": { "meta": {}, "type": { "labels": "string[]" } },


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-7783
https://ag-grid.atlassian.net/browse/AG-7790

Switches `Legend` to use the HTML-based `Tooltip` class, removing the (ab)use of `Canvas.title` to manage legend tooltips.

Additionally introduces `TooltipManager` to handle conflicts from multiple tooltip sources correctly.