### PR TITLE
AG-7906 Use standard import for AgChart

### DIFF
--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api-explorer/examples/baseline/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api-explorer/examples/baseline/main.ts
@@ -1,5 +1,4 @@
-import * as agCharts from 'ag-charts-community';
-import { AgChartOptions } from 'ag-charts-community';
+import { AgChart, AgChartOptions } from 'ag-charts-community';
 import { getData } from "./data";
 
 
@@ -9,4 +8,4 @@ const options: AgChartOptions = {
   // INSERT OPTIONS HERE.
 }
 
-agCharts.AgChart.create(options)
+AgChart.create(options)

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/examples/create-update/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/examples/create-update/main.ts
@@ -1,5 +1,4 @@
-import * as agCharts from "ag-charts-community";
-import { AgAreaSeriesOptions, AgChartLegendPosition, AgChartOptions } from "ag-charts-community";
+import { AgChart, AgAreaSeriesOptions, AgChartLegendPosition, AgChartOptions } from "ag-charts-community";
 import { getData } from "./data";
 
 
@@ -38,14 +37,14 @@ const options: AgChartOptions = {
   legend,
 };
 
-let chart = agCharts.AgChart.create(options);
+let chart = AgChart.create(options);
 
 function reverseSeries() {
   // Mutate options.
   options.series = series.reverse();
 
   // Apply changes.
-  agCharts.AgChart.update(chart, options);
+  AgChart.update(chart, options);
 }
 
 function swapTitles() {
@@ -55,7 +54,7 @@ function swapTitles() {
   options.subtitle = oldTitle
 
   // Apply changes.
-  agCharts.AgChart.update(chart, options);
+  AgChart.update(chart, options);
 }
 
 function rotateLegend() {
@@ -65,5 +64,5 @@ function rotateLegend() {
 
   // Apply changes.
   options.legend = legend;
-  agCharts.AgChart.update(chart, options);
+  AgChart.update(chart, options);
 }

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/examples/update-partial/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/examples/update-partial/main.ts
@@ -1,6 +1,5 @@
-import * as agCharts from "ag-charts-community"
 import {
-  AgAreaSeriesOptions,
+  AgChart, AgAreaSeriesOptions,
   AgChartLegendPosition,
 } from "ag-charts-community"
 import { getData } from "./data"
@@ -27,7 +26,7 @@ const legend = {
   position: positions[1],
 }
 
-let chart = agCharts.AgChart.create({
+let chart = AgChart.create({
   container: document.getElementById("myChart"),
   title: {
     text: "Browser Usage Statistics",
@@ -46,7 +45,7 @@ function reverseSeries() {
   series!.reverse()
 
   // Apply changes.
-  agCharts.AgChart.updateDelta(chart, { series })
+  AgChart.updateDelta(chart, { series })
 }
 
 function swapTitles() {
@@ -54,7 +53,7 @@ function swapTitles() {
   const { title, subtitle } = chart.getOptions()
 
   // Apply changes.
-  agCharts.AgChart.updateDelta(chart, { title: subtitle, subtitle: title })
+  AgChart.updateDelta(chart, { title: subtitle, subtitle: title })
 }
 
 function rotateLegend() {
@@ -65,11 +64,11 @@ function rotateLegend() {
   const newPosition = positions[(currentIdx + 1) % positions.length]
 
   // Apply changes.
-  agCharts.AgChart.updateDelta(chart, { legend: { position: newPosition } })
+  AgChart.updateDelta(chart, { legend: { position: newPosition } })
 }
 
 function changeTheme() {
-  agCharts.AgChart.updateDelta(chart, {
+  AgChart.updateDelta(chart, {
     theme: { overrides: { area: { series: { marker: { enabled: true } } } } },
   })
 }

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-area-series/examples/missing-data-area/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-area-series/examples/missing-data-area/main.ts
@@ -1,6 +1,5 @@
-import * as agCharts from "ag-charts-community"
 import {
-  AgAreaSeriesOptions,
+  AgChart, AgAreaSeriesOptions,
   AgCartesianChartOptions,
 } from "ag-charts-community"
 import { getData } from "./data"
@@ -61,7 +60,7 @@ const options: AgCartesianChartOptions = {
   ],
 }
 
-let chart = agCharts.AgChart.create(options)
+let chart = AgChart.create(options)
 
 function missingYValues() {
   const data = getData()
@@ -70,7 +69,7 @@ function missingYValues() {
 
   options.data = data
 
-  agCharts.AgChart.update(chart, options)
+  AgChart.update(chart, options)
 }
 
 function missingXValues() {
@@ -82,20 +81,20 @@ function missingXValues() {
 
   options.data = data
 
-  agCharts.AgChart.update(chart, options)
+  AgChart.update(chart, options)
 }
 
 function stack() {
   options.series = series.map(s => ({ ...s, stacked: true }))
-  agCharts.AgChart.update(chart, options)
+  AgChart.update(chart, options)
 }
 
 function group() {
   options.series = series.map(s => ({ ...s, stacked: false }))
-  agCharts.AgChart.update(chart, options)
+  AgChart.update(chart, options)
 }
 
 function reset() {
   options.data = getData()
-  agCharts.AgChart.update(chart, options)
+  AgChart.update(chart, options)
 }

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-area-series/examples/multi-area/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-area-series/examples/multi-area/main.ts
@@ -1,5 +1,4 @@
-import * as agCharts from "ag-charts-community";
-import { AgChartOptions } from "ag-charts-community";
+import { AgChart, AgChartOptions } from "ag-charts-community";
 import { getData } from "./data";
 
 
@@ -42,4 +41,4 @@ const options: AgChartOptions = {
   },
 }
 
-agCharts.AgChart.create(options)
+AgChart.create(options)

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-area-series/examples/normalized-area/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-area-series/examples/normalized-area/main.ts
@@ -1,5 +1,4 @@
-import * as agCharts from "ag-charts-community";
-import { AgChartOptions } from "ag-charts-community";
+import { AgChart, AgChartOptions } from "ag-charts-community";
 import { getData } from "./data";
 
 
@@ -48,4 +47,4 @@ const options: AgChartOptions = {
   ],
 }
 
-agCharts.AgChart.create(options)
+AgChart.create(options)

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-area-series/examples/single-area-markers-labels/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-area-series/examples/single-area-markers-labels/main.ts
@@ -1,5 +1,4 @@
-import * as agCharts from 'ag-charts-community';
-import { AgChartOptions } from 'ag-charts-community';
+import { AgChart, AgChartOptions } from 'ag-charts-community';
 import { getData } from "./data";
 
 const options: AgChartOptions = {
@@ -37,4 +36,4 @@ const options: AgChartOptions = {
   },
 }
 
-agCharts.AgChart.create(options)
+AgChart.create(options)

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-area-series/examples/single-area-markers/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-area-series/examples/single-area-markers/main.ts
@@ -1,5 +1,4 @@
-import * as agCharts from 'ag-charts-community';
-import { AgChartOptions } from 'ag-charts-community';
+import { AgChart, AgChartOptions } from 'ag-charts-community';
 import { getData } from "./data";
 
 const options: AgChartOptions = {
@@ -34,4 +33,4 @@ const options: AgChartOptions = {
   },
 }
 
-agCharts.AgChart.create(options)
+AgChart.create(options)

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-area-series/examples/single-area/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-area-series/examples/single-area/main.ts
@@ -1,5 +1,4 @@
-import * as agCharts from 'ag-charts-community';
-import { AgChartOptions } from 'ag-charts-community';
+import { AgChart, AgChartOptions } from 'ag-charts-community';
 import { getData } from "./data";
 
 
@@ -25,4 +24,4 @@ const options: AgChartOptions = {
   },
 }
 
-agCharts.AgChart.create(options)
+AgChart.create(options)

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-area-series/examples/stacked-area/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-area-series/examples/stacked-area/main.ts
@@ -1,5 +1,4 @@
-import * as agCharts from "ag-charts-community";
-import { AgChartOptions } from "ag-charts-community";
+import { AgChart, AgChartOptions } from "ag-charts-community";
 import { getData } from "./data";
 
 const options: AgChartOptions = {
@@ -43,4 +42,4 @@ const options: AgChartOptions = {
   ],
 }
 
-agCharts.AgChart.create(options)
+AgChart.create(options)

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-axes/examples/axis-cross-lines/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-axes/examples/axis-cross-lines/main.ts
@@ -1,5 +1,4 @@
-import * as agCharts from 'ag-charts-community';
-import { AgChartOptions } from 'ag-charts-community';
+import { AgChart, AgChartOptions, time } from 'ag-charts-community';
 import { getData } from './data';
 
 const options: AgChartOptions = {
@@ -55,7 +54,7 @@ const options: AgChartOptions = {
       position: 'bottom',
       type: 'time',
       tick: {
-        count: agCharts.time.month.every(2),
+        count: time.month.every(2),
       },
       title: {
         text: 'Date',
@@ -135,4 +134,4 @@ const options: AgChartOptions = {
   ],
 };
 
-var chart = agCharts.AgChart.create(options);
+var chart = AgChart.create(options);

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-axes/examples/axis-grid-lines/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-axes/examples/axis-grid-lines/main.ts
@@ -1,5 +1,4 @@
-import { AgCartesianChartOptions } from 'ag-charts-community'
-import * as agCharts from 'ag-charts-community'
+import { AgCartesianChartOptions, AgChart } from 'ag-charts-community'
 
 const options: AgCartesianChartOptions = {
   container: document.getElementById('myChart'),
@@ -38,7 +37,7 @@ const options: AgCartesianChartOptions = {
   },
 }
 
-var chart = agCharts.AgChart.create(options)
+var chart = AgChart.create(options)
 
 function useGridStyle1() {
   var gridStyle = [
@@ -53,7 +52,7 @@ function useGridStyle1() {
   ]
   options.axes![0].gridStyle = gridStyle
   options.axes![1].gridStyle = gridStyle
-  agCharts.AgChart.update(chart, options)
+  AgChart.update(chart, options)
 }
 
 function useGridStyle2() {
@@ -71,7 +70,7 @@ function useGridStyle2() {
   ]
   options.axes![0].gridStyle = xGridStyle
   options.axes![1].gridStyle = yGridStyle
-  agCharts.AgChart.update(chart, options)
+  AgChart.update(chart, options)
 }
 
 function useDefaultGridStyle() {
@@ -83,5 +82,5 @@ function useDefaultGridStyle() {
   ]
   options.axes![0].gridStyle = gridStyle
   options.axes![1].gridStyle = gridStyle
-  agCharts.AgChart.update(chart, options)
+  AgChart.update(chart, options)
 }

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-axes/examples/axis-label-formatter/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-axes/examples/axis-label-formatter/main.ts
@@ -1,5 +1,4 @@
-import { AgChartOptions } from 'ag-charts-community'
-import * as agCharts from 'ag-charts-community'
+import { AgChartOptions, AgChart } from 'ag-charts-community'
 
 const options: AgChartOptions = {
   container: document.getElementById('myChart'),
@@ -43,4 +42,4 @@ const options: AgChartOptions = {
   },
 }
 
-agCharts.AgChart.create(options)
+AgChart.create(options)

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-axes/examples/axis-label-rotation/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-axes/examples/axis-label-rotation/main.ts
@@ -1,5 +1,4 @@
-import { AgCartesianChartOptions, AgBarSeriesOptions } from 'ag-charts-community'
-import * as agCharts from 'ag-charts-community'
+import { AgCartesianChartOptions, AgBarSeriesOptions, AgChart } from 'ag-charts-community'
 import { getData } from './data';
 
 const options: AgCartesianChartOptions = {
@@ -31,7 +30,7 @@ const options: AgCartesianChartOptions = {
   },
 }
 
-const chart = agCharts.AgChart.create(options);
+const chart = AgChart.create(options);
 
 function reset() {
   const element = document.getElementsByClassName('ag-chart-wrapper')![0]! as HTMLElement;
@@ -46,7 +45,7 @@ function reset() {
   delete options.axes![1].label!.avoidCollisions;
 
   options.series![0].xKey = 'year';
-  agCharts.AgChart.update(chart, options);
+  AgChart.update(chart, options);
 }
 
 function disableRotation() {
@@ -55,7 +54,7 @@ function disableRotation() {
   options.axes![0].label!.autoRotate = false;
   options.axes![1].label!.autoRotate = false;
 
-  agCharts.AgChart.update(chart, options);
+  AgChart.update(chart, options);
 }
 
 function fixedRotation() {
@@ -64,7 +63,7 @@ function fixedRotation() {
   options.axes![0].label!.autoRotate = false;
   options.axes![1].label!.autoRotate = false;
 
-  agCharts.AgChart.update(chart, options);
+  AgChart.update(chart, options);
 }
 
 function autoRotation() {
@@ -73,29 +72,29 @@ function autoRotation() {
   options.axes![0].label!.autoRotate = true;
   options.axes![1].label!.autoRotate = true;
 
-  agCharts.AgChart.update(chart, options);
+  AgChart.update(chart, options);
 }
 
 function uniformLabels() {
   options.series![0].xKey = 'year';
-  agCharts.AgChart.update(chart, options);
+  AgChart.update(chart, options);
 }
 
 function irregularLabels() {
   options.series![0].xKey = 'country';
-  agCharts.AgChart.update(chart, options);
+  AgChart.update(chart, options);
 }
 
 function noCollisionDetection() {
   options.axes![0].label!.avoidCollisions = false;
   options.axes![1].label!.avoidCollisions = false;
 
-  agCharts.AgChart.update(chart, options);
+  AgChart.update(chart, options);
 }
 
 function autoCollisionDetection() {
   options.axes![0].label!.avoidCollisions = true;
   options.axes![1].label!.avoidCollisions = true;
 
-  agCharts.AgChart.update(chart, options);
+  AgChart.update(chart, options);
 }

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-axes/examples/axis-tick-count/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-axes/examples/axis-tick-count/main.ts
@@ -1,5 +1,4 @@
-import { AgCartesianChartOptions } from 'ag-charts-community'
-import * as agCharts from 'ag-charts-community'
+import { AgCartesianChartOptions, AgChart } from 'ag-charts-community'
 
 const options: AgCartesianChartOptions = {
   container: document.getElementById('myChart'),
@@ -35,18 +34,18 @@ const options: AgCartesianChartOptions = {
   },
 }
 
-var chart = agCharts.AgChart.create(options)
+var chart = AgChart.create(options)
 
 function setTickCountTo5() {
   options.axes![0].tick!.count = 5
   options.axes![1].tick!.count = 5
-  agCharts.AgChart.update(chart, options)
+  AgChart.update(chart, options)
 }
 
 function setTickCountTo10() {
   options.axes![0].tick!.count = 10
   options.axes![1].tick!.count = 10
-  agCharts.AgChart.update(chart, options)
+  AgChart.update(chart, options)
 }
 
 function generateSpiralData() {

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-axes/examples/axis-title/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-axes/examples/axis-title/main.ts
@@ -1,5 +1,4 @@
-import { AgCartesianChartOptions } from 'ag-charts-community'
-import * as agCharts from 'ag-charts-community'
+import { AgCartesianChartOptions, AgChart } from 'ag-charts-community'
 
 const options: AgCartesianChartOptions = {
   container: document.getElementById('myChart'),
@@ -38,16 +37,16 @@ const options: AgCartesianChartOptions = {
   },
 }
 
-var chart = agCharts.AgChart.create(options)
+var chart = AgChart.create(options)
 
 function showAxisTitles() {
   options.axes![0].title!.enabled = true
   options.axes![1].title!.enabled = true
-  agCharts.AgChart.update(chart, options)
+  AgChart.update(chart, options)
 }
 
 function hideAxisTitles() {
   options.axes![0].title!.enabled = false
   options.axes![1].title!.enabled = false
-  agCharts.AgChart.update(chart, options)
+  AgChart.update(chart, options)
 }

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-axes/examples/multiple-axes/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-axes/examples/multiple-axes/main.ts
@@ -1,5 +1,4 @@
-import * as agCharts from "ag-charts-community";
-import { AgChartOptions } from "ag-charts-community";
+import { AgChart, AgChartOptions } from "ag-charts-community";
 import { getData } from "./data";
 
 const options: AgChartOptions = {
@@ -91,4 +90,4 @@ const options: AgChartOptions = {
   },
 }
 
-var chart = agCharts.AgChart.create(options)
+var chart = AgChart.create(options)

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-axes/examples/number-axis-currency-format/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-axes/examples/number-axis-currency-format/main.ts
@@ -1,5 +1,4 @@
-import { AgChartOptions } from 'ag-charts-community'
-import * as agCharts from 'ag-charts-community'
+import { AgChartOptions, AgChart, time } from 'ag-charts-community'
 
 const options: AgChartOptions = {
   container: document.getElementById('myChart'),
@@ -26,7 +25,7 @@ const options: AgChartOptions = {
       nice: false,
       position: 'bottom',
       tick: {
-        count: agCharts.time.month,
+        count: time.month,
       },
       label: {
         format: '%b %Y',
@@ -66,4 +65,4 @@ const options: AgChartOptions = {
   ],
 }
 
-agCharts.AgChart.create(options)
+AgChart.create(options)

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-axes/examples/number-axis-label-format/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-axes/examples/number-axis-label-format/main.ts
@@ -1,5 +1,4 @@
-import { AgChartOptions } from 'ag-charts-community'
-import * as agCharts from 'ag-charts-community'
+import { AgChartOptions, AgChart, time } from 'ag-charts-community'
 
 const options: AgChartOptions = {
   container: document.getElementById('myChart'),
@@ -26,7 +25,7 @@ const options: AgChartOptions = {
       nice: false,
       position: 'bottom',
       tick: {
-        count: agCharts.time.month,
+        count: time.month, 
       },
       label: {
         format: '%b %Y',
@@ -66,4 +65,4 @@ const options: AgChartOptions = {
   ],
 }
 
-agCharts.AgChart.create(options)
+AgChart.create(options)

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-axes/examples/number-vs-log/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-axes/examples/number-vs-log/main.ts
@@ -1,5 +1,4 @@
-import { AgCartesianChartOptions } from 'ag-charts-community'
-import * as agCharts from 'ag-charts-community'
+import { AgCartesianChartOptions, AgChart } from 'ag-charts-community'
 
 const options: AgCartesianChartOptions = {
   container: document.getElementById('myChart'),
@@ -36,7 +35,7 @@ const options: AgCartesianChartOptions = {
   },
 }
 
-var chart = agCharts.AgChart.create(options)
+var chart = AgChart.create(options)
 
 function useNumberAxis() {
   options.axes = [
@@ -56,7 +55,7 @@ function useNumberAxis() {
       },
     },
   ]
-  agCharts.AgChart.update(chart, options)
+  AgChart.update(chart, options)
 }
 
 function useLogAxis() {
@@ -77,7 +76,7 @@ function useLogAxis() {
       },
     },
   ]
-  agCharts.AgChart.update(chart, options)
+  AgChart.update(chart, options)
 }
 
 function useBaseTwoLogAxis() {
@@ -99,7 +98,7 @@ function useBaseTwoLogAxis() {
       base: 2,
     },
   ]
-  agCharts.AgChart.update(chart, options)
+  AgChart.update(chart, options)
 }
 
 function useLogAxisWithFewerTicks() {
@@ -120,5 +119,5 @@ function useLogAxisWithFewerTicks() {
       },
     },
   ]
-  agCharts.AgChart.update(chart, options)
+  AgChart.update(chart, options)
 }

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-axes/examples/time-axis-label-format/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-axes/examples/time-axis-label-format/main.ts
@@ -1,5 +1,4 @@
-import { AgCartesianChartOptions } from 'ag-charts-community'
-import * as agCharts from 'ag-charts-community'
+import { AgCartesianChartOptions, AgChart, time } from 'ag-charts-community'
 
 const options: AgCartesianChartOptions = {
   container: document.getElementById('myChart'),
@@ -19,7 +18,7 @@ const options: AgCartesianChartOptions = {
       nice: false,
       position: 'bottom',
       tick: {
-        count: agCharts.time.month,
+        count: time.month,
       },
       label: {
         format: '%b %Y',
@@ -68,14 +67,14 @@ const options: AgCartesianChartOptions = {
   ],
 }
 
-var chart = agCharts.AgChart.create(options)
+var chart = AgChart.create(options)
 
 function useOneMonthInterval() {
-  options.axes![0].tick!.count = agCharts.time.month
-  agCharts.AgChart.update(chart, options)
+  options.axes![0].tick!.count = time.month
+  AgChart.update(chart, options)
 }
 
 function useTwoMonthInterval() {
-  options.axes![0].tick!.count = agCharts.time.month.every(2)
-  agCharts.AgChart.update(chart, options)
+  options.axes![0].tick!.count = time.month.every(2)
+  AgChart.update(chart, options)
 }

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-bar-series/examples/grouped-column/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-bar-series/examples/grouped-column/main.ts
@@ -1,5 +1,4 @@
-import * as agCharts from 'ag-charts-community';
-import { AgChartOptions } from 'ag-charts-community';
+import { AgChart, AgChartOptions } from 'ag-charts-community';
 import { getData } from "./data";
 
 const options: AgChartOptions = {
@@ -56,4 +55,4 @@ const options: AgChartOptions = {
   ],
 }
 
-agCharts.AgChart.create(options)
+AgChart.create(options)

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-bar-series/examples/labeled-column/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-bar-series/examples/labeled-column/main.ts
@@ -1,5 +1,4 @@
-import * as agCharts from 'ag-charts-community';
-import { AgChartOptions } from 'ag-charts-community';
+import { AgChart, AgChartOptions } from 'ag-charts-community';
 import { getData } from "./data";
 
 const formatter = ({ value }: { value?: number }) => value == null ? '' : value.toFixed(0);
@@ -57,4 +56,4 @@ const options: AgChartOptions = {
   ],
 }
 
-agCharts.AgChart.create(options)
+AgChart.create(options)

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-bar-series/examples/normalized-column/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-bar-series/examples/normalized-column/main.ts
@@ -1,5 +1,4 @@
-import * as agCharts from 'ag-charts-community';
-import { AgChartOptions } from 'ag-charts-community';
+import { AgChart, AgChartOptions } from 'ag-charts-community';
 import { getData } from "./data";
 
 const options: AgChartOptions = {
@@ -68,4 +67,4 @@ const options: AgChartOptions = {
   ],
 }
 
-agCharts.AgChart.create(options)
+AgChart.create(options)

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-bar-series/examples/regular-column/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-bar-series/examples/regular-column/main.ts
@@ -1,5 +1,4 @@
-import * as agCharts from 'ag-charts-community';
-import { AgChartOptions } from 'ag-charts-community';
+import { AgChart, AgChartOptions } from 'ag-charts-community';
 import { getData } from "./data";
 
 const options: AgChartOptions = {
@@ -20,4 +19,4 @@ const options: AgChartOptions = {
   ],
 }
 
-agCharts.AgChart.create(options)
+AgChart.create(options)

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-bar-series/examples/stacked-bar/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-bar-series/examples/stacked-bar/main.ts
@@ -1,5 +1,4 @@
-import * as agCharts from 'ag-charts-community';
-import { AgChartOptions } from 'ag-charts-community';
+import { AgChart, AgChartOptions } from 'ag-charts-community';
 import { getData } from "./data";
 
 const options: AgChartOptions = {
@@ -50,4 +49,4 @@ const options: AgChartOptions = {
   ],
 }
 
-agCharts.AgChart.create(options)
+AgChart.create(options)

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-bar-series/examples/stacked-column/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-bar-series/examples/stacked-column/main.ts
@@ -1,5 +1,4 @@
-import * as agCharts from 'ag-charts-community';
-import { AgChartOptions } from 'ag-charts-community';
+import { AgChart, AgChartOptions } from 'ag-charts-community';
 import { getData } from "./data";
 
 const options: AgChartOptions = {
@@ -50,4 +49,4 @@ const options: AgChartOptions = {
   ],
 }
 
-agCharts.AgChart.create(options)
+AgChart.create(options)

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-combination-series/examples/combination/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-combination-series/examples/combination/main.ts
@@ -1,7 +1,6 @@
 import { getData } from "./data";
 
-import { AgCartesianChartOptions, AgCartesianAxisOptions, AgCartesianSeriesOptions, AgBarSeriesOptions, AgLineSeriesOptions, AgCartesianSeriesTooltipRendererParams } from "ag-charts-community"
-import * as agCharts from "ag-charts-community"
+import { AgCartesianChartOptions, AgCartesianAxisOptions, AgCartesianSeriesOptions, AgBarSeriesOptions, AgLineSeriesOptions, AgCartesianSeriesTooltipRendererParams, AgChart } from "ag-charts-community"
 
 function tooltipRenderer(params: AgCartesianSeriesTooltipRendererParams) {
   const { yValue, xValue } = params;
@@ -112,16 +111,16 @@ const options: AgCartesianChartOptions = {
   },
 };
 
-var chart = agCharts.AgChart.create(options);
+var chart = AgChart.create(options);
 
 function columnLine() {
   console.log("Column & Line", COLUMN_AND_LINE);
   options.series = COLUMN_AND_LINE;
-  agCharts.AgChart.update(chart, options);
+  AgChart.update(chart, options);
 }
 
 function areaColumn() {
   console.log("Column & Area", AREA_AND_COLUMN);
   options.series = AREA_AND_COLUMN;
-  agCharts.AgChart.update(chart, options);
+  AgChart.update(chart, options);
 }

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-events/examples/legend-item-click-event/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-events/examples/legend-item-click-event/main.ts
@@ -1,6 +1,5 @@
-import * as agCharts from "ag-charts-community"
 import {
-  AgCartesianChartOptions,
+  AgChart, AgCartesianChartOptions,
   AgChartLegendClickEvent,
 } from "ag-charts-community"
 
@@ -58,4 +57,4 @@ let options: AgCartesianChartOptions = {
   },
 };
 
-agCharts.AgChart.create(options);
+AgChart.create(options);

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-events/examples/node-click-event/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-events/examples/node-click-event/main.ts
@@ -1,5 +1,4 @@
-import { AgChartOptions } from 'ag-charts-community'
-import * as agCharts from 'ag-charts-community'
+import { AgChartOptions, AgChart } from 'ag-charts-community'
 
 const options: AgChartOptions = {
   container: document.getElementById('myChart'),
@@ -49,7 +48,7 @@ const options: AgChartOptions = {
   },
 }
 
-var chart = agCharts.AgChart.create(options)
+var chart = AgChart.create(options)
 
 function listUnitsSoldByBrand(brands: Record<string, number>) {
   var result = ''

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-events/examples/node-click-select/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-events/examples/node-click-select/main.ts
@@ -1,5 +1,4 @@
-import { AgCartesianChartOptions } from 'ag-charts-community'
-import * as agCharts from 'ag-charts-community'
+import { AgCartesianChartOptions, AgChart } from 'ag-charts-community'
 
 const options: AgCartesianChartOptions = {
   container: document.getElementById('myChart'),
@@ -54,7 +53,7 @@ const options: AgCartesianChartOptions = {
   },
 }
 
-var chart = agCharts.AgChart.create(options)
+var chart = AgChart.create(options)
 
 function listUnitsSoldByBrand(brands: Record<string, number>) {
   var result = ''

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-events/examples/series-node-click-event/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-events/examples/series-node-click-event/main.ts
@@ -1,5 +1,4 @@
-import { AgChartOptions } from 'ag-charts-community'
-import * as agCharts from 'ag-charts-community'
+import { AgChartOptions, AgChart } from 'ag-charts-community'
 
 const options: AgChartOptions = {
   container: document.getElementById('myChart'),
@@ -57,4 +56,4 @@ const options: AgChartOptions = {
   },
 }
 
-agCharts.AgChart.create(options)
+AgChart.create(options)

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-formatters/examples/legend-item-formatter/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-formatters/examples/legend-item-formatter/main.ts
@@ -1,5 +1,4 @@
-import * as agCharts from "ag-charts-community"
-import { AgChartOptions, AgChartLegendLabelFormatterParams } from "ag-charts-community"
+import { AgChart, AgChartOptions, AgChartLegendLabelFormatterParams } from "ag-charts-community"
 
 function formatter({ value }: AgChartLegendLabelFormatterParams) {
   switch (value) {
@@ -63,4 +62,4 @@ const options: AgChartOptions = {
   },
 }
 
-agCharts.AgChart.create(options)
+AgChart.create(options)

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-formatters/examples/marker-formatter/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-formatters/examples/marker-formatter/main.ts
@@ -1,5 +1,4 @@
-import { AgChartOptions } from 'ag-charts-community'
-import * as agCharts from 'ag-charts-community'
+import { AgChartOptions, AgChart } from 'ag-charts-community'
 
 function formatter({ yKey, size }: { yKey: string, size: number }) {
   return { size: yKey === 'electric' ? 12 : size };
@@ -52,4 +51,4 @@ const options: AgChartOptions = {
   ],
 }
 
-agCharts.AgChart.create(options)
+AgChart.create(options)

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-formatters/examples/series-formatter/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-formatters/examples/series-formatter/main.ts
@@ -1,5 +1,4 @@
-import { AgChartOptions } from 'ag-charts-community'
-import * as agCharts from 'ag-charts-community'
+import { AgChartOptions, AgChart } from 'ag-charts-community'
 
 const options: AgChartOptions = {
   container: document.getElementById('myChart'),
@@ -44,4 +43,4 @@ const options: AgChartOptions = {
   ],
 }
 
-agCharts.AgChart.create(options)
+AgChart.create(options)

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-histogram-series/examples/irregular-intervals/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-histogram-series/examples/irregular-intervals/main.ts
@@ -1,5 +1,4 @@
-import * as agCharts from 'ag-charts-community';
-import { AgChartOptions } from 'ag-charts-community';
+import { AgChart, AgChartOptions } from 'ag-charts-community';
 import { getData } from "./data";
 
 const options: AgChartOptions = {
@@ -42,4 +41,4 @@ const options: AgChartOptions = {
   ],
 }
 
-agCharts.AgChart.create(options)
+AgChart.create(options)

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-histogram-series/examples/larger-bin-count/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-histogram-series/examples/larger-bin-count/main.ts
@@ -1,5 +1,4 @@
-import * as agCharts from 'ag-charts-community';
-import { AgChartOptions } from 'ag-charts-community';
+import { AgChart, AgChartOptions } from 'ag-charts-community';
 import { getData } from "./data";
 
 const options: AgChartOptions = {
@@ -36,4 +35,4 @@ const options: AgChartOptions = {
   ],
 }
 
-agCharts.AgChart.create(options)
+AgChart.create(options)

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-histogram-series/examples/mean-histogram/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-histogram-series/examples/mean-histogram/main.ts
@@ -1,5 +1,4 @@
-import * as agCharts from 'ag-charts-community';
-import { AgChartOptions } from 'ag-charts-community';
+import { AgChart, AgChartOptions } from 'ag-charts-community';
 import { getData } from "./data";
 
 const options: AgChartOptions = {
@@ -35,4 +34,4 @@ const options: AgChartOptions = {
   ],
 }
 
-agCharts.AgChart.create(options)
+AgChart.create(options)

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-histogram-series/examples/simple/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-histogram-series/examples/simple/main.ts
@@ -1,5 +1,4 @@
-import * as agCharts from 'ag-charts-community';
-import { AgChartOptions } from 'ag-charts-community';
+import { AgChart, AgChartOptions } from 'ag-charts-community';
 import { getData } from "./data";
 
 const options: AgChartOptions = {
@@ -32,4 +31,4 @@ const options: AgChartOptions = {
   ],
 }
 
-agCharts.AgChart.create(options)
+AgChart.create(options)

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-histogram-series/examples/sum-histogram/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-histogram-series/examples/sum-histogram/main.ts
@@ -1,5 +1,4 @@
-import * as agCharts from 'ag-charts-community';
-import { AgChartOptions } from 'ag-charts-community';
+import { AgChart, AgChartOptions } from 'ag-charts-community';
 import { getData } from "./data";
 
 const options: AgChartOptions = {
@@ -38,4 +37,4 @@ const options: AgChartOptions = {
   ],
 }
 
-agCharts.AgChart.create(options)
+AgChart.create(options)

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-legend/examples/legend-click-series-toggle/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-legend/examples/legend-click-series-toggle/main.ts
@@ -1,5 +1,4 @@
-import * as agCharts from "ag-charts-community"
-import { AgChartLegendClickEvent, AgChartOptions } from "ag-charts-community"
+import { AgChart, AgChartLegendClickEvent, AgChartOptions } from "ag-charts-community"
 import { getData } from "./data"
 
 const colors = [
@@ -175,4 +174,4 @@ const options: AgChartOptions = {
   },
 }
 
-agCharts.AgChart.create(options)
+AgChart.create(options)

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-legend/examples/legend-constraints/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-legend/examples/legend-constraints/main.ts
@@ -1,5 +1,4 @@
-import { AgChartOptions } from 'ag-charts-community'
-import * as agCharts from 'ag-charts-community'
+import { AgChartOptions, AgChart } from 'ag-charts-community'
 
 const colors = [
   '#AC9BF5',
@@ -83,13 +82,13 @@ const options: AgChartOptions = {
   },
 }
 
-var chart = agCharts.AgChart.create(options);
+var chart = AgChart.create(options);
 
 function updateLegendItemPaddingX(event: any) {
   var value = +event.target.value;
 
   options.legend!.item!.paddingX = value;
-  agCharts.AgChart.update(chart, options);
+  AgChart.update(chart, options);
 
   document.getElementById('xPaddingValue')!.innerHTML = String(value);
 }
@@ -98,7 +97,7 @@ function updateLegendItemPaddingY(event: any) {
   var value = event.target.value;
 
   options.legend!.item!.paddingY = +event.target.value;
-  agCharts.AgChart.update(chart, options);
+  AgChart.update(chart, options);
 
   document.getElementById('yPaddingValue')!.innerHTML = String(value);
 }
@@ -107,7 +106,7 @@ function updateLegendItemSpacing(event: any) {
   var value = +event.target.value;
 
   options.legend!.item!.marker!.padding = value;
-  agCharts.AgChart.update(chart, options);
+  AgChart.update(chart, options);
 
   document.getElementById('markerPaddingValue')!.innerHTML = String(value);
 }
@@ -116,7 +115,7 @@ function updateLegendItemMaxWidth(event: any) {
   var value = +event.target.value;
 
   options.legend!.item!.maxWidth = value;
-  agCharts.AgChart.update(chart, options);
+  AgChart.update(chart, options);
 
   document.getElementById('maxWidthValue')!.innerHTML = String(value);
 }

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-legend/examples/legend-layout-horizontal/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-legend/examples/legend-layout-horizontal/main.ts
@@ -1,5 +1,4 @@
-import { AgChartOptions } from 'ag-charts-community'
-import * as agCharts from 'ag-charts-community'
+import { AgChartOptions, AgChart } from 'ag-charts-community'
 
 const colors = [
   '#AC9BF5',
@@ -84,13 +83,13 @@ const options: AgChartOptions = {
   },
 }
 
-var chart = agCharts.AgChart.create(options)
+var chart = AgChart.create(options)
 
 function updateWidth(event: any) {
   var value = +event.target.value
 
   options.width = value
-  agCharts.AgChart.update(chart, options)
+  AgChart.update(chart, options)
 
   document.getElementById('sliderValue')!.innerHTML = String(value)
 }

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-legend/examples/legend-layout-vertical/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-legend/examples/legend-layout-vertical/main.ts
@@ -1,5 +1,4 @@
-import * as agCharts from "ag-charts-community"
-import { AgChartOptions } from "ag-charts-community"
+import { AgChart, AgChartOptions } from "ag-charts-community"
 
 const colors = [
   "#AC9BF5",
@@ -81,13 +80,13 @@ const options: AgChartOptions = {
   ],
 }
 
-var chart = agCharts.AgChart.create(options)
+var chart = AgChart.create(options)
 
 function updateHeight(event: any) {
   var value = +event.target.value
 
   options.height = value
-  agCharts.AgChart.update(chart, options)
+  AgChart.update(chart, options)
 
   document.getElementById("sliderValue")!.innerHTML = String(value)
 }

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-legend/examples/legend-pagination/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-legend/examples/legend-pagination/main.ts
@@ -1,5 +1,4 @@
-import * as agCharts from "ag-charts-community"
-import { AgChartLegendPosition, AgChartOptions } from "ag-charts-community"
+import { AgChart, AgChartLegendPosition, AgChartOptions } from "ag-charts-community"
 import { getData } from "./data"
 
 const colors = [
@@ -157,7 +156,7 @@ const options: AgChartOptions = {
   },
 }
 
-var chart = agCharts.AgChart.create(options)
+var chart = AgChart.create(options)
 
 function updateLegendPosition(value: AgChartLegendPosition) {
   options.legend!.position = value
@@ -174,5 +173,5 @@ function updateLegendPosition(value: AgChartLegendPosition) {
       break
   }
 
-  agCharts.AgChart.update(chart, options)
+  AgChart.update(chart, options)
 }

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-legend/examples/legend-position/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-legend/examples/legend-position/main.ts
@@ -1,5 +1,4 @@
-import * as agCharts from "ag-charts-community"
-import { AgChartLegendPosition, AgChartOptions } from "ag-charts-community"
+import { AgChart, AgChartLegendPosition, AgChartOptions } from "ag-charts-community"
 
 const options: AgChartOptions = {
   container: document.getElementById("myChart"),
@@ -80,14 +79,14 @@ const options: AgChartOptions = {
   },
 }
 
-var chart = agCharts.AgChart.create(options)
+var chart = AgChart.create(options)
 
 function updateLegendPosition(value: AgChartLegendPosition) {
   options.legend!.position = value
-  agCharts.AgChart.update(chart, options)
+  AgChart.update(chart, options)
 }
 
 function setLegendEnabled(enabled: boolean) {
   options.legend!.enabled = enabled
-  agCharts.AgChart.update(chart, options)
+  AgChart.update(chart, options)
 }

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-line-series/examples/basic-line-labels/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-line-series/examples/basic-line-labels/main.ts
@@ -1,5 +1,4 @@
-import { AgChartOptions } from 'ag-charts-community'
-import * as agCharts from 'ag-charts-community'
+import { AgChartOptions, AgChart } from 'ag-charts-community'
 
 const options: AgChartOptions = {
   container: document.getElementById('myChart'),
@@ -39,4 +38,4 @@ const options: AgChartOptions = {
   ],
 }
 
-agCharts.AgChart.create(options)
+AgChart.create(options)

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-line-series/examples/basic-line/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-line-series/examples/basic-line/main.ts
@@ -1,5 +1,4 @@
-import { AgChartOptions } from 'ag-charts-community'
-import * as agCharts from 'ag-charts-community'
+import { AgChartOptions, AgChart } from 'ag-charts-community'
 
 const options: AgChartOptions = {
   container: document.getElementById('myChart'),
@@ -36,4 +35,4 @@ const options: AgChartOptions = {
   ],
 }
 
-agCharts.AgChart.create(options)
+AgChart.create(options)

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-line-series/examples/gap-line/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-line-series/examples/gap-line/main.ts
@@ -1,5 +1,4 @@
-import * as agCharts from 'ag-charts-community';
-import { AgChartOptions } from 'ag-charts-community';
+import { AgChart, AgChartOptions } from 'ag-charts-community';
 import { getData } from "./data";
 
 const options: AgChartOptions = {
@@ -23,4 +22,4 @@ const options: AgChartOptions = {
   },
 }
 
-agCharts.AgChart.create(options)
+AgChart.create(options)

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-line-series/examples/legend-info/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-line-series/examples/legend-info/main.ts
@@ -1,5 +1,4 @@
-import { AgChartOptions } from 'ag-charts-community'
-import * as agCharts from 'ag-charts-community'
+import { AgChartOptions, AgChart } from 'ag-charts-community'
 
 const options: AgChartOptions = {
   container: document.getElementById('myChart'),
@@ -43,4 +42,4 @@ const options: AgChartOptions = {
   ],
 }
 
-agCharts.AgChart.create(options)
+AgChart.create(options)

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-line-series/examples/line-marker-colors/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-line-series/examples/line-marker-colors/main.ts
@@ -1,5 +1,4 @@
-import { AgChartOptions } from 'ag-charts-community'
-import * as agCharts from 'ag-charts-community'
+import { AgChartOptions, AgChart } from 'ag-charts-community'
 
 const options: AgChartOptions = {
   container: document.getElementById('myChart'),
@@ -48,4 +47,4 @@ const options: AgChartOptions = {
   ],
 }
 
-agCharts.AgChart.create(options)
+AgChart.create(options)

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-line-series/examples/multi-line/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-line-series/examples/multi-line/main.ts
@@ -1,5 +1,4 @@
-import { AgChartOptions } from 'ag-charts-community'
-import * as agCharts from 'ag-charts-community'
+import { AgChartOptions, AgChart } from 'ag-charts-community'
 
 const options: AgChartOptions = {
   container: document.getElementById('myChart'),
@@ -41,4 +40,4 @@ const options: AgChartOptions = {
   ],
 }
 
-agCharts.AgChart.create(options)
+AgChart.create(options)

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-line-series/examples/real-time/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-line-series/examples/real-time/main.ts
@@ -1,5 +1,4 @@
-import * as agCharts from 'ag-charts-community';
-import { AgChartOptions } from 'ag-charts-community';
+import { AgChart, AgChartOptions, time } from 'ag-charts-community';
 
 var lastTime = new Date('07 Jan 2020 13:25:00 GMT').getTime()
 var data: { time: Date, voltage: number }[] = []
@@ -33,7 +32,7 @@ const options: AgChartOptions = {
       position: 'bottom',
       nice: false,
       tick: {
-        count: agCharts.time.second.every(5),
+        count: time.second.every(5),
       },
       label: {
         format: '%H:%M:%S',
@@ -55,7 +54,7 @@ const options: AgChartOptions = {
   },
 }
 
-var chart = agCharts.AgChart.create(options)
+var chart = AgChart.create(options)
 var updating = false
 
 function startUpdates() {
@@ -73,5 +72,5 @@ function startUpdates() {
 /** inScope */
 function update() {
   options.data = getData()
-  agCharts.AgChart.update(chart, options)
+  AgChart.update(chart, options)
 }

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-line-series/examples/real-time/provided/modules/typescript/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-line-series/examples/real-time/provided/modules/typescript/main.ts
@@ -1,5 +1,4 @@
-import * as agCharts from 'ag-charts-community';
-import { AgChartOptions } from 'ag-charts-community';
+import { AgChart, AgChartOptions, time } from 'ag-charts-community';
 
 var lastTime = new Date('07 Jan 2020 13:25:00 GMT').getTime()
 var data: { time: Date, voltage: number }[] = []
@@ -33,7 +32,7 @@ const options: AgChartOptions = {
       position: 'bottom',
       nice: false,
       tick: {
-        count: agCharts.time.second.every(5),
+        count: time.second.every(5),
       },
       label: {
         format: '%H:%M:%S',
@@ -55,7 +54,7 @@ const options: AgChartOptions = {
   },
 }
 
-var chart = agCharts.AgChart.create(options)
+var chart = AgChart.create(options)
 var updating = false
 
 function startUpdates() {
@@ -70,7 +69,7 @@ function startUpdates() {
 
 function update() {
   options.data = getData()
-  agCharts.AgChart.update(chart, options)
+  AgChart.update(chart, options)
 }
 
 

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-line-series/examples/time-line/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-line-series/examples/time-line/main.ts
@@ -1,5 +1,4 @@
-import { AgChartOptions } from 'ag-charts-community'
-import * as agCharts from 'ag-charts-community'
+import { AgChartOptions, AgChart } from 'ag-charts-community'
 
 const options: AgChartOptions = {
   container: document.getElementById('myChart'),
@@ -108,4 +107,4 @@ const options: AgChartOptions = {
   },
 }
 
-agCharts.AgChart.create(options)
+AgChart.create(options)

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-line-series/examples/two-number-axes/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-line-series/examples/two-number-axes/main.ts
@@ -1,5 +1,4 @@
-import { AgChartOptions } from 'ag-charts-community'
-import * as agCharts from 'ag-charts-community'
+import { AgChartOptions, AgChart } from 'ag-charts-community'
 
 const options: AgChartOptions = {
   container: document.getElementById('myChart'),
@@ -28,7 +27,7 @@ const options: AgChartOptions = {
   },
 }
 
-agCharts.AgChart.create(options)
+AgChart.create(options)
 
 function generateSpiralData() {
   // r = a + bθ

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-markers/examples/custom-marker/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-markers/examples/custom-marker/main.ts
@@ -1,5 +1,4 @@
-import * as agCharts from 'ag-charts-community';
-import { AgChartOptions } from 'ag-charts-community';
+import { AgChart, AgChartOptions, Marker } from 'ag-charts-community';
 import { getData } from "./data";
 
 const options: AgChartOptions = {
@@ -24,10 +23,10 @@ const options: AgChartOptions = {
   },
 }
 
-agCharts.AgChart.create(options)
+AgChart.create(options)
 
 function heartFactory() {
-  class Heart extends agCharts.Marker {
+  class Heart extends Marker {
     rad(degree: number) {
       return degree / 180 * Math.PI;
     }

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-markers/examples/marker-shape/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-markers/examples/marker-shape/main.ts
@@ -1,5 +1,4 @@
-import * as agCharts from 'ag-charts-community';
-import { AgChartOptions } from 'ag-charts-community';
+import { AgChart, AgChartOptions } from 'ag-charts-community';
 import { getData } from "./data";
 
 const options: AgChartOptions = {
@@ -44,4 +43,4 @@ const options: AgChartOptions = {
     ],
 }
 
-agCharts.AgChart.create(options)
+AgChart.create(options)

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-navigator/examples/navigator-styling/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-navigator/examples/navigator-styling/main.ts
@@ -1,5 +1,4 @@
-import * as agCharts from "ag-charts-community"
-import { AgChartOptions } from "ag-charts-community"
+import { AgChart, AgChartOptions } from "ag-charts-community"
 import { getData } from "./data"
 
 const options: AgChartOptions = {
@@ -81,4 +80,4 @@ const options: AgChartOptions = {
   },
 }
 
-var chart = agCharts.AgChart.create(options)
+var chart = AgChart.create(options)

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-navigator/examples/navigator/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-navigator/examples/navigator/main.ts
@@ -1,5 +1,4 @@
-import { AgCartesianChartOptions } from 'ag-charts-community'
-import * as agCharts from 'ag-charts-community'
+import { AgCartesianChartOptions, AgChart } from 'ag-charts-community'
 import { getData } from './data';
 
 const options: AgCartesianChartOptions = {
@@ -64,9 +63,9 @@ const options: AgCartesianChartOptions = {
   },
 }
 
-var chart = agCharts.AgChart.create(options)
+var chart = AgChart.create(options)
 
 function toggleEnabled(value: boolean) {
   options.navigator!.enabled = value
-  agCharts.AgChart.update(chart, options)
+  AgChart.update(chart, options)
 }

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-overview/examples/100--stacked-area/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-overview/examples/100--stacked-area/main.ts
@@ -1,5 +1,4 @@
-import * as agCharts from "ag-charts-community";
-import { AgChartOptions } from "ag-charts-community";
+import { AgChart, AgChartOptions } from "ag-charts-community";
 import { getData } from "./data";
 
 const options: AgChartOptions = {
@@ -107,4 +106,4 @@ const options: AgChartOptions = {
   },
 }
 
-var chart = agCharts.AgChart.create(options)
+var chart = AgChart.create(options)

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-overview/examples/100--stacked-bar/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-overview/examples/100--stacked-bar/main.ts
@@ -1,5 +1,4 @@
-import * as agCharts from 'ag-charts-community';
-import { AgChartOptions } from 'ag-charts-community';
+import { AgChart, AgChartOptions } from 'ag-charts-community';
 import { getData } from "./data";
 
 const options: AgChartOptions = {
@@ -76,4 +75,4 @@ const options: AgChartOptions = {
   ],
 }
 
-var chart = agCharts.AgChart.create(options)
+var chart = AgChart.create(options)

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-overview/examples/100--stacked-column/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-overview/examples/100--stacked-column/main.ts
@@ -1,5 +1,4 @@
-import * as agCharts from "ag-charts-community";
-import { AgChartOptions } from "ag-charts-community";
+import { AgChart, AgChartOptions } from "ag-charts-community";
 import { getData } from "./data";
 
 const options: AgChartOptions = {
@@ -103,4 +102,4 @@ const options: AgChartOptions = {
   ],
 }
 
-var chart = agCharts.AgChart.create(options)
+var chart = AgChart.create(options)

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-overview/examples/area-with-negative-values/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-overview/examples/area-with-negative-values/main.ts
@@ -1,5 +1,4 @@
-import * as agCharts from "ag-charts-community";
-import { AgChartOptions } from "ag-charts-community";
+import { AgChart, AgChartOptions } from "ag-charts-community";
 import { getData } from "./data";
 
 const options: AgChartOptions = {
@@ -82,4 +81,4 @@ const options: AgChartOptions = {
   },
 }
 
-var chart = agCharts.AgChart.create(options)
+var chart = AgChart.create(options)

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-overview/examples/bar-with-labels/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-overview/examples/bar-with-labels/main.ts
@@ -1,5 +1,4 @@
-import * as agCharts from 'ag-charts-community';
-import { AgChartOptions } from 'ag-charts-community';
+import { AgChart, AgChartOptions } from 'ag-charts-community';
 import { getData } from "./data";
 
 const options: AgChartOptions = {
@@ -53,4 +52,4 @@ const options: AgChartOptions = {
   },
 }
 
-var chart = agCharts.AgChart.create(options)
+var chart = AgChart.create(options)

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-overview/examples/bubble-with-categories/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-overview/examples/bubble-with-categories/main.ts
@@ -1,5 +1,4 @@
-import * as agCharts from 'ag-charts-community';
-import { AgChartOptions } from 'ag-charts-community';
+import { AgChart, AgChartOptions } from 'ag-charts-community';
 import { getData } from "./data";
 
 const options: AgChartOptions = {
@@ -70,4 +69,4 @@ const options: AgChartOptions = {
   },
 }
 
-var chart = agCharts.AgChart.create(options)
+var chart = AgChart.create(options)

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-overview/examples/bubble-with-negative-values/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-overview/examples/bubble-with-negative-values/main.ts
@@ -1,5 +1,4 @@
-import * as agCharts from 'ag-charts-community';
-import { AgChartOptions } from 'ag-charts-community';
+import { AgChart, AgChartOptions } from 'ag-charts-community';
 import { getData } from "./data";
 
 const options: AgChartOptions = {
@@ -60,4 +59,4 @@ const options: AgChartOptions = {
   },
 }
 
-var chart = agCharts.AgChart.create(options)
+var chart = AgChart.create(options)

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-overview/examples/chart-customisation/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-overview/examples/chart-customisation/main.ts
@@ -1,5 +1,4 @@
-import * as agCharts from "ag-charts-community";
-import { AgChartOptions } from "ag-charts-community";
+import { AgChart, AgChartOptions, time } from "ag-charts-community";
 import { getData } from "./data";
 
 const options: AgChartOptions = {
@@ -61,7 +60,7 @@ const options: AgChartOptions = {
       position: "top",
       type: "time",
       tick: {
-        count: agCharts.time.year.every(10),
+        count: time.year.every(10),
         width: 3,
         color: "#3f7cbf",
       },
@@ -132,4 +131,4 @@ const options: AgChartOptions = {
   },
 }
 
-var chart = agCharts.AgChart.create(options)
+var chart = AgChart.create(options)

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-overview/examples/column-with-negative-values/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-overview/examples/column-with-negative-values/main.ts
@@ -1,5 +1,4 @@
-import * as agCharts from "ag-charts-community";
-import { AgChartOptions } from "ag-charts-community";
+import { AgChart, AgChartOptions } from "ag-charts-community";
 import { getData } from "./data";
 
 const options: AgChartOptions = {
@@ -57,4 +56,4 @@ const options: AgChartOptions = {
   ],
 }
 
-var chart = agCharts.AgChart.create(options)
+var chart = AgChart.create(options)

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-overview/examples/combination-of-different-series-types/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-overview/examples/combination-of-different-series-types/main.ts
@@ -1,5 +1,4 @@
-import * as agCharts from "ag-charts-community";
-import { AgChartOptions } from "ag-charts-community";
+import { AgChart, AgChartOptions } from "ag-charts-community";
 import { getData } from "./data";
 
 const options: AgChartOptions = {
@@ -87,4 +86,4 @@ const options: AgChartOptions = {
   },
 }
 
-var chart = agCharts.AgChart.create(options)
+var chart = AgChart.create(options)

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-overview/examples/cross-lines/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-overview/examples/cross-lines/main.ts
@@ -1,5 +1,4 @@
-import * as agCharts from "ag-charts-community";
-import { AgChartOptions } from "ag-charts-community";
+import { AgChart, AgChartOptions } from "ag-charts-community";
 import { getData } from "./data";
 
 const options: AgChartOptions = {
@@ -145,4 +144,4 @@ const options: AgChartOptions = {
   ],
 }
 
-var chart = agCharts.AgChart.create(options)
+var chart = AgChart.create(options)

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-overview/examples/custom-marker-shapes/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-overview/examples/custom-marker-shapes/main.ts
@@ -1,5 +1,4 @@
-import * as agCharts from "ag-charts-community";
-import { AgChartOptions } from "ag-charts-community";
+import { AgChart, AgChartOptions, Marker } from "ag-charts-community";
 import { getData } from "./data";
 
 var markerSize = 10
@@ -147,10 +146,10 @@ const options: AgChartOptions = {
   ],
 }
 
-var chart = agCharts.AgChart.create(options)
+var chart = AgChart.create(options)
 
 function heartFactory() {
-  class Heart extends agCharts.Marker {
+  class Heart extends Marker {
     rad(degree: number) {
       return (degree / 180) * Math.PI
     }

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-overview/examples/custom-tooltips/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-overview/examples/custom-tooltips/main.ts
@@ -1,8 +1,7 @@
 import { getData } from "./data";
 
 import { AgCartesianSeriesTooltipRendererParams } from "ag-charts-community"
-import { AgChartOptions } from "ag-charts-community"
-import * as agCharts from "ag-charts-community"
+import { AgChartOptions, AgChart } from "ag-charts-community"
 
 function tooltipRenderer(params: AgCartesianSeriesTooltipRendererParams) {
   var formatThousands = function (value: number) {
@@ -133,4 +132,4 @@ const options: AgChartOptions = {
   },
 }
 
-var chart = agCharts.AgChart.create(options)
+var chart = AgChart.create(options)

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-overview/examples/grouped-bar/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-overview/examples/grouped-bar/main.ts
@@ -1,5 +1,4 @@
-import * as agCharts from "ag-charts-community";
-import { AgChartOptions } from "ag-charts-community";
+import { AgChart, AgChartOptions } from "ag-charts-community";
 import { getData } from "./data";
 
 const options: AgChartOptions = {
@@ -65,4 +64,4 @@ const options: AgChartOptions = {
   },
 }
 
-var chart = agCharts.AgChart.create(options)
+var chart = AgChart.create(options)

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-overview/examples/grouped-column/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-overview/examples/grouped-column/main.ts
@@ -1,5 +1,4 @@
-import * as agCharts from "ag-charts-community";
-import { AgChartOptions } from "ag-charts-community";
+import { AgChart, AgChartOptions } from "ag-charts-community";
 import { getData } from "./data";
 
 const options: AgChartOptions = {
@@ -51,4 +50,4 @@ const options: AgChartOptions = {
   ],
 }
 
-var chart = agCharts.AgChart.create(options)
+var chart = AgChart.create(options)

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-overview/examples/histogram-with-specified-bins/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-overview/examples/histogram-with-specified-bins/main.ts
@@ -1,5 +1,4 @@
-import * as agCharts from 'ag-charts-community';
-import { AgChartOptions } from 'ag-charts-community';
+import { AgChart, AgChartOptions } from 'ag-charts-community';
 import { getData } from "./data";
 
 const options: AgChartOptions = {
@@ -74,4 +73,4 @@ const options: AgChartOptions = {
   },
 }
 
-var chart = agCharts.AgChart.create(options)
+var chart = AgChart.create(options)

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-overview/examples/large-datasets/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-overview/examples/large-datasets/main.ts
@@ -1,5 +1,4 @@
-import * as agCharts from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCartesianSeriesOptions } from 'ag-charts-community';
+import { AgChart, AgCartesianChartOptions, AgCartesianSeriesOptions } from 'ag-charts-community';
 import { getData } from "./data";
 
 const count = 100_000;
@@ -71,5 +70,5 @@ const options: AgCartesianChartOptions = {
   series,
 };
 
-const chart = agCharts.AgChart.create(options);
+const chart = AgChart.create(options);
 (window as any).chart = chart;

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-overview/examples/line-with-gaps/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-overview/examples/line-with-gaps/main.ts
@@ -1,5 +1,4 @@
-import * as agCharts from "ag-charts-community";
-import { AgChartOptions } from "ag-charts-community";
+import { AgChart, AgChartOptions } from "ag-charts-community";
 import { getData } from "./data";
 
 const options: AgChartOptions = {
@@ -227,4 +226,4 @@ const options: AgChartOptions = {
   },
 }
 
-var chart = agCharts.AgChart.create(options)
+var chart = AgChart.create(options)

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-overview/examples/log-axis/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-overview/examples/log-axis/main.ts
@@ -1,7 +1,6 @@
 import { getData } from "./data";
 
-import { AgCartesianChartOptions } from 'ag-charts-community'
-import * as agCharts from 'ag-charts-community'
+import { AgCartesianChartOptions, AgChart } from 'ag-charts-community'
 
 const options: AgCartesianChartOptions = {
   container: document.getElementById('myChart'),
@@ -47,7 +46,7 @@ const options: AgCartesianChartOptions = {
   },
 }
 
-var chart = agCharts.AgChart.create(options)
+var chart = AgChart.create(options)
 
 function useNumberAxis() {
   options.subtitle = {
@@ -64,7 +63,7 @@ function useNumberAxis() {
       fontSize: 10,
     },
   }
-  agCharts.AgChart.update(chart, options)
+  AgChart.update(chart, options)
 }
 
 function useLogAxis() {
@@ -82,5 +81,5 @@ function useLogAxis() {
       fontSize: 10,
     },
   }
-  agCharts.AgChart.update(chart, options)
+  AgChart.update(chart, options)
 }

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-overview/examples/market-index-treemap/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-overview/examples/market-index-treemap/main.ts
@@ -1,5 +1,4 @@
-import { AgChartOptions, AgTreemapSeriesTooltipRendererParams } from 'ag-charts-community'
-import * as agCharts from 'ag-charts-community'
+import { AgChartOptions, AgTreemapSeriesTooltipRendererParams, AgChart } from 'ag-charts-community'
 import { data } from './data'
 
 const options: AgChartOptions = {
@@ -65,4 +64,4 @@ function tooltipRenderer(params: AgTreemapSeriesTooltipRendererParams<any>) {
   }
 }
 
-agCharts.AgChart.create(options)
+AgChart.create(options)

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-overview/examples/per-marker-customisation/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-overview/examples/per-marker-customisation/main.ts
@@ -1,5 +1,4 @@
-import * as agCharts from 'ag-charts-community';
-import { AgChartOptions } from 'ag-charts-community';
+import { AgChart, AgChartOptions } from 'ag-charts-community';
 import { getData } from "./data";
 
 var minSize = 5
@@ -101,4 +100,4 @@ const options: AgChartOptions = {
   },
 }
 
-var chart = agCharts.AgChart.create(options)
+var chart = AgChart.create(options)

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-overview/examples/pie-in-a-doughnut/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-overview/examples/pie-in-a-doughnut/main.ts
@@ -1,5 +1,4 @@
-import * as agCharts from 'ag-charts-community';
-import { AgChartOptions, AgPolarSeriesOptions } from 'ag-charts-community';
+import { AgChart, AgChartOptions, AgPolarSeriesOptions } from 'ag-charts-community';
 import { getData2020, getData2022 } from './data';
 
 const numFormatter = new Intl.NumberFormat('en-US', { style: 'percent', maximumFractionDigits: 0 });
@@ -91,4 +90,4 @@ const options: AgChartOptions = {
     ],
 };
 
-const chart = agCharts.AgChart.create(options);
+const chart = AgChart.create(options);

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-overview/examples/pie-with-variable-radius/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-overview/examples/pie-with-variable-radius/main.ts
@@ -1,5 +1,4 @@
-import * as agCharts from 'ag-charts-community';
-import { AgChartOptions } from 'ag-charts-community';
+import { AgChart, AgChartOptions } from 'ag-charts-community';
 import { getData } from './data';
 
 const numFormatter = new Intl.NumberFormat('en-US');
@@ -74,4 +73,4 @@ const options: AgChartOptions = {
     },
 };
 
-const chart = agCharts.AgChart.create(options);
+const chart = AgChart.create(options);

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-overview/examples/real-time-data-updates/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-overview/examples/real-time-data-updates/main.ts
@@ -1,5 +1,4 @@
-import { AgCartesianChartOptions } from "ag-charts-community"
-import * as agCharts from "ag-charts-community"
+import { AgCartesianChartOptions, AgChart } from "ag-charts-community"
 
 var systemLoad = 0
 var userLoad = 0
@@ -82,13 +81,13 @@ const options: AgCartesianChartOptions = {
   },
 }
 
-var chart = agCharts.AgChart.create(options)
+var chart = AgChart.create(options)
 
 /** inScope */
 function updateData() {
   var now = Date.now()
   options.data = getData()
-  agCharts.AgChart.update(chart, options)
+  AgChart.update(chart, options)
 }
 //@ts-ignore
 setInterval(this.updateData, refreshRateInMilliseconds)

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-overview/examples/real-time-data-updates/provided/modules/typescript/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-overview/examples/real-time-data-updates/provided/modules/typescript/main.ts
@@ -1,5 +1,4 @@
-import * as agCharts from "ag-charts-community"
-import { AgCartesianChartOptions } from "ag-charts-community"
+import { AgChart, AgCartesianChartOptions } from "ag-charts-community"
 
 var systemLoad = 0
 var userLoad = 0
@@ -83,11 +82,11 @@ const options: AgCartesianChartOptions = {
   },
 }
 
-var chart = agCharts.AgChart.create(options)
+var chart = AgChart.create(options)
 
 function updateData() {
   var now = Date.now()
   options.data = getData()
-  agCharts.AgChart.update(chart, options)
+  AgChart.update(chart, options)
 }
 setInterval(updateData, refreshRateInMilliseconds)

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-overview/examples/simple-area/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-overview/examples/simple-area/main.ts
@@ -1,5 +1,4 @@
-import * as agCharts from 'ag-charts-community';
-import { AgChartOptions } from 'ag-charts-community';
+import { AgChart, AgChartOptions } from 'ag-charts-community';
 import { getData } from "./data";
 
 const options: AgChartOptions = {
@@ -85,4 +84,4 @@ const options: AgChartOptions = {
   },
 }
 
-var chart = agCharts.AgChart.create(options)
+var chart = AgChart.create(options)

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-overview/examples/simple-bar/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-overview/examples/simple-bar/main.ts
@@ -1,5 +1,4 @@
-import * as agCharts from 'ag-charts-community';
-import { AgChartOptions } from 'ag-charts-community';
+import { AgChart, AgChartOptions } from 'ag-charts-community';
 import { getData } from "./data";
 
 const options: AgChartOptions = {
@@ -48,4 +47,4 @@ const options: AgChartOptions = {
   },
 }
 
-var chart = agCharts.AgChart.create(options)
+var chart = AgChart.create(options)

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-overview/examples/simple-bubble/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-overview/examples/simple-bubble/main.ts
@@ -1,5 +1,4 @@
-import * as agCharts from 'ag-charts-community';
-import { AgChartOptions } from 'ag-charts-community';
+import { AgChart, AgChartOptions } from 'ag-charts-community';
 import { getData } from "./data";
 
 const options: AgChartOptions = {
@@ -55,4 +54,4 @@ const options: AgChartOptions = {
   },
 }
 
-var chart = agCharts.AgChart.create(options)
+var chart = AgChart.create(options)

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-overview/examples/simple-column/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-overview/examples/simple-column/main.ts
@@ -1,5 +1,4 @@
-import * as agCharts from 'ag-charts-community';
-import { AgChartOptions } from 'ag-charts-community';
+import { AgChart, AgChartOptions } from 'ag-charts-community';
 import { getData } from "./data";
 
 function formatNumber(value: number) {
@@ -64,4 +63,4 @@ const options: AgChartOptions = {
   },
 }
 
-var chart = agCharts.AgChart.create(options)
+var chart = AgChart.create(options)

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-overview/examples/simple-doughnut/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-overview/examples/simple-doughnut/main.ts
@@ -1,5 +1,4 @@
-import * as agCharts from 'ag-charts-community';
-import { AgChartOptions } from 'ag-charts-community';
+import { AgChart, AgChartOptions } from 'ag-charts-community';
 import { getData } from './data';
 
 const data = getData();
@@ -77,4 +76,4 @@ const options: AgChartOptions = {
     ],
 };
 
-const chart = agCharts.AgChart.create(options);
+const chart = AgChart.create(options);

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-overview/examples/simple-histogram/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-overview/examples/simple-histogram/main.ts
@@ -1,5 +1,4 @@
-import * as agCharts from 'ag-charts-community';
-import { AgChartOptions } from 'ag-charts-community';
+import { AgChart, AgChartOptions } from 'ag-charts-community';
 import { getData } from "./data";
 
 const options: AgChartOptions = {
@@ -42,4 +41,4 @@ const options: AgChartOptions = {
   },
 }
 
-var chart = agCharts.AgChart.create(options)
+var chart = AgChart.create(options)

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-overview/examples/simple-line/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-overview/examples/simple-line/main.ts
@@ -1,5 +1,4 @@
-import * as agCharts from 'ag-charts-community';
-import { AgChartOptions } from 'ag-charts-community';
+import { AgChart, AgChartOptions, time } from 'ag-charts-community';
 import { getData } from "./data";
 
 const options: AgChartOptions = {
@@ -54,7 +53,7 @@ const options: AgChartOptions = {
       position: 'bottom',
       type: 'time',
       tick: {
-        count: agCharts.time.month.every(2),
+        count: time.month.every(2),
       },
       title: {
         text: 'Date',
@@ -70,4 +69,4 @@ const options: AgChartOptions = {
   ],
 }
 
-var chart = agCharts.AgChart.create(options)
+var chart = AgChart.create(options)

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-overview/examples/simple-pie/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-overview/examples/simple-pie/main.ts
@@ -1,5 +1,4 @@
-import * as agCharts from 'ag-charts-community';
-import { AgChartOptions } from 'ag-charts-community';
+import { AgChart, AgChartOptions } from 'ag-charts-community';
 import { getData } from './data';
 
 const numFormatter = new Intl.NumberFormat('en-US');
@@ -73,4 +72,4 @@ const options: AgChartOptions = {
     },
 };
 
-const chart = agCharts.AgChart.create(options);
+const chart = AgChart.create(options);

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-overview/examples/simple-scatter/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-overview/examples/simple-scatter/main.ts
@@ -1,5 +1,4 @@
-import * as agCharts from 'ag-charts-community';
-import { AgChartOptions } from 'ag-charts-community';
+import { AgChart, AgChartOptions } from 'ag-charts-community';
 import { getData } from "./data";
 
 const options: AgChartOptions = {
@@ -47,4 +46,4 @@ const options: AgChartOptions = {
   },
 }
 
-var chart = agCharts.AgChart.create(options)
+var chart = AgChart.create(options)

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-overview/examples/stacked-area/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-overview/examples/stacked-area/main.ts
@@ -1,5 +1,4 @@
-import * as agCharts from "ag-charts-community";
-import { AgChartOptions } from "ag-charts-community";
+import { AgChart, AgChartOptions } from "ag-charts-community";
 import { getData } from "./data";
 
 const options: AgChartOptions = {
@@ -102,4 +101,4 @@ const options: AgChartOptions = {
   },
 }
 
-var chart = agCharts.AgChart.create(options)
+var chart = AgChart.create(options)

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-overview/examples/stacked-bar/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-overview/examples/stacked-bar/main.ts
@@ -1,5 +1,4 @@
-import * as agCharts from "ag-charts-community";
-import { AgChartOptions } from "ag-charts-community";
+import { AgChart, AgChartOptions } from "ag-charts-community";
 import { getData } from "./data";
 
 function getTotal(datum: any) {
@@ -84,4 +83,4 @@ const options: AgChartOptions = {
   },
 }
 
-var chart = agCharts.AgChart.create(options)
+var chart = AgChart.create(options)

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-overview/examples/stacked-column/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-overview/examples/stacked-column/main.ts
@@ -1,5 +1,4 @@
-import * as agCharts from "ag-charts-community";
-import { AgChartOptions } from "ag-charts-community";
+import { AgChart, AgChartOptions } from "ag-charts-community";
 import { getData } from "./data";
 
 const options: AgChartOptions = {
@@ -95,4 +94,4 @@ const options: AgChartOptions = {
   },
 }
 
-var chart = agCharts.AgChart.create(options)
+var chart = AgChart.create(options)

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-overview/examples/time-axis-with-irregular-intervals/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-overview/examples/time-axis-with-irregular-intervals/main.ts
@@ -1,5 +1,4 @@
-import { AgChartOptions } from 'ag-charts-community'
-import * as agCharts from 'ag-charts-community'
+import { AgChartOptions, AgChart } from 'ag-charts-community'
 import { data } from './data'
 
 const options: AgChartOptions = {
@@ -80,4 +79,4 @@ const options: AgChartOptions = {
   },
 }
 
-var chart = agCharts.AgChart.create(options)
+var chart = AgChart.create(options)

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-overview/examples/xy-histogram-with-mean-aggregation/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-overview/examples/xy-histogram-with-mean-aggregation/main.ts
@@ -1,5 +1,4 @@
-import * as agCharts from 'ag-charts-community';
-import { AgChartOptions } from 'ag-charts-community';
+import { AgChart, AgChartOptions } from 'ag-charts-community';
 import { getData } from "./data";
 
 const options: AgChartOptions = {
@@ -55,4 +54,4 @@ const options: AgChartOptions = {
   },
 }
 
-var chart = agCharts.AgChart.create(options)
+var chart = AgChart.create(options)

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-pie-series/examples/basic-pie/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-pie-series/examples/basic-pie/main.ts
@@ -1,5 +1,4 @@
-import { AgChartOptions } from 'ag-charts-community'
-import * as agCharts from 'ag-charts-community'
+import { AgChartOptions, AgChart } from 'ag-charts-community'
 
 const options: AgChartOptions = {
   container: document.getElementById('myChart'),
@@ -19,4 +18,4 @@ const options: AgChartOptions = {
   ],
 }
 
-agCharts.AgChart.create(options)
+AgChart.create(options)

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-pie-series/examples/doughnut-chart/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-pie-series/examples/doughnut-chart/main.ts
@@ -1,5 +1,4 @@
-import { AgChartOptions } from 'ag-charts-community'
-import * as agCharts from 'ag-charts-community'
+import { AgChartOptions, AgChart } from 'ag-charts-community'
 
 const options: AgChartOptions = {
   container: document.getElementById('myChart'),
@@ -21,4 +20,4 @@ const options: AgChartOptions = {
   ],
 }
 
-agCharts.AgChart.create(options)
+AgChart.create(options)

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-pie-series/examples/multi-doughnut/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-pie-series/examples/multi-doughnut/main.ts
@@ -1,5 +1,4 @@
-import { AgChartOptions } from 'ag-charts-community'
-import * as agCharts from 'ag-charts-community'
+import { AgChartOptions, AgChart } from 'ag-charts-community'
 
 const options: AgChartOptions = {
   container: document.getElementById('myChart'),
@@ -34,4 +33,4 @@ const options: AgChartOptions = {
   ],
 }
 
-agCharts.AgChart.create(options)
+AgChart.create(options)

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-pie-series/examples/pie-labels/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-pie-series/examples/pie-labels/main.ts
@@ -1,5 +1,4 @@
-import { AgChartOptions } from 'ag-charts-community';
-import * as agCharts from 'ag-charts-community';
+import { AgChartOptions, AgChart } from 'ag-charts-community';
 import { getData } from './data';
 
 const options: AgChartOptions = {
@@ -19,4 +18,4 @@ const options: AgChartOptions = {
     ],
 };
 
-agCharts.AgChart.create(options);
+AgChart.create(options);

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-pie-series/examples/sector-radius/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-pie-series/examples/sector-radius/main.ts
@@ -1,5 +1,4 @@
-import { AgChartOptions } from 'ag-charts-community'
-import * as agCharts from 'ag-charts-community'
+import { AgChartOptions, AgChart } from 'ag-charts-community'
 
 const options: AgChartOptions = {
   container: document.getElementById('myChart'),
@@ -22,4 +21,4 @@ const options: AgChartOptions = {
   ],
 }
 
-agCharts.AgChart.create(options)
+AgChart.create(options)

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-pie-series/examples/text-inside-doughnut/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-pie-series/examples/text-inside-doughnut/main.ts
@@ -1,5 +1,4 @@
-import {AgChartOptions} from 'ag-charts-community';
-import * as agCharts from 'ag-charts-community';
+import { AgChartOptions, AgChart } from 'ag-charts-community';
 import {getData} from './data';
 
 const data = getData();
@@ -35,4 +34,4 @@ const options: AgChartOptions = {
     ],
 }
 
-agCharts.AgChart.create(options)
+AgChart.create(options)

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-scatter-series/examples/bubble-chart-labels/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-scatter-series/examples/bubble-chart-labels/main.ts
@@ -1,5 +1,4 @@
-import { AgCartesianChartOptions } from 'ag-charts-community';
-import * as agCharts from 'ag-charts-community';
+import { AgCartesianChartOptions, AgChart } from 'ag-charts-community';
 declare var maleHeightWeight: any[];
 declare var femaleHeightWeight: any[];
 
@@ -86,14 +85,14 @@ const options: AgCartesianChartOptions = {
   ],
 }
 
-var chart = agCharts.AgChart.create(options)
+var chart = AgChart.create(options)
 
 function updateFontSize(event: any) {
   var value = +event.target.value
 
   options.series![0].label!.fontSize = value
   options.series![1].label!.fontSize = value
-  agCharts.AgChart.update(chart, options)
+  AgChart.update(chart, options)
 
   document.getElementById('fontSizeSliderValue')!.innerHTML = String(value)
 }

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-scatter-series/examples/bubble-chart/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-scatter-series/examples/bubble-chart/main.ts
@@ -1,5 +1,4 @@
-import { AgChartOptions } from 'ag-charts-community'
-import * as agCharts from 'ag-charts-community'
+import { AgChartOptions, AgChart } from 'ag-charts-community'
 declare var maleHeightWeight: any[];
 declare var femaleHeightWeight: any[];
 
@@ -78,4 +77,4 @@ const options: AgChartOptions = {
   ],
 }
 
-agCharts.AgChart.create(options)
+AgChart.create(options)

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-scatter-series/examples/scatter-chart/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-scatter-series/examples/scatter-chart/main.ts
@@ -1,5 +1,4 @@
-import * as agCharts from 'ag-charts-community';
-import { AgChartOptions } from 'ag-charts-community';
+import { AgChart, AgChartOptions } from 'ag-charts-community';
 import { getData } from "./data";
 
 const options: AgChartOptions = {
@@ -19,4 +18,4 @@ const options: AgChartOptions = {
   ],
 }
 
-agCharts.AgChart.create(options)
+AgChart.create(options)

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-series-highlighting/examples/basic-column/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-series-highlighting/examples/basic-column/main.ts
@@ -1,5 +1,4 @@
-import { AgChartOptions } from "ag-charts-community"
-import * as agCharts from "ag-charts-community"
+import { AgChartOptions, AgChart } from "ag-charts-community"
 
 var data = [
   {
@@ -61,4 +60,4 @@ const options: AgChartOptions = {
   ],
 }
 
-agCharts.AgChart.create(options)
+AgChart.create(options)

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-series-highlighting/examples/basic-pie-theme/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-series-highlighting/examples/basic-pie-theme/main.ts
@@ -1,5 +1,4 @@
-import { AgChartOptions } from 'ag-charts-community'
-import * as agCharts from 'ag-charts-community'
+import { AgChartOptions, AgChart } from 'ag-charts-community'
 
 const data = [
   {
@@ -116,4 +115,4 @@ const options: AgChartOptions = {
   ],
 }
 
-agCharts.AgChart.create(options)
+AgChart.create(options)

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-series-highlighting/examples/basic-pie/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-series-highlighting/examples/basic-pie/main.ts
@@ -1,5 +1,4 @@
-import { AgChartOptions } from 'ag-charts-community'
-import * as agCharts from 'ag-charts-community'
+import { AgChartOptions, AgChart } from 'ag-charts-community'
 
 const data = [
   {
@@ -111,4 +110,4 @@ const options: AgChartOptions = {
   ],
 }
 
-agCharts.AgChart.create(options)
+AgChart.create(options)

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-series-highlighting/examples/lines/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-series-highlighting/examples/lines/main.ts
@@ -1,5 +1,4 @@
-import * as agCharts from 'ag-charts-community';
-import { AgChartOptions } from 'ag-charts-community';
+import { AgChart, AgChartOptions } from 'ag-charts-community';
 import { getData } from "./data";
 
 const options: AgChartOptions = {
@@ -247,4 +246,4 @@ const options: AgChartOptions = {
   },
 }
 
-var chart = agCharts.AgChart.create(options)
+var chart = AgChart.create(options)

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-themes/examples/advanced-theme/typescript/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-themes/examples/advanced-theme/typescript/main.ts
@@ -1,5 +1,4 @@
-import * as agCharts from "ag-charts-community"
-import { AgChartOptions, AgChartTheme } from "ag-charts-community"
+import { AgChart, AgChartOptions, AgChartTheme } from "ag-charts-community"
 
 var myTheme: AgChartTheme = {
   baseTheme: "ag-default-dark",
@@ -137,5 +136,5 @@ var chartOptions2: AgChartOptions = {
   ],
 }
 
-var chart1 = agCharts.AgChart.create(chartOptions1)
-var chart2 = agCharts.AgChart.create(chartOptions2)
+var chart1 = AgChart.create(chartOptions1)
+var chart2 = AgChart.create(chartOptions2)

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-themes/examples/custom-theme/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-themes/examples/custom-theme/main.ts
@@ -1,5 +1,4 @@
-import { AgChartOptions, AgChartTheme } from "ag-charts-community"
-import * as agCharts from "ag-charts-community"
+import { AgChartOptions, AgChartTheme , AgChart } from "ag-charts-community"
 
 var myTheme: AgChartTheme = {
   baseTheme: "ag-default-dark",
@@ -52,10 +51,10 @@ const options: AgChartOptions = {
   ],
 }
 
-var chart = agCharts.AgChart.create(options)
+var chart = AgChart.create(options)
 
 /** inScope */
 function applyTheme(theme: AgChartTheme) {
   options.theme = theme
-  agCharts.AgChart.update(chart, options)
+  AgChart.update(chart, options)
 }

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-themes/examples/stock-themes/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-themes/examples/stock-themes/main.ts
@@ -1,5 +1,4 @@
-import { AgChartOptions, AgChartTheme } from 'ag-charts-community'
-import * as agCharts from 'ag-charts-community'
+import { AgChartOptions, AgChartTheme, AgChart } from 'ag-charts-community'
 
 const options: AgChartOptions = {
   container: document.getElementById('myChart'),
@@ -29,9 +28,9 @@ const options: AgChartOptions = {
   ],
 }
 
-var chart = agCharts.AgChart.create(options)
+var chart = AgChart.create(options)
 
 function applyTheme(theme: AgChartTheme) {
   options.theme = theme
-  agCharts.AgChart.update(chart, options)
+  AgChart.update(chart, options)
 }

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-tooltips/examples/default-tooltip-styling/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-tooltips/examples/default-tooltip-styling/main.ts
@@ -1,5 +1,4 @@
-import { AgChartOptions } from 'ag-charts-community'
-import * as agCharts from 'ag-charts-community'
+import { AgChartOptions, AgChart } from 'ag-charts-community'
 
 const options: AgChartOptions = {
   container: document.getElementById('myChart'),
@@ -30,4 +29,4 @@ const options: AgChartOptions = {
   },
 }
 
-var chart = agCharts.AgChart.create(options)
+var chart = AgChart.create(options)

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-tooltips/examples/default-tooltip/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-tooltips/examples/default-tooltip/main.ts
@@ -1,5 +1,4 @@
-import { AgCartesianChartOptions } from "ag-charts-community"
-import * as agCharts from "ag-charts-community"
+import { AgCartesianChartOptions, AgChart } from "ag-charts-community"
 
 const options: AgCartesianChartOptions = {
   container: document.getElementById("myChart"),
@@ -26,16 +25,16 @@ const options: AgCartesianChartOptions = {
   ],
 }
 
-var chart = agCharts.AgChart.create(options)
+var chart = AgChart.create(options)
 
 function setYNames() {
   options.series![0].yName = "Sweaters Made";
   options.series![1].yName = "Hats Made";
-  agCharts.AgChart.update(chart, options)
+  AgChart.update(chart, options)
 }
 
 function resetYNames() {
   options.series![0].yName = undefined;;
   options.series![1].yName = undefined;;
-  agCharts.AgChart.update(chart, options)
+  AgChart.update(chart, options)
 }

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-tooltips/examples/tooltip-content-title/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-tooltips/examples/tooltip-content-title/main.ts
@@ -1,8 +1,8 @@
 import {
   AgCartesianSeriesTooltipRendererParams,
   AgChartOptions,
+  AgChart
 } from "ag-charts-community"
-import * as agCharts from "ag-charts-community"
 
 function renderer(params: AgCartesianSeriesTooltipRendererParams) {
   return {
@@ -50,4 +50,4 @@ const options: AgChartOptions = {
   ],
 }
 
-var chart = agCharts.AgChart.create(options)
+var chart = AgChart.create(options)

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-tooltips/examples/tooltip-renderer/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-tooltips/examples/tooltip-renderer/main.ts
@@ -1,8 +1,8 @@
 import {
   AgCartesianSeriesTooltipRendererParams,
   AgChartOptions,
+  AgChart
 } from "ag-charts-community"
-import * as agCharts from "ag-charts-community"
 
 function renderer(params: AgCartesianSeriesTooltipRendererParams) {
   return (
@@ -56,4 +56,4 @@ const options: AgChartOptions = {
   ],
 }
 
-var chart = agCharts.AgChart.create(options)
+var chart = AgChart.create(options)

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-treemap-series/examples/org-chart/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-treemap-series/examples/org-chart/main.ts
@@ -1,5 +1,4 @@
-import { AgChartOptions } from 'ag-charts-community'
-import * as agCharts from 'ag-charts-community'
+import { AgChartOptions, AgChart } from 'ag-charts-community'
 import { data } from './data'
 
 const options: AgChartOptions = {
@@ -33,4 +32,4 @@ const options: AgChartOptions = {
   },
 }
 
-agCharts.AgChart.create(options)
+AgChart.create(options)

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-treemap-series/examples/stock-market-index/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-treemap-series/examples/stock-market-index/main.ts
@@ -1,5 +1,4 @@
-import { AgChartOptions } from 'ag-charts-community'
-import * as agCharts from 'ag-charts-community'
+import { AgChartOptions, AgChart } from 'ag-charts-community'
 import { data } from './data'
 
 const options: AgChartOptions = {
@@ -36,4 +35,4 @@ const options: AgChartOptions = {
   },
 }
 
-agCharts.AgChart.create(options)
+AgChart.create(options)

--- a/grid-packages/ag-grid-docs/example-generator-documentation.js
+++ b/grid-packages/ag-grid-docs/example-generator-documentation.js
@@ -516,10 +516,17 @@ function createExampleGenerator(exampleType, prefix, importTypes) {
                     let jsFile = readAsJsFile(tsFile);
                     // replace Typescript new Grid( with Javascript new agGrid.Grid(
                     jsFile = jsFile.replace(/new Grid\(/g, 'new agGrid.Grid(');
-                    // replace Typescript AgChart. with Javascript agCharts.AgChart.
-                    jsFile = jsFile.replace(/(?<!\.)AgChart\./g, 'agCharts.AgChart.');
-                    // replace Typescript time. with Javascript agCharts.time.
-                    jsFile = jsFile.replace(/(?<!\.)time\./g, 'agCharts.time.');
+
+                    // Chart classes that need scoping
+                    const chartImports = typedBindings.imports.find(i => i.module == "'ag-charts-community'");
+                    if (chartImports) {
+                        chartImports.imports.forEach(i => {
+                            const toReplace = `(?<!\\.)${i}([\\s\/.])`
+                            const reg = new RegExp(toReplace, "g");
+                            jsFile = jsFile.replace(reg, `agCharts.${i}$1`);
+                        })
+                    }
+
                     // replace Typescript LicenseManager.setLicenseKey( with Javascript agGrid.LicenseManager.setLicenseKey(
                     jsFile = jsFile.replace(/LicenseManager\.setLicenseKey\(/g, "agGrid.LicenseManager.setLicenseKey(");
 

--- a/grid-packages/ag-grid-docs/example-generator-documentation.js
+++ b/grid-packages/ag-grid-docs/example-generator-documentation.js
@@ -518,6 +518,8 @@ function createExampleGenerator(exampleType, prefix, importTypes) {
                     jsFile = jsFile.replace(/new Grid\(/g, 'new agGrid.Grid(');
                     // replace Typescript AgChart. with Javascript agCharts.AgChart.
                     jsFile = jsFile.replace(/(?<!\.)AgChart\./g, 'agCharts.AgChart.');
+                    // replace Typescript time. with Javascript agCharts.time.
+                    jsFile = jsFile.replace(/(?<!\.)time\./g, 'agCharts.time.');
                     // replace Typescript LicenseManager.setLicenseKey( with Javascript agGrid.LicenseManager.setLicenseKey(
                     jsFile = jsFile.replace(/LicenseManager\.setLicenseKey\(/g, "agGrid.LicenseManager.setLicenseKey(");
 

--- a/grid-packages/ag-grid-docs/src/example-generation/chart-vanilla-src-parser.ts
+++ b/grid-packages/ag-grid-docs/src/example-generation/chart-vanilla-src-parser.ts
@@ -11,7 +11,7 @@ const PROPERTIES = [optionsVariableName];
 
 function tsGenerateWithOptionReferences(node, srcFile) {
     return tsGenerate(node, srcFile)
-        .replace(new RegExp(`agCharts\\.AgChart\\.update\\(chart, options\\);?`, 'g'), '');
+        .replace(new RegExp(`AgChart\\.update\\(chart, options\\);?`, 'g'), '');
 }
 
 export function parser(examplePath, fileName, srcFile, html) {

--- a/grid-packages/ag-grid-docs/src/example-generation/chart-vanilla-src-parser.ts
+++ b/grid-packages/ag-grid-docs/src/example-generation/chart-vanilla-src-parser.ts
@@ -15,7 +15,7 @@ function tsGenerateWithOptionReferences(node, srcFile) {
 }
 
 export function parser(examplePath, fileName, srcFile, html) {
-    const bindings = internalParser(readAsJsFile(srcFile), html);
+    const bindings = internalParser(readAsJsFile(srcFile, { includeImports: true }), html);
     const typedBindings = internalParser(srcFile, html);
     return { bindings, typedBindings };
 }

--- a/grid-packages/ag-grid-docs/src/example-generation/chart-vanilla-to-react.ts
+++ b/grid-packages/ag-grid-docs/src/example-generation/chart-vanilla-to-react.ts
@@ -10,13 +10,17 @@ export function processFunction(code: string): string {
         'this.setState({ options });');
 }
 
-function getImports(componentFilenames: string[]): string[] {
+function getImports(componentFilenames: string[], properties: { name: string, value: string }[]): string[] {
     const imports = [
         "import React, { Component } from 'react';",
         "import { render } from 'react-dom';",
-        "import * as agCharts from 'ag-charts-community';",
         "import { AgChartsReact } from 'ag-charts-react';",
     ];
+
+    if (properties.some(p => p?.value?.includes(' time.'))) {
+        imports.push("import { time } from 'ag-charts-community';");
+    }
+
 
     if (componentFilenames) {
         imports.push(...componentFilenames.map(getImport));
@@ -38,7 +42,7 @@ function getTemplate(bindings: any, componentAttributes: string[]): string {
 export function vanillaToReact(bindings: any, componentFilenames: string[]): () => string {
     return () => {
         const { properties } = bindings;
-        const imports = getImports(componentFilenames);
+        const imports = getImports(componentFilenames, properties);
         const stateProperties = [];
         const componentAttributes = [];
         const instanceBindings = [];

--- a/grid-packages/ag-grid-docs/src/example-generation/chart-vanilla-to-vue.ts
+++ b/grid-packages/ag-grid-docs/src/example-generation/chart-vanilla-to-vue.ts
@@ -7,12 +7,16 @@ function processFunction(code: string): string {
     return wrapOptionsUpdateCode(removeFunctionKeyword(code));
 }
 
-function getImports(componentFileNames: string[]): string[] {
+function getImports(componentFileNames: string[], properties: { name: string, value: string }[]): string[] {
     const imports = [
         "import Vue from 'vue';",
-        "import * as agCharts from 'ag-charts-community';",
         "import { AgChartsVue } from 'ag-charts-vue';",
     ];
+
+    if (properties.some(p => p?.value?.includes(' time.'))) {
+        imports.push("import { time } from 'ag-charts-community';");
+    }
+
 
     if (componentFileNames) {
         imports.push(...componentFileNames.map(getImport));
@@ -78,7 +82,7 @@ function getAllMethods(bindings: any): [string[], string[], string[]] {
 
 export function vanillaToVue(bindings: any, componentFileNames: string[]): () => string {
     return () => {
-        const imports = getImports(componentFileNames);
+        const imports = getImports(componentFileNames, bindings.properties);
         const [propertyAssignments, propertyVars, propertyAttributes] = getPropertyBindings(bindings, componentFileNames);
         const [externalEventHandlers, instanceMethods, globalMethods] = getAllMethods(bindings);
         const template = getTemplate(bindings, propertyAttributes);

--- a/grid-packages/ag-grid-docs/src/example-generation/chart-vanilla-to-vue.ts
+++ b/grid-packages/ag-grid-docs/src/example-generation/chart-vanilla-to-vue.ts
@@ -1,4 +1,4 @@
-import { getFunctionName, isInstanceMethod, removeFunctionKeyword } from './parser-utils';
+import { BindingImport, getFunctionName, isInstanceMethod, removeFunctionKeyword } from './parser-utils';
 import { templatePlaceholder } from './chart-vanilla-src-parser';
 import { toInput, toConst, toMember, toAssignment, convertTemplate, getImport } from './vue-utils';
 import { wrapOptionsUpdateCode } from './chart-utils';
@@ -7,14 +7,18 @@ function processFunction(code: string): string {
     return wrapOptionsUpdateCode(removeFunctionKeyword(code));
 }
 
-function getImports(componentFileNames: string[], properties: { name: string, value: string }[]): string[] {
+function getImports(componentFileNames: string[], bindingImports: BindingImport[]): string[] {
     const imports = [
         "import Vue from 'vue';",
         "import { AgChartsVue } from 'ag-charts-vue';",
     ];
 
-    if (properties.some(p => p?.value?.includes(' time.'))) {
-        imports.push("import { time } from 'ag-charts-community';");
+    const chartsImport = bindingImports.find(i => i.module === "'ag-charts-community'");
+    if (chartsImport) {
+        const extraImports = chartsImport.imports.filter(i => i !== 'AgChart');
+        if (extraImports.length > 0) {
+            imports.push(`import { ${extraImports.join(', ')} } from 'ag-charts-community';`);
+        }
     }
 
 
@@ -82,7 +86,7 @@ function getAllMethods(bindings: any): [string[], string[], string[]] {
 
 export function vanillaToVue(bindings: any, componentFileNames: string[]): () => string {
     return () => {
-        const imports = getImports(componentFileNames, bindings.properties);
+        const imports = getImports(componentFileNames, bindings.imports);
         const [propertyAssignments, propertyVars, propertyAttributes] = getPropertyBindings(bindings, componentFileNames);
         const [externalEventHandlers, instanceMethods, globalMethods] = getAllMethods(bindings);
         const template = getTemplate(bindings, propertyAttributes);

--- a/grid-packages/ag-grid-docs/src/example-generation/chart-vanilla-to-vue3.ts
+++ b/grid-packages/ag-grid-docs/src/example-generation/chart-vanilla-to-vue3.ts
@@ -7,12 +7,16 @@ function processFunction(code: string): string {
     return wrapOptionsUpdateCode(removeFunctionKeyword(code));
 }
 
-function getImports(componentFileNames: string[]): string[] {
+function getImports(componentFileNames: string[], properties: { name: string, value: string }[]): string[] {
     const imports = [
         "import { createApp } from 'vue';",
-        "import * as agCharts from 'ag-charts-community';",
         "import { AgChartsVue } from 'ag-charts-vue3';",
     ];
+
+    if (properties.some(p => p?.value?.includes(' time.'))) {
+        imports.push("import { time } from 'ag-charts-community';");
+    }
+
 
     if (componentFileNames) {
         imports.push(...componentFileNames.map(getImport));
@@ -78,7 +82,7 @@ function getAllMethods(bindings: any): [string[], string[], string[]] {
 
 export function vanillaToVue3(bindings: any, componentFileNames: string[]): () => string {
     return () => {
-        const imports = getImports(componentFileNames);
+        const imports = getImports(componentFileNames, bindings.properties);
         const [propertyAssignments, propertyVars, propertyAttributes] = getPropertyBindings(bindings, componentFileNames);
         const [externalEventHandlers, instanceMethods, globalMethods] = getAllMethods(bindings);
         const template = getTemplate(bindings, propertyAttributes);

--- a/grid-packages/ag-grid-docs/src/example-generation/parser-utils.ts
+++ b/grid-packages/ag-grid-docs/src/example-generation/parser-utils.ts
@@ -209,7 +209,7 @@ export function tsNodeIsGlobalFunctionCall(node: ts.Node) {
     // Get top level function calls like 
     // setInterval(callback, 500)
     // but don't match things like
-    // agCharts.AgChart.create(options)
+    // AgChart.create(options)
     if (ts.isExpressionStatement(node)) {
         return ts.isSourceFile(node.parent) && ts.isCallExpression(node.expression) && ts.isIdentifier(node.expression.expression);
     }

--- a/grid-packages/ag-grid-docs/src/example-generation/parser-utils.ts
+++ b/grid-packages/ag-grid-docs/src/example-generation/parser-utils.ts
@@ -12,10 +12,10 @@ export interface BindingImport {
 
 const moduleMapping = require('../../documentation/doc-pages/modules/modules.json');
 
-export function readAsJsFile(srcFile) {
+export function readAsJsFile(srcFile, options: { includeImports: boolean } = undefined) {
     const tsFile = srcFile
         // Remove imports that are not required in javascript
-        .replace(/import.*from.*\n/g, '')
+        .replace((options?.includeImports ? '' : /import.*from.*\n/g), '')
         // Remove export statement
         .replace(/export /g, "")
 


### PR DESCRIPTION
The following could be made cleaner by just directly importing AgChart in our typescript examples. So instead of 

```
  import * as agCharts from "ag-charts-community";
  agCharts.AgChart.update(chart, options);

 agCharts.time.month;
```
We would have the more standard

```
import { AgChart, time } from "ag-charts-community";
AgChart.update(chart, options);

time.month
```