### PR TITLE
AG 8058 Interaction range docs for tooltips and node clicks

### DIFF
--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-events/examples/interaction-ranges/index.html
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-events/examples/interaction-ranges/index.html
@@ -1,0 +1,8 @@
+<div class="wrapper">
+  <div id="toolPanel">
+    <button onclick="nearest()">Nearest</button>
+    <button onclick="exact()">Exact</button>
+    <button onclick="distance()">Distance (10 Pixels)</button>
+  </div>
+  <div id="myChart"></div>
+</div>

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-events/examples/interaction-ranges/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-events/examples/interaction-ranges/main.ts
@@ -1,0 +1,82 @@
+import {
+  AgCartesianChartOptions,
+  AgChart,
+  AgChartInteractionRange,
+} from "ag-charts-community"
+
+let options: AgCartesianChartOptions = {
+  container: document.getElementById("myChart"),
+  autoSize: true,
+  tooltip: {
+    range: "nearest",
+  },
+  data: [
+    {
+      quarter: "Q1",
+      petrol: 200,
+      diesel: 100,
+    },
+    {
+      quarter: "Q2",
+      petrol: 300,
+      diesel: 130,
+    },
+    {
+      quarter: "Q3",
+      petrol: 350,
+      diesel: 160,
+    },
+    {
+      quarter: "Q4",
+      petrol: 400,
+      diesel: 200,
+    },
+  ],
+  series: [
+    {
+      xKey: "quarter",
+      yKey: "petrol",
+      nodeClickRange: "nearest",
+      listeners: {
+        nodeClick: event =>
+          window.alert(`${event.yKey} - ${event.datum.petrol}`),
+      },
+    },
+    {
+      xKey: "quarter",
+      yKey: "diesel",
+      nodeClickRange: "nearest",
+      listeners: {
+        nodeClick: event =>
+          window.alert(`${event.yKey} - ${event.datum.diesel}`),
+      },
+    },
+  ],
+  axes: [
+    { type: "category", position: "bottom" },
+    { type: "number", position: "left" },
+  ],
+}
+
+var chart = AgChart.create(options)
+
+function updateRange(range: AgChartInteractionRange) {
+  if (options.tooltip) options.tooltip.range = range
+  options.series = options.series?.map(s => ({
+    ...s,
+    nodeClickRange: range,
+  }))
+  AgChart.update(chart, options)
+}
+
+function nearest() {
+  updateRange("nearest")
+}
+
+function exact() {
+  updateRange("exact")
+}
+
+function distance() {
+  updateRange(10)
+}

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-events/examples/interaction-ranges/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-events/examples/interaction-ranges/main.ts
@@ -1,8 +1,4 @@
-import {
-  AgCartesianChartOptions,
-  AgChart,
-  AgChartInteractionRange,
-} from "ag-charts-community"
+import { AgCartesianChartOptions, AgChart } from "ag-charts-community"
 
 let options: AgCartesianChartOptions = {
   container: document.getElementById("myChart"),
@@ -60,23 +56,26 @@ let options: AgCartesianChartOptions = {
 
 var chart = AgChart.create(options)
 
-function updateRange(range: AgChartInteractionRange) {
-  if (options.tooltip) options.tooltip.range = range
+function nearest() {
   options.series = options.series?.map(s => ({
     ...s,
-    nodeClickRange: range,
+    nodeClickRange: "nearest",
   }))
   AgChart.update(chart, options)
 }
 
-function nearest() {
-  updateRange("nearest")
-}
-
 function exact() {
-  updateRange("exact")
+  options.series = options.series?.map(s => ({
+    ...s,
+    nodeClickRange: "exact",
+  }))
+  AgChart.update(chart, options)
 }
 
 function distance() {
-  updateRange(10)
+  options.series = options.series?.map(s => ({
+    ...s,
+    nodeClickRange: 10,
+  }))
+  AgChart.update(chart, options)
 }

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-events/examples/interaction-ranges/styles.css
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-events/examples/interaction-ranges/styles.css
@@ -1,0 +1,17 @@
+.wrapper {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+#toolPanel {
+  text-align: center;
+}
+
+#toolPanel button {
+  margin-left: 20px;
+}
+
+#myChart {
+  height: 100%;
+}

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-events/examples/series-node-click-event/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-events/examples/series-node-click-event/main.ts
@@ -1,56 +1,53 @@
-import { AgChartOptions, AgChart } from 'ag-charts-community'
+import { AgChart, AgChartOptions } from "ag-charts-community"
 
 const options: AgChartOptions = {
-  container: document.getElementById('myChart'),
+  container: document.getElementById("myChart"),
   title: {
-    text: 'Average low/high temperatures in London',
+    text: "Average low/high temperatures in London",
   },
   subtitle: {
-    text: '(click a data point for details)',
+    text: "(click a data point for details)",
   },
   data: [
-    { month: 'March', low: 3.9, high: 11.3 },
-    { month: 'April', low: 5.5, high: 14.2 },
-    { month: 'May', low: 8.7, high: 17.9 },
+    { month: "March", low: 3.9, high: 11.3 },
+    { month: "April", low: 5.5, high: 14.2 },
+    { month: "May", low: 8.7, high: 17.9 },
   ],
   series: [
     {
-      type: 'line',
-      xKey: 'month',
-      yKey: 'high',
+      type: "line",
+      xKey: "month",
+      yKey: "high",
     },
     {
-      type: 'column',
-      xKey: 'month',
-      yKey: 'low',
+      type: "column",
+      xKey: "month",
+      yKey: "low",
     },
   ],
   axes: [
     {
-      type: 'category',
-      position: 'bottom',
+      type: "category",
+      position: "bottom",
     },
     {
-      type: 'number',
-      position: 'left',
+      type: "number",
+      position: "left",
     },
   ],
   legend: {
     enabled: false,
   },
-  tooltip: {
-    tracking: false
-  },
   listeners: {
     seriesNodeClick: ({ datum, xKey, yKey, seriesId }) => {
       window.alert(
-        'Temperature in ' +
-        datum[xKey!] +
-        ': ' +
-        String(datum[yKey!]) +
-        '°C' +
-        '\nSeries: ' +
-        seriesId
+        "Temperature in " +
+          datum[xKey!] +
+          ": " +
+          String(datum[yKey!]) +
+          "°C" +
+          "\nSeries: " +
+          seriesId
       )
     },
   },

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-events/index.md
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-events/index.md
@@ -45,6 +45,16 @@ Unlike other series, the `nodeClick` event `datum` parameter for Histogram serie
 
 <interface-documentation interfaceName='AgHistogramBinDatum' config='{ "lookupRoot": "charts-api" }'></interface-documentation>
 
+## Interaction Ranges
+
+By default, the `nodeClick` event is only triggered when the user clicks exactly on a node. You can use the `nodeClickRange` option to instead define a range at which the event is triggered. This can be set to one of three values: `'nearest'`, `'exact'` or a number as a distance in pixels.
+
+<!-- <chart-example title='Exact' name='interaction-range-exact' type='generated'></chart-example> -->
+
+<chart-example title='Interaction Ranges' name='interaction-ranges' type='generated'></chart-example>
+
+<!-- <chart-example title='Distance' name='interaction-range-distance' type='generated'></chart-example> -->
+
 ## Chart Event - seriesNodeClick
 
 The `seriesNodeClick` event can be used to listen to `nodeClick` events of all series at once.

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-events/index.md
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-events/index.md
@@ -49,11 +49,11 @@ Unlike other series, the `nodeClick` event `datum` parameter for Histogram serie
 
 By default, the `nodeClick` event is only triggered when the user clicks exactly on a node. You can use the `nodeClickRange` option to instead define a range at which the event is triggered. This can be set to one of three values: `'nearest'`, `'exact'` or a number as a distance in pixels.
 
-<!-- <chart-example title='Exact' name='interaction-range-exact' type='generated'></chart-example> -->
+### Example: Interaction range variations
+
+This example shows the three different types of interaction range that are possible.
 
 <chart-example title='Interaction Ranges' name='interaction-ranges' type='generated'></chart-example>
-
-<!-- <chart-example title='Distance' name='interaction-range-distance' type='generated'></chart-example> -->
 
 ## Chart Event - seriesNodeClick
 

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-events/index.md
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-events/index.md
@@ -53,6 +53,10 @@ By default, the `nodeClick` event is only triggered when the user clicks exactly
 
 This example shows the three different types of interaction range that are possible.
 
+- `'exact'` (default) will trigger the event if the user clicks exactly on a node
+- `'nearest'` will trigger the event for whichever node is nearest on the whole chart
+- given a number it will trigger the event when the click is made within that many pixels of a node
+
 <chart-example title='Interaction Ranges' name='interaction-ranges' type='generated'></chart-example>
 
 ## Chart Event - seriesNodeClick

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-tooltips/examples/interaction-range/index.html
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-tooltips/examples/interaction-range/index.html
@@ -1,0 +1,8 @@
+<div class="wrapper">
+  <div id="toolPanel">
+    <button onclick="nearest()">Nearest</button>
+    <button onclick="exact()">Exact</button>
+    <button onclick="distance()">Distance (10 Pixels)</button>
+  </div>
+  <div id="myChart"></div>
+</div>

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-tooltips/examples/interaction-range/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-tooltips/examples/interaction-range/main.ts
@@ -1,0 +1,56 @@
+import { AgCartesianChartOptions, AgChart } from "ag-charts-community"
+
+const options: AgCartesianChartOptions = {
+  container: document.getElementById("myChart"),
+  tooltip: {
+    range: "nearest",
+  },
+  data: [
+    {
+      month: "Jun",
+      value1: 50,
+      hats_made: 40,
+    },
+    {
+      month: "Jul",
+      value1: 70,
+      hats_made: 50,
+    },
+    {
+      month: "Aug",
+      value1: 60,
+      hats_made: 30,
+    },
+  ],
+  series: [
+    {
+      type: "line",
+      xKey: "month",
+      yKey: "value1",
+      yName: "Sweaters Made",
+    },
+    {
+      type: "line",
+      xKey: "month",
+      yKey: "hats_made",
+      yName: "Hats Made",
+    },
+  ],
+}
+
+var chart = AgChart.create(options)
+
+function nearest() {
+  if (options.tooltip) options.tooltip.range = "nearest"
+  AgChart.update(chart, options)
+}
+
+function exact() {
+  if (options.tooltip) options.tooltip.range = "exact"
+  AgChart.update(chart, options)
+}
+
+function distance() {
+  if (options.tooltip) options.tooltip.range = 10
+  AgChart.update(chart, options)
+}

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-tooltips/examples/interaction-range/style.css
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-tooltips/examples/interaction-range/style.css
@@ -1,0 +1,17 @@
+.wrapper {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+#toolPanel {
+  text-align: center;
+}
+
+#toolPanel button {
+  margin-left: 20px;
+}
+
+#myChart {
+  height: 100%;
+}

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-tooltips/index.md
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-tooltips/index.md
@@ -15,8 +15,8 @@ The default chart tooltip has the following template:
 
 ```html
 <div class="ag-chart-tooltip">
-    <div class="ag-chart-tooltip-title"></div>
-    <div class="ag-chart-tooltip-content"></div>
+  <div class="ag-chart-tooltip-title"></div>
+  <div class="ag-chart-tooltip-content"></div>
 </div>
 ```
 
@@ -33,15 +33,14 @@ To make the tooltip title visible you need to specify the series' `yName`, or `l
 
 In the sample data below the `value1` key is not descriptive, while `hats_made` is not very presentable:
 
-
 ```js
 data: [
-    {
-        month: 'Jun',
-        value1: 50,
-        hats_made: 40
-    },
-    // ...
+  {
+    month: "Jun",
+    value1: 50,
+    hats_made: 40,
+  },
+  // ...
 ]
 ```
 
@@ -59,26 +58,23 @@ Also note that for numeric values the tooltips show two digits after the decimal
 
 The default tooltip already uses `ag-chart-tooltip`, `ag-chart-tooltip-title` and `ag-chart-tooltip-content` CSS classes, but these classes are not meant to be used directly to add custom CSS rules to, unless you want to change the styling of all the tooltips in your app. Instead, users of the charting library should provide their own tooltip class name via the `chart.tooltip.class` config. This class name will be added to the class list of the tooltip element for only that particular chart instance.
 
-
 For example, if we wanted to set the tooltip's content `background-color` to `gold`, we'd add a custom class name to our chart in the code:
 
-
 ```js
-chart.tooltip.class = 'my-tooltip';
+chart.tooltip.class = "my-tooltip"
 ```
 
 And then in the CSS:
 
 ```css
 .my-tooltip .ag-chart-tooltip-content {
-    background-color: gold;
+  background-color: gold;
 }
 ```
 
 This limits the styling changes to this chart instance alone (or instances that use the same tooltip class). We could style the title element and the container element in the same manner.
 
 Note that your styles don't override the default tooltip styles but complement them.
-
 
 ### Example: Tooltip Styling
 
@@ -89,7 +85,6 @@ In this example we show how to change the content's background color and the col
 ## Modifying Content / Title
 
 To control what goes into the title and content divs of the tooltip one can set up a tooltip renderer function (one per series) that receives values associated with the highlighted data point and returns an object with the `title` and `content` fields containing plain text or inner HTML that goes into the corresponding divs:
-
 
 ```ts
 tooltip: {
@@ -106,34 +101,33 @@ The actual type of the `params` object passed into the tooltip renderer will dep
 
 ```ts
 interface AgTooltipRendererParams {
-    // the element of the series' data represented by the highlighted item
-    datum: any;
-    // the title of the series, if any
-    title?: string;
-    // the color of the series
-    color?: string;
+  // the element of the series' data represented by the highlighted item
+  datum: any
+  // the title of the series, if any
+  title?: string
+  // the color of the series
+  color?: string
 
-    // the xKey used to fetch the xValue from the datum, same as series xKey
-    xKey: string;
-    // the actual xValue used
-    xValue?: any;
-    // same as series.xName
-    xName?: string;
+  // the xKey used to fetch the xValue from the datum, same as series xKey
+  xKey: string
+  // the actual xValue used
+  xValue?: any
+  // same as series.xName
+  xName?: string
 
-    // the yKey used to fetch the yValue from the datum,
-    // equals to the value of `yKey` for one of the elements in the series,
-    // depending on which bar inside a stack/group is highlighted
-    yKey: string;
-    // the actuall yValue used
-    yValue?: any;
-    // equals to the value of `yName` for one of the elements in the series
-    yName?: string;
+  // the yKey used to fetch the yValue from the datum,
+  // equals to the value of `yKey` for one of the elements in the series,
+  // depending on which bar inside a stack/group is highlighted
+  yKey: string
+  // the actuall yValue used
+  yValue?: any
+  // equals to the value of `yName` for one of the elements in the series
+  yName?: string
 }
 ```
 
 Let's say we wanted to remove the digits after the decimal point from the values shown in tooltips.
 We could use the following tooltip renderer to achieve that:
-
 
 ```js
 tooltip: {
@@ -156,16 +150,23 @@ Instead of having the tooltip renderer return an object with title and content s
 
 Let's say we wanted to remove the digits after the decimal point from the values shown in tooltips (by default the tooltips show two digits after the decimal point for numeric values). We could use the following tooltip renderer to achieve that:
 
-
 ```js
-series: [{
-    type: 'column',
+series: [
+  {
+    type: "column",
     tooltip: {
-        renderer: function (params) {
-            return '<div class="ag-chart-tooltip-title" ' + 'style="background-color:' + params.color + '">' + params.xValue + '</div>' + '<div class="ag-chart-tooltip-content">' + params.yValue + '</div>';
-        }
-    }
-}]
+      renderer: function (params) {
+        return `
+            <div class="ag-chart-tooltip-title" style="background-color: ${params.color}">
+                ${params.xValue}
+            </div>
+            <div class="ag-chart-tooltip-content">
+                ${params.yValue}
+            </div>`
+      },
+    },
+  },
+]
 ```
 
 The tooltip renderer function receives the `params` object as a single parameter. Inside that object you get the `xValue` and `yValue` for the highlighted data point as well as the reference to the raw `datum` element from the `chart.data` or `series.data` array. You can then process the raw values however you like before using them as a part of the returned HTML string.
@@ -187,6 +188,20 @@ Notice that the tooltip renderer in the example below:
 
 <chart-example title='Column Series with Tooltip Renderer' name='tooltip-renderer' type='generated'></chart-example>
 
+## Tooltip Range
+
+By default, the tooltip of the nearest node is visible when the cursor is on the chart. However, this behaviour can be changed with the `chart.tooltip.range` property.
+
+### Example: Tooltip range variations
+
+The example below shows the three types of interaction range:
+
+- `'nearest'` (default) will show the tooltip of the nearest node anywhere on the chart
+- `'exact'` will show the tooltip if the user hovers over a node
+- given a number the tooltip will show if the cursor is within that distance in pixels of a node
+
+<chart-example title='Tooltip Range' name='interaction-range' type='generated'></chart-example>
+
 ## API Reference
 
 ### Bar/Column Tooltips
@@ -196,7 +211,6 @@ Notice that the tooltip renderer in the example below:
 ### Area Tooltips
 
 <interface-documentation interfaceName='AgAreaSeriesTooltip' config='{ "showSnippets": false, "lookupRoot": "charts-api" }'></interface-documentation>
-
 
 ### Line Tooltips
 
@@ -217,4 +231,3 @@ Notice that the tooltip renderer in the example below:
 ## Next Up
 
 Continue to the next section to learn about [axes](/charts-axes/).
-

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-tooltips/index.md
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-tooltips/index.md
@@ -88,7 +88,7 @@ To control what goes into the title and content divs of the tooltip one can set 
 
 ```ts
 tooltip: {
-    renderer?: (params: AgTooltipRendererParams) => AgTooltipRendererResult;
+    renderer?: (params: AgSeriesTooltipRendererParams) => AgTooltipRendererResult;
 }
 
 interface AgTooltipRendererResult {
@@ -97,34 +97,7 @@ interface AgTooltipRendererResult {
 }
 ```
 
-The actual type of the `params` object passed into the tooltip renderer will depend on the series type being used. For example, bar series' tooltip renderer params object will have the following structure:
-
-```ts
-interface AgTooltipRendererParams {
-  // the element of the series' data represented by the highlighted item
-  datum: any
-  // the title of the series, if any
-  title?: string
-  // the color of the series
-  color?: string
-
-  // the xKey used to fetch the xValue from the datum, same as series xKey
-  xKey: string
-  // the actual xValue used
-  xValue?: any
-  // same as series.xName
-  xName?: string
-
-  // the yKey used to fetch the yValue from the datum,
-  // equals to the value of `yKey` for one of the elements in the series,
-  // depending on which bar inside a stack/group is highlighted
-  yKey: string
-  // the actuall yValue used
-  yValue?: any
-  // equals to the value of `yName` for one of the elements in the series
-  yName?: string
-}
-```
+The actual type of the `params` object passed into the tooltip renderer will depend on the series type being used. See the [tooltips API Reference](#api-reference) `renderer` function examples.
 
 Let's say we wanted to remove the digits after the decimal point from the values shown in tooltips.
 We could use the following tooltip renderer to achieve that:


### PR DESCRIPTION
PR for https://ag-grid.atlassian.net/browse/AG-8058

Adds docs for `tooltip.range` and `series[].nodeClickRange` with switchable examples.