### PR TITLE
Ag 7909/axes tick values

### DIFF
--- a/charts-packages/ag-charts-community/src/axis.ts
+++ b/charts-packages/ag-charts-community/src/axis.ts
@@ -453,17 +453,13 @@ export class Axis<S extends Scale<D, number, TickInterval<S>>, D = any> {
             dataDomain,
             tick: { values: tickValues },
         } = this;
-        const continuous = scale instanceof ContinuousScale;
-        if (!continuous || !tickValues) {
-            scale.domain = dataDomain;
-            return;
-        }
-
-        if (scale instanceof ContinuousScale) {
+        if (tickValues && scale instanceof ContinuousScale) {
             const [tickMin, tickMax] = extent(tickValues) ?? [Infinity, -Infinity];
             const min = Math.min(scale.fromDomain(dataDomain[0]), tickMin);
             const max = Math.max(scale.fromDomain(dataDomain[1]), tickMax);
             scale.domain = [scale.toDomain(min), scale.toDomain(max)];
+        } else {
+            scale.domain = dataDomain;
         }
     }
 

--- a/charts-packages/ag-charts-community/src/axis.ts
+++ b/charts-packages/ag-charts-community/src/axis.ts
@@ -438,8 +438,8 @@ export class Axis<S extends Scale<D, number, TickInterval<S>>, D = any> {
             this._title = value;
 
             // position title so that it doesn't briefly get rendered in the top left hand corner of the canvas before update is called.
-            this.setTickCount();
-            this.setTickInterval();
+            this.setTickCount(this.tick.count);
+            this.setTickInterval(this.tick.interval);
             this.updateTitle({ ticks: this.scale.ticks!() });
         }
     }
@@ -468,7 +468,7 @@ export class Axis<S extends Scale<D, number, TickInterval<S>>, D = any> {
     }
 
     private setTickInterval(interval?: TickInterval<S>) {
-        this.scale.interval = interval;
+        this.scale.interval = this.tick.interval ?? interval;
     }
 
     private setTickCount(count?: TickCount<S> | number) {
@@ -583,7 +583,7 @@ export class Axis<S extends Scale<D, number, TickInterval<S>>, D = any> {
         const nice = this.nice;
         this.setDomain();
 
-        this.setTickInterval();
+        this.setTickInterval(this.tick.interval);
 
         if (scale instanceof ContinuousScale) {
             scale.nice = nice;

--- a/charts-packages/ag-charts-community/src/axis.ts
+++ b/charts-packages/ag-charts-community/src/axis.ts
@@ -1161,14 +1161,14 @@ export class Axis<S extends Scale<D, number, TickInterval<S>>, D = any> {
 
         if (label.formatter) {
             return label.formatter({
-                value: fractionDigits >= 0 ? datum : String(datum),
+                value: fractionDigits > 0 ? datum : String(datum),
                 index,
                 fractionDigits,
                 formatter: labelFormatter,
             });
         } else if (labelFormatter) {
             return labelFormatter(datum);
-        } else if (!logScale && typeof datum === 'number' && fractionDigits >= 0) {
+        } else if (!logScale && typeof datum === 'number' && fractionDigits > 0) {
             // the `datum` is a floating point number
             return datum.toFixed(fractionDigits);
         }

--- a/charts-packages/ag-charts-community/src/axis.ts
+++ b/charts-packages/ag-charts-community/src/axis.ts
@@ -43,6 +43,7 @@ import { AgAxisGridStyle, AgAxisLabelFormatterParams, FontStyle, FontWeight } fr
 import { LogScale } from './scale/logScale';
 import { Default } from './util/default';
 import { Deprecated } from './util/deprecation';
+import { extent } from './util/array';
 
 const TICK_COUNT = predicateWithMessage(
     (v: any, ctx) => NUMBER(0)(v, ctx) || v instanceof TimeInterval,
@@ -81,10 +82,9 @@ interface AxisNodeDatum {
     readonly translationY: number;
 }
 
-type TimeTick = number | TimeInterval;
-type NumberTick = number;
+type TickCount<S> = S extends TimeScale ? number | TimeInterval : number;
 
-type TickType<S> = S extends TimeScale ? TimeTick : NumberTick;
+export type TickInterval<S> = S extends TimeScale ? number | TimeInterval : number;
 
 export class AxisLine {
     @Validate(NUMBER(0))
@@ -125,10 +125,10 @@ class AxisTick<S extends Scale<D, number>, D = any> {
      */
     @Validate(OPT_TICK_COUNT)
     @Deprecated('Use tick.interval or tick.minSpacing and tick.maxSpacing instead')
-    count?: TickType<S> = undefined;
+    count?: TickCount<S> = undefined;
 
     @Validate(OPT_TICK_INTERVAL)
-    interval?: TickType<S> = undefined;
+    interval?: TickInterval<S> = undefined;
 
     @Validate(OPT_ARRAY())
     values?: any[] = undefined;
@@ -248,7 +248,7 @@ export class AxisLabel {
  * The generic `D` parameter is the type of the domain of the axis' scale.
  * The output range of the axis' scale is always numeric (screen coordinates).
  */
-export class Axis<S extends Scale<D, number>, D = any> {
+export class Axis<S extends Scale<D, number, TickInterval<S>>, D = any> {
     static readonly defaultTickMinSpacing = 80;
 
     readonly id = createId(this);
@@ -438,8 +438,8 @@ export class Axis<S extends Scale<D, number>, D = any> {
             this._title = value;
 
             // position title so that it doesn't briefly get rendered in the top left hand corner of the canvas before update is called.
-            this.setTickCount(this.scale, this.tick.count);
-            this.setTickInterval(this.scale, this.tick.interval);
+            this.setTickCount();
+            this.setTickInterval();
             this.updateTitle({ ticks: this.scale.ticks!() });
         }
     }
@@ -447,19 +447,32 @@ export class Axis<S extends Scale<D, number>, D = any> {
         return this._title;
     }
 
-    private setTickInterval<S extends Scale<D, number>, D = any>(scale: S, interval?: any) {
-        if (!interval || typeof interval === 'number') {
-            scale.interval = interval;
+    private setDomain() {
+        const {
+            scale,
+            dataDomain,
+            tick: { values: tickValues },
+        } = this;
+        const continuous = scale instanceof ContinuousScale;
+        if (!continuous || !tickValues) {
+            scale.domain = dataDomain;
             return;
         }
 
-        if (scale instanceof TimeScale && interval instanceof TimeInterval) {
-            scale.interval = interval;
-            return;
+        if (scale instanceof ContinuousScale) {
+            const [tickMin, tickMax] = extent(tickValues) ?? [Infinity, -Infinity];
+            const min = Math.min(scale.fromDomain(dataDomain[0]), tickMin);
+            const max = Math.max(scale.fromDomain(dataDomain[1]), tickMax);
+            scale.domain = [scale.toDomain(min), scale.toDomain(max)];
         }
     }
 
-    private setTickCount<S extends Scale<D, number>, D = any>(scale: S, count?: any) {
+    private setTickInterval(interval?: TickInterval<S>) {
+        this.scale.interval = interval;
+    }
+
+    private setTickCount(count?: TickCount<S> | number) {
+        const { scale } = this;
         if (!(count && scale instanceof ContinuousScale)) {
             return;
         }
@@ -469,8 +482,8 @@ export class Axis<S extends Scale<D, number>, D = any> {
             return;
         }
 
-        if (scale instanceof TimeScale && count instanceof TimeInterval) {
-            this.setTickInterval(scale, count);
+        if (scale instanceof TimeScale) {
+            this.setTickInterval(count);
         }
     }
 
@@ -568,13 +581,13 @@ export class Axis<S extends Scale<D, number>, D = any> {
         const regularFlipRotation = normalizeAngle360(rotation - Math.PI / 2);
 
         const nice = this.nice;
-        scale.domain = this.dataDomain;
+        this.setDomain();
 
-        this.setTickInterval(scale, this.tick.interval);
+        this.setTickInterval();
 
         if (scale instanceof ContinuousScale) {
             scale.nice = nice;
-            this.setTickCount(scale, this.tick.count);
+            this.setTickCount(this.tick.count);
             scale.update();
         }
 
@@ -623,7 +636,7 @@ export class Axis<S extends Scale<D, number>, D = any> {
                 } else if (filteredTicks && filteredTicks.length > 0) {
                     ticks = filteredTicks;
                 } else if (!secondaryAxis) {
-                    this.setTickCount(scale, this.tick.count ?? tickCount);
+                    this.setTickCount(this.tick.count ?? tickCount);
                     ticks = scale.ticks!();
                 }
 

--- a/charts-packages/ag-charts-community/src/chart/axis/timeAxis.ts
+++ b/charts-packages/ag-charts-community/src/chart/axis/timeAxis.ts
@@ -3,7 +3,7 @@ import { TimeScale } from '../../scale/timeScale';
 import { extent } from '../../util/array';
 import { ChartAxis } from '../chartAxis';
 
-export class TimeAxis extends ChartAxis<TimeScale> {
+export class TimeAxis extends ChartAxis<TimeScale, number | Date> {
     static className = 'TimeAxis';
     static type = 'time' as const;
 

--- a/charts-packages/ag-charts-community/src/chart/chartAxis.ts
+++ b/charts-packages/ag-charts-community/src/chart/chartAxis.ts
@@ -1,5 +1,5 @@
 import { Scale } from '../scale/scale';
-import { Axis } from '../axis';
+import { Axis, TickInterval } from '../axis';
 import { Series } from './series/series';
 import { LinearScale } from '../scale/linearScale';
 import { POSITION, STRING_ARRAY, Validate } from '../util/validation';
@@ -18,7 +18,10 @@ export function flipChartAxisDirection(direction: ChartAxisDirection): ChartAxis
     }
 }
 
-export class ChartAxis<S extends Scale<any, number> = Scale<any, number>, D = any> extends Axis<S, D> {
+export class ChartAxis<S extends Scale<D, number, TickInterval<S>> = Scale<any, number, any>, D = any> extends Axis<
+    S,
+    D
+> {
     @Validate(STRING_ARRAY)
     keys: string[] = [];
 

--- a/charts-packages/ag-charts-community/src/scale/bandScale.ts
+++ b/charts-packages/ag-charts-community/src/scale/bandScale.ts
@@ -7,7 +7,7 @@ function clamp(x: number, min: number, max: number) {
 /**
  * Maps a discrete domain to a continuous numeric range.
  */
-export class BandScale<D> implements Scale<D, number> {
+export class BandScale<D> implements Scale<D, number, number> {
     readonly type = 'band';
 
     interval?: number;

--- a/charts-packages/ag-charts-community/src/scale/colorScale.ts
+++ b/charts-packages/ag-charts-community/src/scale/colorScale.ts
@@ -2,7 +2,7 @@ import { Scale } from './scale';
 import { Color } from '../util/color';
 import interpolateColor from '../interpolate/color';
 
-export class ColorScale implements Scale<number, string> {
+export class ColorScale implements Scale<number, string, number> {
     domain = [0, 1];
 
     private _range = ['red', 'green'];

--- a/charts-packages/ag-charts-community/src/scale/linearScale.ts
+++ b/charts-packages/ag-charts-community/src/scale/linearScale.ts
@@ -5,10 +5,18 @@ import { tickFormat } from '../util/numberFormat';
 /**
  * Maps continuous domain to a continuous range.
  */
-export class LinearScale extends ContinuousScale {
+export class LinearScale extends ContinuousScale<number> {
     readonly type = 'linear';
 
     interval?: number;
+
+    public constructor() {
+        super([0, 1], [0, 1]);
+    }
+
+    toDomain(d: number): number {
+        return d;
+    }
 
     ticks() {
         const count = this.tickCount ?? ContinuousScale.defaultTickCount;

--- a/charts-packages/ag-charts-community/src/scale/logScale.ts
+++ b/charts-packages/ag-charts-community/src/scale/logScale.ts
@@ -5,11 +5,16 @@ import { NUMBER, Validate } from '../util/validation';
 
 const identity = (x: any) => x;
 
-export class LogScale extends ContinuousScale {
+export class LogScale extends ContinuousScale<number> {
     readonly type = 'log';
 
-    domain = [1, 10];
-    interval?: number;
+    public constructor() {
+        super([1, 10], [0, 1]);
+    }
+
+    toDomain(d: number): number {
+        return d;
+    }
 
     @Validate(NUMBER(0))
     base = 10;

--- a/charts-packages/ag-charts-community/src/scale/scale.ts
+++ b/charts-packages/ag-charts-community/src/scale/scale.ts
@@ -1,5 +1,3 @@
-import { TimeInterval } from '../util/time/interval';
-
 export interface ScaleClampParams {
     /**
      * If `true` the values outside of the domain will become `NaN`.
@@ -14,12 +12,12 @@ export interface ScaleTickFormatParams {
     specifier?: any;
 }
 
-export interface Scale<D, R> {
+export interface Scale<D, R, I = number> {
     domain: D[];
     range: R[];
     nice?: boolean;
     tickCount?: number;
-    interval?: number | TimeInterval;
+    interval?: I;
     convert(value: D, params?: ScaleClampParams): R;
     invert?(value: R): D;
     ticks?(): D[];

--- a/charts-packages/ag-charts-community/src/scale/timeScale.ts
+++ b/charts-packages/ag-charts-community/src/scale/timeScale.ts
@@ -48,11 +48,9 @@ function toNumber(x: any) {
     return x instanceof Date ? x.getTime() : x;
 }
 
-export class TimeScale extends ContinuousScale {
+export class TimeScale extends ContinuousScale<Date, TimeInterval | number> {
     readonly type = 'time';
 
-    domain: Date[] = [new Date(2022, 11, 7), new Date(2022, 11, 8)];
-    interval?: TimeInterval | number;
     protected cacheProps: Array<keyof this> = ['domain', 'range', 'nice', 'tickCount', 'interval'];
 
     private year: CountableTimeInterval = timeYear;
@@ -98,6 +96,14 @@ export class TimeScale extends ContinuousScale {
         [this.month, 6, 6 * durationMonth],
         [this.year, 1, durationYear],
     ];
+
+    public constructor() {
+        super([new Date(2022, 11, 7), new Date(2022, 11, 8)], [0, 1]);
+    }
+
+    toDomain(d: number): Date {
+        return new Date(d);
+    }
 
     calculateDefaultTickFormat(ticks: any[] | undefined = []) {
         let defaultTimeFormat = DefaultTimeFormats.YEAR as DefaultTimeFormats;

--- a/enterprise-modules/sparklines/src/sparkline/area/areaSparkline.ts
+++ b/enterprise-modules/sparklines/src/sparkline/area/areaSparkline.ts
@@ -152,8 +152,8 @@ export class AreaSparkline extends Sparkline {
             const yDatum = yData[i];
             const xDatum = xData[i];
 
-            const x = xScale.convert(xDatum) + offsetX;
-            const y = yScale.convert(yDatum);
+            const x = xScale.convert(xScale.toDomain(xDatum)) + offsetX;
+            const y = yDatum ? yScale.convert(yDatum) : NaN;
 
             // if this iteration is not the last, set nextX using the next value in the data array
             if (i + 1 < n) {

--- a/enterprise-modules/sparklines/src/sparkline/bar-column/barSparkline.ts
+++ b/enterprise-modules/sparklines/src/sparkline/bar-column/barSparkline.ts
@@ -5,7 +5,7 @@ import { Point } from '../sparkline';
 const { isNumber } = _Util;
 const { BandScale } = _Scale;
 
-interface BarNodeDatum extends RectNodeDatum { }
+interface BarNodeDatum extends RectNodeDatum {}
 export class BarSparkline extends BarColumnSparkline {
     static className = 'BarSparkline';
 
@@ -80,15 +80,12 @@ export class BarSparkline extends BarColumnSparkline {
             }
 
             const y = xScale.convert(xDatum);
-            const x = Math.min(yScale.convert(yDatum), yZero);
+            const x = Math.min(yDatum ? yScale.convert(yDatum) : NaN, yZero);
 
-            const bottom: number = Math.max(yScale.convert(yDatum), yZero);
+            const bottom: number = Math.max(yDatum ? yScale.convert(yDatum) : NaN, yZero);
 
             // if the scale is a band scale, the width of the rects will be the bandwidth, otherwise the width of the rects will be the range / number of items in the data
-            const height =
-                xScale instanceof BandScale
-                    ? xScale.bandwidth
-                    : this.bandWidth;
+            const height = xScale instanceof BandScale ? xScale.bandwidth : this.bandWidth;
 
             const width = bottom - x;
 

--- a/enterprise-modules/sparklines/src/sparkline/bar-column/columnSparkline.ts
+++ b/enterprise-modules/sparklines/src/sparkline/bar-column/columnSparkline.ts
@@ -78,10 +78,10 @@ export class ColumnSparkline extends BarColumnSparkline {
                 yDatum = 0;
             }
 
-            const y = Math.min(yScale.convert(yDatum), yZero);
+            const y = Math.min(yDatum ? yScale.convert(yDatum) : NaN, yZero);
             const x = xScale.convert(xDatum);
 
-            const bottom: number = Math.max(yScale.convert(yDatum), yZero);
+            const bottom: number = Math.max(yDatum ? yScale.convert(yDatum) : NaN, yZero);
 
             // if the scale is a band scale, the width of the rects will be the bandwidth, otherwise the width of the rects will be the range / number of items in the data
             const width =

--- a/enterprise-modules/sparklines/src/sparkline/line/lineSparkline.ts
+++ b/enterprise-modules/sparklines/src/sparkline/line/lineSparkline.ts
@@ -241,7 +241,7 @@ export class LineSparkline extends Sparkline {
             const yDatum = yData[i];
 
             const x = xScale.convert(xDatum) + offsetX;
-            const y = yScale.convert(yDatum);
+            const y = yDatum ? yScale.convert(yDatum) : NaN;
 
             if (yDatum == undefined) {
                 moveTo = true;

--- a/enterprise-modules/sparklines/src/sparkline/sparkline.ts
+++ b/enterprise-modules/sparklines/src/sparkline/sparkline.ts
@@ -108,7 +108,7 @@ export abstract class Sparkline {
     // Maximum y value in provided data.
     protected max: number | undefined = undefined;
 
-    protected xScale!: ScaleType;
+    protected xScale!: any;
     protected yScale: _Scale.LinearScale = new LinearScale();
 
     readonly axis = new SparklineAxis();

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/doc-interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/doc-interfaces.AUTO.json
@@ -5,9 +5,8 @@
     "tick": { "type": { "returnType": "any", "optional": false } },
     "translationY": { "type": { "returnType": "number", "optional": false } }
   },
-  "TimeTick": {},
-  "NumberTick": {},
-  "TickType": { "meta": { "typeParams": ["S"] } },
+  "TickCount": { "meta": { "typeParams": ["S"] } },
+  "TickInterval": { "meta": { "typeParams": ["S"] } },
   "Size": {},
   "OffscreenCanvasRenderingContext2D": {},
   "OffscreenCanvas": {},
@@ -5182,9 +5181,7 @@
     "range": { "type": { "returnType": "R[]", "optional": false } },
     "nice": { "type": { "returnType": "boolean", "optional": true } },
     "tickCount": { "type": { "returnType": "number", "optional": true } },
-    "interval": {
-      "type": { "returnType": "number | TimeInterval", "optional": true }
-    },
+    "interval": { "type": { "returnType": "I", "optional": true } },
     "convert": {
       "type": {
         "arguments": { "value": "D", "params?": "ScaleClampParams" },
@@ -5210,7 +5207,7 @@
       }
     },
     "bandwidth": { "type": { "returnType": "number", "optional": true } },
-    "meta": { "typeParams": ["D", "R"] }
+    "meta": { "typeParams": ["D", "R", "I = number"] }
   },
   "DefaultTimeFormats": {},
   "RedrawType": {},

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
@@ -8,14 +8,13 @@
     "meta": {},
     "type": { "tick": "any", "translationY": "number" }
   },
-  "TimeTick": {
-    "meta": { "isTypeAlias": true },
-    "type": "number | TimeInterval"
-  },
-  "NumberTick": { "meta": { "isTypeAlias": true }, "type": "number" },
-  "TickType": {
+  "TickCount": {
     "meta": { "isTypeAlias": true, "typeParams": ["S"] },
-    "type": "S extends TimeScale ? TimeTick : NumberTick"
+    "type": "S extends TimeScale ? number | TimeInterval : number"
+  },
+  "TickInterval": {
+    "meta": { "isTypeAlias": true, "typeParams": ["S"] },
+    "type": "S extends TimeScale ? number | TimeInterval : number"
   },
   "Size": {
     "meta": { "isTypeAlias": true },
@@ -3632,13 +3631,13 @@
     "type": { "count?": "any", "ticks?": "any[]", "specifier?": "any" }
   },
   "Scale": {
-    "meta": { "typeParams": ["D", "R"] },
+    "meta": { "typeParams": ["D", "R", "I = number"] },
     "type": {
       "domain": "D[]",
       "range": "R[]",
       "nice?": "boolean",
       "tickCount?": "number",
-      "interval?": "number | TimeInterval",
+      "interval?": "I",
       "convert(value: D, params?: ScaleClampParams)": "R",
       "invert?(value: R)": "D",
       "ticks?()": "D[]",


### PR DESCRIPTION
PR for https://ag-grid.atlassian.net/browse/AG-7909

Extends scale domain so that all provided tick values are displayed
Removes default formatting so exact tick values are displayed

Some tightening of the types for scales