### PR TITLE
AG-8462 Pie initial load animation

### DIFF
--- a/charts-community-modules/ag-charts-community/src/chart/chart.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/chart.ts
@@ -253,9 +253,8 @@ export abstract class Chart extends Observable implements AgChartInstance {
         this.layoutService = new LayoutService();
         this.updateService = new UpdateService((type = ChartUpdateType.FULL) => this.update(type));
 
-        // Delay playing animations by a 10ms to avoid the initial ~150ms jerk
-        setTimeout(() => this.animationManager.play(), 10);
         this.animationManager.skipAnimations = true;
+        this.animationManager.play();
 
         SizeMonitor.observe(this.element, (size) => {
             const { width, height } = size;

--- a/charts-community-modules/ag-charts-community/src/chart/chart.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/chart.ts
@@ -253,8 +253,9 @@ export abstract class Chart extends Observable implements AgChartInstance {
         this.layoutService = new LayoutService();
         this.updateService = new UpdateService((type = ChartUpdateType.FULL) => this.update(type));
 
+        // Delay playing animations by a 10ms to avoid the initial ~150ms jerk
+        setTimeout(() => this.animationManager.play(), 10);
         this.animationManager.skipAnimations = true;
-        this.animationManager.play();
 
         SizeMonitor.observe(this.element, (size) => {
             const { width, height } = size;

--- a/charts-community-modules/ag-charts-community/src/chart/interaction/animationManager.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/interaction/animationManager.ts
@@ -74,7 +74,7 @@ export class AnimationManager extends BaseManager<AnimationEventType, AnimationE
             ...opts,
             autoplay: this.isPlaying ? opts.autoplay : false,
             driver: this.createDriver(id),
-            duration: this.skipAnimations ? 0 : opts.duration,
+            duration: this.skipAnimations ? 1 : opts.duration,
         };
         const controller = baseAnimate(optsExtra);
 

--- a/charts-community-modules/ag-charts-community/src/chart/interaction/animationManager.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/interaction/animationManager.ts
@@ -83,7 +83,6 @@ export class AnimationManager extends BaseManager<AnimationEventType, AnimationE
             ...opts,
             autoplay: this.isPlaying ? opts.autoplay : false,
             driver: this.createDriver(id),
-            duration: this.skipAnimations ? 1 : opts.duration,
         };
         const controller = baseAnimate(optsExtra);
 
@@ -93,6 +92,15 @@ export class AnimationManager extends BaseManager<AnimationEventType, AnimationE
         }
 
         this.controllers[id] = controller;
+
+        if (this.skipAnimations) {
+            // Initialise the animation with the final values immediately and then stop the animation
+            opts.onUpdate?.(opts.to);
+            controller.stop();
+        } else {
+            // Initialise the animation immediately without requesting a frame to prevent flashes
+            opts.onUpdate?.(opts.from);
+        }
 
         return controller;
     }

--- a/charts-community-modules/ag-charts-community/src/chart/interaction/animationManager.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/interaction/animationManager.ts
@@ -34,8 +34,17 @@ export class AnimationManager extends BaseManager<AnimationEventType, AnimationE
     private isPlaying = false;
     private requestId?: number;
     private lastTime?: number;
+    private readyToPlay = false;
 
     public skipAnimations = false;
+
+    constructor() {
+        super();
+
+        window.addEventListener('DOMContentLoaded', () => {
+            this.readyToPlay = true;
+        });
+    }
 
     public play() {
         if (this.isPlaying) return;
@@ -170,6 +179,11 @@ export class AnimationManager extends BaseManager<AnimationEventType, AnimationE
 
     private startAnimationCycle() {
         const frame = (time: number) => {
+            if (!this.readyToPlay) {
+                this.requestId = requestAnimationFrame(frame);
+                return;
+            }
+
             if (this.lastTime === undefined) this.lastTime = time;
             const delta = time - this.lastTime;
             this.lastTime = time;

--- a/charts-community-modules/ag-charts-community/src/chart/interaction/animationManager.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/interaction/animationManager.ts
@@ -2,7 +2,7 @@ import { BaseManager } from './baseManager';
 import {
     animate as baseAnimate,
     AnimationControls,
-    AnimationOptions,
+    AnimationOptions as BaseAnimationOptions,
     Driver,
     tween,
     TweenControls,
@@ -16,6 +16,8 @@ interface AnimationEvent<AnimationEventType> {
     type: AnimationEventType;
     delta: number;
 }
+
+interface AnimationOptions<T> extends Omit<BaseAnimationOptions<T>, 'driver'> {}
 
 interface AnimationManyOptions<T> extends Omit<AnimationOptions<T>, 'from' | 'to' | 'onUpdate'> {
     onUpdate: (props: Array<T>) => void;

--- a/charts-community-modules/ag-charts-community/src/chart/series/polar/pieSeries.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/series/polar/pieSeries.ts
@@ -345,39 +345,7 @@ export class PieSeries extends PolarSeries<PieNodeDatum> {
                 on: {
                     load: {
                         target: 'ready',
-                        action: () => {
-                            const rotation = Math.PI / -2 + toRadians(this.rotation);
-
-                            this.groupSelection.selectByTag<Sector>(PieNodeTag.Sector).forEach((node) => {
-                                const { datum } = node;
-
-                                if (!this.animationManager) {
-                                    node.startAngle = datum.startAngle;
-                                    node.endAngle = datum.endAngle;
-                                    return;
-                                }
-
-                                node.startAngle = rotation;
-                                node.endAngle = rotation;
-
-                                this.animationManager.animateMany<number>(
-                                    `${this.id}_empty-load-ready_${node.id}`,
-                                    [
-                                        { from: rotation, to: datum.startAngle },
-                                        { from: rotation, to: datum.endAngle },
-                                    ],
-                                    {
-                                        duration: 600,
-                                        repeat: 0,
-                                        ease: easing.easeInOut,
-                                        onUpdate: ([startAngle, endAngle]) => {
-                                            node.startAngle = startAngle;
-                                            node.endAngle = endAngle;
-                                        },
-                                    }
-                                );
-                            });
-                        },
+                        action: () => this.animateEmptyLoadReady(),
                     },
                 },
             },
@@ -1447,6 +1415,40 @@ export class PieSeries extends PolarSeries<PieNodeDatum> {
             if (datum[legendItemKey] === datumToggledLegendItemValue) {
                 this.toggleSeriesItem(datumItemId, enabled);
             }
+        });
+    }
+
+    animateEmptyLoadReady() {
+        const rotation = Math.PI / -2 + toRadians(this.rotation);
+
+        this.groupSelection.selectByTag<Sector>(PieNodeTag.Sector).forEach((node) => {
+            const { datum } = node;
+
+            if (!this.animationManager) {
+                node.startAngle = datum.startAngle;
+                node.endAngle = datum.endAngle;
+                return;
+            }
+
+            node.startAngle = rotation;
+            node.endAngle = rotation;
+
+            this.animationManager.animateMany<number>(
+                `${this.id}_empty-load-ready_${node.id}`,
+                [
+                    { from: rotation, to: datum.startAngle },
+                    { from: rotation, to: datum.endAngle },
+                ],
+                {
+                    duration: 600,
+                    repeat: 0,
+                    ease: easing.easeInOut,
+                    onUpdate: ([startAngle, endAngle]) => {
+                        node.startAngle = startAngle;
+                        node.endAngle = endAngle;
+                    },
+                }
+            );
         });
     }
 }

--- a/charts-community-modules/ag-charts-community/src/chart/series/polar/pieSeries.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/series/polar/pieSeries.ts
@@ -1429,16 +1429,7 @@ export class PieSeries extends PolarSeries<PieNodeDatum> {
         this.groupSelection.selectByTag<Sector>(PieNodeTag.Sector).forEach((node) => {
             const { datum } = node;
 
-            if (!this.animationManager || this.animationManager.skipAnimations) {
-                node.startAngle = datum.startAngle;
-                node.endAngle = datum.endAngle;
-                return;
-            }
-
-            node.startAngle = rotation;
-            node.endAngle = rotation;
-
-            this.animationManager.animateMany<number>(
+            this.animationManager?.animateMany<number>(
                 `${this.id}_empty-update-ready_${node.id}`,
                 [
                     { from: rotation, to: datum.startAngle },

--- a/charts-community-modules/ag-charts-community/src/chart/series/polar/pieSeries.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/series/polar/pieSeries.ts
@@ -1429,7 +1429,7 @@ export class PieSeries extends PolarSeries<PieNodeDatum> {
         this.groupSelection.selectByTag<Sector>(PieNodeTag.Sector).forEach((node) => {
             const { datum } = node;
 
-            if (!this.animationManager) {
+            if (!this.animationManager || this.animationManager.skipAnimations) {
                 node.startAngle = datum.startAngle;
                 node.endAngle = datum.endAngle;
                 return;

--- a/charts-community-modules/ag-charts-community/src/chart/series/polar/pieSeries.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/series/polar/pieSeries.ts
@@ -40,6 +40,8 @@ import {
     AgPieSeriesFormatterParams,
 } from '../../agChartOptions';
 import { LegendItemClickChartEvent, LegendItemDoubleClickChartEvent } from '../../interaction/chartEventManager';
+import { StateMachine } from '../../../motion/states';
+import * as easing from '../../../motion/easing';
 
 class PieSeriesNodeBaseClickEvent extends SeriesNodeBaseClickEvent<any> {
     readonly angleKey: string;
@@ -167,6 +169,10 @@ export class DoughnutInnerCircle {
     fillOpacity? = 1;
 }
 
+type PieAnimationState = 'empty' | 'ready';
+type PieAnimationEvent = 'load';
+class PieStateMachine extends StateMachine<PieAnimationState, PieAnimationEvent> {}
+
 export class PieSeries extends PolarSeries<PieNodeDatum> {
     static className = 'PieSeries';
     static type = 'pie' as const;
@@ -177,6 +183,8 @@ export class PieSeries extends PolarSeries<PieNodeDatum> {
     private calloutLabelSelection: Selection<Group, PieNodeDatum>;
     private sectorLabelSelection: Selection<Text, PieNodeDatum>;
     private innerLabelsSelection: Selection<Text, DoughnutInnerLabel>;
+
+    private animationStates: PieStateMachine;
 
     // The group node that contains the background graphics.
     readonly backgroundGroup: Group;
@@ -331,6 +339,52 @@ export class PieSeries extends PolarSeries<PieNodeDatum> {
         this.calloutLabelSelection = Selection.select(pieCalloutLabels, Group);
         this.sectorLabelSelection = Selection.select(pieSectorLabels, Text);
         this.innerLabelsSelection = Selection.select(innerLabels, Text);
+
+        this.animationStates = new PieStateMachine('empty', {
+            empty: {
+                on: {
+                    load: {
+                        target: 'ready',
+                        action: () => {
+                            const rotation = Math.PI / -2 + toRadians(this.rotation);
+
+                            this.groupSelection.selectByTag<Sector>(PieNodeTag.Sector).forEach((node) => {
+                                const { datum } = node;
+
+                                if (!this.animationManager) {
+                                    node.startAngle = datum.startAngle;
+                                    node.endAngle = datum.endAngle;
+                                    return;
+                                }
+
+                                node.startAngle = rotation;
+                                node.endAngle = rotation;
+
+                                this.animationManager.animateMany<number>(
+                                    `${this.id}_empty-load-ready_${node.id}`,
+                                    [
+                                        { from: rotation, to: datum.startAngle },
+                                        { from: rotation, to: datum.endAngle },
+                                    ],
+                                    {
+                                        duration: 600,
+                                        repeat: 0,
+                                        ease: easing.easeInOut,
+                                        onUpdate: ([startAngle, endAngle]) => {
+                                            node.startAngle = startAngle;
+                                            node.endAngle = endAngle;
+                                        },
+                                    }
+                                );
+                            });
+                        },
+                    },
+                },
+            },
+            ready: {
+                on: {},
+            },
+        });
     }
 
     addChartEventListeners(): void {
@@ -748,8 +802,10 @@ export class PieSeries extends PolarSeries<PieNodeDatum> {
             sector.innerRadius = Math.max(0, innerRadius);
             sector.outerRadius = Math.max(0, radius);
 
-            sector.startAngle = datum.startAngle;
-            sector.endAngle = datum.endAngle;
+            if (isDatumHighlighted) {
+                sector.startAngle = datum.startAngle;
+                sector.endAngle = datum.endAngle;
+            }
 
             const format = this.getSectorFormat(datum.datum, datum.itemId, index, isDatumHighlighted);
 
@@ -779,6 +835,8 @@ export class PieSeries extends PolarSeries<PieNodeDatum> {
                 updateSectorFn(node, node.datum, index, isDatumHighlighted);
             }
         });
+
+        this.animationStates.transition('load');
 
         this.updateCalloutLineNodes();
         this.updateCalloutLabelNodes(seriesBox);

--- a/charts-community-modules/ag-charts-community/src/chart/series/polar/pieSeries.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/series/polar/pieSeries.ts
@@ -1440,9 +1440,9 @@ export class PieSeries extends PolarSeries<PieNodeDatum> {
                     { from: rotation, to: datum.endAngle },
                 ],
                 {
-                    duration: 600,
+                    duration: 1000,
                     repeat: 0,
-                    ease: easing.easeInOut,
+                    ease: easing.linear,
                     onUpdate: ([startAngle, endAngle]) => {
                         node.startAngle = startAngle;
                         node.endAngle = endAngle;

--- a/charts-community-modules/ag-charts-community/src/chart/series/polar/pieSeries.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/series/polar/pieSeries.ts
@@ -170,7 +170,7 @@ export class DoughnutInnerCircle {
 }
 
 type PieAnimationState = 'empty' | 'ready';
-type PieAnimationEvent = 'load';
+type PieAnimationEvent = 'update';
 class PieStateMachine extends StateMachine<PieAnimationState, PieAnimationEvent> {}
 
 export class PieSeries extends PolarSeries<PieNodeDatum> {
@@ -343,14 +343,19 @@ export class PieSeries extends PolarSeries<PieNodeDatum> {
         this.animationStates = new PieStateMachine('empty', {
             empty: {
                 on: {
-                    load: {
+                    update: {
                         target: 'ready',
-                        action: () => this.animateEmptyLoadReady(),
+                        action: () => this.animateEmptyUpdateReady(),
                     },
                 },
             },
             ready: {
-                on: {},
+                on: {
+                    update: {
+                        target: 'ready',
+                        action: () => this.animateReadyUpdateReady(),
+                    },
+                },
             },
         });
     }
@@ -804,7 +809,7 @@ export class PieSeries extends PolarSeries<PieNodeDatum> {
             }
         });
 
-        this.animationStates.transition('load');
+        this.animationStates.transition('update');
 
         this.updateCalloutLineNodes();
         this.updateCalloutLabelNodes(seriesBox);
@@ -1418,7 +1423,7 @@ export class PieSeries extends PolarSeries<PieNodeDatum> {
         });
     }
 
-    animateEmptyLoadReady() {
+    animateEmptyUpdateReady() {
         const rotation = Math.PI / -2 + toRadians(this.rotation);
 
         this.groupSelection.selectByTag<Sector>(PieNodeTag.Sector).forEach((node) => {
@@ -1434,7 +1439,7 @@ export class PieSeries extends PolarSeries<PieNodeDatum> {
             node.endAngle = rotation;
 
             this.animationManager.animateMany<number>(
-                `${this.id}_empty-load-ready_${node.id}`,
+                `${this.id}_empty-update-ready_${node.id}`,
                 [
                     { from: rotation, to: datum.startAngle },
                     { from: rotation, to: datum.endAngle },
@@ -1449,6 +1454,15 @@ export class PieSeries extends PolarSeries<PieNodeDatum> {
                     },
                 }
             );
+        });
+    }
+
+    animateReadyUpdateReady() {
+        this.groupSelection.selectByTag<Sector>(PieNodeTag.Sector).forEach((node) => {
+            const { datum } = node;
+
+            node.startAngle = datum.startAngle;
+            node.endAngle = datum.endAngle;
         });
     }
 }

--- a/charts-community-modules/ag-charts-community/src/motion/states.ts
+++ b/charts-community-modules/ag-charts-community/src/motion/states.ts
@@ -1,12 +1,12 @@
 import { Logger } from '../util/logger';
 
-interface StateDefinition<State extends string> {
+interface StateDefinition<State extends string, Event extends string> {
     actions?: {
         onEnter?: () => void;
         onExit?: () => void;
     };
     on: {
-        [key: string]: {
+        [key in Event]: {
             target: State;
             action: () => void;
         };
@@ -14,12 +14,12 @@ interface StateDefinition<State extends string> {
 }
 
 export class StateMachine<State extends string, Event extends string> {
-    private states: Record<State, StateDefinition<State>>;
+    private states: Record<State, StateDefinition<State, Event>>;
     private state: State;
 
     debug = false;
 
-    constructor(initialState: State, states: Record<State, StateDefinition<State>>) {
+    constructor(initialState: State, states: Record<State, StateDefinition<State, Event>>) {
         this.state = initialState;
         this.states = states;
 

--- a/charts-community-modules/ag-charts-community/src/motion/states.ts
+++ b/charts-community-modules/ag-charts-community/src/motion/states.ts
@@ -17,7 +17,7 @@ export class StateMachine<State extends string, Event extends string> {
     private states: Record<State, StateDefinition<State>>;
     private state: State;
 
-    debug = true;
+    debug = false;
 
     constructor(initialState: State, states: Record<State, StateDefinition<State>>) {
         this.state = initialState;

--- a/charts-community-modules/ag-charts-community/src/motion/states.ts
+++ b/charts-community-modules/ag-charts-community/src/motion/states.ts
@@ -1,0 +1,56 @@
+import { Logger } from '../util/logger';
+
+interface StateDefinition<State extends string> {
+    actions?: {
+        onEnter?: () => void;
+        onExit?: () => void;
+    };
+    on: {
+        [key: string]: {
+            target: State;
+            action: () => void;
+        };
+    };
+}
+
+export class StateMachine<State extends string, Event extends string> {
+    private states: Record<State, StateDefinition<State>>;
+    private state: State;
+
+    debug = true;
+
+    constructor(initialState: State, states: Record<State, StateDefinition<State>>) {
+        this.state = initialState;
+        this.states = states;
+
+        if (this.debug) Logger.debug(`%c${this.constructor.name} | init -> ${initialState}`, 'color: green');
+    }
+
+    transition(event: Event) {
+        const currentStateConfig = this.states[this.state];
+        const destinationTransition = currentStateConfig?.on[event];
+
+        if (!destinationTransition) {
+            if (this.debug)
+                Logger.debug(`%c${this.constructor.name} | ${this.state} -> ${event} -> ${this.state}`, 'color: grey');
+            return;
+        }
+
+        const destinationState = destinationTransition.target;
+        const destinationStateConfig = this.states[destinationState];
+
+        if (this.debug)
+            Logger.debug(
+                `%c${this.constructor.name} | ${this.state} -> ${event} -> ${destinationState}`,
+                'color: green'
+            );
+
+        destinationTransition.action();
+        currentStateConfig?.actions?.onExit?.();
+        destinationStateConfig?.actions?.onEnter?.();
+
+        this.state = destinationState;
+
+        return this.state;
+    }
+}

--- a/charts-enterprise-modules/ag-charts-enterprise/src/animation/animation.ts
+++ b/charts-enterprise-modules/ag-charts-enterprise/src/animation/animation.ts
@@ -17,5 +17,8 @@ export class Animation extends _ModuleSupport.BaseModuleInstance implements _Mod
     constructor(readonly ctx: _ModuleSupport.ModuleContext) {
         super();
         this.animationManager = ctx.animationManager;
+
+        // TODO: why is newValue called before the constructor??
+        this.animationManager.skipAnimations = false;
     }
 }

--- a/charts-enterprise-modules/ag-charts-enterprise/src/animation/animation.ts
+++ b/charts-enterprise-modules/ag-charts-enterprise/src/animation/animation.ts
@@ -17,8 +17,6 @@ export class Animation extends _ModuleSupport.BaseModuleInstance implements _Mod
     constructor(readonly ctx: _ModuleSupport.ModuleContext) {
         super();
         this.animationManager = ctx.animationManager;
-
-        // TODO: why is newValue called before the constructor??
         this.animationManager.skipAnimations = false;
     }
 }

--- a/charts-enterprise-modules/ag-charts-enterprise/src/animation/animationModule.ts
+++ b/charts-enterprise-modules/ag-charts-enterprise/src/animation/animationModule.ts
@@ -5,7 +5,7 @@ export const AnimationModule: _ModuleSupport.Module = {
     type: 'root',
     optionsKey: 'animation',
     packageType: 'enterprise',
-    chartTypes: ['cartesian'],
+    chartTypes: ['cartesian', 'polar'],
     instanceConstructor: Animation,
 };
 

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/doc-interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/doc-interfaces.AUTO.json
@@ -6416,11 +6416,11 @@
     },
     "on": {
       "type": {
-        "returnType": "{\n        [key: string]: {\n            target: State;\n            action: () => void;\n        };\n    }",
+        "returnType": "{\n        [key in Event]: {\n            target: State;\n            action: () => void;\n        };\n    }",
         "optional": false
       }
     },
-    "meta": { "typeParams": ["State extends string"] }
+    "meta": { "typeParams": ["State extends string", "Event extends string"] }
   },
   "ScaleClampParams": {
     "strict": {

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/doc-interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/doc-interfaces.AUTO.json
@@ -6217,6 +6217,8 @@
     }
   },
   "PieNodeTag": {},
+  "PieAnimationState": {},
+  "PieAnimationEvent": {},
   "SeriesNodeDatum": {
     "series": { "type": { "returnType": "Series<any>", "optional": false } },
     "itemId": { "type": { "returnType": "any", "optional": true } },

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/doc-interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/doc-interfaces.AUTO.json
@@ -6405,6 +6405,21 @@
     "meta": { "typeParams": ["T"] }
   },
   "Easing": { "meta": { "typeParams": ["T"] } },
+  "StateDefinition": {
+    "actions": {
+      "type": {
+        "returnType": "{\n        onEnter?: () => void;\n        onExit?: () => void;\n    }",
+        "optional": true
+      }
+    },
+    "on": {
+      "type": {
+        "returnType": "{\n        [key: string]: {\n            target: State;\n            action: () => void;\n        };\n    }",
+        "optional": false
+      }
+    },
+    "meta": { "typeParams": ["State extends string"] }
+  },
   "ScaleClampParams": {
     "strict": {
       "description": "/** If `true` the values outside of the domain will become `NaN`.\n     * If `false` such values will be clamped to the domain edges.\n     */",

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/doc-interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/doc-interfaces.AUTO.json
@@ -5662,6 +5662,37 @@
     "delta": { "type": { "returnType": "number", "optional": false } },
     "meta": { "typeParams": ["AnimationEventType"] }
   },
+  "AnimationOptions": {
+    "driver": { "type": { "returnType": "Driver", "optional": false } },
+    "autoplay": { "type": { "returnType": "boolean", "optional": true } },
+    "delay": { "type": { "returnType": "number", "optional": true } },
+    "repeat": { "type": { "returnType": "number", "optional": true } },
+    "repeatType": { "type": { "returnType": "RepeatType", "optional": true } },
+    "onComplete": {
+      "type": { "arguments": {}, "returnType": "void", "optional": true }
+    },
+    "onPlay": {
+      "type": { "arguments": {}, "returnType": "void", "optional": true }
+    },
+    "onRepeat": {
+      "type": { "arguments": {}, "returnType": "void", "optional": true }
+    },
+    "onStop": {
+      "type": { "arguments": {}, "returnType": "void", "optional": true }
+    },
+    "onUpdate": {
+      "type": {
+        "arguments": { "v": "T" },
+        "returnType": "void",
+        "optional": true
+      }
+    },
+    "meta": { "typeParams": ["T"] },
+    "duration": { "type": { "returnType": "number", "optional": false } },
+    "from": { "type": { "returnType": "T", "optional": false } },
+    "to": { "type": { "returnType": "T", "optional": false } },
+    "ease": { "type": { "returnType": "Easing<T>", "optional": true } }
+  },
   "AnimationManyOptions": {
     "meta": { "typeParams": ["T"] },
     "driver": { "type": { "returnType": "Driver", "optional": false } },
@@ -5680,6 +5711,10 @@
     },
     "onStop": {
       "type": { "arguments": {}, "returnType": "void", "optional": true }
+    },
+    "duration": { "type": { "returnType": "number", "optional": false } },
+    "ease": {
+      "type": { "returnType": "Easing<AnimationOptions<T>>", "optional": true }
     }
   },
   "ChartEventType": {},
@@ -6296,37 +6331,6 @@
     "meta": { "typeParams": ["T"] }
   },
   "RepeatType": {},
-  "AnimationOptions": {
-    "driver": { "type": { "returnType": "Driver", "optional": false } },
-    "autoplay": { "type": { "returnType": "boolean", "optional": true } },
-    "delay": { "type": { "returnType": "number", "optional": true } },
-    "repeat": { "type": { "returnType": "number", "optional": true } },
-    "repeatType": { "type": { "returnType": "RepeatType", "optional": true } },
-    "onComplete": {
-      "type": { "arguments": {}, "returnType": "void", "optional": true }
-    },
-    "onPlay": {
-      "type": { "arguments": {}, "returnType": "void", "optional": true }
-    },
-    "onRepeat": {
-      "type": { "arguments": {}, "returnType": "void", "optional": true }
-    },
-    "onStop": {
-      "type": { "arguments": {}, "returnType": "void", "optional": true }
-    },
-    "onUpdate": {
-      "type": {
-        "arguments": { "v": "T" },
-        "returnType": "void",
-        "optional": true
-      }
-    },
-    "meta": { "typeParams": ["T"] },
-    "duration": { "type": { "returnType": "number", "optional": false } },
-    "from": { "type": { "returnType": "T", "optional": false } },
-    "to": { "type": { "returnType": "T", "optional": false } },
-    "ease": { "type": { "returnType": "Easing<T>", "optional": true } }
-  },
   "AnimationControls": {
     "isPlaying": { "type": { "returnType": "boolean", "optional": false } },
     "play": {

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
@@ -4457,10 +4457,10 @@
     "type": "(opts: EasingOpts<T>) => (time: number) => T"
   },
   "StateDefinition": {
-    "meta": { "typeParams": ["State extends string"] },
+    "meta": { "typeParams": ["State extends string", "Event extends string"] },
     "type": {
       "actions?": "{ onEnter?: () => void; onExit?: () => void; }",
-      "on": "{ [key: string]: { target: State; action: () => void; }; }"
+      "on": "{[key in Event]: { target: State; action: () => void; }}"
     }
   },
   "ScaleClampParams": {

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
@@ -3754,6 +3754,25 @@
     "meta": { "typeParams": ["AnimationEventType"] },
     "type": { "type": "AnimationEventType", "delta": "number" }
   },
+  "AnimationOptions": {
+    "meta": { "typeParams": ["T"] },
+    "type": {
+      "driver": "Driver",
+      "autoplay?": "boolean",
+      "delay?": "number",
+      "repeat?": "number",
+      "repeatType?": "RepeatType",
+      "onComplete?": "() => void",
+      "onPlay?": "() => void",
+      "onRepeat?": "() => void",
+      "onStop?": "() => void",
+      "onUpdate?": "(v: T) => void",
+      "duration": "number",
+      "from": "T",
+      "to": "T",
+      "ease?": "Easing<T>"
+    }
+  },
   "AnimationManyOptions": {
     "meta": { "typeParams": ["T"] },
     "type": {
@@ -3766,7 +3785,9 @@
       "onPlay?": "() => void",
       "onRepeat?": "() => void",
       "onStop?": "() => void",
-      "onUpdate?": "(v: AnimationOptions<T>) => void"
+      "onUpdate?": "(v: AnimationOptions<T>) => void",
+      "duration": "number",
+      "ease?": "Easing<AnimationOptions<T>>"
     }
   },
   "ChartEventType": {
@@ -4382,25 +4403,6 @@
     "meta": { "isEnum": true },
     "type": ["Loop = 'loop'", "Reverse = 'reverse'"],
     "docs": [null, null]
-  },
-  "AnimationOptions": {
-    "meta": { "typeParams": ["T"] },
-    "type": {
-      "driver": "Driver",
-      "autoplay?": "boolean",
-      "delay?": "number",
-      "repeat?": "number",
-      "repeatType?": "RepeatType",
-      "onComplete?": "() => void",
-      "onPlay?": "() => void",
-      "onRepeat?": "() => void",
-      "onStop?": "() => void",
-      "onUpdate?": "(v: T) => void",
-      "duration": "number",
-      "from": "T",
-      "to": "T",
-      "ease?": "Easing<T>"
-    }
   },
   "AnimationControls": {
     "meta": {},

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
@@ -4451,6 +4451,13 @@
     "meta": { "isTypeAlias": true, "typeParams": ["T"] },
     "type": "(opts: EasingOpts<T>) => (time: number) => T"
   },
+  "StateDefinition": {
+    "meta": { "typeParams": ["State extends string"] },
+    "type": {
+      "actions?": "{ onEnter?: () => void; onExit?: () => void; }",
+      "on": "{ [key: string]: { target: State; action: () => void; }; }"
+    }
+  },
   "ScaleClampParams": {
     "meta": {},
     "type": { "strict": "boolean" },

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
@@ -4301,6 +4301,11 @@
     "type": ["Sector", "Callout", "Label"],
     "docs": [null, null, null]
   },
+  "PieAnimationState": {
+    "meta": { "isTypeAlias": true },
+    "type": "'empty' | 'ready'"
+  },
+  "PieAnimationEvent": { "meta": { "isTypeAlias": true }, "type": "'load'" },
   "SeriesNodeDatum": {
     "meta": {
       "doc": "/** Processed series datum used in node selections,\n * contains information used to render pie sectors, bars, markers, etc.\n */"

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
@@ -4305,7 +4305,7 @@
     "meta": { "isTypeAlias": true },
     "type": "'empty' | 'ready'"
   },
-  "PieAnimationEvent": { "meta": { "isTypeAlias": true }, "type": "'load'" },
+  "PieAnimationEvent": { "meta": { "isTypeAlias": true }, "type": "'update'" },
   "SeriesNodeDatum": {
     "meta": {
       "doc": "/** Processed series datum used in node selections,\n * contains information used to render pie sectors, bars, markers, etc.\n */"

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-context-menu/examples/context-menu-actions/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-context-menu/examples/context-menu-actions/main.ts
@@ -10,7 +10,6 @@ const options: AgCartesianChartOptions = {
     text: "Sweaters made",
   },
   contextMenu: {
-    enabled: true,
     extraActions: [
       {
         label: "Say hello",


### PR DESCRIPTION
PR for https://ag-grid.atlassian.net/browse/AG-8462

This is the first of the series initial load animations. I've added a basic state machine to handle transitioning between different animation states. Happy to hear thoughts on this approach.

The pie series state machine currently starts in the `empty` state, then on the `load` event transitions to `ready`. The transition event is where the animation occurs. Once in the `ready` state it can no longer transition anywhere (currently), so the animation can't happen again even if the `load` event is called.

_edit: changed to `update` instead of `load`_

In the future this will also have a `highlight`, `add`, `remove` and `update` events with related states.

I may also look at adding event blocking and queue so that if the user adds a node in the middle of the initial loading animation it will queue that to happen after the load has finished.

https://github.com/ag-grid/ag-grid/assets/3817697/ee9ade09-df6f-42af-a4b2-f003a629211c