### PR TITLE
AG-7293 - Add basic Charts FW wrapper export of chart reference.

### DIFF
--- a/charts-packages/ag-charts-angular/projects/ag-charts-angular/src/lib/ag-charts-angular.component.ts
+++ b/charts-packages/ag-charts-angular/projects/ag-charts-angular/src/lib/ag-charts-angular.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewInit, Component, ElementRef, Input, OnChanges, OnDestroy, ViewEncapsulation } from "@angular/core";
+import { AfterViewInit, Component, EventEmitter, ElementRef, Input, Output, OnChanges, OnDestroy, ViewEncapsulation } from "@angular/core";
 
 import { AgChartInstance, AgChart, AgChartOptions } from 'ag-charts-community';
 
@@ -12,12 +12,14 @@ export class AgChartsAngular implements AfterViewInit, OnChanges, OnDestroy {
 
     private _nativeElement: any;
     private _initialised = false;
-    private _destroyed = false;
 
-    private _chart!: AgChartInstance;
+    public chart?: AgChartInstance;
 
     @Input()
-    public options!: AgChartOptions;
+    public options: AgChartOptions = {};
+
+    @Output()
+    public onChartReady: EventEmitter<AgChartInstance> = new EventEmitter();
 
     constructor(elementDef: ElementRef) {
         this._nativeElement = elementDef.nativeElement;
@@ -26,24 +28,29 @@ export class AgChartsAngular implements AfterViewInit, OnChanges, OnDestroy {
     ngAfterViewInit(): void {
         const options = this.applyContainerIfNotSet(this.options);
 
-        this._chart = AgChart.create(options);
-
+        this.chart = AgChart.create(options);
         this._initialised = true;
+
+        (this.chart as any).chart.waitForUpdate()
+            .then(() => {
+                this.onChartReady.emit(this.chart);
+            });
     }
 
-  // noinspection JSUnusedGlobalSymbols,JSUnusedLocalSymbols
+    // noinspection JSUnusedGlobalSymbols,JSUnusedLocalSymbols
     ngOnChanges(changes: any): void {
-        if (this._initialised) {
-            AgChart.update(this._chart, this.applyContainerIfNotSet(this.options));
+        if (!this._initialised || !this.chart) {
+            return;
         }
+
+        AgChart.update(this.chart, this.applyContainerIfNotSet(this.options));
     }
 
     public ngOnDestroy(): void {
-        if (this._initialised) {
-            if (this._chart) {
-                this._chart.destroy();
-            }
-            this._destroyed = true;
+        if (this._initialised && this.chart) {
+            this.chart.destroy();
+            this.chart = undefined;
+            this._initialised = false;
         }
     }
 

--- a/charts-packages/ag-charts-react/src/agChartsReact.ts
+++ b/charts-packages/ag-charts-react/src/agChartsReact.ts
@@ -4,6 +4,8 @@ import { AgChartInstance, AgChart, AgChartOptions } from "ag-charts-community";
 
 export interface AgChartProps {
     options: AgChartOptions;
+    onChartReady?: (chart: AgChartInstance) => void;
+    containerStyle: {};
 }
 
 interface AgChartState {
@@ -12,12 +14,12 @@ interface AgChartState {
 export class AgChartsReact extends Component<AgChartProps, AgChartState> {
     static propTypes: any;
 
-    private chart!: AgChartInstance;
+    public chart?: AgChartInstance;
 
     protected chartRef: RefObject<HTMLElement>;
 
-    constructor(public props: any, public state: any) {
-        super(props, state);
+    constructor(public props: AgChartProps) {
+        super(props);
         this.chartRef = createRef();
     }
 
@@ -37,7 +39,12 @@ export class AgChartsReact extends Component<AgChartProps, AgChartState> {
 
     componentDidMount() {
         const options = this.applyContainerIfNotSet(this.props.options);
-        this.chart = AgChart.create(options);
+
+        const chart = AgChart.create(options);
+        this.chart = chart;
+
+        (chart as any).chart.waitForUpdate()
+            .then(() => this.props.onChartReady?.(chart));
     }
 
     private applyContainerIfNotSet(propsOptions: any) {
@@ -58,12 +65,15 @@ export class AgChartsReact extends Component<AgChartProps, AgChartState> {
     }
 
     processPropsChanges(prevProps: any, nextProps: any) {
-        AgChart.update(this.chart, this.applyContainerIfNotSet(nextProps.options));
+        if (this.chart) {
+            AgChart.update(this.chart, this.applyContainerIfNotSet(nextProps.options));
+        }
     }
 
     componentWillUnmount() {
         if (this.chart) {
             this.chart.destroy();
+            this.chart = undefined;
         }
     }
 }

--- a/charts-packages/ag-charts-vue/src/AgChartsVue.ts
+++ b/charts-packages/ag-charts-vue/src/AgChartsVue.ts
@@ -7,10 +7,10 @@ import { AgChart, AgChartInstance, AgChartOptions } from 'ag-charts-community';
     },
 })
 export class AgChartsVue extends Vue {
+    public chart?: AgChartInstance;
+
     private isCreated = false;
     private isDestroyed = false;
-
-    private chart!: AgChartInstance;
 
     private options!: AgChartOptions;
 
@@ -28,6 +28,9 @@ export class AgChartsVue extends Vue {
         });
 
         this.isCreated = true;
+
+        (this.chart as any).chart.waitForUpdate()
+            .then(() => this.$emit('onChartReady', this.chart));
     }
 
     public destroyed() {
@@ -41,7 +44,7 @@ export class AgChartsVue extends Vue {
     }
 
     private processChanges(currentValue: any, previousValue: any) {
-        if (this.isCreated) {
+        if (this.isCreated && this.chart) {
             AgChart.update(this.chart, this.applyContainerIfNotSet(this.options));
         }
     }

--- a/charts-packages/ag-charts-vue3/src/AgChartsVue.ts
+++ b/charts-packages/ag-charts-vue3/src/AgChartsVue.ts
@@ -7,6 +7,7 @@ import {toRaw} from '@vue/reactivity';
     props: {
         options: {},
     },
+    emits: ['onChartReady'],
     // watch: {
     //     options: {
     //         handler(currentValue, previousValue) {
@@ -17,10 +18,10 @@ import {toRaw} from '@vue/reactivity';
     // },
 })
 export class AgChartsVue extends Vue {
+    public chart?: AgChartInstance;
+
     private isCreated = false;
     private isDestroyed = false;
-
-    private chart!: AgChartInstance;
 
     private options!: AgChartOptions;
 
@@ -41,6 +42,9 @@ export class AgChartsVue extends Vue {
         });
 
         this.isCreated = true;
+
+        (this.chart as any).chart.waitForUpdate()
+            .then(() => this.$emit('onChartReady', this.chart!));
     }
 
     public destroyed() {
@@ -58,7 +62,7 @@ export class AgChartsVue extends Vue {
     }
 
     public processChanges(currentValue: any, previousValue: any) {
-        if (this.isCreated) {
+        if (this.isCreated && this.chart) {
             AgChart.update(this.chart, toRaw(this.applyContainerIfNotSet(toRaw(this.options))));
         }
     }


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-7293

Adds support for exposing the Chart instance managed by FW wrapper tags, to allow use of `AgChart.download()` and other API features.

- Angular ([example](https://plnkr.co/edit/p58uM0Z9NtjceJ1Y?open=app%2Fapp.component.ts)):
  - Exposes `AgChartsAgnular.chart` for parent elements to be able to access via a `@ViewChild()` decorated property.
  - Adds a `onChartReady` event which is triggered after the initial rendering of the chart completes.
- React ([example](https://plnkr.co/edit/HXnjbkzjXtKXtcMR?open=index.jsx&preview)):
  - Exposes `AgChartsReact.chart` for parent elements to be able to access via a `ref`.
  - Adds a `onChartReady` event which is triggered after the initial rendering of the chart completes.
- Vue ([example](https://plnkr.co/edit/WHUxB6dxBRoZaeEx?open=main.js)):
  - Adds a `onChartReady` callback which is triggered after the initial rendering of the chart completes.
  - Exposes `AgChartsVue.chart` and AgChartsVue3.chart` for parent elements to be able to access (I'm not familiar with whether this is actually necessary).
