### PR TITLE
AG-8142 - Fix clipRect high DPR cases

### DIFF
--- a/charts-community-modules/ag-charts-community/src/canvas/hdpiCanvas.ts
+++ b/charts-community-modules/ag-charts-community/src/canvas/hdpiCanvas.ts
@@ -167,7 +167,6 @@ export class HdpiCanvas {
         HdpiCanvas.overrideScale(this.context, pixelRatio);
 
         this._pixelRatio = pixelRatio;
-        this.resize(this.width, this.height);
     }
 
     set pixelated(value: boolean) {

--- a/charts-community-modules/ag-charts-community/src/canvas/hdpiCanvas.ts
+++ b/charts-community-modules/ag-charts-community/src/canvas/hdpiCanvas.ts
@@ -12,7 +12,7 @@ type OffscreenCanvasRenderingContext2D = any;
 export class HdpiCanvas {
     readonly document: Document;
     readonly element: HTMLCanvasElement;
-    readonly context: CanvasRenderingContext2D;
+    readonly context: CanvasRenderingContext2D & { verifyDepthZero?: () => void };
     readonly imageSource: HTMLCanvasElement;
 
     // The width/height attributes of the Canvas element default to
@@ -155,17 +155,13 @@ export class HdpiCanvas {
      * or uses the window.devicePixelRatio (default), then resizes the Canvas
      * element accordingly (default).
      */
-    setPixelRatio(ratio?: number) {
+    private setPixelRatio(ratio?: number) {
         let pixelRatio = ratio ?? window.devicePixelRatio;
         if (!isDesktop()) {
             // Mobile browsers have stricter memory limits, we reduce rendering resolution to
             // improve stability on mobile browsers. iOS Safari 12->16 are pain-points since they
             // have memory allocation quirks - see https://bugs.webkit.org/show_bug.cgi?id=195325.
             pixelRatio = 1;
-        }
-
-        if (pixelRatio === this.pixelRatio) {
-            return;
         }
 
         HdpiCanvas.overrideScale(this.context, pixelRatio);
@@ -363,7 +359,7 @@ export class HdpiCanvas {
                     this.$restore();
                     depth--;
                 } else {
-                    throw new Error('Unable to restore() past depth 0');
+                    throw new Error('AG Charts - Unable to restore() past depth 0');
                 }
             },
             setTransform(a: number, b: number, c: number, d: number, e: number, f: number) {
@@ -377,6 +373,11 @@ export class HdpiCanvas {
                 // As of Jan 8, 2019, `resetTransform` is still an "experimental technology",
                 // and doesn't work in IE11 and Edge 44.
                 this.$setTransform(scale, 0, 0, scale, 0, 0);
+            },
+            verifyDepthZero() {
+                if (depth !== 0) {
+                    throw new Error('AG Charts - Save/restore depth is non-zero: ' + depth);
+                }
             },
         } as any;
 

--- a/charts-community-modules/ag-charts-community/src/canvas/hdpiOffscreenCanvas.ts
+++ b/charts-community-modules/ag-charts-community/src/canvas/hdpiOffscreenCanvas.ts
@@ -10,7 +10,7 @@ type OffscreenCanvas = any;
  * provide resolution independent rendering based on `window.devicePixelRatio`.
  */
 export class HdpiOffscreenCanvas {
-    readonly context: OffscreenCanvasRenderingContext2D;
+    readonly context: OffscreenCanvasRenderingContext2D & { verifyDepthZero?: () => void };
     readonly canvas: OffscreenCanvas;
     imageSource: ImageBitmap;
 
@@ -65,7 +65,7 @@ export class HdpiOffscreenCanvas {
      * or uses the window.devicePixelRatio (default), then resizes the Canvas
      * element accordingly (default).
      */
-    setPixelRatio(ratio?: number) {
+    private setPixelRatio(ratio?: number) {
         let pixelRatio = ratio ?? window.devicePixelRatio;
         if (!isDesktop()) {
             // Mobile browsers have stricter memory limits, we reduce rendering resolution to
@@ -74,14 +74,9 @@ export class HdpiOffscreenCanvas {
             pixelRatio = 1;
         }
 
-        if (pixelRatio === this.pixelRatio) {
-            return;
-        }
-
         HdpiCanvas.overrideScale(this.context, pixelRatio);
 
         this._pixelRatio = pixelRatio;
-        this.resize(this.width, this.height);
     }
 
     private _width: number = 0;

--- a/charts-community-modules/ag-charts-community/src/chart/cartesianChart.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/cartesianChart.ts
@@ -64,11 +64,7 @@ export class CartesianChart extends Chart {
 
         const { seriesRoot } = this;
         if (clipSeries) {
-            const { x, y, width, height } = seriesRect;
-            const { pixelRatio } = this.scene.canvas;
-            seriesRoot.setClipRectInGroupCoordinateSpace(
-                new BBox(x / pixelRatio, y / pixelRatio, width / pixelRatio, height / pixelRatio)
-            );
+            seriesRoot.setClipRectInGroupCoordinateSpace(seriesRect);
         } else {
             seriesRoot.setClipRectInGroupCoordinateSpace(undefined);
         }

--- a/charts-community-modules/ag-charts-community/src/scene/group.ts
+++ b/charts-community-modules/ag-charts-community/src/scene/group.ts
@@ -4,7 +4,6 @@ import { HdpiCanvas } from '../canvas/hdpiCanvas';
 import { HdpiOffscreenCanvas } from '../canvas/hdpiOffscreenCanvas';
 import { compoundAscending, ascendingStringNumberUndefined } from '../util/compare';
 import { Logger } from '../util/logger';
-import { Matrix } from './matrix';
 
 type OffscreenCanvasRenderingContext2D = any;
 
@@ -217,7 +216,7 @@ export class Group extends Node {
             this.clipCtx(ctx, x, y, width, height);
 
             // clipBBox is in the canvas coordinate space, when we hit a layer we apply the new clipping at which point there are no transforms in play
-            clipBBox = Matrix.fromContext(ctx).transformBBox(clipRect);
+            clipBBox = this.matrix.inverse().transformBBox(clipRect);
         }
 
         if (dirtyZIndex) {

--- a/charts-community-modules/ag-charts-community/src/scene/group.ts
+++ b/charts-community-modules/ag-charts-community/src/scene/group.ts
@@ -264,6 +264,9 @@ export class Group extends Node {
             if (stats) stats.layersRendered++;
             ctx.restore();
             layer.snapshot();
+
+            // Check for save/restore depth of zero!
+            layer.context.verifyDepthZero?.();
         }
 
         if (name && consoleLog && stats) {

--- a/charts-community-modules/ag-charts-community/src/scene/scene.ts
+++ b/charts-community-modules/ag-charts-community/src/scene/scene.ts
@@ -50,8 +50,6 @@ export class Scene {
     readonly canvas: HdpiCanvas;
     readonly layers: SceneLayer[] = [];
 
-    private readonly ctx: CanvasRenderingContext2D;
-
     private readonly opts: SceneOptions;
 
     constructor(
@@ -77,7 +75,6 @@ export class Scene {
         this.debug.dirtyTree = windowValue('agChartsSceneDirtyTree') ?? false;
         this.debug.sceneNodeHighlight = buildSceneNodeHighlight();
         this.canvas = new HdpiCanvas({ document, width, height, overrideDevicePixelRatio });
-        this.ctx = this.canvas.context;
     }
 
     set container(value: HTMLElement | undefined) {
@@ -284,7 +281,7 @@ export class Scene {
 
         this.root = null;
         this._dirty = false;
-        this.ctx.resetTransform();
+        this.canvas.context.resetTransform();
     }
 
     destroy() {
@@ -300,7 +297,7 @@ export class Scene {
         const { debugSplitTimes = [performance.now()], extraDebugStats = {} } = opts || {};
         const {
             canvas,
-            ctx,
+            canvas: { context: ctx },
             root,
             layers,
             pendingSize,
@@ -382,6 +379,9 @@ export class Scene {
             });
             ctx.restore();
         }
+
+        // Check for save/restore depth of zero!
+        ctx.verifyDepthZero?.();
 
         this._dirty = false;
 


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-8142

`ctx.getTransform()` was returning the raw Canvas matrix, including DPR multipliers - when using this as the basis for converting `clipRect` coordinates back to the canvas coordinate space, we were then getting a result that was out by a factor of the DPR.

I've removed use of `ctx.getTransform()` in favour of using the inverse of the locally managed `this.matrix`, which doesn't have DPR multipliers applied.

Bonus:
- Adds a verification that `save()` and `restore()` calls are balanced (discussed offline with @manapeirov)