### PR TITLE
AG-7461 Fix series node click to check distance is zero

### DIFF
--- a/charts-packages/ag-charts-community/src/chart/chart.ts
+++ b/charts-packages/ag-charts-community/src/chart/chart.ts
@@ -891,6 +891,7 @@ export abstract class Chart extends Observable implements AgChartInstance {
         | {
               series: Series<any>;
               datum: SeriesNodeDatum;
+              distance: number;
           }
         | undefined {
         const {
@@ -1006,19 +1007,11 @@ export abstract class Chart extends Observable implements AgChartInstance {
     }
 
     private checkSeriesNodeClick(event: InteractionEvent<'click'>): boolean {
-        const { lastPick } = this;
+        const pick = this.pickSeriesNode({ x: event.offsetX, y: event.offsetY });
 
-        if (lastPick?.datum) {
-            const { datum } = lastPick;
-            datum.series.fireNodeClickEvent(event.sourceEvent, datum);
+        if (pick?.distance === 0) {
+            pick.series.fireNodeClickEvent(event.sourceEvent, pick.datum);
             return true;
-        } else if (event.sourceEvent.type.startsWith('touch')) {
-            const pick = this.pickSeriesNode({ x: event.offsetX, y: event.offsetY });
-
-            if (pick) {
-                pick.series.fireNodeClickEvent(event.sourceEvent, pick.datum);
-                return true;
-            }
         }
 
         return false;

--- a/charts-packages/ag-charts-community/src/chart/chart.ts
+++ b/charts-packages/ag-charts-community/src/chart/chart.ts
@@ -887,21 +887,20 @@ export abstract class Chart extends Observable implements AgChartInstance {
     }
 
     // x/y are local canvas coordinates in CSS pixels, not actual pixels
-    private pickSeriesNode(point: Point):
+    private pickSeriesNode(
+        point: Point,
+        exactMatchOnly: boolean
+    ):
         | {
               series: Series<any>;
               datum: SeriesNodeDatum;
               distance: number;
           }
         | undefined {
-        const {
-            tooltip: { tracking },
-        } = this;
-
         const start = performance.now();
 
         // Disable 'nearest match' options if tooltip.tracking is enabled.
-        const pickModes = tracking ? undefined : [SeriesNodePickMode.EXACT_SHAPE_MATCH];
+        const pickModes = exactMatchOnly ? [SeriesNodePickMode.EXACT_SHAPE_MATCH] : undefined;
 
         // Iterate through series in reverse, as later declared series appears on top of earlier
         // declared series.
@@ -968,7 +967,7 @@ export abstract class Chart extends Observable implements AgChartInstance {
             return;
         }
 
-        const pick = this.pickSeriesNode({ x: offsetX, y: offsetY });
+        const pick = this.pickSeriesNode({ x: offsetX, y: offsetY }, !this.tooltip.tracking);
 
         if (!pick) {
             disablePointer();
@@ -1007,9 +1006,9 @@ export abstract class Chart extends Observable implements AgChartInstance {
     }
 
     private checkSeriesNodeClick(event: InteractionEvent<'click'>): boolean {
-        const pick = this.pickSeriesNode({ x: event.offsetX, y: event.offsetY });
+        const pick = this.pickSeriesNode({ x: event.offsetX, y: event.offsetY }, true);
 
-        if (pick?.distance === 0) {
+        if (pick) {
             pick.series.fireNodeClickEvent(event.sourceEvent, pick.datum);
             return true;
         }


### PR DESCRIPTION
PR for https://ag-grid.atlassian.net/browse/AG-7461

This takes the simplistic approach of checking the pick distance is zero, and doesn't address separating highlighting and clicking behaviour / configuration.