### PR TITLE
AG-7121 double click fixes

### DIFF
--- a/charts-community-modules/ag-charts-community/src/chart/legend.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/legend.ts
@@ -771,14 +771,21 @@ export class Legend {
         event.consume();
 
         if (toggleSeriesVisible) {
-            const singleItemVisible =
-                chart.series.reduce((count, s) => count + s.getLegendData().filter((d) => d.enabled).length, 0) === 1;
+            const legendData: Array<LegendDatum> = chart.series.reduce(
+                (ls, s) => [...ls, ...s.getLegendData()],
+                [] as Array<LegendDatum>
+            );
+            const visibleItemsCount = legendData.filter((d) => d.enabled).length;
+            const clickedItem = legendData.find((d) => d.itemId === itemId);
 
             chart.series.forEach((s) => {
-                const legendData = s.getLegendData();
+                const legendData = s.getLegendData() as any;
 
-                legendData.forEach((d) => {
-                    const newEnabled = d.itemId === itemId || singleItemVisible;
+                legendData.forEach((d: any) => {
+                    const wasClicked = d.itemId === itemId;
+                    const singleSelectedWasNotClicked = visibleItemsCount === 1 && (clickedItem?.enabled ?? false);
+                    const newEnabled = wasClicked || singleSelectedWasNotClicked;
+
                     s.toggleSeriesItem(d.itemId, newEnabled);
                 });
             });

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-events/index.md
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-events/index.md
@@ -53,7 +53,7 @@ This example shows how the `nodeDoubleClick` event listener can be used to liste
 
 The `legendItemClick` and `legendItemDoubleClick` events can be used to listen to legend item clicks and double clicks, respectively.
 
-By default, when a legend item is clicked it hides the related series, and when double clicked it shows that series and hides all others.
+By default, when a legend item is clicked the visibility of the series associated with that legend item will be toggled. In addition, when a legend item is double clicked it toggles the visibility of all other series.
 
 ### Example: legendItemClick & legendItemDoubleClick Events
 
@@ -125,4 +125,3 @@ All series event options have similar interface contracts. See the series-specif
 ### Chart Events
 
 <interface-documentation interfaceName='AgBaseChartListeners' names='["click", "doubleClick", "seriesNodeClick"] ' config='{ "lookupRoot": "charts-api" }'></interface-documentation>
-

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-legend/examples/legend-click-series-toggle/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-legend/examples/legend-click-series-toggle/main.ts
@@ -1,4 +1,8 @@
-import { AgChart, AgChartLegendClickEvent, AgChartOptions } from "ag-charts-community"
+import {
+  AgChart,
+  AgChartLegendClickEvent,
+  AgChartOptions,
+} from "ag-charts-community"
 import { getData } from "./data"
 
 const colors = [
@@ -157,7 +161,7 @@ const options: AgChartOptions = {
         itemId,
         enabled,
       }: AgChartLegendClickEvent) => {
-        window.alert(
+        console.log(
           `seriesId: ${seriesId}, itemId: ${itemId}, enabled: ${enabled}`
         )
       },

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-legend/index.md
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-legend/index.md
@@ -244,6 +244,8 @@ If a callback function is configured via [`legend.listeners.legendItemClick`](#l
 
 ### Example: Legend Click
 
+This example logs a message to the browser console when the legend is clicked.
+
 <chart-example title='Legend Click' name='legend-click-series-toggle' type='generated'></chart-example>
 
 ## API Reference


### PR DESCRIPTION
PR for https://ag-grid.atlassian.net/browse/AG-7121

Fixes toggling legend items when you double click on a legend item that was disabled, while one or more other items were enabled. It will now disable all others and enable only the item clicked.

Also some minor docs improvements.