### PR TITLE
AG-8058 Interaction & highlight range

### DIFF
--- a/charts-community-modules/ag-charts-community/src/chart/agChartOptions.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/agChartOptions.ts
@@ -547,6 +547,13 @@ export interface AgBaseChartListeners {
     doubleClick?: (event: AgChartDoubleClickEvent) => any;
 }
 
+type AgChartHighlightRange = 'tooltip' | 'node';
+
+export interface AgChartHighlightOptions {
+    /** By default, nodes will be highlighted when the cursor is within the `tooltip.range`. Set this to `'node'` to highlight nodes when within the `series[].nodeClickRange`. */
+    range?: AgChartHighlightRange;
+}
+
 /** Configuration common to all charts.  */
 export interface AgBaseChartOptions {
     /** The data to render the chart from. If this is not specified, it must be set on individual series instead. */
@@ -577,8 +584,8 @@ export interface AgBaseChartOptions {
     legend?: AgChartLegendOptions;
     /** A map of event names to event listeners. */
     listeners?: AgBaseChartListeners;
-    /** By default, nodes will be highlighted when the cursor is within the `tooltip.range`. Set this to `'node'` to highlight nodes when within the `series[].nodeClickRange`. */
-    highlightRange?: 'tooltip' | 'node';
+    /** Configuration for the chart highlighting. */
+    highlight: AgChartHighlightOptions;
     /** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide an `AgChartTheme` instance to customise. */
     theme?: string | AgChartTheme; // | ChartTheme
     /** HTML overlays */

--- a/charts-community-modules/ag-charts-community/src/chart/agChartOptions.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/agChartOptions.ts
@@ -577,6 +577,8 @@ export interface AgBaseChartOptions {
     legend?: AgChartLegendOptions;
     /** A map of event names to event listeners. */
     listeners?: AgBaseChartListeners;
+    /** By default, nodes will be highlighted when the cursor is within the `tooltip.range`. Set this to `'node'` to highlight nodes when within the `series[].nodeClickRange`. */
+    highlightRange?: 'tooltip' | 'node';
     /** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide an `AgChartTheme` instance to customise. */
     theme?: string | AgChartTheme; // | ChartTheme
     /** HTML overlays */

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/doc-interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/doc-interfaces.AUTO.json
@@ -5005,6 +5005,7 @@
   "VisibilityMap": {},
   "OptionalHTMLElement": {},
   "TransferableResources": {},
+  "PickedNode": {},
   "BoundSeries": {
     "type": { "type": { "returnType": "string", "optional": false } },
     "getDomain": {

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/doc-interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/doc-interfaces.AUTO.json
@@ -237,6 +237,10 @@
       "description": "/** A map of event names to event listeners. */",
       "type": { "returnType": "AgBaseChartListeners", "optional": true }
     },
+    "highlightRange": {
+      "description": "/** By default, nodes will be highlighted when the cursor is within the `tooltip.range`. Set this to `'node'` to highlight nodes when within the `series[].nodeClickRange`. */",
+      "type": { "returnType": "'tooltip' | 'node'", "optional": true }
+    },
     "theme": {
       "description": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide an `AgChartTheme` instance to customise. */",
       "type": { "returnType": "string | AgChartTheme", "optional": true }
@@ -308,6 +312,10 @@
       "description": "/** A map of event names to event listeners. */",
       "type": { "returnType": "AgBaseChartListeners", "optional": true }
     },
+    "highlightRange": {
+      "description": "/** By default, nodes will be highlighted when the cursor is within the `tooltip.range`. Set this to `'node'` to highlight nodes when within the `series[].nodeClickRange`. */",
+      "type": { "returnType": "'tooltip' | 'node'", "optional": true }
+    },
     "theme": {
       "description": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide an `AgChartTheme` instance to customise. */",
       "type": { "returnType": "string | AgChartTheme", "optional": true }
@@ -378,6 +386,10 @@
     "listeners": {
       "description": "/** A map of event names to event listeners. */",
       "type": { "returnType": "AgBaseChartListeners", "optional": true }
+    },
+    "highlightRange": {
+      "description": "/** By default, nodes will be highlighted when the cursor is within the `tooltip.range`. Set this to `'node'` to highlight nodes when within the `series[].nodeClickRange`. */",
+      "type": { "returnType": "'tooltip' | 'node'", "optional": true }
     },
     "theme": {
       "description": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide an `AgChartTheme` instance to customise. */",
@@ -1834,6 +1846,10 @@
     "listeners": {
       "description": "/** A map of event names to event listeners. */",
       "type": { "returnType": "AgBaseChartListeners", "optional": true }
+    },
+    "highlightRange": {
+      "description": "/** By default, nodes will be highlighted when the cursor is within the `tooltip.range`. Set this to `'node'` to highlight nodes when within the `series[].nodeClickRange`. */",
+      "type": { "returnType": "'tooltip' | 'node'", "optional": true }
     },
     "theme": {
       "description": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide an `AgChartTheme` instance to customise. */",
@@ -4744,6 +4760,10 @@
       "description": "/** A map of event names to event listeners. */",
       "type": { "returnType": "AgBaseChartListeners", "optional": true }
     },
+    "highlightRange": {
+      "description": "/** By default, nodes will be highlighted when the cursor is within the `tooltip.range`. Set this to `'node'` to highlight nodes when within the `series[].nodeClickRange`. */",
+      "type": { "returnType": "'tooltip' | 'node'", "optional": true }
+    },
     "theme": {
       "description": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide an `AgChartTheme` instance to customise. */",
       "type": { "returnType": "string | AgChartTheme", "optional": true }
@@ -4818,6 +4838,10 @@
       "description": "/** A map of event names to event listeners. */",
       "type": { "returnType": "AgBaseChartListeners", "optional": true }
     },
+    "highlightRange": {
+      "description": "/** By default, nodes will be highlighted when the cursor is within the `tooltip.range`. Set this to `'node'` to highlight nodes when within the `series[].nodeClickRange`. */",
+      "type": { "returnType": "'tooltip' | 'node'", "optional": true }
+    },
     "theme": {
       "description": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide an `AgChartTheme` instance to customise. */",
       "type": { "returnType": "string | AgChartTheme", "optional": true }
@@ -4888,6 +4912,10 @@
     "listeners": {
       "description": "/** A map of event names to event listeners. */",
       "type": { "returnType": "AgBaseChartListeners", "optional": true }
+    },
+    "highlightRange": {
+      "description": "/** By default, nodes will be highlighted when the cursor is within the `tooltip.range`. Set this to `'node'` to highlight nodes when within the `series[].nodeClickRange`. */",
+      "type": { "returnType": "'tooltip' | 'node'", "optional": true }
     },
     "theme": {
       "description": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide an `AgChartTheme` instance to customise. */",

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/doc-interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/doc-interfaces.AUTO.json
@@ -237,9 +237,9 @@
       "description": "/** A map of event names to event listeners. */",
       "type": { "returnType": "AgBaseChartListeners", "optional": true }
     },
-    "highlightRange": {
-      "description": "/** By default, nodes will be highlighted when the cursor is within the `tooltip.range`. Set this to `'node'` to highlight nodes when within the `series[].nodeClickRange`. */",
-      "type": { "returnType": "'tooltip' | 'node'", "optional": true }
+    "highlight": {
+      "description": "/** Configuration for the chart highlighting. */",
+      "type": { "returnType": "AgChartHighlightOptions", "optional": false }
     },
     "theme": {
       "description": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide an `AgChartTheme` instance to customise. */",
@@ -312,9 +312,9 @@
       "description": "/** A map of event names to event listeners. */",
       "type": { "returnType": "AgBaseChartListeners", "optional": true }
     },
-    "highlightRange": {
-      "description": "/** By default, nodes will be highlighted when the cursor is within the `tooltip.range`. Set this to `'node'` to highlight nodes when within the `series[].nodeClickRange`. */",
-      "type": { "returnType": "'tooltip' | 'node'", "optional": true }
+    "highlight": {
+      "description": "/** Configuration for the chart highlighting. */",
+      "type": { "returnType": "AgChartHighlightOptions", "optional": false }
     },
     "theme": {
       "description": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide an `AgChartTheme` instance to customise. */",
@@ -387,9 +387,9 @@
       "description": "/** A map of event names to event listeners. */",
       "type": { "returnType": "AgBaseChartListeners", "optional": true }
     },
-    "highlightRange": {
-      "description": "/** By default, nodes will be highlighted when the cursor is within the `tooltip.range`. Set this to `'node'` to highlight nodes when within the `series[].nodeClickRange`. */",
-      "type": { "returnType": "'tooltip' | 'node'", "optional": true }
+    "highlight": {
+      "description": "/** Configuration for the chart highlighting. */",
+      "type": { "returnType": "AgChartHighlightOptions", "optional": false }
     },
     "theme": {
       "description": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide an `AgChartTheme` instance to customise. */",
@@ -1790,6 +1790,13 @@
       }
     }
   },
+  "AgChartHighlightRange": {},
+  "AgChartHighlightOptions": {
+    "range": {
+      "description": "/** By default, nodes will be highlighted when the cursor is within the `tooltip.range`. Set this to `'node'` to highlight nodes when within the `series[].nodeClickRange`. */",
+      "type": { "returnType": "AgChartHighlightRange", "optional": true }
+    }
+  },
   "AgBaseChartOptions": {
     "data": {
       "description": "/** The data to render the chart from. If this is not specified, it must be set on individual series instead. */",
@@ -1847,9 +1854,9 @@
       "description": "/** A map of event names to event listeners. */",
       "type": { "returnType": "AgBaseChartListeners", "optional": true }
     },
-    "highlightRange": {
-      "description": "/** By default, nodes will be highlighted when the cursor is within the `tooltip.range`. Set this to `'node'` to highlight nodes when within the `series[].nodeClickRange`. */",
-      "type": { "returnType": "'tooltip' | 'node'", "optional": true }
+    "highlight": {
+      "description": "/** Configuration for the chart highlighting. */",
+      "type": { "returnType": "AgChartHighlightOptions", "optional": false }
     },
     "theme": {
       "description": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide an `AgChartTheme` instance to customise. */",
@@ -4760,9 +4767,9 @@
       "description": "/** A map of event names to event listeners. */",
       "type": { "returnType": "AgBaseChartListeners", "optional": true }
     },
-    "highlightRange": {
-      "description": "/** By default, nodes will be highlighted when the cursor is within the `tooltip.range`. Set this to `'node'` to highlight nodes when within the `series[].nodeClickRange`. */",
-      "type": { "returnType": "'tooltip' | 'node'", "optional": true }
+    "highlight": {
+      "description": "/** Configuration for the chart highlighting. */",
+      "type": { "returnType": "AgChartHighlightOptions", "optional": false }
     },
     "theme": {
       "description": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide an `AgChartTheme` instance to customise. */",
@@ -4838,9 +4845,9 @@
       "description": "/** A map of event names to event listeners. */",
       "type": { "returnType": "AgBaseChartListeners", "optional": true }
     },
-    "highlightRange": {
-      "description": "/** By default, nodes will be highlighted when the cursor is within the `tooltip.range`. Set this to `'node'` to highlight nodes when within the `series[].nodeClickRange`. */",
-      "type": { "returnType": "'tooltip' | 'node'", "optional": true }
+    "highlight": {
+      "description": "/** Configuration for the chart highlighting. */",
+      "type": { "returnType": "AgChartHighlightOptions", "optional": false }
     },
     "theme": {
       "description": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide an `AgChartTheme` instance to customise. */",
@@ -4913,9 +4920,9 @@
       "description": "/** A map of event names to event listeners. */",
       "type": { "returnType": "AgBaseChartListeners", "optional": true }
     },
-    "highlightRange": {
-      "description": "/** By default, nodes will be highlighted when the cursor is within the `tooltip.range`. Set this to `'node'` to highlight nodes when within the `series[].nodeClickRange`. */",
-      "type": { "returnType": "'tooltip' | 'node'", "optional": true }
+    "highlight": {
+      "description": "/** Configuration for the chart highlighting. */",
+      "type": { "returnType": "AgChartHighlightOptions", "optional": false }
     },
     "theme": {
       "description": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide an `AgChartTheme` instance to customise. */",

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
@@ -155,6 +155,7 @@
       "tooltip?": "AgChartTooltipOptions",
       "legend?": "AgChartLegendOptions",
       "listeners?": "AgBaseChartListeners",
+      "highlightRange?": "'tooltip' | 'node'",
       "theme?": "string | AgChartTheme",
       "overlays?": "AgChartOverlaysOptions"
     },
@@ -176,6 +177,7 @@
       "tooltip?": "/** Global configuration that applies to all tooltips in the chart. */",
       "legend?": "/** Configuration for the chart legend. */",
       "listeners?": "/** A map of event names to event listeners. */",
+      "highlightRange?": "/** By default, nodes will be highlighted when the cursor is within the `tooltip.range`. Set this to `'node'` to highlight nodes when within the `series[].nodeClickRange`. */",
       "theme?": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide an `AgChartTheme` instance to customise. */",
       "overlays?": "/** HTML overlays */"
     }
@@ -198,6 +200,7 @@
       "tooltip?": "AgChartTooltipOptions",
       "legend?": "AgChartLegendOptions",
       "listeners?": "AgBaseChartListeners",
+      "highlightRange?": "'tooltip' | 'node'",
       "theme?": "string | AgChartTheme",
       "overlays?": "AgChartOverlaysOptions"
     },
@@ -217,6 +220,7 @@
       "tooltip?": "/** Global configuration that applies to all tooltips in the chart. */",
       "legend?": "/** Configuration for the chart legend. */",
       "listeners?": "/** A map of event names to event listeners. */",
+      "highlightRange?": "/** By default, nodes will be highlighted when the cursor is within the `tooltip.range`. Set this to `'node'` to highlight nodes when within the `series[].nodeClickRange`. */",
       "theme?": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide an `AgChartTheme` instance to customise. */",
       "overlays?": "/** HTML overlays */"
     }
@@ -239,6 +243,7 @@
       "tooltip?": "AgChartTooltipOptions",
       "legend?": "AgChartLegendOptions",
       "listeners?": "AgBaseChartListeners",
+      "highlightRange?": "'tooltip' | 'node'",
       "theme?": "string | AgChartTheme",
       "overlays?": "AgChartOverlaysOptions"
     },
@@ -258,6 +263,7 @@
       "tooltip?": "/** Global configuration that applies to all tooltips in the chart. */",
       "legend?": "/** Configuration for the chart legend. */",
       "listeners?": "/** A map of event names to event listeners. */",
+      "highlightRange?": "/** By default, nodes will be highlighted when the cursor is within the `tooltip.range`. Set this to `'node'` to highlight nodes when within the `series[].nodeClickRange`. */",
       "theme?": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide an `AgChartTheme` instance to customise. */",
       "overlays?": "/** HTML overlays */"
     }
@@ -1163,6 +1169,7 @@
       "tooltip?": "AgChartTooltipOptions",
       "legend?": "AgChartLegendOptions",
       "listeners?": "AgBaseChartListeners",
+      "highlightRange?": "'tooltip' | 'node'",
       "theme?": "string | AgChartTheme",
       "overlays?": "AgChartOverlaysOptions"
     },
@@ -1181,6 +1188,7 @@
       "tooltip?": "/** Global configuration that applies to all tooltips in the chart. */",
       "legend?": "/** Configuration for the chart legend. */",
       "listeners?": "/** A map of event names to event listeners. */",
+      "highlightRange?": "/** By default, nodes will be highlighted when the cursor is within the `tooltip.range`. Set this to `'node'` to highlight nodes when within the `series[].nodeClickRange`. */",
       "theme?": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide an `AgChartTheme` instance to customise. */",
       "overlays?": "/** HTML overlays */"
     }
@@ -3056,6 +3064,7 @@
       "tooltip?": "AgChartTooltipOptions",
       "legend?": "AgChartLegendOptions",
       "listeners?": "AgBaseChartListeners",
+      "highlightRange?": "'tooltip' | 'node'",
       "theme?": "string | AgChartTheme",
       "overlays?": "AgChartOverlaysOptions"
     },
@@ -3078,6 +3087,7 @@
       "tooltip?": "/** Global configuration that applies to all tooltips in the chart. */",
       "legend?": "/** Configuration for the chart legend. */",
       "listeners?": "/** A map of event names to event listeners. */",
+      "highlightRange?": "/** By default, nodes will be highlighted when the cursor is within the `tooltip.range`. Set this to `'node'` to highlight nodes when within the `series[].nodeClickRange`. */",
       "theme?": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide an `AgChartTheme` instance to customise. */",
       "overlays?": "/** HTML overlays */"
     }
@@ -3101,6 +3111,7 @@
       "tooltip?": "AgChartTooltipOptions",
       "legend?": "AgChartLegendOptions",
       "listeners?": "AgBaseChartListeners",
+      "highlightRange?": "'tooltip' | 'node'",
       "theme?": "string | AgChartTheme",
       "overlays?": "AgChartOverlaysOptions"
     },
@@ -3121,6 +3132,7 @@
       "tooltip?": "/** Global configuration that applies to all tooltips in the chart. */",
       "legend?": "/** Configuration for the chart legend. */",
       "listeners?": "/** A map of event names to event listeners. */",
+      "highlightRange?": "/** By default, nodes will be highlighted when the cursor is within the `tooltip.range`. Set this to `'node'` to highlight nodes when within the `series[].nodeClickRange`. */",
       "theme?": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide an `AgChartTheme` instance to customise. */",
       "overlays?": "/** HTML overlays */"
     }
@@ -3144,6 +3156,7 @@
       "tooltip?": "AgChartTooltipOptions",
       "legend?": "AgChartLegendOptions",
       "listeners?": "AgBaseChartListeners",
+      "highlightRange?": "'tooltip' | 'node'",
       "theme?": "string | AgChartTheme",
       "overlays?": "AgChartOverlaysOptions"
     },
@@ -3164,6 +3177,7 @@
       "tooltip?": "/** Global configuration that applies to all tooltips in the chart. */",
       "legend?": "/** Configuration for the chart legend. */",
       "listeners?": "/** A map of event names to event listeners. */",
+      "highlightRange?": "/** By default, nodes will be highlighted when the cursor is within the `tooltip.range`. Set this to `'node'` to highlight nodes when within the `series[].nodeClickRange`. */",
       "theme?": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide an `AgChartTheme` instance to customise. */",
       "overlays?": "/** HTML overlays */"
     }

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
@@ -155,7 +155,7 @@
       "tooltip?": "AgChartTooltipOptions",
       "legend?": "AgChartLegendOptions",
       "listeners?": "AgBaseChartListeners",
-      "highlightRange?": "'tooltip' | 'node'",
+      "highlight": "AgChartHighlightOptions",
       "theme?": "string | AgChartTheme",
       "overlays?": "AgChartOverlaysOptions"
     },
@@ -177,7 +177,7 @@
       "tooltip?": "/** Global configuration that applies to all tooltips in the chart. */",
       "legend?": "/** Configuration for the chart legend. */",
       "listeners?": "/** A map of event names to event listeners. */",
-      "highlightRange?": "/** By default, nodes will be highlighted when the cursor is within the `tooltip.range`. Set this to `'node'` to highlight nodes when within the `series[].nodeClickRange`. */",
+      "highlight": "/** Configuration for the chart highlighting. */",
       "theme?": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide an `AgChartTheme` instance to customise. */",
       "overlays?": "/** HTML overlays */"
     }
@@ -200,7 +200,7 @@
       "tooltip?": "AgChartTooltipOptions",
       "legend?": "AgChartLegendOptions",
       "listeners?": "AgBaseChartListeners",
-      "highlightRange?": "'tooltip' | 'node'",
+      "highlight": "AgChartHighlightOptions",
       "theme?": "string | AgChartTheme",
       "overlays?": "AgChartOverlaysOptions"
     },
@@ -220,7 +220,7 @@
       "tooltip?": "/** Global configuration that applies to all tooltips in the chart. */",
       "legend?": "/** Configuration for the chart legend. */",
       "listeners?": "/** A map of event names to event listeners. */",
-      "highlightRange?": "/** By default, nodes will be highlighted when the cursor is within the `tooltip.range`. Set this to `'node'` to highlight nodes when within the `series[].nodeClickRange`. */",
+      "highlight": "/** Configuration for the chart highlighting. */",
       "theme?": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide an `AgChartTheme` instance to customise. */",
       "overlays?": "/** HTML overlays */"
     }
@@ -243,7 +243,7 @@
       "tooltip?": "AgChartTooltipOptions",
       "legend?": "AgChartLegendOptions",
       "listeners?": "AgBaseChartListeners",
-      "highlightRange?": "'tooltip' | 'node'",
+      "highlight": "AgChartHighlightOptions",
       "theme?": "string | AgChartTheme",
       "overlays?": "AgChartOverlaysOptions"
     },
@@ -263,7 +263,7 @@
       "tooltip?": "/** Global configuration that applies to all tooltips in the chart. */",
       "legend?": "/** Configuration for the chart legend. */",
       "listeners?": "/** A map of event names to event listeners. */",
-      "highlightRange?": "/** By default, nodes will be highlighted when the cursor is within the `tooltip.range`. Set this to `'node'` to highlight nodes when within the `series[].nodeClickRange`. */",
+      "highlight": "/** Configuration for the chart highlighting. */",
       "theme?": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide an `AgChartTheme` instance to customise. */",
       "overlays?": "/** HTML overlays */"
     }
@@ -1152,6 +1152,17 @@
       "doubleClick?": "/** The listener to call to signify a double click on the chart by the user. */"
     }
   },
+  "AgChartHighlightRange": {
+    "meta": { "isTypeAlias": true },
+    "type": "'tooltip' | 'node'"
+  },
+  "AgChartHighlightOptions": {
+    "meta": {},
+    "type": { "range?": "AgChartHighlightRange" },
+    "docs": {
+      "range?": "/** By default, nodes will be highlighted when the cursor is within the `tooltip.range`. Set this to `'node'` to highlight nodes when within the `series[].nodeClickRange`. */"
+    }
+  },
   "AgBaseChartOptions": {
     "meta": { "doc": "/** Configuration common to all charts.  */" },
     "type": {
@@ -1169,7 +1180,7 @@
       "tooltip?": "AgChartTooltipOptions",
       "legend?": "AgChartLegendOptions",
       "listeners?": "AgBaseChartListeners",
-      "highlightRange?": "'tooltip' | 'node'",
+      "highlight": "AgChartHighlightOptions",
       "theme?": "string | AgChartTheme",
       "overlays?": "AgChartOverlaysOptions"
     },
@@ -1188,7 +1199,7 @@
       "tooltip?": "/** Global configuration that applies to all tooltips in the chart. */",
       "legend?": "/** Configuration for the chart legend. */",
       "listeners?": "/** A map of event names to event listeners. */",
-      "highlightRange?": "/** By default, nodes will be highlighted when the cursor is within the `tooltip.range`. Set this to `'node'` to highlight nodes when within the `series[].nodeClickRange`. */",
+      "highlight": "/** Configuration for the chart highlighting. */",
       "theme?": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide an `AgChartTheme` instance to customise. */",
       "overlays?": "/** HTML overlays */"
     }
@@ -3064,7 +3075,7 @@
       "tooltip?": "AgChartTooltipOptions",
       "legend?": "AgChartLegendOptions",
       "listeners?": "AgBaseChartListeners",
-      "highlightRange?": "'tooltip' | 'node'",
+      "highlight": "AgChartHighlightOptions",
       "theme?": "string | AgChartTheme",
       "overlays?": "AgChartOverlaysOptions"
     },
@@ -3087,7 +3098,7 @@
       "tooltip?": "/** Global configuration that applies to all tooltips in the chart. */",
       "legend?": "/** Configuration for the chart legend. */",
       "listeners?": "/** A map of event names to event listeners. */",
-      "highlightRange?": "/** By default, nodes will be highlighted when the cursor is within the `tooltip.range`. Set this to `'node'` to highlight nodes when within the `series[].nodeClickRange`. */",
+      "highlight": "/** Configuration for the chart highlighting. */",
       "theme?": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide an `AgChartTheme` instance to customise. */",
       "overlays?": "/** HTML overlays */"
     }
@@ -3111,7 +3122,7 @@
       "tooltip?": "AgChartTooltipOptions",
       "legend?": "AgChartLegendOptions",
       "listeners?": "AgBaseChartListeners",
-      "highlightRange?": "'tooltip' | 'node'",
+      "highlight": "AgChartHighlightOptions",
       "theme?": "string | AgChartTheme",
       "overlays?": "AgChartOverlaysOptions"
     },
@@ -3132,7 +3143,7 @@
       "tooltip?": "/** Global configuration that applies to all tooltips in the chart. */",
       "legend?": "/** Configuration for the chart legend. */",
       "listeners?": "/** A map of event names to event listeners. */",
-      "highlightRange?": "/** By default, nodes will be highlighted when the cursor is within the `tooltip.range`. Set this to `'node'` to highlight nodes when within the `series[].nodeClickRange`. */",
+      "highlight": "/** Configuration for the chart highlighting. */",
       "theme?": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide an `AgChartTheme` instance to customise. */",
       "overlays?": "/** HTML overlays */"
     }
@@ -3156,7 +3167,7 @@
       "tooltip?": "AgChartTooltipOptions",
       "legend?": "AgChartLegendOptions",
       "listeners?": "AgBaseChartListeners",
-      "highlightRange?": "'tooltip' | 'node'",
+      "highlight": "AgChartHighlightOptions",
       "theme?": "string | AgChartTheme",
       "overlays?": "AgChartOverlaysOptions"
     },
@@ -3177,7 +3188,7 @@
       "tooltip?": "/** Global configuration that applies to all tooltips in the chart. */",
       "legend?": "/** Configuration for the chart legend. */",
       "listeners?": "/** A map of event names to event listeners. */",
-      "highlightRange?": "/** By default, nodes will be highlighted when the cursor is within the `tooltip.range`. Set this to `'node'` to highlight nodes when within the `series[].nodeClickRange`. */",
+      "highlight": "/** Configuration for the chart highlighting. */",
       "theme?": "/** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide an `AgChartTheme` instance to customise. */",
       "overlays?": "/** HTML overlays */"
     }

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
@@ -3260,6 +3260,10 @@
     "meta": { "isTypeAlias": true },
     "type": "{ container?: OptionalHTMLElement; scene: Scene; element: HTMLElement; }"
   },
+  "PickedNode": {
+    "meta": { "isTypeAlias": true },
+    "type": "{ series: Series<any>; datum: SeriesNodeDatum; distance: number; }"
+  },
   "BoundSeries": {
     "meta": {},
     "type": {

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-events/examples/interaction-ranges/index.html
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-events/examples/interaction-ranges/index.html
@@ -1,7 +1,7 @@
 <div class="wrapper">
   <div id="toolPanel">
+    <button onclick="exact()">Exact (Default)</button>
     <button onclick="nearest()">Nearest</button>
-    <button onclick="exact()">Exact</button>
     <button onclick="distance()">Distance (10 Pixels)</button>
   </div>
   <div id="myChart"></div>

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-events/examples/interaction-ranges/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-events/examples/interaction-ranges/main.ts
@@ -3,9 +3,6 @@ import { AgCartesianChartOptions, AgChart } from "ag-charts-community"
 let options: AgCartesianChartOptions = {
   container: document.getElementById("myChart"),
   autoSize: true,
-  tooltip: {
-    range: "nearest",
-  },
   data: [
     {
       quarter: "Q1",
@@ -32,7 +29,7 @@ let options: AgCartesianChartOptions = {
     {
       xKey: "quarter",
       yKey: "petrol",
-      nodeClickRange: "nearest",
+      nodeClickRange: "exact",
       listeners: {
         nodeClick: event =>
           window.alert(`${event.yKey} - ${event.datum.petrol}`),
@@ -41,7 +38,7 @@ let options: AgCartesianChartOptions = {
     {
       xKey: "quarter",
       yKey: "diesel",
-      nodeClickRange: "nearest",
+      nodeClickRange: "exact",
       listeners: {
         nodeClick: event =>
           window.alert(`${event.yKey} - ${event.datum.diesel}`),
@@ -56,26 +53,33 @@ let options: AgCartesianChartOptions = {
 
 var chart = AgChart.create(options)
 
-function nearest() {
-  options.series = options.series?.map(s => ({
-    ...s,
-    nodeClickRange: "nearest",
-  }))
+function exact() {
+  if (!options.series) return
+
+  for (let i = 0; i < options.series.length; i++) {
+    options.series[i].nodeClickRange = "exact"
+  }
+
   AgChart.update(chart, options)
 }
 
-function exact() {
-  options.series = options.series?.map(s => ({
-    ...s,
-    nodeClickRange: "exact",
-  }))
+function nearest() {
+  console.log("nearest")
+  if (!options.series) return
+
+  for (let i = 0; i < options.series.length; i++) {
+    options.series[i].nodeClickRange = "nearest"
+  }
+
   AgChart.update(chart, options)
 }
 
 function distance() {
-  options.series = options.series?.map(s => ({
-    ...s,
-    nodeClickRange: 10,
-  }))
+  if (!options.series) return
+
+  for (let i = 0; i < options.series.length; i++) {
+    options.series[i].nodeClickRange = 10
+  }
+
   AgChart.update(chart, options)
 }

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-events/examples/interaction-ranges/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-events/examples/interaction-ranges/main.ts
@@ -64,7 +64,6 @@ function exact() {
 }
 
 function nearest() {
-  console.log("nearest")
   if (!options.series) return
 
   for (let i = 0; i < options.series.length; i++) {


### PR DESCRIPTION
PR for https://ag-grid.atlassian.net/browse/AG-8058

Adds `chart.highlightRange` option to toggle highlighting triggering in line with the tooltip or the node clicking. The default is `'tooltip'` since it would be rare for the tooltip range to be smaller than the node click range.

This has all got bit complect with the pointer, highlighting, tooltip and clicking ranges and toggling. A subject for refactor once behaviour has settled.