### PR TITLE
AG-8202 Avoid visible flash in React when filtering

### DIFF
--- a/grid-community-modules/core/src/ts/rendering/row/rowCtrl.ts
+++ b/grid-community-modules/core/src/ts/rendering/row/rowCtrl.ts
@@ -1328,13 +1328,15 @@ export class RowCtrl extends BeanStub {
     }
 
     // note - this is NOT called by context, as we don't wire / unwire the CellComp for performance reasons.
-    public destroyFirstPass(): void {
+    public destroyFirstPass(animate: boolean = true): void {
         this.active = false;
 
         // why do we have this method? shouldn't everything below be added as a destroy func beside
         // the corresponding create logic?
 
-        this.setupRemoveAnimation();
+        if (animate) {
+            this.setupRemoveAnimation();
+        }
 
         const event: VirtualRowRemovedEvent = this.createRowEvent(Events.EVENT_VIRTUAL_ROW_REMOVED);
 
@@ -1356,9 +1358,7 @@ export class RowCtrl extends BeanStub {
             const rowTop = this.roundRowTopToBounds(this.rowNode.rowTop!);
             this.setRowTop(rowTop);
         } else {
-            executeNextVMTurn(() => {
-                this.allRowGuis.forEach(gui => gui.rowComp.addOrRemoveCssClass('ag-opacity-zero', true));
-            });
+            this.allRowGuis.forEach(gui => gui.rowComp.addOrRemoveCssClass('ag-opacity-zero', true));
         }
     }
 

--- a/grid-community-modules/core/src/ts/rendering/row/rowCtrl.ts
+++ b/grid-community-modules/core/src/ts/rendering/row/rowCtrl.ts
@@ -1356,7 +1356,9 @@ export class RowCtrl extends BeanStub {
             const rowTop = this.roundRowTopToBounds(this.rowNode.rowTop!);
             this.setRowTop(rowTop);
         } else {
-            this.allRowGuis.forEach(gui => gui.rowComp.addOrRemoveCssClass('ag-opacity-zero', true));
+            executeNextVMTurn(() => {
+                this.allRowGuis.forEach(gui => gui.rowComp.addOrRemoveCssClass('ag-opacity-zero', true));
+            });
         }
     }
 

--- a/grid-community-modules/core/src/ts/rendering/row/rowCtrl.ts
+++ b/grid-community-modules/core/src/ts/rendering/row/rowCtrl.ts
@@ -1328,13 +1328,13 @@ export class RowCtrl extends BeanStub {
     }
 
     // note - this is NOT called by context, as we don't wire / unwire the CellComp for performance reasons.
-    public destroyFirstPass(animate: boolean = true): void {
+    public destroyFirstPass(): void {
         this.active = false;
 
         // why do we have this method? shouldn't everything below be added as a destroy func beside
         // the corresponding create logic?
 
-        if (animate) {
+        if (this.beans.gridOptionsService.isAnimateRows()) {
             this.setupRemoveAnimation();
         }
 

--- a/grid-community-modules/core/src/ts/rendering/rowRenderer.ts
+++ b/grid-community-modules/core/src/ts/rendering/rowRenderer.ts
@@ -1116,7 +1116,7 @@ export class RowRenderer extends BeanStub {
                 return;
             }
 
-            rowCtrl.destroyFirstPass(animate);
+            rowCtrl.destroyFirstPass();
             if (animate) {
                 this.zombieRowCtrls[rowCtrl.getInstanceId()] = rowCtrl;
                 executeInAWhileFuncs.push(() => {

--- a/grid-community-modules/core/src/ts/rendering/rowRenderer.ts
+++ b/grid-community-modules/core/src/ts/rendering/rowRenderer.ts
@@ -1116,7 +1116,7 @@ export class RowRenderer extends BeanStub {
                 return;
             }
 
-            rowCtrl.destroyFirstPass();
+            rowCtrl.destroyFirstPass(animate);
             if (animate) {
                 this.zombieRowCtrls[rowCtrl.getInstanceId()] = rowCtrl;
                 executeInAWhileFuncs.push(() => {


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-8202

Currently when filtering in React 18 the rows flash when updating a filter via a component. (does not impact filtering via the api methods)

What is happening is that as part of `setupRemoveAnimation` the `ag-opacity-zero` is applied synchronously to the existing row components. This immediately hides the contents of the rows that are going to be removed. However, as the rows are not actually removed until after React has asynchronously updated the row controllers we see the grid in a state where some rows are hidden and others are visible. 

It happens very fast but slow enough to see a visible flash. This does not impact the api methods as they are already using an async update method for filters. 

The fix is to only apply the `ag-opacity-zero` class when row animation is switched on. React correctly animates the rows when doing a row animation. So it seems sensible to only apply these remove animations when the user is actually animating.

We potentially have not noticed this previously because the dom was updated to remove the rows in the same VM turn as the class was added. 