### PR TITLE
Fix typos in getting started sample code comments

### DIFF
--- a/grid-packages/ag-grid-docs/documentation/doc-pages/getting-started/_angular.md
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/getting-started/_angular.md
@@ -214,7 +214,7 @@
 |
 |  constructor(private http: HttpClient) {}
 |
-|  // Example load data from sever
+|  // Example load data from server
 |  onGridReady(params: GridReadyEvent) {
 |    this.rowData$ = this.http
 |      .get<any[]>('https://www.ag-grid.com/example-assets/row-data.json');
@@ -327,7 +327,7 @@
 | public rowData$!: Observable<any[]>;
 | ...
 |
-| // Example load data from sever
+| // Example load data from server
 | onGridReady(params: GridReadyEvent) {
 |   this.rowData$ = this.http
 |     .get<any[]>('https://www.ag-grid.com/example-assets/row-data.json');

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/getting-started/_react.md
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/getting-started/_react.md
@@ -169,7 +169,7 @@
 |    console.log('cellClicked', event);
 |  }, []);
 |
-|  // Example load data from sever
+|  // Example load data from server
 |  useEffect(() => {
 |    fetch('https://www.ag-grid.com/example-assets/row-data.json')
 |    .then(result => result.json())
@@ -250,7 +250,7 @@
 |
 |...
 |
-|// Example load data from sever
+|// Example load data from server
 |useEffect(() => {
 |    fetch('https://www.ag-grid.com/example-assets/row-data.json')
 |    .then(result => result.json())

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/getting-started/_vue.md
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/getting-started/_vue.md
@@ -210,7 +210,7 @@
 |      flex: 1
 |    };
 |
-|    // Example load data from sever
+|    // Example load data from server
 |    onMounted(() => {
 |      fetch("https://www.ag-grid.com/example-assets/row-data.json")
 |        .then((result) => result.json())
@@ -281,7 +281,7 @@
 |
 |...
 |
-| // Example load data from sever
+| // Example load data from server
 | onMounted(() => {
 |   fetch("https://www.ag-grid.com/example-assets/row-data.json")
 |     .then((result) => result.json())


### PR DESCRIPTION
I noticed some typos in comments of sample codes at "getting started" section. Decided to fix them.