### PR TITLE
AG-8482 - Remove BarSeries.flipXY.

### DIFF
--- a/charts-community-modules/ag-charts-community/src/chart/agChartOptions.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/agChartOptions.ts
@@ -1298,7 +1298,6 @@ export interface AgBarSeriesOptions<DatumType = any> extends AgBaseSeriesOptions
     xName?: string;
     /** Human-readable description of the y-values. If supplied, a corresponding `yName` will be shown in the default tooltip and passed to the tooltip renderer as one of the parameters. */
     yName?: string;
-    flipXY?: boolean;
     /** The colour to use for the fill of the bars. */
     fill?: CssColor;
     /** The colours to use for the stroke of the bars. */

--- a/charts-community-modules/ag-charts-community/src/chart/chartAxis.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/chartAxis.ts
@@ -8,14 +8,6 @@ import { AgCartesianAxisPosition, AgCartesianAxisType } from './agChartOptions';
 import { AxisLayout } from './layout/layoutService';
 import { AxisContext, AxisModule, ModuleContext, ModuleInstance } from '../util/module';
 
-export function flipChartAxisDirection(direction: ChartAxisDirection): ChartAxisDirection {
-    if (direction === ChartAxisDirection.X) {
-        return ChartAxisDirection.Y;
-    } else {
-        return ChartAxisDirection.X;
-    }
-}
-
 interface BoundSeries {
     type: string;
     getDomain(direction: ChartAxisDirection): any[];

--- a/charts-community-modules/ag-charts-community/src/chart/factory/seriesTypes.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/factory/seriesTypes.ts
@@ -1,6 +1,6 @@
 import { Series } from '../series/series';
 import { AreaSeries } from '../series/cartesian/areaSeries';
-import { BarSeries } from '../series/cartesian/barSeries';
+import { BarSeries, ColumnSeries } from '../series/cartesian/barSeries';
 import { HistogramSeries } from '../series/cartesian/histogramSeries';
 import { LineSeries } from '../series/cartesian/lineSeries';
 import { ScatterSeries } from '../series/cartesian/scatterSeries';
@@ -12,7 +12,7 @@ type SeriesConstructor = new () => Series<any>;
 const BUILT_IN_SERIES_FACTORIES: Record<string, SeriesConstructor> = {
     area: AreaSeries,
     bar: BarSeries,
-    column: BarSeries,
+    column: ColumnSeries,
     histogram: HistogramSeries,
     line: LineSeries,
     pie: PieSeries,

--- a/charts-community-modules/ag-charts-community/src/chart/mapping/__snapshots__/prepare.test.ts.snap
+++ b/charts-community-modules/ag-charts-community/src/chart/mapping/__snapshots__/prepare.test.ts.snap
@@ -677,7 +677,6 @@ Object {
         "#c16068",
         "#a2bf8a",
       ],
-      "flipXY": false,
       "grouped": true,
       "hideInLegend": Array [],
       "highlightStyle": Object {
@@ -1737,7 +1736,6 @@ Object {
         "#c84164",
         "#888888",
       ],
-      "flipXY": false,
       "hideInLegend": Array [],
       "highlightStyle": Object {
         "item": Object {
@@ -3453,7 +3451,6 @@ Object {
       "fills": Array [
         "#f3622d",
       ],
-      "flipXY": true,
       "grouped": true,
       "hideInLegend": Array [],
       "highlightStyle": Object {
@@ -3750,7 +3747,6 @@ Object {
       "fills": Array [
         "rgba(0, 117, 163, 0.9)",
       ],
-      "flipXY": true,
       "grouped": true,
       "hideInLegend": Array [],
       "highlightStyle": Object {
@@ -4589,7 +4585,6 @@ Object {
         "#19A0AA",
         "#F15F36",
       ],
-      "flipXY": false,
       "grouped": true,
       "hideInLegend": Array [],
       "highlightStyle": Object {
@@ -4909,7 +4904,6 @@ Object {
         "rgba(0, 117, 163, 0.9)",
         "rgba(226, 188, 34, 0.9)",
       ],
-      "flipXY": true,
       "grouped": true,
       "hideInLegend": Array [],
       "highlightStyle": Object {
@@ -5237,7 +5231,6 @@ Object {
         "#9a42c8",
         "#c84164",
       ],
-      "flipXY": false,
       "grouped": true,
       "hideInLegend": Array [],
       "highlightStyle": Object {
@@ -7919,7 +7912,6 @@ Object {
         "#ffbb33",
         "#ff4444",
       ],
-      "flipXY": true,
       "hideInLegend": Array [],
       "highlightStyle": Object {
         "item": Object {
@@ -8250,7 +8242,6 @@ Object {
         "#9b59b6",
         "#34495e",
       ],
-      "flipXY": false,
       "hideInLegend": Array [],
       "highlightStyle": Object {
         "item": Object {
@@ -9124,7 +9115,6 @@ Object {
       "fills": Array [
         "#0084e7",
       ],
-      "flipXY": false,
       "grouped": true,
       "hideInLegend": Array [],
       "highlightStyle": Object {
@@ -11117,7 +11107,6 @@ Object {
         "#57b757",
         "#41a9c9",
       ],
-      "flipXY": true,
       "hideInLegend": Array [],
       "highlightStyle": Object {
         "item": Object {
@@ -11438,7 +11427,6 @@ Object {
         "#E55934",
         "#FA7921",
       ],
-      "flipXY": false,
       "hideInLegend": Array [],
       "highlightStyle": Object {
         "item": Object {

--- a/charts-community-modules/ag-charts-community/src/chart/test/examples.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/test/examples.ts
@@ -181,9 +181,8 @@ export const GROUPED_CATEGORY_AXIS_EXAMPLE: AgChartOptions = {};
                 yKey: 'totalWinnings',
                 yName: 'Total Winnings',
                 showInLegend: false,
-                flipXY: false,
                 grouped: true,
-                type: 'bar',
+                type: 'column',
             },
         ],
         title: {

--- a/charts-community-modules/ag-charts-community/src/chart/themes/chartTheme.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/themes/chartTheme.ts
@@ -142,7 +142,6 @@ export class ChartTheme {
     private static getBarSeriesDefaults() {
         return {
             ...this.getSeriesDefaults(),
-            flipXY: false,
             fillOpacity: 1,
             strokeOpacity: 1,
             xKey: '',
@@ -324,11 +323,9 @@ export class ChartTheme {
         series: {
             column: {
                 ...ChartTheme.getBarSeriesDefaults(),
-                flipXY: false,
             },
             bar: {
                 ...ChartTheme.getBarSeriesDefaults(),
-                flipXY: true,
             },
             line: {
                 ...ChartTheme.getLineSeriesDefaults(),

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/doc-interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/doc-interfaces.AUTO.json
@@ -3728,7 +3728,6 @@
       "description": "/** Human-readable description of the y-values. If supplied, a corresponding `yName` will be shown in the default tooltip and passed to the tooltip renderer as one of the parameters. */",
       "type": { "returnType": "string", "optional": true }
     },
-    "flipXY": { "type": { "returnType": "boolean", "optional": true } },
     "fill": {
       "description": "/** The colour to use for the fill of the bars. */",
       "type": { "returnType": "CssColor", "optional": true }

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
@@ -2450,7 +2450,6 @@
       "yKey?": "string",
       "xName?": "string",
       "yName?": "string",
-      "flipXY?": "boolean",
       "fill?": "CssColor",
       "stroke?": "CssColor",
       "strokeWidth?": "PixelSize",


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-8482

Removes the pointless `flipXY` options from `BarSeries`, which was a proxy for `type` being set to `column` or `bar`.

Adds `ColumnSeries` which trivially overrides some methods to vary rendering behaviour.