### PR TITLE
AG-7461 Add default cursor behaviour for nodes with click listeners 

### DIFF
--- a/charts-community-modules/ag-charts-community/src/chart/agChartOptions.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/agChartOptions.ts
@@ -529,7 +529,7 @@ export interface AgChartDoubleClickEvent extends AgChartEvent<'doubleClick'> {}
 export interface AgBaseChartListeners {
     /** The listener to call when a node (marker, column, bar, tile or a pie sector) in any series is clicked. In case a chart has multiple series, the chart's `seriesNodeClick` event can be used to listen to `nodeClick` events of all the series at once. */
     seriesNodeClick?: (event: AgNodeClickEvent) => any;
-    /** The listener to call when a node (marker, column, bar, tile or a pie sector) in any series is double clicked. In case a chart has multiple series, the chart's `seriesNodeClick` event can be used to listen to `nodeDoubleClick` events of all the series at once. */
+    /** The listener to call when a node (marker, column, bar, tile or a pie sector) in any series is double clicked. In case a chart has multiple series, the chart's `seriesNodeDoubleClick` event can be used to listen to `nodeDoubleClick` events of all the series at once. */
     seriesNodeDoubleClick?: (event: AgNodeDoubleClickEvent) => any;
     /** The listener to call to signify a general click on the chart by the user. */
     click?: (event: AgChartClickEvent) => any;

--- a/charts-community-modules/ag-charts-community/src/chart/agChartV2.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/agChartV2.ts
@@ -415,6 +415,11 @@ function applyChartOptions(chart: Chart, processedOptions: Partial<AgChartOption
         );
     }
 
+    // Needs to be done before applying the series to detect if a seriesNode[Double]Click listener has been added
+    if (processedOptions.listeners) {
+        registerListeners(chart, processedOptions.listeners);
+    }
+
     applyOptionValues(chart, processedOptions, { skip });
 
     let forceNodeDataRefresh = false;
@@ -440,9 +445,6 @@ function applyChartOptions(chart: Chart, processedOptions: Partial<AgChartOption
     // Needs to be done last to avoid overrides by width/height properties.
     if (processedOptions.autoSize != null) {
         chart.autoSize = processedOptions.autoSize;
-    }
-    if (processedOptions.listeners) {
-        registerListeners(chart, processedOptions.listeners);
     }
     if (processedOptions.legend?.listeners) {
         Object.assign(chart.legend.listeners, processedOptions.legend.listeners ?? {});

--- a/charts-community-modules/ag-charts-community/src/chart/chart.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/chart.ts
@@ -562,8 +562,12 @@ export abstract class Chart extends Observable implements AgChartInstance {
         if (!series.data) {
             series.data = this.data;
         }
-        series.addEventListener('nodeClick', this.onSeriesNodeClick);
-        series.addEventListener('nodeDoubleClick', this.onSeriesNodeDoubleClick);
+        if (this.hasEventListener('seriesNodeClick')) {
+            series.addEventListener('nodeClick', this.onSeriesNodeClick);
+        }
+        if (this.hasEventListener('seriesNodeDoubleClick')) {
+            series.addEventListener('nodeDoubleClick', this.onSeriesNodeDoubleClick);
+        }
     }
 
     protected freeSeries(series: Series<any>) {
@@ -953,9 +957,8 @@ export abstract class Chart extends Observable implements AgChartInstance {
         this.lastInteractionEvent = undefined;
     });
     protected handlePointer(event: InteractionEvent<'hover'>) {
-        const { lastPick, tooltip } = this;
-        const { range } = tooltip;
-        const { pageX, pageY, offsetX, offsetY } = event;
+        const { lastPick } = this;
+        const { offsetX, offsetY } = event;
 
         const disablePointer = () => {
             if (lastPick) {
@@ -968,6 +971,18 @@ export abstract class Chart extends Observable implements AgChartInstance {
             disablePointer();
             return;
         }
+
+        // Handle node highlighting and tooltip toggling when pointer within `tooltip.range`
+        this.handlePointerTooltip(event, disablePointer);
+
+        // Handle mouse cursor when pointer withing `series[].nodeClickRange`
+        this.handlePointerNodeCursor(event);
+    }
+
+    protected handlePointerTooltip(event: InteractionEvent<'hover'>, disablePointer: () => void) {
+        const { lastPick, tooltip } = this;
+        const { range } = tooltip;
+        const { pageX, pageY, offsetX, offsetY } = event;
 
         let pixelRange;
         if (typeof range === 'number' && Number.isFinite(range)) {
@@ -1003,6 +1018,18 @@ export abstract class Chart extends Observable implements AgChartInstance {
         }
     }
 
+    protected handlePointerNodeCursor(event: InteractionEvent<'hover'>) {
+        const found = this.checkSeriesNodeRange(event, (series: Series, _datum: any) => {
+            if (series.hasEventListener('nodeClick') || series.hasEventListener('nodeDoubleClick')) {
+                this.cursorManager.updateCursor('chart', 'pointer');
+            }
+        });
+
+        if (!found) {
+            this.cursorManager.updateCursor('chart');
+        }
+    }
+
     protected onClick(event: InteractionEvent<'click'>) {
         if (this.checkSeriesNodeClick(event)) {
             this.update(ChartUpdateType.SERIES_UPDATE);
@@ -1026,27 +1053,27 @@ export abstract class Chart extends Observable implements AgChartInstance {
     }
 
     private checkSeriesNodeClick(event: InteractionEvent<'click'>): boolean {
-        return this.checkSeriesNodeAnyClick(event, (series: Series, datum: any) =>
+        return this.checkSeriesNodeRange(event, (series: Series, datum: any) =>
             series.fireNodeClickEvent(event.sourceEvent, datum)
         );
     }
 
     private checkSeriesNodeDoubleClick(event: InteractionEvent<'dblclick'>): boolean {
-        return this.checkSeriesNodeAnyClick(event, (series: Series, datum: any) =>
+        return this.checkSeriesNodeRange(event, (series: Series, datum: any) =>
             series.fireNodeDoubleClickEvent(event.sourceEvent, datum)
         );
     }
 
-    private checkSeriesNodeAnyClick(
-        event: InteractionEvent<'click' | 'dblclick'>,
-        fireEventFn: (series: Series, datum: any) => void
+    private checkSeriesNodeRange(
+        event: InteractionEvent<'click' | 'dblclick' | 'hover'>,
+        callback: (series: Series, datum: any) => void
     ): boolean {
         const datum = this.lastPick?.datum;
         const nodeClickRange = datum?.series.nodeClickRange;
 
-        // First check if we should fire the event based on nearest node
+        // First check if we should trigger the callback based on nearest node
         if (datum && nodeClickRange === 'nearest') {
-            fireEventFn(datum.series, datum);
+            callback(datum.series, datum);
             return true;
         }
 
@@ -1064,12 +1091,12 @@ export abstract class Chart extends Observable implements AgChartInstance {
 
         if (!pick) return false;
 
-        // Then if we've picked a node within the pixel range, or exactly, fire the event
+        // Then if we've picked a node within the pixel range, or exactly, trigger the callback
         const isPixelRange = pixelRange != null;
         const exactlyMatched = nodeClickRange === 'exact' && pick.distance === 0;
 
         if (isPixelRange || exactlyMatched) {
-            fireEventFn(pick.series, pick.datum);
+            callback(pick.series, pick.datum);
             return true;
         }
 

--- a/charts-community-modules/ag-charts-community/src/chart/themes/chartTheme.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/themes/chartTheme.ts
@@ -114,7 +114,6 @@ export class ChartTheme {
             },
             visible: true,
             showInLegend: true,
-            cursor: 'default',
             highlightStyle: {
                 item: {
                     fill: 'yellow',

--- a/charts-community-modules/ag-charts-community/src/scene/node.ts
+++ b/charts-community-modules/ag-charts-community/src/scene/node.ts
@@ -389,14 +389,6 @@ export abstract class Node extends ChangeDetectable {
         return bbox;
     }
 
-    computeBBoxCenter(): [number, number] {
-        const bbox = this.computeBBox && this.computeBBox();
-        if (bbox) {
-            return [bbox.x + bbox.width * 0.5, bbox.y + bbox.height * 0.5];
-        }
-        return [0, 0];
-    }
-
     computeTransformMatrix() {
         if (!this._dirtyTransform) {
             return;

--- a/charts-community-modules/ag-charts-community/src/util/observable.ts
+++ b/charts-community-modules/ag-charts-community/src/util/observable.ts
@@ -37,6 +37,10 @@ export class Observable {
         }
     }
 
+    hasEventListener(type: string): boolean {
+        return this.allEventListeners.has(type);
+    }
+
     clearEventListeners() {
         this.allEventListeners.clear();
     }

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/doc-interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/doc-interfaces.AUTO.json
@@ -5536,6 +5536,7 @@
       }
     }
   },
+  "Command": {},
   "Point": {
     "x": { "type": { "returnType": "number", "optional": false } },
     "y": { "type": { "returnType": "number", "optional": false } }

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/doc-interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/doc-interfaces.AUTO.json
@@ -1718,7 +1718,7 @@
       }
     },
     "seriesNodeDoubleClick": {
-      "description": "/** The listener to call when a node (marker, column, bar, tile or a pie sector) in any series is double clicked. In case a chart has multiple series, the chart's `seriesNodeClick` event can be used to listen to `nodeDoubleClick` events of all the series at once. */",
+      "description": "/** The listener to call when a node (marker, column, bar, tile or a pie sector) in any series is double clicked. In case a chart has multiple series, the chart's `seriesNodeDoubleClick` event can be used to listen to `nodeDoubleClick` events of all the series at once. */",
       "type": {
         "arguments": { "event": "AgNodeDoubleClickEvent" },
         "returnType": "any",

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
@@ -3877,6 +3877,11 @@
       "removeLayer(canvas: Layer)": "void"
     }
   },
+  "Command": {
+    "meta": { "isEnum": true },
+    "type": ["Move", "Line", "Arc", "Curve", "ClosePath"],
+    "docs": [null, null, null, null, null]
+  },
   "Point": { "meta": {}, "type": { "x": "number", "y": "number" } },
   "SizedPoint": {
     "meta": {},

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
@@ -1115,7 +1115,7 @@
     },
     "docs": {
       "seriesNodeClick?": "/** The listener to call when a node (marker, column, bar, tile or a pie sector) in any series is clicked. In case a chart has multiple series, the chart's `seriesNodeClick` event can be used to listen to `nodeClick` events of all the series at once. */",
-      "seriesNodeDoubleClick?": "/** The listener to call when a node (marker, column, bar, tile or a pie sector) in any series is double clicked. In case a chart has multiple series, the chart's `seriesNodeClick` event can be used to listen to `nodeDoubleClick` events of all the series at once. */",
+      "seriesNodeDoubleClick?": "/** The listener to call when a node (marker, column, bar, tile or a pie sector) in any series is double clicked. In case a chart has multiple series, the chart's `seriesNodeDoubleClick` event can be used to listen to `nodeDoubleClick` events of all the series at once. */",
       "click?": "/** The listener to call to signify a general click on the chart by the user. */",
       "doubleClick?": "/** The listener to call to signify a double click on the chart by the user. */"
     }


### PR DESCRIPTION
PR for https://ag-grid.atlassian.net/browse/AG-7461

Checkout this branch and see this plunker for a demo - https://plnkr.co/edit/JSpdRMVodhtiEX6N?open=main.ts&preview

New behaviour is:

- If the cursor is within `tooltip.range` and the `cursor` option is defined, display that cursor
- If the cursor is within `series[].nodeClickRange` and a listener is attached to one of: `seriesNodeClick`, `seriesNodeDoubleClick`, `series[].nodeClick` or `series[].nodeDoubleClick`, then display a `pointer` cursor

In the plunker above it will display the `wait` cursor when within tooltip range of the `foo` series, the `pointer` cursor when within node click range of the `foo` or `qux` series, and finally it will not change the cursor for the `bar` series as that one has no listeners. Note `qux` is a double click listener.