### PR TITLE
AG-7461 Fix area series to force pick nearest node not exact match

### DIFF
--- a/charts-packages/ag-charts-community/src/chart/chart.test.ts
+++ b/charts-packages/ag-charts-community/src/chart/chart.test.ts
@@ -238,7 +238,7 @@ describe('Chart', () => {
         });
     });
 
-    describe.skip(`Area Series Pointer Events`, () => {
+    describe(`Area Series Pointer Events`, () => {
         testPointerEvents({
             ...cartesianTestParams,
             seriesOptions: <AgAreaSeriesOptions>{

--- a/charts-packages/ag-charts-community/src/chart/chart.ts
+++ b/charts-packages/ag-charts-community/src/chart/chart.ts
@@ -1006,11 +1006,17 @@ export abstract class Chart extends Observable implements AgChartInstance {
     }
 
     private checkSeriesNodeClick(event: InteractionEvent<'click'>): boolean {
-        const pick = this.pickSeriesNode({ x: event.offsetX, y: event.offsetY }, true);
+        const datum = this.lastPick?.datum;
 
-        if (pick) {
-            pick.series.fireNodeClickEvent(event.sourceEvent, pick.datum);
+        if (datum && datum.series.pickForceNearestMatching) {
+            datum.series.fireNodeClickEvent(event.sourceEvent, datum);
             return true;
+        } else {
+            const pick = this.pickSeriesNode({ x: event.offsetX, y: event.offsetY }, true);
+            if (pick) {
+                pick.series.fireNodeClickEvent(event.sourceEvent, pick.datum);
+                return true;
+            }
         }
 
         return false;

--- a/charts-packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
@@ -121,6 +121,8 @@ export class AreaSeries extends CartesianSeries<AreaSeriesNodeDataContext> {
 
     readonly label = new AreaSeriesLabel();
 
+    pickForceNearestMatching = true;
+
     @Validate(COLOR_STRING_ARRAY)
     fills: string[] = ['#c16068', '#a2bf8a', '#ebcc87', '#80a0c3', '#b58dae', '#85c0d1'];
 

--- a/charts-packages/ag-charts-community/src/chart/series/series.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/series.ts
@@ -186,6 +186,9 @@ export abstract class Series<C extends SeriesNodeDataContext = SeriesNodeDataCon
 
     pickModes: SeriesNodePickMode[];
 
+    // Does the series force node click matching to always use nearest, and not exact shape.
+    pickForceNearestMatching: boolean = false;
+
     @Validate(STRING)
     cursor = 'default';
 


### PR DESCRIPTION
PR for https://ag-grid.atlassian.net/browse/AG-7461

This is a temporary fix pending changes from https://ag-grid.atlassian.net/browse/AG-8058

Area series have to use nearest match since the user expects to click in the area, but the node they click is still just the point on the line that defines the edge of the area. Unlike the column series where the whole column is the node that registers the click.