### PR TITLE
Ag 7761/legend item truncation

### DIFF
--- a/charts-packages/ag-charts-community/src/chart/legend.ts
+++ b/charts-packages/ag-charts-community/src/chart/legend.ts
@@ -369,7 +369,6 @@ export class Legend {
         const paddedMarkerWidth = markerSize + markerPadding + paddingX;
 
         itemSelection.each((markerLabel, datum) => {
-            let text = datum.label.text ?? '<unknown>';
             markerLabel.markerSize = markerSize;
             markerLabel.spacing = markerPadding;
             markerLabel.fontStyle = fontStyle;
@@ -378,9 +377,9 @@ export class Legend {
             markerLabel.fontFamily = fontFamily;
 
             const id = datum.itemId || datum.id;
-            text = this.truncate(text, maxLength, maxItemWidth, paddedMarkerWidth, font, id);
+            const text = datum.label.text ?? '<unknown>';
+            markerLabel.text = this.truncate(text, maxLength, maxItemWidth, paddedMarkerWidth, font, id);
 
-            markerLabel.text = text;
             bboxes.push(markerLabel.computeBBox());
         });
 

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-legend/examples/legend-constraints/index.html
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-legend/examples/legend-constraints/index.html
@@ -29,8 +29,8 @@
     <div class="toolPanel">
         <div class="slider">
             <label for="maxWidthLabel"><strong>item.maxWidth:</strong></label>
-            <span id="maxWidthValue" class="slider-value">100</span>
-            <input type="range" id="maxWidthLabel" min="0" max="100" value="100"
+            <span id="maxWidthValue" class="slider-value">130</span>
+            <input type="range" id="maxWidthLabel" min="0" max="130" value="130"
                 oninput="updateLegendItemMaxWidth(event)"
                 onchange="updateLegendItemMaxWidth(event)" />
         </div>

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-legend/examples/legend-constraints/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-legend/examples/legend-constraints/main.ts
@@ -73,6 +73,7 @@ const options: AgChartOptions = {
     position: 'bottom',
     maxHeight: 200,
     item: {
+      maxWidth: 130,
       paddingX: 32,
       paddingY: 8,
       marker: {


### PR DESCRIPTION
PR for https://ag-grid.atlassian.net/browse/AG-7761

- Modified legend constraints docs example so it doesn't jump when the user interacts with the `item.maxWidth` slider
- Split legend item text label truncation into its own function