### PR TITLE
RTI-1426 Fix removing default Tooltip class name

### DIFF
--- a/charts-community-modules/ag-charts-community/src/chart/themes/chartTheme.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/themes/chartTheme.ts
@@ -15,7 +15,6 @@ import {
     AgChartInteractionRange,
     AgTooltipPositionType,
 } from '../agChartOptions';
-import { DEFAULT_TOOLTIP_CLASS } from '../tooltip/tooltip';
 import { CHART_TYPES } from '../chartTypes';
 
 const palette: AgChartThemePalette = {
@@ -307,7 +306,6 @@ export class ChartTheme {
                 enabled: true,
                 range: 'nearest' as AgChartInteractionRange,
                 delay: 0,
-                class: DEFAULT_TOOLTIP_CLASS,
             },
             listeners: {},
         };


### PR DESCRIPTION
The value assigned through the theme is treated as the "previous", when another one is assigned through options.