### PR TITLE
100x hover/scroll performance when having large buffer size

### DIFF
--- a/grid-community-modules/core/src/ts/rendering/rowRenderer.ts
+++ b/grid-community-modules/core/src/ts/rendering/rowRenderer.ts
@@ -606,16 +606,22 @@ export class RowRenderer extends BeanStub {
     }
 
     public getAllCellCtrls(): CellCtrl[] {
-        let res: CellCtrl[] = [];
-        this.getAllRowCtrls().forEach(rowCtrl => res = res.concat(rowCtrl.getAllCellCtrls()));
+        const res: CellCtrl[] = [];
+        const all = this.getAllRowCtrls()
+        for (const rowCtrl of all) {
+            for (const cell of rowCtrl.getAllCellCtrls()){
+                res.push(cell)
+            }
+        }
         return res;
     }
 
     private getAllRowCtrls(): RowCtrl[] {
         const stickyRowCtrls = (this.stickyRowFeature && this.stickyRowFeature.getStickyRowCtrls()) || [];
         const res = [...this.topRowCtrls, ...this.bottomRowCtrls, ...stickyRowCtrls];
-
-        Object.keys(this.rowCtrlsByRowIndex).forEach(key => res.push(this.rowCtrlsByRowIndex[key]));
+        for (const key in this.rowCtrlsByRowIndex){
+            res.push(this.rowCtrlsByRowIndex[key])
+        }
         return res;
     }
 


### PR DESCRIPTION
Not an active user of ag-grid anymore, but I had this gist snippet laying around that I thought could be of use

I tried 500 row buffer on a 150k row table, and it was unusable(2fps) which made me a bit confused so checked the code, and one of the core functions is poorly written. The below change ran x100 faster on my above table, and I think it should make any grid with 5k+ rows & larger array buffer ~5-20% faster

Most notably `res.concat(rowCtrl.getAllCellCtrls())` is extremely expensive on larger tables, as it would create huge amounts of unused intermediate arrays 

Found this old loom as well to prove it: https://www.loom.com/share/5a44c244c66141f192fb2cd6202c101e