### PR TITLE
Cleanup chart.ts set/get side-effect methods.

### DIFF
--- a/charts-community-modules/ag-charts-community/src/chart/cartesianChart.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/cartesianChart.ts
@@ -26,7 +26,11 @@ export class CartesianChart extends Chart {
     async performLayout() {
         this.scene.root!.visible = true;
 
-        const { width, height, legend, padding } = this;
+        const {
+            legend,
+            padding,
+            scene: { width, height },
+        } = this;
 
         let shrinkRect = new BBox(0, 0, width, height);
         shrinkRect.x += padding.left;

--- a/charts-community-modules/ag-charts-community/src/chart/chart.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/chart.ts
@@ -57,8 +57,10 @@ export abstract class Chart extends Observable implements AgChartInstance {
     readonly legend: Legend;
     readonly tooltip: Tooltip;
 
-    @ActionOnWrite<Chart>(function (value) {
-        this.scene.debug.consoleLog = value;
+    @ActionOnWrite<Chart>({
+        add(value) {
+            this.scene.debug.consoleLog = value;
+        },
     })
     public debug;
 
@@ -84,25 +86,33 @@ export abstract class Chart extends Observable implements AgChartInstance {
         return this._container;
     }
 
-    @ActionOnWrite<Chart>(function (value) {
-        this.series?.forEach((series) => (series.data = value));
+    @ActionOnWrite<Chart>({
+        add(value) {
+            this.series?.forEach((series) => (series.data = value));
+        },
     })
     public data: any = [];
 
-    @ActionOnWrite<Chart>(function (value) {
-        this.autoSize = false;
-        this.resize(value, this.scene.height);
+    @ActionOnWrite<Chart>({
+        add(value) {
+            this.autoSize = false;
+            this.resize(value, this.scene.height);
+        },
     })
     width?: number;
 
-    @ActionOnWrite<Chart>(function (value) {
-        this.autoSize = false;
-        this.resize(this.scene.width, value);
+    @ActionOnWrite<Chart>({
+        add(value) {
+            this.autoSize = false;
+            this.resize(this.scene.width, value);
+        },
     })
     height?: number;
 
-    @ActionOnWrite<Chart>(function (value) {
-        this.autoSizeChanged(value);
+    @ActionOnWrite<Chart>({
+        change(value) {
+            this.autoSizeChanged(value);
+        },
     })
     @Validate(BOOLEAN)
     public autoSize;
@@ -132,24 +142,24 @@ export abstract class Chart extends Observable implements AgChartInstance {
 
     padding = new Padding(20);
 
-    @ActionOnWrite<Chart>(
-        function (value) {
+    @ActionOnWrite<Chart>({
+        add(value) {
             this.scene.root?.appendChild(value.node);
         },
-        function (oldValue) {
+        remove(oldValue) {
             this.scene.root?.removeChild(oldValue.node);
-        }
-    )
+        },
+    })
     public title?: Caption = undefined;
 
-    @ActionOnWrite<Chart>(
-        function (value) {
+    @ActionOnWrite<Chart>({
+        add(value) {
             this.scene.root?.appendChild(value.node);
         },
-        function (oldValue) {
+        remove(oldValue) {
             this.scene.root?.removeChild(oldValue.node);
-        }
-    )
+        },
+    })
     public subtitle?: Caption = undefined;
 
     @Validate(STRING_UNION('standalone', 'integrated'))

--- a/charts-community-modules/ag-charts-community/src/chart/hierarchyChart.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/hierarchyChart.ts
@@ -17,7 +17,11 @@ export class HierarchyChart extends Chart {
     async performLayout() {
         this.scene.root!!.visible = true;
 
-        const { width, height, legend, padding } = this;
+        const {
+            scene: { width, height },
+            legend,
+            padding,
+        } = this;
 
         let shrinkRect = new BBox(0, 0, width, height);
         shrinkRect.shrink(padding.left, 'left');

--- a/charts-community-modules/ag-charts-community/src/chart/polarChart.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/polarChart.ts
@@ -20,7 +20,10 @@ export class PolarChart extends Chart {
     async performLayout() {
         this.scene.root!.visible = true;
 
-        const { width, height, padding } = this;
+        const {
+            padding,
+            scene: { width, height },
+        } = this;
 
         let shrinkRect = new BBox(0, 0, width, height);
         shrinkRect.shrink(padding.left, 'left');

--- a/charts-community-modules/ag-charts-community/src/util/proxy.ts
+++ b/charts-community-modules/ag-charts-community/src/util/proxy.ts
@@ -1,11 +1,5 @@
 import { addTransformToInstanceProperty } from './decorator';
 
-/**
- * Wraps the target property with a set method that will write assigned value into a nested object with the same
- * property key.
- *
- * @param proxyProperty property name of this, which has the child object to receive values.
- */
 export function ProxyOnWrite(proxyProperty: string) {
     return addTransformToInstanceProperty((target, _, value) => {
         target[proxyProperty] = value;
@@ -14,13 +8,6 @@ export function ProxyOnWrite(proxyProperty: string) {
     });
 }
 
-/**
- * Wraps the target property with a set method that will write assigned value into a nested object with a specified
- * property key.
- *
- * @param childName property name of this, which has the child object to receive values.
- * @param childProperty property key of the child object to receive values.
- */
 export function ProxyPropertyOnWrite(childName: string, childProperty?: string) {
     return addTransformToInstanceProperty((target, key, value) => {
         target[childName][childProperty ?? key] = value;
@@ -30,12 +17,12 @@ export function ProxyPropertyOnWrite(childName: string, childProperty?: string) 
 }
 
 /**
- * Allows side-effects to be triggered on property write. Exactly one callback is invoked on every
- * write, provided the assigned value changes.
+ * Allows side-effects to be triggered on property write.
  *
- * @param opts.addFn called when a new value is set
- * @param opts.removeFn called with the old value when a new value is set
- * @param opts.changeFn called on any change to the value
+ * @param opts.add called when a new value is set - never called for undefined values.
+ * @param opts.remove called with the old value when a new value is set - never called for undefined
+ *                    values.
+ * @param opts.change called on any change to the value - always called.
  */
 export function ActionOnWrite<T>(opts: {
     add?: (this: T, newValue: any) => void;

--- a/charts-community-modules/ag-charts-community/src/util/proxy.ts
+++ b/charts-community-modules/ag-charts-community/src/util/proxy.ts
@@ -1,5 +1,11 @@
 import { addTransformToInstanceProperty } from './decorator';
 
+/**
+ * Wraps the target property with a set method that will write assigned value into a nested object with the same
+ * property key.
+ *
+ * @param proxyProperty property name of this, which has the child object to receive values.
+ */
 export function ProxyOnWrite(proxyProperty: string) {
     return addTransformToInstanceProperty((target, _, value) => {
         target[proxyProperty] = value;
@@ -8,10 +14,59 @@ export function ProxyOnWrite(proxyProperty: string) {
     });
 }
 
+/**
+ * Wraps the target property with a set method that will write assigned value into a nested object with a specified
+ * property key.
+ *
+ * @param childName property name of this, which has the child object to receive values.
+ * @param childProperty property key of the child object to receive values.
+ */
 export function ProxyPropertyOnWrite(childName: string, childProperty?: string) {
     return addTransformToInstanceProperty((target, key, value) => {
         target[childName][childProperty ?? key] = value;
 
         return value;
+    });
+}
+
+/**
+ * Allows side-effects to be triggered on property write. Exactly one callback is invoked on every
+ * write, provided the assigned value changes.
+ *
+ * If `change` is unspecified, `remove` then `add` will be invoked on value changes.
+ * If `change` is specified, `add` and `remove` will only be invoked when moving from/to `undefined` respectively.
+ *
+ * @param addFn called when a new value is set
+ * @param removeFn called with the old value when a new value is set
+ * @param changeFn called on any change to the value
+ */
+export function ActionOnWrite<T>(
+    addFn: (this: T, newValue: any) => void,
+    removeFn: (this: T, oldValue: any) => void = () => undefined,
+    changeFn?: (this: T, oldValue?: any, newValue?: any) => void
+) {
+    return addTransformToInstanceProperty((target, __, newValue, oldValue) => {
+        if (newValue === oldValue) {
+            return newValue;
+        }
+
+        if (changeFn) {
+            if (oldValue === undefined) {
+                addFn.call(target, newValue);
+            } else if (newValue === undefined) {
+                removeFn.call(target, oldValue);
+            } else {
+                changeFn.call(target, oldValue, newValue);
+            }
+        } else {
+            if (oldValue !== undefined) {
+                removeFn.call(target, oldValue);
+            }
+            if (newValue !== undefined) {
+                addFn.call(target, newValue);
+            }
+        }
+
+        return newValue;
     });
 }

--- a/grid-enterprise-modules/charts/src/charts/chartComp/chartTitle/titleEdit.ts
+++ b/grid-enterprise-modules/charts/src/charts/chartComp/chartTitle/titleEdit.ts
@@ -61,7 +61,7 @@ export class TitleEdit extends Component {
                 const bbox = title.node.computeBBox()!;
                 const xy = title.node.inverseTransformPoint(bbox.x, bbox.y);
 
-                this.startEditing({ ...bbox, ...xy });
+                this.startEditing({ ...bbox, ...xy }, canvas.width);
             }
         });
 
@@ -83,7 +83,7 @@ export class TitleEdit extends Component {
         ];
     }
 
-    private startEditing(titleBBox: BBox): void {
+    private startEditing(titleBBox: BBox, canvasWidth: number): void {
         if (this.chartMenu && this.chartMenu.isVisible()) {
             // currently, we ignore requests to edit the chart title while the chart menu is showing
             // because the click to edit the chart will also close the chart menu, making the position
@@ -97,8 +97,7 @@ export class TitleEdit extends Component {
         this.editing = true;
 
         const minimumTargetInputWidth: number = 300;
-        const maximumInputWidth: number = this.chartController.getChartProxy().getChart().width;
-        const inputWidth = Math.max(Math.min(titleBBox.width + 20, maximumInputWidth), minimumTargetInputWidth);
+        const inputWidth = Math.max(Math.min(titleBBox.width + 20, canvasWidth), minimumTargetInputWidth);
 
         const element = this.getGui() as HTMLTextAreaElement;
 

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
@@ -3926,7 +3926,7 @@
   },
   "TransformFn": {
     "meta": { "isTypeAlias": true },
-    "type": "(target: any, key: string | symbol, value: any) => any | typeof BREAK_TRANSFORM_CHAIN"
+    "type": "(target: any, key: string | symbol, value: any, oldValue?: any) => any | typeof BREAK_TRANSFORM_CHAIN"
   },
   "TransformConfig": {
     "meta": { "isTypeAlias": true },


### PR DESCRIPTION
Adds `@ActionOnWrite` decorator to try and clean-up the pattern of private property with set/get pair with side-effect on set. Applied to `chart.ts` for now to verify the pattern.