### PR TITLE
Ag 7908/axis tick interval

### DIFF
--- a/charts-packages/ag-charts-community/src/axis.ts
+++ b/charts-packages/ag-charts-community/src/axis.ts
@@ -53,6 +53,11 @@ const OPT_TICK_COUNT = predicateWithMessage(
     `expecting an optional tick count Number value or, for a time axis, a Time Interval such as 'agCharts.time.month'`
 );
 
+const OPT_TICK_INTERVAL = predicateWithMessage(
+    (v: any, ctx) => OPTIONAL(v, ctx, (v: any, ctx) => NUMBER(0)(v, ctx) || v instanceof TimeInterval),
+    `expecting an optional positive Number value or, for a time axis, a Time Interval such as 'agCharts.time.month'`
+);
+
 const GRID_STYLE_KEYS = ['stroke', 'lineDash'];
 const GRID_STYLE = predicateWithMessage(
     ARRAY(undefined, (o) => {
@@ -122,7 +127,7 @@ class AxisTick<S extends Scale<D, number>, D = any> {
     @Deprecated('Use tick.interval or tick.minSpacing and tick.maxSpacing instead')
     count?: TickType<S> = undefined;
 
-    @Validate(OPT_TICK_COUNT)
+    @Validate(OPT_TICK_INTERVAL)
     interval?: TickType<S> = undefined;
 
     @Validate(OPT_ARRAY())

--- a/charts-packages/ag-charts-community/src/axis.ts
+++ b/charts-packages/ag-charts-community/src/axis.ts
@@ -54,8 +54,8 @@ const OPT_TICK_COUNT = predicateWithMessage(
 );
 
 const OPT_TICK_INTERVAL = predicateWithMessage(
-    (v: any, ctx) => OPTIONAL(v, ctx, (v: any, ctx) => NUMBER(0)(v, ctx) || v instanceof TimeInterval),
-    `expecting an optional positive Number value or, for a time axis, a Time Interval such as 'agCharts.time.month'`
+    (v: any, ctx) => OPTIONAL(v, ctx, (v: any, ctx) => (v !== 0 && NUMBER(0)(v, ctx)) || v instanceof TimeInterval),
+    `expecting an optional non-zero positive Number value or, for a time axis, a Time Interval such as 'agCharts.time.month'`
 );
 
 const GRID_STYLE_KEYS = ['stroke', 'lineDash'];

--- a/charts-packages/ag-charts-community/src/scale/continuousScale.ts
+++ b/charts-packages/ag-charts-community/src/scale/continuousScale.ts
@@ -110,7 +110,17 @@ export abstract class ContinuousScale implements Scale<any, any> {
         }
     }
 
-    protected isDenseInterval({ start, stop, interval }: { start: number; stop: number; interval: number }): boolean {
+    protected isDenseInterval({
+        start,
+        stop,
+        interval,
+        count,
+    }: {
+        start: number;
+        stop: number;
+        interval: number | TimeInterval;
+        count?: number;
+    }): boolean {
         const { range } = this;
         const domain = stop - start;
 
@@ -118,10 +128,13 @@ export abstract class ContinuousScale implements Scale<any, any> {
         const max = Math.max(range[0], range[1]);
 
         const availableRange = max - min;
-        const stepCount = domain / interval;
-        if (stepCount >= availableRange) {
+        const step = typeof interval === 'number' ? interval : 1;
+        count ??= domain / step;
+        if (count >= availableRange) {
             console.warn(
-                `AG Charts - the configured tick interval, ${interval}, results in more than 1 tick per pixel, no ticks will be displayed. Supply a larger tick interval or omit this configuration.`
+                `AG Charts - the configured tick interval, ${JSON.stringify(
+                    interval
+                )}, results in more than 1 tick per pixel, ignoring. Supply a larger tick interval or omit this configuration.`
             );
             return true;
         }

--- a/charts-packages/ag-charts-community/src/scale/linearScale.ts
+++ b/charts-packages/ag-charts-community/src/scale/linearScale.ts
@@ -22,11 +22,9 @@ export class LinearScale extends ContinuousScale {
 
         if (interval) {
             const step = Math.abs(interval);
-            if (this.isDenseInterval({ start: d0, stop: d1, interval: step })) {
-                return [];
+            if (!this.isDenseInterval({ start: d0, stop: d1, interval: step })) {
+                return range(d0, d1, step);
             }
-
-            return range(d0, d1, step);
         }
 
         return ticks(d0, d1, count);

--- a/charts-packages/ag-charts-community/src/scale/logScale.ts
+++ b/charts-packages/ag-charts-community/src/scale/logScale.ts
@@ -101,9 +101,13 @@ export class LogScale extends ContinuousScale {
         if (this.interval) {
             const step = Math.abs(this.interval);
             const absDiff = Math.abs(p1 - p0);
-            return range(p0, p1, Math.min(absDiff, step))
+            const ticks = range(p0, p1, Math.min(absDiff, step))
                 .map((x) => this.pow(x))
                 .filter((t) => t >= d0 && t <= d1);
+
+            if (!this.isDenseInterval({ start: d0, stop: d1, interval: step, count: ticks.length })) {
+                return ticks;
+            }
         }
 
         const isBaseInteger = base % 1 === 0;

--- a/charts-packages/ag-charts-community/src/scale/timeScale.ts
+++ b/charts-packages/ag-charts-community/src/scale/timeScale.ts
@@ -291,8 +291,12 @@ export class TimeScale extends ContinuousScale {
             }
         }
 
-        const t = this.getTickInterval({ start: t0, stop: t1, count: this.tickCount });
-        return t ? t.range(new Date(t0), new Date(t1)) : []; // inclusive stop
+        return this.getDefaultTicks({ start: t0, stop: t1 });
+    }
+
+    private getDefaultTicks({ start, stop }: { start: number; stop: number }) {
+        const t = this.getTickInterval({ start, stop, count: this.tickCount });
+        return t ? t.range(new Date(start), new Date(stop)) : []; // inclusive stop
     }
 
     private getTicksForInterval({ start, stop }: { start: number; stop: number }): Date[] {
@@ -303,13 +307,18 @@ export class TimeScale extends ContinuousScale {
         }
 
         if (interval instanceof TimeInterval) {
-            return interval.range(new Date(start), new Date(stop));
+            const ticks = interval.range(new Date(start), new Date(stop));
+            if (this.isDenseInterval({ start, stop, interval, count: ticks.length })) {
+                return this.getDefaultTicks({ start, stop });
+            }
+
+            return ticks;
         }
 
         const absInterval = Math.abs(interval);
 
         if (this.isDenseInterval({ start, stop, interval: absInterval })) {
-            return [];
+            return this.getDefaultTicks({ start, stop });
         }
 
         const timeInterval = tickIntervals.reverse().find((tickInterval) => absInterval % tickInterval[2] === 0);

--- a/charts-packages/ag-charts-community/src/util/ticks.ts
+++ b/charts-packages/ag-charts-community/src/util/ticks.ts
@@ -47,11 +47,15 @@ export class NumericTicks extends Array<number> {
 }
 
 export function range(start: number, stop: number, step: number): NumericTicks {
-    const fractionalRemainder = step.toString().split('.')[1];
-    const fractionDigits = fractionalRemainder?.length ?? 0;
-    const f = Math.pow(10, fractionDigits);
+    const countDigits = (expNo: string) => {
+        const parts = expNo.split('e');
+        return Math.max((parts[0].split('.')[1]?.length ?? 0) - Number(parts[1]), 0);
+    };
+
+    const fractionalDigits = countDigits((step % 1).toExponential());
+    const f = Math.pow(10, fractionalDigits);
     const n = Math.ceil((stop - start) / step);
-    const values = new NumericTicks(fractionDigits);
+    const values = new NumericTicks(fractionalDigits);
 
     for (let i = 0; i <= n; i++) {
         const value = start + step * i;

--- a/charts-packages/ag-charts-community/src/util/ticks.ts
+++ b/charts-packages/ag-charts-community/src/util/ticks.ts
@@ -47,8 +47,8 @@ export class NumericTicks extends Array<number> {
 }
 
 export function range(start: number, stop: number, step: number): NumericTicks {
-    const fractionalRemainder = step % 1;
-    const fractionDigits = fractionalRemainder === 0 ? 0 : -Math.floor(Math.log10(fractionalRemainder));
+    const fractionalRemainder = step.toString().split('.')[1];
+    const fractionDigits = fractionalRemainder?.length ?? 0;
     const f = Math.pow(10, fractionDigits);
     const n = Math.ceil((stop - start) / step);
     const values = new NumericTicks(fractionDigits);

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-axes/index.md
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-axes/index.md
@@ -170,13 +170,18 @@ tick: {
 }
 ```
 
-For `log` axes, the `interval` property can be a `number` which would modify the step for the exponent that the logarithm base is raised to.
+For `log` axes, the `interval` property can be a `number` which modifies the step for the exponent that the logarithm base is raised to.
 
-By default, the `interval` is `1`. When the common log base `10` axis is used, depending on the domain, in the following ticks are produced: 10^0, 10^1, 10^2, 10^3, 10^4, 10^5, 10^6 --> 1, 10, 100, 1000, 1000, 100000, 1000000. Here the exponent or power is being increased by `1` every time.
+By default, the `interval` is `1`. Increasing the `interval` will result in less ticks as the powers are incremented by a larger step. Reducing the `interval` to a fractional number more than `0` and less than `1` will result in more ticks with smaller intervals.
 
-Increasing the `interval` will result in less ticks as the powers are incremented by a larger step. If the `interval` is changed to `2` for example, the power would be incremented by `2` for every tick: 10^0, 10^2, 10^4, 10^6 --> 1, 100, 10000, 1000000.
+The table below shows the result of different `interval` values depending on the base.
 
-Reducing the `interval` to a fractional number more than `0` and less than `1` will result in more ticks with smaller intervals.
+| Interval | Base 10 | Base 2 |
+| --------- | --------- | --------- |
+| 1 | 10^0, 10^1, 10^2, 10^3, 10^4 | 2^0, 2^1, 2^2, 2^3, 2^4 |
+| 2 | 10^0, 10^2, 10^4 | 2^0, 2^2, 2^4 |
+| 0.5 | 10^0, 10^0.5, 10^1, 10^1.5, 10^2, 10^2.5, 10^3, 10^3.5, 10^4 | 2^0, 2^0.5, 2^1, 2^1.5, 2^2, 2^2.5, 2^3, 2^3.5, 2^4  |
+
 
 For `time` axes the `interval` property can be set to a time interval such as `agCharts.time.month`, which makes the axis show a tick every month, or to an interval derived from one of the predefined intervals, such as `agCharts.time.month.every(3)`.
 

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-axes/index.md
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-axes/index.md
@@ -162,7 +162,7 @@ tick: {
 
 `tick.interval` is the step value between ticks specified in the units of the axis.
 
-For number axes, the `interval` property should be set to a `number` to show a tick every `interval` value.
+For `number` axes, the `interval` property should be set to a `number` to show a tick every `interval` value.
 
 ```js
 tick: {
@@ -170,7 +170,15 @@ tick: {
 }
 ```
 
-For time axes the `interval` property can be set to a time interval such as `agCharts.time.month`, which makes the axis show a tick every month, or to an interval derived from one of the predefined intervals, such as `agCharts.time.month.every(3)`.
+For `log` axes, the `interval` property can be a `number` which would modify the step for the exponent that the logarithm base is raised to.
+
+By default, the `interval` is `1`. When the common log base `10` axis is used, depending on the domain, in the following ticks are produced: 10^0, 10^1, 10^2, 10^3, 10^4, 10^5, 10^6 --> 1, 10, 100, 1000, 1000, 100000, 1000000. Here the exponent or power is being increased by `1` every time.
+
+Increasing the `interval` will result in less ticks as the powers are incremented by a larger step. If the `interval` is changed to `2` for example, the power would be incremented by `2` for every tick: 10^0, 10^2, 10^4, 10^6 --> 1, 100, 10000, 1000000.
+
+Reducing the `interval` to a fractional number more than `0` and less than `1` will result in more ticks with smaller intervals.
+
+For `time` axes the `interval` property can be set to a time interval such as `agCharts.time.month`, which makes the axis show a tick every month, or to an interval derived from one of the predefined intervals, such as `agCharts.time.month.every(3)`.
 
 ```js
 tick: {


### PR DESCRIPTION
PR for https://ag-grid.atlassian.net/browse/AG-7908

Addresses Davids comments:
https://ag-grid.atlassian.net/browse/AG-7908?focusedCommentId=47309

1/

Requesting too many ticks via a small interval, warns the user as expected. 

However, no ticks at all are rendered. If we are ignoring the provided interval, we should display the default ‘nice’ tick number.

2/

Invalid options of providing a string is handled correctly. 
When provided with a negative interval, it is ignored but the message does not mention why.

Property [interval] cannot be set to [-1]; expecting an optional tick count Number value or, for a time axis, a Time Interval such as 'agCharts.time.month', ignoring.

3/
When providing an interval of 0, it is ignored (I think), and no warning message is displayed.


4/
Axis intervals don’t work properly at two decimal places.
https://plnkr.co/edit/dXcBmGSOa89vAaCn?open=main.js
The axis interval should be 0.75, but alternates between 0.7 and 0.8