### PR TITLE
AG-8047 - Add axis module lifecycle handling and DI.

### DIFF
--- a/charts-community-modules/ag-charts-community/src/axis.ts
+++ b/charts-community-modules/ag-charts-community/src/axis.ts
@@ -337,6 +337,10 @@ export class Axis<S extends Scale<D, number, TickInterval<S>>, D = any> {
         this.refreshScale();
     }
 
+    public destroy() {
+        // For override by sub-classes.
+    }
+
     protected refreshScale() {
         this.requestedRange = this.scale.range.slice();
         this.crossLines?.forEach((crossLine) => {

--- a/charts-community-modules/ag-charts-community/src/chart/agChartV2.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/agChartV2.ts
@@ -12,6 +12,7 @@ import {
     AgPieSeriesOptions,
     AgTreemapSeriesOptions,
     AgChartInstance,
+    AgBaseAxisOptions,
 } from './agChartOptions';
 import { CartesianChart } from './cartesianChart';
 import { PolarChart } from './polarChart';
@@ -47,9 +48,11 @@ import {
 import { SeriesOptionsTypes } from './mapping/defaults';
 import { CrossLine } from './crossline/crossLine';
 import { windowValue } from '../util/window';
-import { REGISTERED_MODULES } from '../module-support';
-import { Module, RootModule } from '../util/module';
+import { AxisModule, Module, RootModule } from '../util/module';
 import { Logger } from '../util/logger';
+
+// Deliberately imported via `module-support` so that internal module registration happens.
+import { REGISTERED_MODULES } from '../module-support';
 
 type ChartType = CartesianChart | PolarChart | HierarchyChart;
 
@@ -543,7 +546,7 @@ function applyAxes(chart: Chart, options: AgCartesianChartOptions) {
         }
     }
 
-    chart.axes = createAxis(optAxes);
+    chart.axes = createAxis(chart, optAxes);
     return true;
 }
 
@@ -586,35 +589,63 @@ function createSeries(options: SeriesOptionsTypes[]): Series[] {
     return series;
 }
 
-function createAxis(options: AgCartesianAxisOptions[]): ChartAxis[] {
+function createAxis(chart: Chart, options: AgCartesianAxisOptions[]): ChartAxis[] {
     const axes: ChartAxis[] = [];
+    const skip = ['axes[].type'];
+    const moduleContext = chart.getModuleContext();
 
     let index = 0;
     for (const axisOptions of options || []) {
-        const path = `axes[${index++}]`;
-        const skip = ['axes[].type'];
+        let axis;
         switch (axisOptions.type) {
             case 'number':
-                axes.push(applyOptionValues(new NumberAxis(), axisOptions, { path, skip }));
+                axis = new NumberAxis(moduleContext);
                 break;
             case LogAxis.type:
-                axes.push(applyOptionValues(new LogAxis(), axisOptions, { path, skip }));
+                axis = new LogAxis(moduleContext);
                 break;
             case CategoryAxis.type:
-                axes.push(applyOptionValues(new CategoryAxis(), axisOptions, { path, skip }));
+                axis = new CategoryAxis(moduleContext);
                 break;
             case GroupedCategoryAxis.type:
-                axes.push(applyOptionValues(new GroupedCategoryAxis(), axisOptions, { path, skip }));
+                axis = new GroupedCategoryAxis(moduleContext);
                 break;
             case TimeAxis.type:
-                axes.push(applyOptionValues(new TimeAxis(), axisOptions, { path, skip }));
+                axis = new TimeAxis(moduleContext);
                 break;
             default:
                 throw new Error('AG Charts - unknown axis type: ' + axisOptions['type']);
         }
+
+        const path = `axes[${index++}]`;
+        applyAxisModules(axis, axisOptions);
+        applyOptionValues(axis, axisOptions, { path, skip });
+
+        axes.push(axis);
     }
 
     return axes;
+}
+
+function applyAxisModules(axis: ChartAxis, options: AgBaseAxisOptions) {
+    let modulesChanged = false;
+    const rootModules = REGISTERED_MODULES.filter((m): m is AxisModule => m.type === 'axis');
+
+    for (const next of rootModules) {
+        const shouldBeEnabled = (options as any)[next.optionsKey] != null;
+        const isEnabled = axis.isModuleEnabled(next);
+
+        if (shouldBeEnabled === isEnabled) continue;
+        modulesChanged = true;
+
+        if (shouldBeEnabled) {
+            axis.addModule(next);
+        } else {
+            axis.removeModule(next);
+        }
+    }
+
+    return modulesChanged;
 }
 
 type ObservableLike = {

--- a/charts-community-modules/ag-charts-community/src/chart/axis/categoryAxis.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/axis/categoryAxis.ts
@@ -10,7 +10,7 @@ export class CategoryAxis extends ChartAxis<BandScale<string | object>> {
     private _paddingOverrideEnabled = false;
 
     constructor(moduleCtx: ModuleContext) {
-        super(new BandScale<string>(), moduleCtx);
+        super(moduleCtx, new BandScale<string>());
 
         this.includeInvisibleDomains = true;
     }

--- a/charts-community-modules/ag-charts-community/src/chart/axis/categoryAxis.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/axis/categoryAxis.ts
@@ -1,14 +1,16 @@
 import { NUMBER, Validate } from '../../util/validation';
 import { BandScale } from '../../scale/bandScale';
 import { ChartAxis } from '../chartAxis';
+import { ModuleContext } from '../../util/module';
+
 export class CategoryAxis extends ChartAxis<BandScale<string | object>> {
     static className = 'CategoryAxis';
     static type = 'category' as const;
 
     private _paddingOverrideEnabled = false;
 
-    constructor() {
-        super(new BandScale<string>());
+    constructor(moduleCtx: ModuleContext) {
+        super(new BandScale<string>(), moduleCtx);
 
         this.includeInvisibleDomains = true;
     }

--- a/charts-community-modules/ag-charts-community/src/chart/axis/groupedCategoryAxis.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/axis/groupedCategoryAxis.ts
@@ -12,6 +12,7 @@ import { extent } from '../../util/array';
 import { Point } from '../../scene/point';
 import { BOOLEAN, OPT_COLOR_STRING, Validate } from '../../util/validation';
 import { calculateLabelRotation } from '../label';
+import { ModuleContext } from '../../util/module';
 
 class GroupedCategoryAxisLabel extends AxisLabel {
     @Validate(BOOLEAN)
@@ -32,8 +33,8 @@ export class GroupedCategoryAxis extends ChartAxis<BandScale<string | number>> {
     private labelSelection: Selection<Text, any>;
     private tickTreeLayout?: TreeLayout;
 
-    constructor() {
-        super(new BandScale<string | number>());
+    constructor(moduleCtx: ModuleContext) {
+        super(new BandScale<string | number>(), moduleCtx);
         this.includeInvisibleDomains = true;
 
         const { tickLineGroup, tickLabelGroup, gridLineGroup, tickScale, scale } = this;

--- a/charts-community-modules/ag-charts-community/src/chart/axis/groupedCategoryAxis.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/axis/groupedCategoryAxis.ts
@@ -34,7 +34,7 @@ export class GroupedCategoryAxis extends ChartAxis<BandScale<string | number>> {
     private tickTreeLayout?: TreeLayout;
 
     constructor(moduleCtx: ModuleContext) {
-        super(new BandScale<string | number>(), moduleCtx);
+        super(moduleCtx, new BandScale<string | number>());
         this.includeInvisibleDomains = true;
 
         const { tickLineGroup, tickLabelGroup, gridLineGroup, tickScale, scale } = this;

--- a/charts-community-modules/ag-charts-community/src/chart/axis/logAxis.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/axis/logAxis.ts
@@ -4,6 +4,7 @@ import { LogScale } from '../../scale/logScale';
 import { NumberAxis } from './numberAxis';
 import { extent } from '../../util/array';
 import { Logger } from '../../util/logger';
+import { ModuleContext } from '../../util/module';
 
 function NON_ZERO_NUMBER() {
     // Cannot be 0
@@ -69,8 +70,8 @@ export class LogAxis extends NumberAxis {
         return (this.scale as LogScale).base;
     }
 
-    constructor() {
-        super(new LogScale());
+    constructor(moduleCtx: ModuleContext) {
+        super(moduleCtx, new LogScale());
         this.scale.strictClampByDefault = true;
     }
 }

--- a/charts-community-modules/ag-charts-community/src/chart/axis/numberAxis.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/axis/numberAxis.ts
@@ -6,13 +6,14 @@ import { Validate, GREATER_THAN, AND, LESS_THAN, NUMBER_OR_NAN } from '../../uti
 import { Default } from '../../util/default';
 import { calculateNiceSecondaryAxis } from '../../util/secondaryAxisTicks';
 import { Logger } from '../../util/logger';
+import { ModuleContext } from '../../module-support';
 
 export class NumberAxis extends ChartAxis<LinearScale | LogScale, number> {
     static className = 'NumberAxis';
     static type = 'number' as 'number' | 'log';
 
-    constructor(scale = new LinearScale() as LinearScale | LogScale) {
-        super(scale);
+    constructor(moduleCtx: ModuleContext, scale = new LinearScale() as LinearScale | LogScale) {
+        super(scale, moduleCtx);
         scale.strictClampByDefault = true;
     }
 

--- a/charts-community-modules/ag-charts-community/src/chart/axis/numberAxis.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/axis/numberAxis.ts
@@ -13,7 +13,7 @@ export class NumberAxis extends ChartAxis<LinearScale | LogScale, number> {
     static type = 'number' as 'number' | 'log';
 
     constructor(moduleCtx: ModuleContext, scale = new LinearScale() as LinearScale | LogScale) {
-        super(scale, moduleCtx);
+        super(moduleCtx, scale);
         scale.strictClampByDefault = true;
     }
 

--- a/charts-community-modules/ag-charts-community/src/chart/axis/timeAxis.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/axis/timeAxis.ts
@@ -2,6 +2,7 @@ import { Validate, AND, LESS_THAN, GREATER_THAN, OPT_DATE_OR_DATETIME_MS } from 
 import { TimeScale } from '../../scale/timeScale';
 import { extent } from '../../util/array';
 import { ChartAxis } from '../chartAxis';
+import { ModuleContext } from '../../util/module';
 
 export class TimeAxis extends ChartAxis<TimeScale, number | Date> {
     static className = 'TimeAxis';
@@ -10,8 +11,8 @@ export class TimeAxis extends ChartAxis<TimeScale, number | Date> {
     private datumFormat = '%m/%d/%y, %H:%M:%S';
     private datumFormatter: (date: Date) => string;
 
-    constructor() {
-        super(new TimeScale());
+    constructor(moduleCtx: ModuleContext) {
+        super(new TimeScale(), moduleCtx);
 
         const { scale } = this;
         scale.strictClampByDefault = true;

--- a/charts-community-modules/ag-charts-community/src/chart/axis/timeAxis.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/axis/timeAxis.ts
@@ -12,7 +12,7 @@ export class TimeAxis extends ChartAxis<TimeScale, number | Date> {
     private datumFormatter: (date: Date) => string;
 
     constructor(moduleCtx: ModuleContext) {
-        super(new TimeScale(), moduleCtx);
+        super(moduleCtx, new TimeScale());
 
         const { scale } = this;
         scale.strictClampByDefault = true;

--- a/charts-community-modules/ag-charts-community/src/chart/chart.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/chart.ts
@@ -26,7 +26,7 @@ import { Layers } from './layers';
 import { CursorManager } from './interaction/cursorManager';
 import { HighlightChangeEvent, HighlightManager } from './interaction/highlightManager';
 import { TooltipManager } from './interaction/tooltipManager';
-import { Module, ModuleInstanceMeta, RootModule } from '../util/module';
+import { Module, ModuleContext, ModuleInstanceMeta, RootModule } from '../util/module';
 import { ZoomManager } from './interaction/zoomManager';
 import { LayoutService } from './layout/layoutService';
 import { ChartUpdateType } from './chartUpdateType';
@@ -282,24 +282,7 @@ export abstract class Chart extends Observable implements AgChartInstance {
             throw new Error('AG Charts - module already initialised: ' + module.optionsKey);
         }
 
-        const {
-            scene,
-            interactionManager,
-            zoomManager,
-            cursorManager,
-            highlightManager,
-            tooltipManager,
-            layoutService,
-        } = this;
-        const moduleMeta = module.initialiseModule({
-            scene,
-            interactionManager,
-            zoomManager,
-            cursorManager,
-            highlightManager,
-            tooltipManager,
-            layoutService,
-        });
+        const moduleMeta = module.initialiseModule(this.getModuleContext());
         this.modules[module.optionsKey] = moduleMeta;
 
         (this as any)[module.optionsKey] = moduleMeta.instance;
@@ -313,6 +296,27 @@ export abstract class Chart extends Observable implements AgChartInstance {
 
     isModuleEnabled(module: Module) {
         return this.modules[module.optionsKey] != null;
+    }
+
+    getModuleContext(): ModuleContext {
+        const {
+            scene,
+            interactionManager,
+            zoomManager,
+            cursorManager,
+            highlightManager,
+            tooltipManager,
+            layoutService,
+        } = this;
+        return {
+            scene,
+            interactionManager,
+            zoomManager,
+            cursorManager,
+            highlightManager,
+            tooltipManager,
+            layoutService,
+        };
     }
 
     destroy(opts?: { keepTransferableResources: boolean }): TransferableResources | undefined {
@@ -347,6 +351,9 @@ export abstract class Chart extends Observable implements AgChartInstance {
 
         this.series.forEach((s) => s.destroy());
         this.series = [];
+
+        this.axes.forEach((a) => a.destroy());
+        this.axes = [];
 
         this._destroyed = true;
 
@@ -516,10 +523,19 @@ export abstract class Chart extends Observable implements AgChartInstance {
 
     protected _axes: ChartAxis[] = [];
     set axes(values: ChartAxis[]) {
-        this._axes.forEach((axis) => axis.detachAxis(this.axisGroup));
+        const removedAxes = new Set<ChartAxis>();
+        this._axes.forEach((axis) => {
+            axis.detachAxis(this.axisGroup);
+            removedAxes.add(axis);
+        });
         // make linked axes go after the regular ones (simulates stable sort by `linkedTo` property)
         this._axes = values.filter((a) => !a.linkedTo).concat(values.filter((a) => a.linkedTo));
-        this._axes.forEach((axis) => axis.attachAxis(this.axisGroup));
+        this._axes.forEach((axis) => {
+            axis.attachAxis(this.axisGroup);
+            removedAxes.delete(axis);
+        });
+
+        removedAxes.forEach((axis) => axis.destroy());
     }
     get axes(): ChartAxis[] {
         return this._axes;

--- a/charts-community-modules/ag-charts-community/src/chart/chartAxis.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/chartAxis.ts
@@ -54,7 +54,7 @@ export class ChartAxis<S extends Scale<D, number, TickInterval<S>> = Scale<any, 
         return this.scale instanceof LinearScale;
     }
 
-    protected constructor(scale: S, private readonly moduleCtx: ModuleContext) {
+    protected constructor(private readonly moduleCtx: ModuleContext, scale: S) {
         super(scale);
     }
 

--- a/charts-community-modules/ag-charts-community/src/chart/chartAxis.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/chartAxis.ts
@@ -5,6 +5,7 @@ import { LinearScale } from '../scale/linearScale';
 import { POSITION, STRING_ARRAY, Validate } from '../util/validation';
 import { AgCartesianAxisPosition, AgCartesianAxisType } from './agChartOptions';
 import { AxisLayout } from './layout/layoutService';
+import { AxisContext, AxisModule, ModuleContext, ModuleInstanceMeta } from '../util/module';
 
 export function flipChartAxisDirection(direction: ChartAxisDirection): ChartAxisDirection {
     if (direction === ChartAxisDirection.X) {
@@ -40,6 +41,8 @@ export class ChartAxis<S extends Scale<D, number, TickInterval<S>> = Scale<any, 
     linkedTo?: ChartAxis;
     includeInvisibleDomains: boolean = false;
 
+    protected readonly modules: Record<string, ModuleInstanceMeta> = {};
+
     get type(): AgCartesianAxisType {
         return (this.constructor as any).type || '';
     }
@@ -49,6 +52,10 @@ export class ChartAxis<S extends Scale<D, number, TickInterval<S>> = Scale<any, 
         // calculated or user-supplied tick-count, and time axes need special handling depending on
         // the time-range involved.
         return this.scale instanceof LinearScale;
+    }
+
+    protected constructor(scale: S, private readonly moduleCtx: ModuleContext) {
+        super(scale);
     }
 
     @Validate(POSITION)
@@ -81,6 +88,11 @@ export class ChartAxis<S extends Scale<D, number, TickInterval<S>> = Scale<any, 
                     this.label.mirrored = false;
                     this.label.parallel = false;
                     break;
+            }
+
+            if (this.axisContext) {
+                this.axisContext.position = this.position;
+                this.axisContext.direction = this.direction;
             }
         }
     }
@@ -119,5 +131,50 @@ export class ChartAxis<S extends Scale<D, number, TickInterval<S>> = Scale<any, 
             rect: this.computeBBox(),
             ...this.layout,
         };
+    }
+
+    private axisContext?: AxisContext;
+    addModule(module: AxisModule) {
+        if (this.modules[module.optionsKey] != null) {
+            throw new Error('AG Charts - module already initialised: ' + module.optionsKey);
+        }
+
+        if (this.axisContext == null) {
+            this.axisContext = {
+                axisId: this.id,
+                position: this.position,
+                direction: this.direction,
+                scaleConvert: (val) => this.scale.convert(val),
+                scaleInvert: (val) => this.scale.invert?.(val) ?? undefined,
+            };
+        }
+
+        const moduleMeta = module.initialiseModule({
+            ...this.moduleCtx,
+            parent: this.axisContext,
+        });
+        this.modules[module.optionsKey] = moduleMeta;
+
+        (this as any)[module.optionsKey] = moduleMeta.instance;
+    }
+
+    removeModule(module: AxisModule) {
+        this.modules[module.optionsKey]?.instance?.destroy();
+        delete this.modules[module.optionsKey];
+        delete (this as any)[module.optionsKey];
+    }
+
+    isModuleEnabled(module: AxisModule) {
+        return this.modules[module.optionsKey] != null;
+    }
+
+    public destroy(): void {
+        super.destroy();
+
+        for (const [key, module] of Object.entries(this.modules)) {
+            module.instance.destroy();
+            delete this.modules[key];
+            delete (this as any)[key];
+        }
     }
 }


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-8047

Implements support for `axis` module types:
- Lifecycle management, directed from `AgChartV2`.
- Pseudo-DI via `ModuleContext` being made available to `ChartAxis` for injecting into module instances.