### PR TITLE
Ag 5568/axis tick labels

### DIFF
--- a/charts-community-modules/ag-charts-community/src/axis.ts
+++ b/charts-community-modules/ag-charts-community/src/axis.ts
@@ -95,6 +95,9 @@ export class AxisLine {
 }
 
 class AxisTick<S extends Scale<D, number>, D = any> {
+    @Validate(BOOLEAN)
+    enabled = true;
+
     /**
      * The line width to be used by axis ticks.
      */
@@ -759,7 +762,7 @@ export class Axis<S extends Scale<D, number, TickInterval<S>>, D = any> {
         tickLineGroupSelection.each(visibleFn);
         tickLabelGroupSelection.each(visibleFn);
 
-        this.tickLineGroup.visible = anyTickVisible;
+        this.tickLineGroup.visible = this.tick.enabled && anyTickVisible;
         this.tickLabelGroup.visible = enabledLabels && anyTickVisible;
         this.gridLineGroup.visible = anyTickVisible;
         this.gridArcGroup.visible = anyTickVisible;

--- a/charts-community-modules/ag-charts-community/src/axis.ts
+++ b/charts-community-modules/ag-charts-community/src/axis.ts
@@ -143,6 +143,9 @@ class AxisTick<S extends Scale<D, number>, D = any> {
 }
 
 export class AxisLabel {
+    @Validate(BOOLEAN)
+    enabled = true;
+
     @Validate(OPT_FONT_STYLE)
     fontStyle?: FontStyle = undefined;
 
@@ -593,7 +596,7 @@ export class Axis<S extends Scale<D, number, TickInterval<S>>, D = any> {
             scale,
             gridLength,
             tick,
-            label: { parallel: parallelLabels, mirrored, avoidCollisions },
+            label: { enabled: enabledLabels, parallel: parallelLabels, mirrored, avoidCollisions },
             requestedRange,
         } = this;
         const requestedRangeMin = Math.min(...requestedRange);
@@ -643,7 +646,8 @@ export class Axis<S extends Scale<D, number, TickInterval<S>>, D = any> {
         const continuous = scale instanceof ContinuousScale;
         const secondaryAxis = primaryTickCount !== undefined;
 
-        const checkForOverlap = avoidCollisions && this.tick.interval === undefined && this.tick.values === undefined;
+        const checkForOverlap =
+            enabledLabels && avoidCollisions && this.tick.interval === undefined && this.tick.values === undefined;
         const tickSpacing = !isNaN(this.tick.minSpacing) || !isNaN(this.tick.maxSpacing);
         const maxIterations = this.tick.count || !continuous || isNaN(maxTickCount) ? 10 : maxTickCount;
 
@@ -756,7 +760,7 @@ export class Axis<S extends Scale<D, number, TickInterval<S>>, D = any> {
         tickLabelGroupSelection.each(visibleFn);
 
         this.tickLineGroup.visible = anyTickVisible;
-        this.tickLabelGroup.visible = anyTickVisible;
+        this.tickLabelGroup.visible = enabledLabels && anyTickVisible;
         this.gridLineGroup.visible = anyTickVisible;
         this.gridArcGroup.visible = anyTickVisible;
 
@@ -999,12 +1003,17 @@ export class Axis<S extends Scale<D, number, TickInterval<S>>, D = any> {
         sideFlag: -1 | 1;
         parallelFlipRotation: number;
         regularFlipRotation: number;
-    }) {
+    }): { labelData: PointLabelDatum[]; rotated: boolean } {
         const {
             label,
-            label: { parallel, rotation },
+            label: { enabled: labelsEnabled, parallel, rotation },
             tick,
         } = this;
+
+        if (!labelsEnabled) {
+            return { labelData: [], rotated: false };
+        }
+
         let labelAutoRotation = 0;
 
         const { autoRotation, labelRotation, parallelFlipFlag, regularFlipFlag } = calculateLabelRotation({

--- a/charts-community-modules/ag-charts-community/src/chart/agChartOptions.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/agChartOptions.ts
@@ -639,6 +639,8 @@ export interface AgAxisLineOptions {
 }
 
 export interface AgAxisBaseTickOptions {
+    /** Set to false to hide the axis tick lines. */
+    enabled?: boolean;
     /** The width in pixels of the axis ticks (and corresponding grid line). */
     width?: PixelSize;
     /** The length in pixels of the axis ticks. */

--- a/charts-community-modules/ag-charts-community/src/chart/agChartOptions.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/agChartOptions.ts
@@ -689,6 +689,8 @@ export interface AgAxisLabelFormatterParams {
 }
 
 export interface AgAxisLabelOptions {
+    /** Set to false to hide the axis labels. */
+    enabled?: boolean;
     /** The font style to use for the labels. */
     fontStyle?: FontStyle;
     /** The font weight to use for the labels. */

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/doc-interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/doc-interfaces.AUTO.json
@@ -2004,6 +2004,10 @@
     }
   },
   "AgAxisBaseTickOptions": {
+    "enabled": {
+      "description": "/** Set to false to hide the axis tick lines. */",
+      "type": { "returnType": "boolean", "optional": true }
+    },
     "width": {
       "description": "/** The width in pixels of the axis ticks (and corresponding grid line). */",
       "type": { "returnType": "PixelSize", "optional": true }
@@ -2030,6 +2034,10 @@
     }
   },
   "AgAxisCategoryTickOptions": {
+    "enabled": {
+      "description": "/** Set to false to hide the axis tick lines. */",
+      "type": { "returnType": "boolean", "optional": true }
+    },
     "width": {
       "description": "/** The width in pixels of the axis ticks (and corresponding grid line). */",
       "type": { "returnType": "PixelSize", "optional": true }
@@ -2064,6 +2072,10 @@
       "description": "/** The step value between ticks specified as a number. If the configured interval results in too many ticks given the chart size, it will be ignored.\n     */",
       "type": { "returnType": "number", "optional": true }
     },
+    "enabled": {
+      "description": "/** Set to false to hide the axis tick lines. */",
+      "type": { "returnType": "boolean", "optional": true }
+    },
     "width": {
       "description": "/** The width in pixels of the axis ticks (and corresponding grid line). */",
       "type": { "returnType": "PixelSize", "optional": true }
@@ -2097,6 +2109,10 @@
     "interval": {
       "description": "/** The step value between ticks specified as a TimeInterval or a number. If the configured interval results in dense ticks given the data domain, the ticks will be removed.\n     */",
       "type": { "returnType": "any", "optional": true }
+    },
+    "enabled": {
+      "description": "/** Set to false to hide the axis tick lines. */",
+      "type": { "returnType": "boolean", "optional": true }
     },
     "width": {
       "description": "/** The width in pixels of the axis ticks (and corresponding grid line). */",

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/doc-interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/doc-interfaces.AUTO.json
@@ -2136,6 +2136,10 @@
     }
   },
   "AgAxisLabelOptions": {
+    "enabled": {
+      "description": "/** Set to false to hide the axis labels. */",
+      "type": { "returnType": "boolean", "optional": true }
+    },
     "fontStyle": {
       "description": "/** The font style to use for the labels. */",
       "type": { "returnType": "FontStyle", "optional": true }

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
@@ -1315,6 +1315,7 @@
   "AgAxisBaseTickOptions": {
     "meta": {},
     "type": {
+      "enabled?": "boolean",
       "width?": "PixelSize",
       "size?": "PixelSize",
       "color?": "CssColor",
@@ -1323,6 +1324,7 @@
       "maxSpacing?": "number"
     },
     "docs": {
+      "enabled?": "/** Set to false to hide the axis tick lines. */",
       "width?": "/** The width in pixels of the axis ticks (and corresponding grid line). */",
       "size?": "/** The length in pixels of the axis ticks. */",
       "color?": "/** The colour of the axis ticks. */",
@@ -1334,6 +1336,7 @@
   "AgAxisCategoryTickOptions": {
     "meta": {},
     "type": {
+      "enabled?": "boolean",
       "width?": "PixelSize",
       "size?": "PixelSize",
       "color?": "CssColor",
@@ -1342,6 +1345,7 @@
       "maxSpacing?": "number"
     },
     "docs": {
+      "enabled?": "/** Set to false to hide the axis tick lines. */",
       "width?": "/** The width in pixels of the axis ticks (and corresponding grid line). */",
       "size?": "/** The length in pixels of the axis ticks. */",
       "color?": "/** The colour of the axis ticks. */",
@@ -1355,6 +1359,7 @@
     "type": {
       "count?": "number",
       "interval?": "number",
+      "enabled?": "boolean",
       "width?": "PixelSize",
       "size?": "PixelSize",
       "color?": "CssColor",
@@ -1365,6 +1370,7 @@
     "docs": {
       "count?": "/** A hint of how many ticks to use across an axis.\n     * The axis is not guaranteed to use exactly this number of ticks, but will try to use a number of ticks that is close to the number given.\n     * @deprecated since v7.1.0 (ag-grid v29.1.0) Use tick.interval or tick.minSpacing and tick.maxSpacing instead.\n     */",
       "interval?": "/** The step value between ticks specified as a number. If the configured interval results in too many ticks given the chart size, it will be ignored.\n     */",
+      "enabled?": "/** Set to false to hide the axis tick lines. */",
       "width?": "/** The width in pixels of the axis ticks (and corresponding grid line). */",
       "size?": "/** The length in pixels of the axis ticks. */",
       "color?": "/** The colour of the axis ticks. */",
@@ -1378,6 +1384,7 @@
     "type": {
       "count?": "any",
       "interval?": "any",
+      "enabled?": "boolean",
       "width?": "PixelSize",
       "size?": "PixelSize",
       "color?": "CssColor",
@@ -1388,6 +1395,7 @@
     "docs": {
       "count?": "/** A hint of how many ticks to use across an axis.\n     * The axis is not guaranteed to use exactly this number of ticks, but will try to use a number of ticks that is close to the number given.\n     * The following intervals from the `agCharts.time` namespace can be used:\n     * `millisecond, second, minute, hour, day, sunday, monday, tuesday, wednesday, thursday, friday, saturday, month, year, utcMinute, utcHour, utcDay, utcMonth, utcYear`.\n     * Derived intervals can be created by using the `every` method on the default ones. For example, `agCharts.time.month.every(2)` will return a derived interval that will make the axis place ticks for every other month. */",
       "interval?": "/** The step value between ticks specified as a TimeInterval or a number. If the configured interval results in dense ticks given the data domain, the ticks will be removed.\n     */",
+      "enabled?": "/** Set to false to hide the axis tick lines. */",
       "width?": "/** The width in pixels of the axis ticks (and corresponding grid line). */",
       "size?": "/** The length in pixels of the axis ticks. */",
       "color?": "/** The colour of the axis ticks. */",

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
@@ -1408,6 +1408,7 @@
   "AgAxisLabelOptions": {
     "meta": {},
     "type": {
+      "enabled?": "boolean",
       "fontStyle?": "FontStyle",
       "fontWeight?": "FontWeight",
       "fontSize?": "FontSize",
@@ -1423,6 +1424,7 @@
       "formatter?": "(params: AgAxisLabelFormatterParams) => string | undefined"
     },
     "docs": {
+      "enabled?": "/** Set to false to hide the axis labels. */",
       "fontStyle?": "/** The font style to use for the labels. */",
       "fontWeight?": "/** The font weight to use for the labels. */",
       "fontSize?": "/** The font size in pixels to use for the labels. */",


### PR DESCRIPTION
PR for https://ag-grid.atlassian.net/browse/AG-5568.

Add `enabled` property to `axis.label` and `axis.tick` to hide all labels and ticks.