### PR TITLE
AG-7848 Update browser utils

### DIFF
--- a/community-modules/core/src/ts/dragAndDrop/dragAndDropService.ts
+++ b/community-modules/core/src/ts/dragAndDrop/dragAndDropService.ts
@@ -9,8 +9,8 @@ import { RowDropZoneParams } from "../gridBodyComp/rowDragFeature";
 import { escapeString } from "../utils/string";
 import { createIcon } from "../utils/icon";
 import { flatten, removeFromArray } from "../utils/array";
+import { getBodyHeight, getBodyWidth } from "../utils/browser";
 import { loadTemplate, clearElement } from "../utils/dom";
-import { getBodyWidth, getBodyHeight } from "../utils/browser";
 import { isFunction } from "../utils/function";
 import { IRowNode } from "../interfaces/iRowNode";
 

--- a/community-modules/core/src/ts/dragAndDrop/dragAndDropService.ts
+++ b/community-modules/core/src/ts/dragAndDrop/dragAndDropService.ts
@@ -10,6 +10,7 @@ import { escapeString } from "../utils/string";
 import { createIcon } from "../utils/icon";
 import { flatten, removeFromArray } from "../utils/array";
 import { loadTemplate, clearElement } from "../utils/dom";
+import { getBodyWidth, getBodyHeight } from "../utils/browser";
 import { isFunction } from "../utils/function";
 import { IRowNode } from "../interfaces/iRowNode";
 
@@ -442,8 +443,8 @@ export class DragAndDropService extends BeanStub {
         // for some reason, without the '-2', it still overlapped by 1 or 2 pixels, which
         // then brought in scrollbars to the browser. no idea why, but putting in -2 here
         // works around it which is good enough for me.
-        const browserWidth = this.getBodyWidth() - 2;
-        const browserHeight = this.getBodyHeight() - 2;
+        const browserWidth = getBodyWidth() - 2;
+        const browserHeight = getBodyHeight() - 2;
 
         let top = event.pageY - (ghostHeight / 2);
         let left = event.pageX - 10;
@@ -472,15 +473,6 @@ export class DragAndDropService extends BeanStub {
 
         ghost.style.left = `${left}px`;
         ghost.style.top = `${top}px`;
-    }
-
-
-    private getBodyWidth(): number {
-        return document.body?.clientWidth ?? (window.innerHeight || document.documentElement?.clientWidth || -1);
-    }
-
-    private getBodyHeight(): number {
-        return document.body?.clientHeight ?? (window.innerHeight || document.documentElement?.clientHeight || -1);
     }
 
     private removeGhost(): void {

--- a/community-modules/core/src/ts/dragAndDrop/dragAndDropService.ts
+++ b/community-modules/core/src/ts/dragAndDrop/dragAndDropService.ts
@@ -9,7 +9,6 @@ import { RowDropZoneParams } from "../gridBodyComp/rowDragFeature";
 import { escapeString } from "../utils/string";
 import { createIcon } from "../utils/icon";
 import { flatten, removeFromArray } from "../utils/array";
-import { getBodyHeight, getBodyWidth } from "../utils/browser";
 import { loadTemplate, clearElement } from "../utils/dom";
 import { isFunction } from "../utils/function";
 import { IRowNode } from "../interfaces/iRowNode";
@@ -443,8 +442,8 @@ export class DragAndDropService extends BeanStub {
         // for some reason, without the '-2', it still overlapped by 1 or 2 pixels, which
         // then brought in scrollbars to the browser. no idea why, but putting in -2 here
         // works around it which is good enough for me.
-        const browserWidth = getBodyWidth() - 2;
-        const browserHeight = getBodyHeight() - 2;
+        const browserWidth = this.getBodyWidth() - 2;
+        const browserHeight = this.getBodyHeight() - 2;
 
         let top = event.pageY - (ghostHeight / 2);
         let left = event.pageX - 10;
@@ -473,6 +472,15 @@ export class DragAndDropService extends BeanStub {
 
         ghost.style.left = `${left}px`;
         ghost.style.top = `${top}px`;
+    }
+
+
+    private getBodyWidth(): number {
+        return document.body?.clientWidth ?? (window.innerHeight || document.documentElement?.clientWidth || -1);
+    }
+
+    private getBodyHeight(): number {
+        return document.body?.clientHeight ?? (window.innerHeight || document.documentElement?.clientHeight || -1);
     }
 
     private removeGhost(): void {

--- a/community-modules/core/src/ts/filter/provided/number/numberFilter.ts
+++ b/community-modules/core/src/ts/filter/provided/number/numberFilter.ts
@@ -3,7 +3,7 @@ import { ConditionPosition, ISimpleFilterModel, Tuple } from '../simpleFilter';
 import { ScalarFilter, Comparator, IScalarFilterParams } from '../scalarFilter';
 import { makeNull } from '../../../utils/generic';
 import { AgInputTextField } from '../../../widgets/agInputTextField';
-import { isBrowserChrome, isBrowserEdge } from '../../../utils/browser';
+import { isBrowserChrome } from '../../../utils/browser';
 import { IFilterParams } from '../../../interfaces/iFilter';
 
 export interface NumberFilterModel extends ISimpleFilterModel {
@@ -193,8 +193,8 @@ export class NumberFilter extends ScalarFilter<NumberFilterModel, number> {
             return allowedCharPattern;
         }
 
-        if (!isBrowserChrome() && !isBrowserEdge()) {
-            // only Chrome and Edge support the HTML5 number field, so for other browsers we provide an equivalent
+        if (!isBrowserChrome()) {
+            // only Chrome and Edge (Chromium) support the HTML5 number field, so for other browsers we provide an equivalent
             // constraint instead
             return '\\d\\-\\.';
         }

--- a/community-modules/core/src/ts/rendering/cell/cellMouseListenerFeature.ts
+++ b/community-modules/core/src/ts/rendering/cell/cellMouseListenerFeature.ts
@@ -1,6 +1,6 @@
 import { Column } from "../../entities/column";
 import { CellClickedEvent, CellDoubleClickedEvent, CellMouseOutEvent, CellMouseOverEvent, Events } from "../../events";
-import { isBrowserEdge, isBrowserSafari, isIOSUserAgent } from "../../utils/browser";
+import { isBrowserSafari, isIOSUserAgent } from "../../utils/browser";
 import { isElementChildOfClass, isFocusableFormField } from "../../utils/dom";
 import { isEventSupported, isStopPropagationForAgGrid } from "../../utils/event";
 import { Beans } from "../beans";
@@ -125,10 +125,10 @@ export class CellMouseListenerFeature extends Beans {
         const ranges = rangeService && rangeService.getCellRanges().length != 0;
 
         if (!shiftKey || !ranges) {
-            // We only need to pass true to focusCell when the browser is IE/Edge/Safari and we are trying
+            // We only need to pass true to focusCell when the browser is Safari and we are trying
             // to focus the cell itself. This should never be true if the mousedown was triggered
             // due to a click on a cell editor for example.
-            const forceBrowserFocus = (isBrowserEdge() || isBrowserSafari()) && !this.cellCtrl.isEditing() && !isFocusableFormField(target);
+            const forceBrowserFocus = (isBrowserSafari()) && !this.cellCtrl.isEditing() && !isFocusableFormField(target);
 
             this.cellCtrl.focusCell(forceBrowserFocus);
         }

--- a/community-modules/core/src/ts/utils/browser.ts
+++ b/community-modules/core/src/ts/utils/browser.ts
@@ -119,6 +119,14 @@ export function getMaxDivHeight(): number {
     return res;
 }
 
+export function getBodyWidth(): number {
+    return document.body?.clientWidth ?? (window.innerHeight || document.documentElement?.clientWidth || -1);
+}
+
+export function getBodyHeight(): number {
+    return document.body?.clientHeight ?? (window.innerHeight || document.documentElement?.clientHeight || -1);
+}
+
 export function getScrollbarWidth(): number | null {
     if (browserScrollbarWidth == null) {
         initScrollbarWidthAndVisibility();

--- a/community-modules/core/src/ts/utils/browser.ts
+++ b/community-modules/core/src/ts/utils/browser.ts
@@ -1,73 +1,42 @@
 /**
  * These variables are lazy loaded, as otherwise they try and get initialised when we are loading
  * unit tests and we don't have references to window or document in the unit tests
- * from http://stackoverflow.com/questions/9847580/how-to-detect-safari-chrome-ie-firefox-and-opera-browser
  */
 let isSafari: boolean;
+let safariVersion: number;
 let isChrome: boolean;
 let isFirefox: boolean;
 let isMacOs: boolean;
 let isIOS: boolean;
 let invisibleScrollbar: boolean;
 let browserScrollbarWidth: number;
-let browserInfo: { name: string, version: number };
-
-/**
- * from https://stackoverflow.com/a/16938481/1388233
- */
-function getBrowserInfo(): { name: string, version: number } {
-    if (browserInfo) {
-        return browserInfo;
-    }
-    const userAgent = navigator.userAgent;
-    let match = userAgent.match(/(opera|chrome|safari|firefox|msie|trident(?=\/))\/?\s*(\d+)/i) || [];
-    let tem;
-    let version: number;
-
-    if (/trident/i.test(match[1])) {
-        tem = /\brv[ :]+(\d+)/g.exec(userAgent) || [];
-        version = tem[1] != null ? parseFloat(tem[1]) : 0;
-        return {
-            name:'IE',
-            version
-        };
-    }
-
-    if (match[1] === 'Chrome') {
-        tem = userAgent.match(/\bOPR|Edge\/(\d+)/);
-        if (tem != null) {
-            version = tem[1] != null ? parseFloat(tem[1]) : 0;
-            return {
-                name:'Opera',
-                version
-            };
-        }
-    }
-
-    match = match[2] ? [match[1], match[2]] : [navigator.appName, navigator.appVersion, '-?'];
-    tem = userAgent.match(/version\/(\d+)/i);
-
-    if (tem != null) {
-        match.splice(1, 1, tem[1]);
-    }
-
-    const name = match[0];
-    version = match[1] != null ? parseFloat(match[1]) : 0;
-
-    browserInfo = { name, version };
-
-    return browserInfo;
- }
 
 export function isBrowserSafari(): boolean {
     if (isSafari === undefined) {
-        // taken from https://stackoverflow.com/a/23522755/1388233
         isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
     }
-
     return isSafari;
 }
 
+function getSafariVersion(): number {
+    if (safariVersion === undefined) {
+        if (isBrowserSafari()) {
+            const versionMatch = navigator.userAgent.match(/version\/(\d+)/i);
+            if (versionMatch) {
+                safariVersion = versionMatch[1] != null ? parseFloat(versionMatch[1]) : 0;
+            }
+        } else {
+            safariVersion = 0;
+        }
+    }
+
+    return safariVersion;
+}
+
+
+/**
+ * Returns true for Chrome and also for Edge (Chromium)
+ */
 export function isBrowserChrome(): boolean {
     if (isChrome === undefined) {
         const win = window as any;
@@ -98,7 +67,6 @@ export function isMacOsUserAgent(): boolean {
 
 export function isIOSUserAgent(): boolean {
     if (isIOS === undefined) {
-        // taken from https://stackoverflow.com/a/58064481/1388233
         isIOS = (/iPad|iPhone|iPod/.test(navigator.platform) ||
             // eslint-disable-next-line
             (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1)) &&
@@ -112,7 +80,7 @@ export function isIOSUserAgent(): boolean {
 export function browserSupportsPreventScroll(): boolean {
     // all browsers except safari support focus({ preventScroll: true }).
     // this feature was added on Safari 15+
-    return !isBrowserSafari() || getBrowserInfo().version >= 15;
+    return !isBrowserSafari() || getSafariVersion() >= 15;
 }
 
 export function getTabIndex(el: HTMLElement | null): string | null {

--- a/community-modules/core/src/ts/utils/browser.ts
+++ b/community-modules/core/src/ts/utils/browser.ts
@@ -213,36 +213,3 @@ export function isInvisibleScrollbar(): boolean {
     }
     return invisibleScrollbar;
 }
-
-/** @deprecated */
-export function hasOverflowScrolling(): boolean {
-    const prefixes: string[] = ['webkit', 'moz', 'o', 'ms'];
-    const div: HTMLElement = document.createElement('div');
-    const body: HTMLBodyElement = document.getElementsByTagName('body')[0];
-    let found: boolean = false;
-    let p: string;
-
-    body.appendChild(div);
-    div.setAttribute('style', prefixes.map(prefix => `-${prefix}-overflow-scrolling: touch`).concat('overflow-scrolling: touch').join(';'));
-
-    const computedStyle: CSSStyleDeclaration = window.getComputedStyle(div);
-
-    if ((computedStyle as any).overflowScrolling === 'touch') {
-        found = true;
-    }
-
-    if (!found) {
-        for (p of prefixes) {
-            if ((computedStyle as any)[`${p}OverflowScrolling`] === 'touch') {
-                found = true;
-                break;
-            }
-        }
-    }
-
-    if (div.parentNode) {
-        div.parentNode.removeChild(div);
-    }
-
-    return found;
-}

--- a/community-modules/core/src/ts/utils/browser.ts
+++ b/community-modules/core/src/ts/utils/browser.ts
@@ -4,8 +4,6 @@
  * from http://stackoverflow.com/questions/9847580/how-to-detect-safari-chrome-ie-firefox-and-opera-browser
  */
 let isSafari: boolean;
-let isIE: boolean;
-let isEdge: boolean;
 let isChrome: boolean;
 let isFirefox: boolean;
 let isMacOs: boolean;
@@ -60,22 +58,6 @@ function getBrowserInfo(): { name: string, version: number } {
 
     return browserInfo;
  }
-
-function isBrowserIE(): boolean {
-    if (isIE === undefined) {
-        isIE = /*@cc_on!@*/false || !!(document as any).documentMode; // At least IE6
-    }
-
-    return isIE;
-}
-
-export function isBrowserEdge(): boolean {
-    if (isEdge === undefined) {
-        isEdge = !isBrowserIE() && !!(window as any).StyleMedia;
-    }
-
-    return isEdge;
-}
 
 export function isBrowserSafari(): boolean {
     if (isSafari === undefined) {

--- a/community-modules/core/src/ts/utils/browser.ts
+++ b/community-modules/core/src/ts/utils/browser.ts
@@ -17,7 +17,7 @@ let browserInfo: { name: string, version: number };
 /**
  * from https://stackoverflow.com/a/16938481/1388233
  */
-export function getBrowserInfo(): { name: string, version: number } {
+function getBrowserInfo(): { name: string, version: number } {
     if (browserInfo) {
         return browserInfo;
     }
@@ -245,46 +245,4 @@ export function hasOverflowScrolling(): boolean {
     }
 
     return found;
-}
-
-/**
- * Gets the document body width
- * from: http://stackoverflow.com/questions/1038727/how-to-get-browser-width-using-javascript-code
- * @returns {number}
- */
-export function getBodyWidth(): number {
-    if (document.body) {
-        return document.body.clientWidth;
-    }
-
-    if (window.innerHeight) {
-        return window.innerWidth;
-    }
-
-    if (document.documentElement && document.documentElement.clientWidth) {
-        return document.documentElement.clientWidth;
-    }
-
-    return -1;
-}
-
-/**
- * Gets the body height
- * from: http://stackoverflow.com/questions/1038727/how-to-get-browser-width-using-javascript-code
- * @returns {number}
- */
-export function getBodyHeight(): number {
-    if (document.body) {
-        return document.body.clientHeight;
-    }
-
-    if (window.innerHeight) {
-        return window.innerHeight;
-    }
-
-    if (document.documentElement && document.documentElement.clientHeight) {
-        return document.documentElement.clientHeight;
-    }
-
-    return -1;
 }

--- a/community-modules/core/src/ts/utils/browser.ts
+++ b/community-modules/core/src/ts/utils/browser.ts
@@ -49,9 +49,7 @@ export function isBrowserChrome(): boolean {
 
 export function isBrowserFirefox(): boolean {
     if (isFirefox === undefined) {
-        const win = window as any;
-
-        isFirefox = typeof win.InstallTrigger !== 'undefined';
+        isFirefox = /(firefox)/i.test(navigator.userAgent);
     }
 
     return isFirefox;

--- a/community-modules/core/src/ts/utils/keyboard.ts
+++ b/community-modules/core/src/ts/utils/keyboard.ts
@@ -4,13 +4,9 @@ import { Column } from '../entities/column';
 import { ColumnGroup } from '../entities/columnGroup';
 import { GridOptionsService } from '../gridOptionsService';
 import { IRowNode } from '../interfaces/iRowNode';
-import { isBrowserEdge, isMacOsUserAgent } from './browser';
+import { isMacOsUserAgent } from './browser';
 import { exists } from './generic';
 
-const NUMPAD_DEL_NUMLOCK_ON_KEY = 'Del';
-
-// Using legacy values to match AZERTY keyboards
-const NUMPAD_DEL_NUMLOCK_ON_KEYCODE = 46;
 const A_KEYCODE = 65;
 const C_KEYCODE = 67;
 const V_KEYCODE = 86;
@@ -26,11 +22,7 @@ export function isEventFromPrintableCharacter(event: KeyboardEvent): boolean {
     // non-printable characters have names, eg 'Enter' or 'Backspace'.
     const printableCharacter = event.key.length === 1;
 
-    // IE11 & Edge treat the numpad del key differently - with numlock on we get "Del" for key,
-    // so this addition checks if its IE11/Edge and handles that specific case the same was as all other browsers
-    const numpadDelWithNumlockOnForEdgeOrIe = isNumpadDelWithNumLockOnForEdge(event);
-
-    return printableCharacter || numpadDelWithNumlockOnForEdgeOrIe;
+    return printableCharacter;
 }
 
 /**
@@ -99,12 +91,6 @@ export function isUserSuppressingHeaderKeyboardEvent(
     };
 
     return !!colDefFunc(params);
-}
-
-function isNumpadDelWithNumLockOnForEdge(event: KeyboardEvent) {
-    return (isBrowserEdge()) &&
-        event.key === NUMPAD_DEL_NUMLOCK_ON_KEY &&
-        event.charCode === NUMPAD_DEL_NUMLOCK_ON_KEYCODE;
 }
 
 export function normaliseQwertyAzerty(keyboardEvent: KeyboardEvent): string {


### PR DESCRIPTION
The browser utils need to be updated to match the current state of our supported browsers. There is some dead code relating to older versions of Edge and IE that can be removed.

Also the Firefox detection is soon to fail as the property used has been deprecated. 

I have also reduced the code require to get the browser version to just what is currently require, i.e the Safari version