### PR TITLE
AG-7905 - Fix listener handling on chart type changes

### DIFF
--- a/charts-packages/ag-charts-community/src/chart/agChartV2.ts
+++ b/charts-packages/ag-charts-community/src/chart/agChartV2.ts
@@ -395,7 +395,7 @@ function applyChartOptions(chart: Chart, processedOptions: Partial<AgChartOption
         registerListeners(chart, processedOptions.listeners);
     }
     if (processedOptions.legend?.listeners) {
-        Object.assign(chart.legend.listeners, processedOptions.legend.listeners);
+        Object.assign(chart.legend.listeners, processedOptions.legend.listeners ?? {});
     }
 
     chart.processedOptions = jsonMerge([chart.processedOptions ?? {}, processedOptions], noDataCloneMergeOptions);

--- a/charts-packages/ag-charts-community/src/chart/agChartV2.ts
+++ b/charts-packages/ag-charts-community/src/chart/agChartV2.ts
@@ -353,19 +353,19 @@ function debug(message?: any, ...optionalParams: any[]): void {
 }
 
 function applyChartOptions(chart: Chart, processedOptions: Partial<AgChartOptions>, userOptions: AgChartOptions): void {
+    let skip = ['type', 'data', 'series', 'autoSize', 'listeners', 'theme', 'legend.listeners'];
     if (isAgCartesianChartOptions(processedOptions)) {
-        applyOptionValues(chart, processedOptions, {
-            skip: ['type', 'data', 'series', 'axes', 'autoSize', 'listeners', 'theme'],
-        });
+        // Append axes to defaults.
+        skip.push('axes');
     } else if (isAgPolarChartOptions(processedOptions) || isAgHierarchyChartOptions(processedOptions)) {
-        applyOptionValues(chart, processedOptions, {
-            skip: ['type', 'data', 'series', 'autoSize', 'listeners', 'theme'],
-        });
+        // Use defaults.
     } else {
         throw new Error(
             `AG Charts - couldn\'t apply configuration, check type of options and chart: ${processedOptions['type']}`
         );
     }
+
+    applyOptionValues(chart, processedOptions, { skip });
 
     let forceNodeDataRefresh = false;
     if (processedOptions.series && processedOptions.series.length > 0) {
@@ -544,7 +544,10 @@ type ObservableLike = {
 function registerListeners<T extends ObservableLike>(source: T, listeners?: {}) {
     source.clearEventListeners();
     for (const property in listeners) {
-        source.addEventListener(property, (listeners as any)[property] as TypedEventListener);
+        const listener = (listeners as any)[property] as TypedEventListener;
+        if (typeof listener !== 'function') continue;
+
+        source.addEventListener(property, listener);
     }
 }
 

--- a/charts-packages/ag-charts-community/src/chart/legend.ts
+++ b/charts-packages/ag-charts-community/src/chart/legend.ts
@@ -19,7 +19,6 @@ import { createId } from '../util/id';
 import { HdpiCanvas } from '../canvas/hdpiCanvas';
 import {
     BOOLEAN,
-    FUNCTION,
     NUMBER,
     OPT_BOOLEAN,
     OPT_FONT_STYLE,

--- a/charts-packages/ag-charts-community/src/chart/legend.ts
+++ b/charts-packages/ag-charts-community/src/chart/legend.ts
@@ -147,13 +147,9 @@ class LegendItem {
     toggleSeriesVisible: boolean = true;
 }
 
-const NO_OP_LISTENER = () => {
-    // Default listener that does nothing.
-};
-
-class LegendListeners implements Required<AgChartLegendListeners> {
-    @Validate(FUNCTION)
-    legendItemClick: (event: AgChartLegendClickEvent) => void = NO_OP_LISTENER;
+class LegendListeners implements AgChartLegendListeners {
+    @Validate(OPT_FUNCTION)
+    legendItemClick?: (event: AgChartLegendClickEvent) => void = undefined;
 }
 
 export class Legend {
@@ -775,7 +771,7 @@ export class Legend {
 
         this.chart.update(ChartUpdateType.PROCESS_DATA, { forceNodeDataRefresh: true });
 
-        legendItemClick({ enabled: newEnabled, itemId, seriesId: series.id });
+        legendItemClick?.({ enabled: newEnabled, itemId, seriesId: series.id });
     }
 
     private handleLegendMouseMove(event: InteractionEvent<'hover'>) {
@@ -822,7 +818,7 @@ export class Legend {
             this.tooltipManager.updateTooltip(this.id);
         }
 
-        if (toggleSeriesVisible || listeners.legendItemClick !== NO_OP_LISTENER) {
+        if (toggleSeriesVisible || listeners.legendItemClick != null) {
             this.cursorManager.updateCursor(this.id, 'pointer');
         }
 

--- a/charts-packages/ag-charts-community/src/chart/themes/chartTheme.ts
+++ b/charts-packages/ag-charts-community/src/chart/themes/chartTheme.ts
@@ -217,6 +217,7 @@ export class ChartTheme {
                 enabled: true,
                 position: RIGHT,
                 spacing: 20,
+                listeners: {},
                 item: {
                     paddingX: 16,
                     paddingY: 8,
@@ -260,6 +261,7 @@ export class ChartTheme {
                 delay: 0,
                 class: DEFAULT_TOOLTIP_CLASS,
             },
+            listeners: {},
         };
     }
 

--- a/charts-packages/ag-charts-community/src/util/json.test.ts
+++ b/charts-packages/ag-charts-community/src/util/json.test.ts
@@ -111,6 +111,31 @@ describe('json module', () => {
                 expect(diff).toMatchSnapshot();
                 expect(diff).toHaveProperty(['foo', '0', 'fn'], target.foo[0].fn);
             });
+
+            it('should correctly diff dictionary of functions (added)', () => {
+                const source = { listeners: {} };
+                const target = { listeners: { seriesNodeClick: (t) => console.log(t) } };
+
+                const diff = jsonDiff(source, target as any) as any;
+                expect(diff).toStrictEqual(target);
+            });
+
+            it('should correctly diff dictionary of functions (removed)', () => {
+                const source = { listeners: { seriesNodeClick: (t) => console.log(t) } };
+                const target = { listeners: { seriesNodeClick: undefined } };
+
+                const diff = jsonDiff(source, target as any) as any;
+                expect(diff).toStrictEqual(target);
+            });
+
+            it('should correctly diff dictionary of functions when no difference', () => {
+                const seriesNodeClick = (t) => console.log(t);
+                const source = { legend: { listeners: { seriesNodeClick } } };
+                const target = { legend: { listeners: { seriesNodeClick } } };
+
+                const diff = jsonDiff(source, target as any);
+                expect(diff).toEqual(null);
+            });
         });
     });
 
@@ -251,6 +276,27 @@ describe('json module', () => {
                 expect(merge.a[0]).toHaveProperty('x', 1);
                 expect(merge.b[0]).toBe(mergee.b[0]);
                 expect(merge.b[0]).toHaveProperty('y', 2);
+            });
+
+            it('should correctly merge dictionary of functions', () => {
+                const source = {};
+                const target = { seriesNodeClick: (t) => console.log(t) };
+
+                const merge = jsonMerge([source, target]) as any;
+                expect(merge).toHaveProperty('seriesNodeClick');
+                expect(merge.seriesNodeClick).toBeInstanceOf(Function);
+            });
+
+            it('should correctly merge dictionary of functions when no difference', () => {
+                const seriesNodeClick = (t) => console.log(t);
+                const source = { legend: { listeners: { seriesNodeClick } } };
+                const target = { listeners: { seriesNodeClick } };
+
+                const merge = jsonMerge([source, target]) as any;
+                expect(merge).toHaveProperty('legend.listeners.seriesNodeClick');
+                expect(merge).toHaveProperty('listeners.seriesNodeClick');
+                expect(merge.legend?.listeners?.seriesNodeClick).toBeInstanceOf(Function);
+                expect(merge.listeners?.seriesNodeClick).toBeInstanceOf(Function);
             });
         });
     });

--- a/charts-packages/ag-charts-community/src/util/observable.ts
+++ b/charts-packages/ag-charts-community/src/util/observable.ts
@@ -8,6 +8,10 @@ export class Observable {
     private allEventListeners = new Map<string, Set<TypedEventListener>>();
 
     addEventListener(type: string, listener: TypedEventListener): void {
+        if (typeof listener !== 'function') {
+            throw new Error('AG Charts - listener must be a Function');
+        }
+
         const { allEventListeners } = this;
         let eventListeners = allEventListeners.get(type);
 

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/integrated-charts-events/examples/standalone-events/index.html
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/integrated-charts-events/examples/standalone-events/index.html
@@ -1,0 +1,1 @@
+<div id="myGrid" class="ag-theme-alpine" style="height: 100%"></div>

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/integrated-charts-events/examples/standalone-events/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/integrated-charts-events/examples/standalone-events/main.ts
@@ -1,0 +1,77 @@
+import {
+  ChartCreated,
+  ChartDestroyed,
+  ChartOptionsChanged,
+  ColDef,
+  Grid,
+  GridApi,
+  GridOptions,
+} from "@ag-grid-community/core"
+import { AgChart } from "ag-charts-community"
+
+const columnDefs: ColDef[] = [
+  { field: "Month", width: 150, chartDataType: "category" },
+  { field: "Sunshine (hours)", chartDataType: "series" },
+  { field: "Rainfall (mm)", chartDataType: "series" },
+]
+
+const gridOptions: GridOptions = {
+  defaultColDef: {
+    editable: true,
+    sortable: true,
+    flex: 1,
+    minWidth: 100,
+    filter: true,
+    resizable: true,
+  },
+  popupParent: document.body,
+  columnDefs: columnDefs,
+  enableRangeSelection: true,
+  enableCharts: true,
+  onChartCreated: onChartCreated,
+  onChartOptionsChanged: onChartOptionsChanged,
+}
+
+function onChartCreated(event: ChartCreated) {
+  update(gridOptions.api!, event)
+
+  console.log("Created chart with ID " + event.chartId)
+}
+
+function onChartOptionsChanged(event: ChartOptionsChanged) {
+  update(gridOptions.api!, event)
+
+  console.log("Options change of chart with ID " + event.chartId)
+}
+
+function update(api: GridApi, event: { chartId: string }) {
+  const chartRef = api.getChartRef(event.chartId)!
+  const chart = chartRef.chart
+
+  AgChart.updateDelta(chart, {
+    legend: {
+      listeners: {
+        legendItemClick: (e: any) => console.log("legendItemClick", e),
+      },
+    },
+    listeners: {
+      seriesNodeClick: (e: any) => console.log("seriesNodeClick", e),
+    },
+  })
+}
+
+// setup the grid after the page has finished loading
+document.addEventListener("DOMContentLoaded", function () {
+  var gridDiv = document.querySelector<HTMLElement>("#myGrid")!
+  new Grid(gridDiv, gridOptions)
+
+  fetch("https://www.ag-grid.com/example-assets/weather-se-england.json")
+    .then(response => response.json())
+    .then(function (data) {
+      gridOptions.api!.setRowData(data)
+      gridOptions.api!.createRangeChart({
+        chartType: "column",
+        cellRange: { columns: ["Month", "Sunshine (hours)", "Rainfall (mm)"] },
+      })
+    })
+})

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/integrated-charts-events/index.md
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/integrated-charts-events/index.md
@@ -70,15 +70,19 @@ Note in the snippet above, the `chartId` is obtained from the [`ChartCreated`](#
 ## Updating Chart Instance
 
 [[only-javascript]]
-|The chart instance can be updated using the `AgChart.updateDelta()` method, as described in the [Standalone Charts - Options Reference](/charts-api/#updating-charts-using-partial-options).
+|The chart instance can be updated using the `AgChart.updateDelta()` method, as described in the [Standalone Charts - API > Create/Update](/charts-api-create-update/#delta-options-update) section.
 
 [[only-frameworks]]
-|The chart instance can be updated using the `AgChart.updateDelta()` method, as described in the [Standalone Charts - Options Reference](/charts-api/#updating-charts-using-partial-options-1).
+|The chart instance can be updated using the `AgChart.updateDelta()` method, as described in the [Standalone Charts - API > Create/Update](/charts-api-create-update/#delta-options-update-1) section.
 
 The example below shows how the chart instance can be used, creating a subtitle and updating
 it dynamically as you change the range selection.
 
 <grid-example title='Accessing & Updating Chart Instance' name='accessing-chart-instance' type='generated' options='{ "enterprise": true, "modules": ["clientside", "menu", "charts"], "enableChartApi": true }'></grid-example>
+
+The example below shows how we can subscribe to [Standalone Charts Events](/charts-events/):
+
+<grid-example title='Subscribing to Standalone Charts Events' name='standalone-events' type='generated' options='{ "enterprise": true, "modules": ["clientside", "menu", "charts"], "enableChartApi": true }'></grid-example>
 
 ## Other Resources
 


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-7905

Fixes setting of `listeners` and `legend.listeners` using `AgChart.updateDelta()` for Integrated Charts use-cases.

Additionally adds a new example to demonstrate this.