### PR TITLE
AG-8047 - Add axis metadata to LayoutCompleteEvent.

### DIFF
--- a/charts-community-modules/ag-charts-community/src/axis.ts
+++ b/charts-community-modules/ag-charts-community/src/axis.ts
@@ -45,6 +45,7 @@ import { extent } from './util/array';
 import { ChartAxisDirection } from './chart/chartAxisDirection';
 import { calculateLabelRotation } from './chart/label';
 import { Logger } from './util/logger';
+import { AxisLayout } from './chart/layout/layoutService';
 
 const TICK_COUNT = predicateWithMessage(
     (v: any, ctx) => NUMBER(0)(v, ctx) || v instanceof TimeInterval,
@@ -315,6 +316,13 @@ export class Axis<S extends Scale<D, number, TickInterval<S>>, D = any> {
 
     readonly translation = { x: 0, y: 0 };
     rotation: number = 0; // axis rotation angle in degrees
+
+    protected readonly layout: Pick<AxisLayout, 'label'> = {
+        label: {
+            align: 'center',
+            baseline: 'middle',
+        },
+    };
 
     private attachCrossLine(crossLine: CrossLine) {
         this.crossLineGroup.appendChild(crossLine.group);
@@ -1127,6 +1135,11 @@ export class Axis<S extends Scale<D, number, TickInterval<S>>, D = any> {
                 },
             });
         });
+
+        this.layout.label = {
+            align: labelTextAlign,
+            baseline: labelTextBaseline,
+        };
 
         return { labelData, rotated: !!(labelRotation || labelAutoRotation) };
     }

--- a/charts-community-modules/ag-charts-community/src/chart/cartesianChart.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/cartesianChart.ts
@@ -59,6 +59,7 @@ export class CartesianChart extends Chart {
         this.layoutService.dispatchLayoutComplete({
             type: 'layout-complete',
             series: { rect: seriesRect, visible: visibility.series },
+            axes: this.axes.map((axis) => ({ id: axis.id, ...axis.getLayoutState() })),
         });
 
         const { seriesRoot } = this;

--- a/charts-community-modules/ag-charts-community/src/chart/chartAxis.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/chartAxis.ts
@@ -4,6 +4,7 @@ import { ChartAxisDirection } from './chartAxisDirection';
 import { LinearScale } from '../scale/linearScale';
 import { POSITION, STRING_ARRAY, Validate } from '../util/validation';
 import { AgCartesianAxisPosition, AgCartesianAxisType } from './agChartOptions';
+import { AxisLayout } from './layout/layoutService';
 
 export function flipChartAxisDirection(direction: ChartAxisDirection): ChartAxisDirection {
     if (direction === ChartAxisDirection.X) {
@@ -111,5 +112,12 @@ export class ChartAxis<S extends Scale<D, number, TickInterval<S>> = Scale<any, 
 
     isAnySeriesActive() {
         return this.boundSeries.some((s) => this.includeInvisibleDomains || s.isEnabled());
+    }
+
+    getLayoutState(): AxisLayout {
+        return {
+            rect: this.computeBBox(),
+            ...this.layout,
+        };
     }
 }

--- a/charts-community-modules/ag-charts-community/src/chart/layout/layoutService.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/layout/layoutService.ts
@@ -3,19 +3,19 @@ import { Listeners } from '../../util/listeners';
 
 export type LayoutStage = 'before-series';
 
+export interface AxisLayout {
+    rect: BBox;
+    label: {
+        baseline: 'hanging' | 'bottom' | 'middle';
+        align: 'start' | 'end' | 'center';
+    };
+}
 export interface LayoutCompleteEvent {
     type: 'layout-complete';
     series: { rect: BBox; visible: boolean };
-    axes?: {
+    axes?: (AxisLayout & {
         id: string;
-        rect: BBox;
-        rotation: number;
-        mirrored: boolean;
-        label: {
-            baseline: 'hanging' | 'bottom' | 'middle';
-            align: 'start' | 'end' | 'center';
-        };
-    }[];
+    })[];
 }
 
 export interface LayoutContext {

--- a/charts-community-modules/ag-charts-community/src/util/module.ts
+++ b/charts-community-modules/ag-charts-community/src/util/module.ts
@@ -1,3 +1,4 @@
+import { AgCartesianAxisPosition } from '../chart/agChartOptions';
 import { CursorManager } from '../chart/interaction/cursorManager';
 import { HighlightManager } from '../chart/interaction/highlightManager';
 import { InteractionManager } from '../chart/interaction/interactionManager';
@@ -22,8 +23,11 @@ export interface ModuleContextWithParent<P> extends ModuleContext {
 
 export interface AxisContext {
     axisId: string;
+    position: AgCartesianAxisPosition;
+    direction: 'x' | 'y';
 
     scaleConvert(val: any): number;
+    scaleInvert(position: number): any;
 }
 
 export interface ModuleInstance {

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/doc-interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/doc-interfaces.AUTO.json
@@ -5028,6 +5028,15 @@
   },
   "Layers": {},
   "LayoutStage": {},
+  "AxisLayout": {
+    "rect": { "type": { "returnType": "BBox", "optional": false } },
+    "label": {
+      "type": {
+        "returnType": "{\n        baseline: 'hanging' | 'bottom' | 'middle';\n        align: 'start' | 'end' | 'center';\n    }",
+        "optional": false
+      }
+    }
+  },
   "LayoutCompleteEvent": {
     "type": {
       "type": { "returnType": "'layout-complete'", "optional": false }
@@ -5040,7 +5049,7 @@
     },
     "axes": {
       "type": {
-        "returnType": "{\n        id: string;\n        rect: BBox;\n        rotation: number;\n        mirrored: boolean;\n        label: {\n            baseline: 'hanging' | 'bottom' | 'middle';\n            align: 'start' | 'end' | 'center';\n        };\n    }[]",
+        "returnType": "(AxisLayout & {\n        id: string;\n    })[]",
         "optional": true
       }
     }
@@ -5685,10 +5694,21 @@
   },
   "AxisContext": {
     "axisId": { "type": { "returnType": "string", "optional": false } },
+    "position": {
+      "type": { "returnType": "AgCartesianAxisPosition", "optional": false }
+    },
+    "direction": { "type": { "returnType": "'x' | 'y'", "optional": false } },
     "scaleConvert": {
       "type": {
         "arguments": { "val": "any" },
         "returnType": "number",
+        "optional": false
+      }
+    },
+    "scaleInvert": {
+      "type": {
+        "arguments": { "position": "number" },
+        "returnType": "any",
         "optional": false
       }
     }

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
@@ -3371,12 +3371,19 @@
     "docs": [null, null, null, null, null, null, null, null]
   },
   "LayoutStage": { "meta": { "isTypeAlias": true }, "type": "'before-series'" },
+  "AxisLayout": {
+    "meta": {},
+    "type": {
+      "rect": "BBox",
+      "label": "{ baseline: 'hanging' | 'bottom' | 'middle'; align: 'start' | 'end' | 'center'; }"
+    }
+  },
   "LayoutCompleteEvent": {
     "meta": {},
     "type": {
       "type": "'layout-complete'",
       "series": "{ rect: BBox; visible: boolean; }",
-      "axes?": "{ id: string; rect: BBox; rotation: number; mirrored: boolean; label: { baseline: 'hanging' | 'bottom' | 'middle'; align: 'start' | 'end' | 'center'; }; }[]"
+      "axes?": "(AxisLayout & { id: string; })[]"
     }
   },
   "LayoutContext": { "meta": {}, "type": { "shrinkRect": "BBox" } },
@@ -4034,7 +4041,13 @@
   },
   "AxisContext": {
     "meta": {},
-    "type": { "axisId": "string", "scaleConvert(val: any)": "number" }
+    "type": {
+      "axisId": "string",
+      "position": "AgCartesianAxisPosition",
+      "direction": "'x' | 'y'",
+      "scaleConvert(val: any)": "number",
+      "scaleInvert(position: number)": "any"
+    }
   },
   "ModuleInstance": {
     "meta": {},


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-8047

Fleshes out the `LayoutCompleteEvent` to allow modules to receive axis-related layout results.