### PR TITLE
AG-3390 - Add website only docs runner

### DIFF
--- a/grid-packages/ag-grid-docs/dev-server.js
+++ b/grid-packages/ag-grid-docs/dev-server.js
@@ -805,6 +805,8 @@ module.exports = async (skipFrameworks, skipExampleFormatting, chartsOnly, skipE
             if (skipExampleGeneration) {
                 console.log("Skipping Example Generation");
             } else {
+                console.time("Generating examples");
+
                 // regenerate examples and then watch them
                 console.log("Watch and Generate Examples");
                 await watchAndGenerateExamples(chartsOnly);
@@ -812,6 +814,9 @@ module.exports = async (skipFrameworks, skipExampleFormatting, chartsOnly, skipE
     
                 console.log("Watch Typescript examples...");
                 await watchValidateExampleTypes();
+
+                console.timeEnd("Generating examples");
+            }
 
             // todo - iterate everything under src and serve it
             // ...or use app.get('/' and handle it that way

--- a/grid-packages/ag-grid-docs/dev-server.js
+++ b/grid-packages/ag-grid-docs/dev-server.js
@@ -735,7 +735,7 @@ const readModulesState = () => {
     return modulesState;
 };
 
-module.exports = async (skipFrameworks, skipExampleFormatting, chartsOnly, done) => {
+module.exports = async (skipFrameworks, skipExampleFormatting, chartsOnly, skipExampleGeneration, done) => {
     tcpPortUsed.check(EXPRESS_HTTPS_PORT)
         .then(async (inUse) => {
             if (inUse) {
@@ -802,13 +802,16 @@ module.exports = async (skipFrameworks, skipExampleFormatting, chartsOnly, done)
 
             serveModuleAndPackages(app, gridCommunityModules, gridEnterpriseModules, chartCommunityModules);
 
-            // regenerate examples and then watch them
-            console.log("Watch and Generate Examples");
-            await watchAndGenerateExamples(chartsOnly);
-            console.log("Examples Generated");
-
-            console.log("Watch Typescript examples...");
-            await watchValidateExampleTypes();
+            if (skipExampleGeneration) {
+                console.log("Skipping Example Generation");
+            } else {
+                // regenerate examples and then watch them
+                console.log("Watch and Generate Examples");
+                await watchAndGenerateExamples(chartsOnly);
+                console.log("Examples Generated");
+    
+                console.log("Watch Typescript examples...");
+                await watchValidateExampleTypes();
 
             // todo - iterate everything under src and serve it
             // ...or use app.get('/' and handle it that way

--- a/grid-packages/ag-grid-docs/gulpfile.js
+++ b/grid-packages/ag-grid-docs/gulpfile.js
@@ -149,7 +149,8 @@ gulp.task('default', series('release'));
 gulp.task('serve-dist', serveDist);
 
 //                                                               this,         skipFrameworks,   skipExampleFormatting, chartsOnly
-gulp.task('serve',                  require('./dev-server').bind(null, false,           true, false));
-gulp.task('serve-core-only',        require('./dev-server').bind(null, true,            true, false));
-gulp.task('serve-with-formatting',  require('./dev-server').bind(null, false,           false, false));
-gulp.task('serve-charts-core-only', require('./dev-server').bind(null, true,            true, true));
+gulp.task('serve',                  require('./dev-server').bind(null, false,           true, false, false));
+gulp.task('serve-core-only',        require('./dev-server').bind(null, true,            true, false, false));
+gulp.task('serve-with-formatting',  require('./dev-server').bind(null, false,           false, false, false));
+gulp.task('serve-charts-core-only', require('./dev-server').bind(null, true,            true, true, false));
+gulp.task('serve-website-only',     require('./dev-server').bind(null, false,           true, false, true));

--- a/grid-packages/ag-grid-docs/package.json
+++ b/grid-packages/ag-grid-docs/package.json
@@ -12,6 +12,7 @@
     "serve-core-only": "NODE_OPTIONS=--max-old-space-size=${AG_DOCS_HEAP_SIZE:-6144} npx gulp serve-core-only",
     "serve-with-formatting": "npx gulp serve-with-formatting",
     "serve-charts-core-only": "npx gulp serve-charts-core-only",
+    "serve-website-only": "npx gulp serve-website-only",
     "tsc": "npx tsc -p tests/config/tsconfig.json",
     "test": "npx jest",
     "test:e2e": "npm run lint-examples && npm run validate-examples && npm run validate-docs",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "docs": "cd grid-packages/ag-grid-docs && npm start",
     "docs-core-only": "cd grid-packages/ag-grid-docs && npm run serve-core-only",
     "docs-charts-core-only": "cd grid-packages/ag-grid-docs && npm run serve-charts-core-only",
+    "docs-serve-website-only": "cd grid-packages/ag-grid-docs && npm run serve-website-only",
     "docs-clean": "cd grid-packages/ag-grid-docs/documentation && npm run clean",
     "docsWithFormatting": "cd grid-packages/ag-grid-docs && npm run serve-with-formatting",
     "initialUpdateAndRebuild": "npm i && npm run bootstrap-single-thread && npm run build",


### PR DESCRIPTION
## Changes

* Add a `npm run docs-serve-website-only` command to skip example generation, and only serve the gatsby server. For website development