### PR TITLE
Add Charts agChartsSceneDebug option.

### DIFF
--- a/charts-packages/ag-charts-community/src/scene/group.ts
+++ b/charts-packages/ag-charts-community/src/scene/group.ts
@@ -104,16 +104,6 @@ export class Group extends Node {
         super.markDirty(source, type, parentType);
     }
 
-    findNode(id: string | RegExp): Node[] | undefined {
-        if (typeof id === 'string' && this.name === id) {
-            return [this];
-        } else if (typeof id !== 'string' && this.name != null && id.test(this.name ?? '')) {
-            return [this];
-        }
-
-        return super.findNode(id);
-    }
-
     // We consider a group to be boundless, thus any point belongs to it.
     containsPoint(_x: number, _y: number): boolean {
         return true;

--- a/charts-packages/ag-charts-community/src/scene/group.ts
+++ b/charts-packages/ag-charts-community/src/scene/group.ts
@@ -104,6 +104,16 @@ export class Group extends Node {
         super.markDirty(source, type, parentType);
     }
 
+    findNode(id: string | RegExp): Node[] | undefined {
+        if (typeof id === 'string' && this.name === id) {
+            return [this];
+        } else if (typeof id !== 'string' && this.name != null && id.test(this.name ?? '')) {
+            return [this];
+        }
+
+        return super.findNode(id);
+    }
+
     // We consider a group to be boundless, thus any point belongs to it.
     containsPoint(_x: number, _y: number): boolean {
         return true;

--- a/charts-packages/ag-charts-community/src/scene/node.ts
+++ b/charts-packages/ag-charts-community/src/scene/node.ts
@@ -335,22 +335,14 @@ export abstract class Node extends ChangeDetectable {
         }
     }
 
-    findNode(id: string | RegExp): Node[] | undefined {
-        if (typeof id === 'string') {
-            if (this.id === id) {
-                return [this];
-            }
+    findNodes(predicate: (node: Node) => boolean): Node[] | undefined {
+        const result: Node[] = predicate(this) ? [this] : [];
 
-            if (this.childSet[id]) {
-                return [this.children.find((n) => n.id === id)!];
-            }
-        } else if (id.test(this.id)) {
-            return [this];
-        }
-
-        const result: Node[] = [];
         for (const child of this.children) {
-            result.push(...(child.findNode(id) ?? []));
+            const childResult = child.findNodes(predicate);
+            if (childResult) {
+                result.push(...childResult);
+            }
         }
 
         return result.length > 0 ? result : undefined;

--- a/charts-packages/ag-charts-community/src/scene/node.ts
+++ b/charts-packages/ag-charts-community/src/scene/node.ts
@@ -25,6 +25,7 @@ export type RenderContext = {
         layersRendered: number;
         layersSkipped: number;
     };
+    debugNodes: Record<string, Node>;
 };
 
 const zIndexChangedCallback = (o: any) => {
@@ -332,6 +333,27 @@ export abstract class Node extends ChangeDetectable {
             // a leaf node, but not a container leaf
             return this;
         }
+    }
+
+    findNode(id: string | RegExp): Node[] | undefined {
+        if (typeof id === 'string') {
+            if (this.id === id) {
+                return [this];
+            }
+
+            if (this.childSet[id]) {
+                return [this.children.find((n) => n.id === id)!];
+            }
+        } else if (id.test(this.id)) {
+            return [this];
+        }
+
+        const result: Node[] = [];
+        for (const child of this.children) {
+            result.push(...(child.findNode(id) ?? []));
+        }
+
+        return result.length > 0 ? result : undefined;
     }
 
     computeBBox(): BBox | undefined {

--- a/charts-packages/ag-charts-community/src/scene/node.ts
+++ b/charts-packages/ag-charts-community/src/scene/node.ts
@@ -335,7 +335,7 @@ export abstract class Node extends ChangeDetectable {
         }
     }
 
-    findNodes(predicate: (node: Node) => boolean): Node[] | undefined {
+    findNodes(predicate: (node: Node) => boolean): Node[] {
         const result: Node[] = predicate(this) ? [this] : [];
 
         for (const child of this.children) {
@@ -345,7 +345,7 @@ export abstract class Node extends ChangeDetectable {
             }
         }
 
-        return result.length > 0 ? result : undefined;
+        return result;
     }
 
     computeBBox(): BBox | undefined {

--- a/charts-packages/ag-charts-community/src/scene/scene.ts
+++ b/charts-packages/ag-charts-community/src/scene/scene.ts
@@ -475,7 +475,7 @@ export class Scene {
 
             const predicate = typeof next === 'string' ? stringPredicate(next) : regexpPredicate(next);
             const nodes = this.root?.findNodes(predicate);
-            if (!nodes) {
+            if (!nodes || nodes.length === 0) {
                 console.warn(`AG Charts - No debugging node with id [${next}] in scene graph.`);
                 continue;
             }

--- a/charts-packages/ag-charts-community/src/scene/scene.ts
+++ b/charts-packages/ag-charts-community/src/scene/scene.ts
@@ -455,10 +455,26 @@ export class Scene {
         sceneNodeHighlight: (string | RegExp)[],
         debugNodes: Record<string, Node>
     ) {
+        const regexpPredicate = (matcher: RegExp) => (n: Node) => {
+            if (matcher.test(n.id)) {
+                return true;
+            }
+
+            return n instanceof Group && n.name != null && matcher.test(n.name);
+        };
+        const stringPredicate = (match: string) => (n: Node) => {
+            if (match === n.id) {
+                return true;
+            }
+
+            return n instanceof Group && n.name != null && match === n.name;
+        };
+
         for (const next of sceneNodeHighlight) {
             if (typeof next === 'string' && debugNodes[next] != null) continue;
 
-            const nodes = this.root?.findNode(next);
+            const predicate = typeof next === 'string' ? stringPredicate(next) : regexpPredicate(next);
+            const nodes = this.root?.findNodes(predicate);
             if (!nodes) {
                 console.warn(`AG Charts - No debugging node with id [${next}] in scene graph.`);
                 continue;

--- a/charts-packages/ag-charts-community/src/scene/shape/range.test.ts
+++ b/charts-packages/ag-charts-community/src/scene/shape/range.test.ts
@@ -89,7 +89,7 @@ describe('Range', () => {
 
                     // Render.
                     ctx.save();
-                    range.render({ ctx, forceRender: true, resized: false });
+                    range.render({ ctx, forceRender: true, resized: false, debugNodes: {} });
                     ctx.restore();
 
                     // Prepare for next case.

--- a/charts-packages/ag-charts-community/src/scene/shape/rect.test.ts
+++ b/charts-packages/ag-charts-community/src/scene/shape/rect.test.ts
@@ -122,7 +122,7 @@ describe('Rect', () => {
 
                     // Render.
                     ctx.save();
-                    rect.render({ ctx, forceRender: true, resized: false });
+                    rect.render({ ctx, forceRender: true, resized: false, debugNodes: {} });
                     ctx.restore();
 
                     // Prepare for next case.

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/doc-interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/doc-interfaces.AUTO.json
@@ -5092,7 +5092,10 @@
     "renderBoundingBoxes": {
       "type": { "returnType": "boolean", "optional": false }
     },
-    "consoleLog": { "type": { "returnType": "boolean", "optional": false } }
+    "consoleLog": { "type": { "returnType": "boolean", "optional": false } },
+    "sceneNodeHighlight": {
+      "type": { "returnType": "(string | RegExp)[]", "optional": false }
+    }
   },
   "SceneOptions": {
     "document": { "type": { "returnType": "Document", "optional": false } },

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
@@ -3580,7 +3580,7 @@
   },
   "RenderContext": {
     "meta": { "isTypeAlias": true },
-    "type": "{ ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D; forceRender: boolean; resized: boolean; clipBBox?: BBox; stats?: { nodesRendered: number; nodesSkipped: number; layersRendered: number; layersSkipped: number; }; }"
+    "type": "{ ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D; forceRender: boolean; resized: boolean; clipBBox?: BBox; stats?: { nodesRendered: number; nodesSkipped: number; layersRendered: number; layersSkipped: number; }; debugNodes: Record<string, Node>; }"
   },
   "Point": { "meta": {}, "type": { "x": "number", "y": "number" } },
   "SizedPoint": {
@@ -3593,7 +3593,8 @@
       "stats": "false | 'basic' | 'detailed'",
       "dirtyTree": "boolean",
       "renderBoundingBoxes": "boolean",
-      "consoleLog": "boolean"
+      "consoleLog": "boolean",
+      "sceneNodeHighlight": "(string | RegExp)[]"
     }
   },
   "SceneOptions": {


### PR DESCRIPTION
Adds `window.agChartsSceneDebug` to render bounding boxes of scene nodes for debugging.

Supports specification of scene graph ids, group names or aliases:
- `layout` - alias for all layout-related groups.

![Screenshot 2023-01-18 at 11 54 59](https://user-images.githubusercontent.com/17544187/213165185-0e8df64c-a362-4a01-8e3d-21cd4c7f38b7.png)
