### PR TITLE
fix RangeHandle height overwritten after editing

### DIFF
--- a/community-modules/styles/src/internal/base/parts/_widgets.scss
+++ b/community-modules/styles/src/internal/base/parts/_widgets.scss
@@ -206,7 +206,7 @@
         color: var(--ag-secondary-foreground-color);
     }
 
-    .ag-cell-wrapper > *:not(.ag-cell-value):not(.ag-group-value) {
+    .ag-cell-wrapper > *:not(.ag-cell-value):not(.ag-group-value):not(.ag-fill-handle) {
         // assign internal variables to simplify the `height` value
         --ag-internal-calculated-line-height: var(--ag-line-height, calc(var(--ag-row-height) - var(--ag-row-border-width)));
         --ag-internal-padded-row-height: calc(var(--ag-row-height) - var(--ag-row-border-width));


### PR DESCRIPTION
If 
  - `ColDef.editable`
  -  `GridOptions.enableRangeHandle`
  -  `GridOptions.stopEditingWhenCellsLoseFocus`

are opening.

When we click on the outside of the table to finish editing, the height of the `div.ag-fill-handle` will appear to be overwritten.