### PR TITLE
AG-8403 - Add DataModel support for accumulated groups + properties

### DIFF
--- a/charts-community-modules/ag-charts-community/src/chart/data/__snapshots__/dataModel.test.ts.snap
+++ b/charts-community-modules/ag-charts-community/src/chart/data/__snapshots__/dataModel.test.ts.snap
@@ -2289,6 +2289,664 @@ Object {
 }
 `;
 
+exports[`DataModel grouped processing - stacked with accumulation and normalised example should generated the expected results 1`] = `
+Object {
+  "data": Array [
+    Object {
+      "aggValues": Array [
+        Array [
+          76.09130289903365,
+          100,
+        ],
+      ],
+      "datum": Array [
+        Object {
+          "housingAssociation": 388,
+          "localAuthority": 274,
+          "ownerOccupied": 4567,
+          "privateRented": 773,
+          "type": "Semi-detached house",
+        },
+      ],
+      "keys": Array [
+        "Semi-detached house",
+      ],
+      "values": Array [
+        Array [
+          76.09130289903365,
+          88.97034321892703,
+          93.5354881706098,
+          100,
+        ],
+      ],
+    },
+    Object {
+      "aggValues": Array [
+        Array [
+          64.11008346492217,
+          100,
+        ],
+      ],
+      "datum": Array [
+        Object {
+          "housingAssociation": 422,
+          "localAuthority": 231,
+          "ownerOccupied": 2842,
+          "privateRented": 938,
+          "type": "Medium/large terraced house",
+        },
+      ],
+      "keys": Array [
+        "Medium/large terraced house",
+      ],
+      "values": Array [
+        Array [
+          64.11008346492217,
+          85.26956914053689,
+          90.48048725468081,
+          100,
+        ],
+      ],
+    },
+    Object {
+      "aggValues": Array [
+        Array [
+          92.01913393756294,
+          100,
+        ],
+      ],
+      "datum": Array [
+        Object {
+          "housingAssociation": 19,
+          "localAuthority": 4,
+          "ownerOccupied": 3655,
+          "privateRented": 294,
+          "type": "Detached house",
+        },
+      ],
+      "keys": Array [
+        "Detached house",
+      ],
+      "values": Array [
+        Array [
+          92.01913393756294,
+          99.42094662638469,
+          99.52165156092649,
+          100,
+        ],
+      ],
+    },
+    Object {
+      "aggValues": Array [
+        Array [
+          25.251116071428573,
+          100,
+        ],
+      ],
+      "datum": Array [
+        Object {
+          "housingAssociation": 919,
+          "localAuthority": 621,
+          "ownerOccupied": 905,
+          "privateRented": 1139,
+          "type": "Purpose-built flat low rise",
+        },
+      ],
+      "keys": Array [
+        "Purpose-built flat low rise",
+      ],
+      "values": Array [
+        Array [
+          25.251116071428573,
+          57.03125,
+          74.35825892857143,
+          100,
+        ],
+      ],
+    },
+    Object {
+      "aggValues": Array [
+        Array [
+          44.081810269799824,
+          100,
+        ],
+      ],
+      "datum": Array [
+        Object {
+          "housingAssociation": 295,
+          "localAuthority": 168,
+          "ownerOccupied": 1013,
+          "privateRented": 822,
+          "type": "Small terraced house",
+        },
+      ],
+      "keys": Array [
+        "Small terraced house",
+      ],
+      "values": Array [
+        Array [
+          44.081810269799824,
+          79.852045256745,
+          87.16275021758051,
+          100,
+        ],
+      ],
+    },
+    Object {
+      "aggValues": Array [
+        Array [
+          70.4933586337761,
+          100,
+        ],
+      ],
+      "datum": Array [
+        Object {
+          "housingAssociation": 228,
+          "localAuthority": 180,
+          "ownerOccupied": 1486,
+          "privateRented": 214,
+          "type": "Bungalow",
+        },
+      ],
+      "keys": Array [
+        "Bungalow",
+      ],
+      "values": Array [
+        Array [
+          70.4933586337761,
+          80.64516129032258,
+          89.18406072106262,
+          100,
+        ],
+      ],
+    },
+    Object {
+      "aggValues": Array [
+        Array [
+          27.155172413793103,
+          100,
+        ],
+      ],
+      "datum": Array [
+        Object {
+          "housingAssociation": 100,
+          "localAuthority": 37,
+          "ownerOccupied": 252,
+          "privateRented": 539,
+          "type": "Converted flat",
+        },
+      ],
+      "keys": Array [
+        "Converted flat",
+      ],
+      "values": Array [
+        Array [
+          27.155172413793103,
+          85.23706896551724,
+          89.22413793103448,
+          100,
+        ],
+      ],
+    },
+    Object {
+      "aggValues": Array [
+        Array [
+          23.774509803921568,
+          100,
+        ],
+      ],
+      "datum": Array [
+        Object {
+          "housingAssociation": 68,
+          "localAuthority": 109,
+          "ownerOccupied": 97,
+          "privateRented": 134,
+          "type": "Purpose-built flat high rise",
+        },
+      ],
+      "keys": Array [
+        "Purpose-built flat high rise",
+      ],
+      "values": Array [
+        Array [
+          23.774509803921568,
+          56.61764705882353,
+          83.33333333333333,
+          100,
+        ],
+      ],
+    },
+  ],
+  "defs": Object {
+    "keys": Array [
+      Object {
+        "index": 0,
+        "missing": false,
+        "property": "type",
+        "type": "key",
+        "valueType": "category",
+      },
+    ],
+    "values": Array [
+      Object {
+        "index": 0,
+        "missing": false,
+        "processor": [Function],
+        "property": "ownerOccupied",
+        "type": "value",
+        "valueType": "range",
+      },
+      Object {
+        "index": 1,
+        "missing": false,
+        "processor": [Function],
+        "property": "privateRented",
+        "type": "value",
+        "valueType": "range",
+      },
+      Object {
+        "index": 2,
+        "missing": false,
+        "processor": [Function],
+        "property": "localAuthority",
+        "type": "value",
+        "valueType": "range",
+      },
+      Object {
+        "index": 3,
+        "missing": false,
+        "processor": [Function],
+        "property": "housingAssociation",
+        "type": "value",
+        "valueType": "range",
+      },
+    ],
+  },
+  "domain": Object {
+    "aggValues": Array [
+      Array [
+        1.6161279573475509,
+        100,
+      ],
+    ],
+    "groups": Array [
+      Array [
+        "Semi-detached house",
+      ],
+      Array [
+        "Medium/large terraced house",
+      ],
+      Array [
+        "Detached house",
+      ],
+      Array [
+        "Purpose-built flat low rise",
+      ],
+      Array [
+        "Small terraced house",
+      ],
+      Array [
+        "Bungalow",
+      ],
+      Array [
+        "Converted flat",
+      ],
+      Array [
+        "Purpose-built flat high rise",
+      ],
+    ],
+    "keys": Array [
+      Array [
+        "Semi-detached house",
+        "Medium/large terraced house",
+        "Detached house",
+        "Purpose-built flat low rise",
+        "Small terraced house",
+        "Bungalow",
+        "Converted flat",
+        "Purpose-built flat high rise",
+      ],
+    ],
+    "values": Array [
+      Array [
+        97,
+        4567,
+      ],
+      Array [
+        231,
+        5340,
+      ],
+      Array [
+        340,
+        5614,
+      ],
+      Array [
+        408,
+        6002,
+      ],
+    ],
+  },
+  "indices": Object {
+    "keys": Object {
+      "type": 0,
+    },
+    "values": Object {
+      "housingAssociation": 3,
+      "localAuthority": 2,
+      "ownerOccupied": 0,
+      "privateRented": 1,
+    },
+  },
+  "reduced": Object {
+    "aggValuesExtent": Array [
+      1.6161279573475509,
+      100,
+    ],
+  },
+  "time": Any<Number>,
+  "type": "grouped",
+}
+`;
+
+exports[`DataModel grouped processing - stacked with accumulation example should generated the expected results 1`] = `
+Object {
+  "data": Array [
+    Object {
+      "datum": Array [
+        Object {
+          "housingAssociation": 388,
+          "localAuthority": 274,
+          "ownerOccupied": 4567,
+          "privateRented": 773,
+          "type": "Semi-detached house",
+        },
+      ],
+      "keys": Array [
+        "Semi-detached house",
+      ],
+      "values": Array [
+        Array [
+          4567,
+          5340,
+          5614,
+          6002,
+        ],
+      ],
+    },
+    Object {
+      "datum": Array [
+        Object {
+          "housingAssociation": 422,
+          "localAuthority": 231,
+          "ownerOccupied": 2842,
+          "privateRented": 938,
+          "type": "Medium/large terraced house",
+        },
+      ],
+      "keys": Array [
+        "Medium/large terraced house",
+      ],
+      "values": Array [
+        Array [
+          2842,
+          3780,
+          4011,
+          4433,
+        ],
+      ],
+    },
+    Object {
+      "datum": Array [
+        Object {
+          "housingAssociation": 19,
+          "localAuthority": 4,
+          "ownerOccupied": 3655,
+          "privateRented": 294,
+          "type": "Detached house",
+        },
+      ],
+      "keys": Array [
+        "Detached house",
+      ],
+      "values": Array [
+        Array [
+          3655,
+          3949,
+          3953,
+          3972,
+        ],
+      ],
+    },
+    Object {
+      "datum": Array [
+        Object {
+          "housingAssociation": 919,
+          "localAuthority": 621,
+          "ownerOccupied": 905,
+          "privateRented": 1139,
+          "type": "Purpose-built flat low rise",
+        },
+      ],
+      "keys": Array [
+        "Purpose-built flat low rise",
+      ],
+      "values": Array [
+        Array [
+          905,
+          2044,
+          2665,
+          3584,
+        ],
+      ],
+    },
+    Object {
+      "datum": Array [
+        Object {
+          "housingAssociation": 295,
+          "localAuthority": 168,
+          "ownerOccupied": 1013,
+          "privateRented": 822,
+          "type": "Small terraced house",
+        },
+      ],
+      "keys": Array [
+        "Small terraced house",
+      ],
+      "values": Array [
+        Array [
+          1013,
+          1835,
+          2003,
+          2298,
+        ],
+      ],
+    },
+    Object {
+      "datum": Array [
+        Object {
+          "housingAssociation": 228,
+          "localAuthority": 180,
+          "ownerOccupied": 1486,
+          "privateRented": 214,
+          "type": "Bungalow",
+        },
+      ],
+      "keys": Array [
+        "Bungalow",
+      ],
+      "values": Array [
+        Array [
+          1486,
+          1700,
+          1880,
+          2108,
+        ],
+      ],
+    },
+    Object {
+      "datum": Array [
+        Object {
+          "housingAssociation": 100,
+          "localAuthority": 37,
+          "ownerOccupied": 252,
+          "privateRented": 539,
+          "type": "Converted flat",
+        },
+      ],
+      "keys": Array [
+        "Converted flat",
+      ],
+      "values": Array [
+        Array [
+          252,
+          791,
+          828,
+          928,
+        ],
+      ],
+    },
+    Object {
+      "datum": Array [
+        Object {
+          "housingAssociation": 68,
+          "localAuthority": 109,
+          "ownerOccupied": 97,
+          "privateRented": 134,
+          "type": "Purpose-built flat high rise",
+        },
+      ],
+      "keys": Array [
+        "Purpose-built flat high rise",
+      ],
+      "values": Array [
+        Array [
+          97,
+          231,
+          340,
+          408,
+        ],
+      ],
+    },
+  ],
+  "defs": Object {
+    "keys": Array [
+      Object {
+        "index": 0,
+        "missing": false,
+        "property": "type",
+        "type": "key",
+        "valueType": "category",
+      },
+    ],
+    "values": Array [
+      Object {
+        "index": 0,
+        "missing": false,
+        "processor": [Function],
+        "property": "ownerOccupied",
+        "type": "value",
+        "valueType": "range",
+      },
+      Object {
+        "index": 1,
+        "missing": false,
+        "processor": [Function],
+        "property": "privateRented",
+        "type": "value",
+        "valueType": "range",
+      },
+      Object {
+        "index": 2,
+        "missing": false,
+        "processor": [Function],
+        "property": "localAuthority",
+        "type": "value",
+        "valueType": "range",
+      },
+      Object {
+        "index": 3,
+        "missing": false,
+        "processor": [Function],
+        "property": "housingAssociation",
+        "type": "value",
+        "valueType": "range",
+      },
+    ],
+  },
+  "domain": Object {
+    "groups": Array [
+      Array [
+        "Semi-detached house",
+      ],
+      Array [
+        "Medium/large terraced house",
+      ],
+      Array [
+        "Detached house",
+      ],
+      Array [
+        "Purpose-built flat low rise",
+      ],
+      Array [
+        "Small terraced house",
+      ],
+      Array [
+        "Bungalow",
+      ],
+      Array [
+        "Converted flat",
+      ],
+      Array [
+        "Purpose-built flat high rise",
+      ],
+    ],
+    "keys": Array [
+      Array [
+        "Semi-detached house",
+        "Medium/large terraced house",
+        "Detached house",
+        "Purpose-built flat low rise",
+        "Small terraced house",
+        "Bungalow",
+        "Converted flat",
+        "Purpose-built flat high rise",
+      ],
+    ],
+    "values": Array [
+      Array [
+        97,
+        4567,
+      ],
+      Array [
+        231,
+        5340,
+      ],
+      Array [
+        340,
+        5614,
+      ],
+      Array [
+        408,
+        6002,
+      ],
+    ],
+  },
+  "indices": Object {
+    "keys": Object {
+      "type": 0,
+    },
+    "values": Object {
+      "housingAssociation": 3,
+      "localAuthority": 2,
+      "ownerOccupied": 0,
+      "privateRented": 1,
+    },
+  },
+  "time": Any<Number>,
+  "type": "grouped",
+}
+`;
+
 exports[`DataModel missing and invalid data processing should generated the expected results 1`] = `
 Object {
   "data": Array [

--- a/charts-community-modules/ag-charts-community/src/chart/data/__snapshots__/dataModel.test.ts.snap
+++ b/charts-community-modules/ag-charts-community/src/chart/data/__snapshots__/dataModel.test.ts.snap
@@ -78,7 +78,7 @@ Object {
       "aggValues": Array [
         Array [
           0,
-          0.012000000000000004,
+          0.012,
         ],
       ],
       "datum": Array [
@@ -267,7 +267,7 @@ Object {
     "aggValues": Array [
       Array [
         0,
-        0.012000000000000004,
+        0.012,
       ],
     ],
     "groups": Array [
@@ -333,7 +333,7 @@ Object {
       "aggValues": Array [
         Array [
           0,
-          25.545454545454547,
+          25.5455,
         ],
       ],
       "datum": Array [
@@ -425,7 +425,7 @@ Object {
       "aggValues": Array [
         Array [
           0,
-          24.428571428571427,
+          24.4286,
         ],
       ],
       "datum": Array [
@@ -607,7 +607,7 @@ Object {
       "aggValues": Array [
         Array [
           0,
-          100,
+          11,
         ],
       ],
       "datum": Array [
@@ -666,7 +666,7 @@ Object {
       "aggValues": Array [
         Array [
           0,
-          100,
+          7,
         ],
       ],
       "datum": Array [
@@ -709,7 +709,7 @@ Object {
       "aggValues": Array [
         Array [
           0,
-          100,
+          2,
         ],
       ],
       "datum": Array [
@@ -745,7 +745,7 @@ Object {
     "aggValues": Array [
       Array [
         0,
-        100,
+        11,
       ],
     ],
     "groups": Array [
@@ -854,7 +854,7 @@ Object {
       "aggValues": Array [
         Array [
           0,
-          6.699999999999999,
+          6.7,
         ],
       ],
       "datum": Array [
@@ -878,7 +878,7 @@ Object {
       "aggValues": Array [
         Array [
           0,
-          6.800000000000001,
+          6.8,
         ],
       ],
       "datum": Array [
@@ -2295,7 +2295,7 @@ Object {
     Object {
       "aggValues": Array [
         Array [
-          76.09130289903365,
+          76.0913,
           100,
         ],
       ],
@@ -2323,7 +2323,7 @@ Object {
     Object {
       "aggValues": Array [
         Array [
-          64.11008346492217,
+          64.1101,
           100,
         ],
       ],
@@ -2351,7 +2351,7 @@ Object {
     Object {
       "aggValues": Array [
         Array [
-          92.01913393756294,
+          92.0191,
           100,
         ],
       ],
@@ -2379,7 +2379,7 @@ Object {
     Object {
       "aggValues": Array [
         Array [
-          25.251116071428573,
+          25.2511,
           100,
         ],
       ],
@@ -2407,7 +2407,7 @@ Object {
     Object {
       "aggValues": Array [
         Array [
-          44.081810269799824,
+          44.0818,
           100,
         ],
       ],
@@ -2435,7 +2435,7 @@ Object {
     Object {
       "aggValues": Array [
         Array [
-          70.4933586337761,
+          70.4934,
           100,
         ],
       ],
@@ -2463,7 +2463,7 @@ Object {
     Object {
       "aggValues": Array [
         Array [
-          27.155172413793103,
+          27.1552,
           100,
         ],
       ],
@@ -2491,7 +2491,7 @@ Object {
     Object {
       "aggValues": Array [
         Array [
-          23.774509803921568,
+          23.7745,
           100,
         ],
       ],
@@ -2565,7 +2565,7 @@ Object {
   "domain": Object {
     "aggValues": Array [
       Array [
-        1.6161279573475509,
+        23.7745,
         100,
       ],
     ],
@@ -2639,7 +2639,7 @@ Object {
   },
   "reduced": Object {
     "aggValuesExtent": Array [
-      1.6161279573475509,
+      23.7745,
       100,
     ],
   },
@@ -3235,6 +3235,168 @@ Object {
       "firefox": 2,
       "ie": 0,
       "safari": 3,
+    },
+  },
+  "time": Any<Number>,
+  "type": "ungrouped",
+}
+`;
+
+exports[`DataModel ungrouped processing - accumulated and normalised properties should generated the expected results 1`] = `
+Object {
+  "data": Array [
+    Object {
+      "datum": Object {
+        "population": 4159000,
+        "religion": "Christian",
+      },
+      "keys": Array [],
+      "values": Array [
+        3.01543592113546,
+        "Christian",
+        4159000,
+      ],
+    },
+    Object {
+      "datum": Object {
+        "population": 97000,
+        "religion": "Buddhist",
+      },
+      "keys": Array [],
+      "values": Array [
+        3.0857646742852896,
+        "Buddhist",
+        97000,
+      ],
+    },
+    Object {
+      "datum": Object {
+        "population": 456000,
+        "religion": "Hindu",
+      },
+      "keys": Array [],
+      "values": Array [
+        3.4163823179587136,
+        "Hindu",
+        456000,
+      ],
+    },
+    Object {
+      "datum": Object {
+        "population": 168000,
+        "religion": "Jewish",
+      },
+      "keys": Array [],
+      "values": Array [
+        3.5381888182594485,
+        "Jewish",
+        168000,
+      ],
+    },
+    Object {
+      "datum": Object {
+        "population": 1215000,
+        "religion": "Muslim",
+      },
+      "keys": Array [],
+      "values": Array [
+        4.419110829362979,
+        "Muslim",
+        1215000,
+      ],
+    },
+    Object {
+      "datum": Object {
+        "population": 123000,
+        "religion": "Sikh",
+      },
+      "keys": Array [],
+      "values": Array [
+        4.5082905885117315,
+        "Sikh",
+        123000,
+      ],
+    },
+    Object {
+      "datum": Object {
+        "population": 174000,
+        "religion": "Other",
+      },
+      "keys": Array [],
+      "values": Array [
+        4.634447320966064,
+        "Other",
+        174000,
+      ],
+    },
+    Object {
+      "datum": Object {
+        "population": 2274000,
+        "religion": "None",
+      },
+      "keys": Array [],
+      "values": Array [
+        6.283185307179586,
+        "None",
+        2274000,
+      ],
+    },
+  ],
+  "defs": Object {
+    "keys": Array [],
+    "values": Array [
+      Object {
+        "index": 0,
+        "missing": false,
+        "processor": [Function],
+        "property": "population",
+        "type": "value",
+        "valueType": "range",
+      },
+      Object {
+        "index": 1,
+        "missing": false,
+        "property": "religion",
+        "type": "value",
+        "valueType": "category",
+      },
+      Object {
+        "index": 2,
+        "missing": false,
+        "property": "population",
+        "type": "value",
+        "valueType": "range",
+      },
+    ],
+  },
+  "domain": Object {
+    "keys": Array [],
+    "values": Array [
+      Array [
+        0.0703287531498292,
+        6.283185307179586,
+      ],
+      Array [
+        "Christian",
+        "Buddhist",
+        "Hindu",
+        "Jewish",
+        "Muslim",
+        "Sikh",
+        "Other",
+        "None",
+      ],
+      Array [
+        97000,
+        8666000,
+      ],
+    ],
+  },
+  "indices": Object {
+    "keys": Object {},
+    "values": Object {
+      "population": 2,
+      "religion": 1,
     },
   },
   "time": Any<Number>,

--- a/charts-community-modules/ag-charts-community/src/chart/data/aggregateFunctions.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/data/aggregateFunctions.ts
@@ -1,4 +1,5 @@
 import { AggregatePropertyDefinition } from './dataModel';
+import { extendDomain } from './utilFunctions';
 
 type ContinuousDomain<T extends number | Date> = [T, T];
 
@@ -39,6 +40,16 @@ export function groupSum<K>(props: K[]): AggregatePropertyDefinition<any, any, [
             return acc;
         },
     };
+}
+
+export function range<K>(props: K[]) {
+    const result: AggregatePropertyDefinition<any, any> = {
+        properties: props,
+        type: 'aggregate',
+        aggregateFunction: (values) => extendDomain(values),
+    };
+
+    return result;
 }
 
 export function count() {

--- a/charts-community-modules/ag-charts-community/src/chart/data/aggregateFunctions.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/data/aggregateFunctions.ts
@@ -1,4 +1,4 @@
-import { AggregatePropertyDefinition } from './dataModel';
+import { AggregatePropertyDefinition, DatumPropertyDefinition } from './dataModel';
 import { extendDomain } from './utilFunctions';
 
 type ContinuousDomain<T extends number | Date> = [T, T];
@@ -123,4 +123,15 @@ export function area<K>(props: K[], aggFn: AggregatePropertyDefinition<any, any>
     }
 
     return result;
+}
+
+export function accumulatedValue(): DatumPropertyDefinition<any>['processor'] {
+    return () => {
+        let value = 0;
+
+        return (datum: any) => {
+            value += datum;
+            return value;
+        };
+    };
 }

--- a/charts-community-modules/ag-charts-community/src/chart/data/processors.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/data/processors.ts
@@ -1,0 +1,141 @@
+import {
+    GroupValueProcessorDefinition,
+    ProcessorOutputPropertyDefinition,
+    PropertyValueProcessorDefinition,
+    ReducerOutputPropertyDefinition,
+} from './dataModel';
+
+export const SMALLEST_KEY_INTERVAL: ReducerOutputPropertyDefinition<number> = {
+    type: 'reducer',
+    property: 'smallestKeyInterval',
+    initialValue: Infinity,
+    reducer: () => {
+        let prevX = NaN;
+        return (smallestSoFar, next) => {
+            const nextX = next.keys[0];
+            const interval = Math.abs(nextX - prevX);
+            prevX = nextX;
+            if (!isNaN(interval) && interval > 0 && interval < smallestSoFar) {
+                return interval;
+            }
+            return smallestSoFar;
+        };
+    },
+};
+
+export const AGG_VALUES_EXTENT: ProcessorOutputPropertyDefinition<[number, number]> = {
+    type: 'processor',
+    property: 'aggValuesExtent',
+    calculate: (processedData) => {
+        const result: [number, number] = [...(processedData.domain.aggValues?.[0] ?? [0, 0])];
+
+        for (const [min, max] of processedData.domain.aggValues?.slice(1) ?? []) {
+            if (min < result[0]) {
+                result[0] = min;
+            }
+            if (max > result[1]) {
+                result[1] = max;
+            }
+        }
+
+        return result;
+    },
+};
+
+export const SORT_DOMAIN_GROUPS: ProcessorOutputPropertyDefinition<any> = {
+    type: 'processor',
+    property: 'sortedGroupDomain',
+    calculate: ({ domain: { groups } }) => {
+        if (groups == null) return undefined;
+
+        return [...groups].sort((a, b) => {
+            for (let i = 0; i < a.length; i++) {
+                const result = a[i] - b[i];
+                if (result !== 0) {
+                    return result;
+                }
+            }
+
+            return 0;
+        });
+    },
+};
+
+export function normaliseGroupTo(
+    properties: (string | number)[],
+    normaliseTo: number,
+    mode: 'sum' | 'range' = 'sum'
+): GroupValueProcessorDefinition<any, any> {
+    const normalise = (val: number, extent: number) => {
+        const result = (val * normaliseTo) / extent;
+        if (result >= 0) {
+            return Math.min(normaliseTo, result);
+        }
+        return Math.max(-normaliseTo, result);
+    };
+
+    return {
+        type: 'group-value-processor',
+        properties,
+        adjust: () => (values: any[], valueIndexes: number[]) => {
+            const valuesExtent = [0, 0];
+            for (const valueIdx of valueIndexes) {
+                const value = values[valueIdx];
+                const valIdx = value < 0 ? 0 : 1;
+                if (mode === 'sum') {
+                    valuesExtent[valIdx] += value;
+                } else if (valIdx === 0) {
+                    valuesExtent[valIdx] = Math.min(valuesExtent[valIdx], value);
+                } else {
+                    valuesExtent[valIdx] = Math.max(valuesExtent[valIdx], value);
+                }
+            }
+
+            const extent = Math.max(Math.abs(valuesExtent[0]), valuesExtent[1]);
+            for (const valueIdx of valueIndexes) {
+                values[valueIdx] = normalise(values[valueIdx], extent);
+            }
+        },
+    };
+}
+
+export function normalisePropertyTo(
+    property: string | number,
+    normaliseTo: number
+): PropertyValueProcessorDefinition<any> {
+    const normalise = (val: number, extent: number) => {
+        const result = (val * normaliseTo) / extent;
+        if (result >= 0) {
+            return Math.min(normaliseTo, result);
+        }
+        return Math.max(-normaliseTo, result);
+    };
+
+    return {
+        type: 'property-value-processor',
+        property,
+        adjust: () => (pData, pIdx) => {
+            const domain = pData.domain.values[pIdx];
+
+            let valuesExtent = 0;
+            for (const value of domain) {
+                const sumAbs = Math.abs(value);
+                if (valuesExtent < sumAbs) {
+                    valuesExtent = sumAbs;
+                }
+            }
+
+            pData.domain.values[pIdx] = [normalise(domain[0], valuesExtent), normalise(domain[1], valuesExtent)];
+
+            for (const group of pData.data) {
+                let groupValues = group.values;
+                if (pData.type === 'ungrouped') {
+                    groupValues = [groupValues];
+                }
+                for (const values of groupValues) {
+                    values[pIdx] = normalise(values[pIdx], valuesExtent);
+                }
+            }
+        },
+    };
+}

--- a/charts-community-modules/ag-charts-community/src/chart/data/utilFunctions.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/data/utilFunctions.ts
@@ -1,0 +1,21 @@
+export type ContinuousDomain<T extends number | Date> = [T, T];
+
+export function extendDomain<T extends number | Date>(
+    values: T[],
+    domain: ContinuousDomain<T> = [Infinity as T, -Infinity as T]
+) {
+    for (const value of values) {
+        if (typeof value !== 'number') {
+            continue;
+        }
+
+        if (value < domain[0]) {
+            domain[0] = value;
+        }
+        if (value > domain[1]) {
+            domain[1] = value;
+        }
+    }
+
+    return domain;
+}

--- a/charts-community-modules/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
@@ -48,6 +48,7 @@ import { LogAxis } from '../../axis/logAxis';
 import { DataModel } from '../../data/dataModel';
 import { TimeAxis } from '../../axis/timeAxis';
 import { sum } from '../../data/aggregateFunctions';
+import { normaliseGroupTo } from '../../data/processors';
 
 interface FillSelectionDatum {
     readonly itemId: string;
@@ -232,7 +233,12 @@ export class AreaSeries extends CartesianSeries<AreaSeriesNodeDataContext> {
         const isContinuousY = yAxis?.scale instanceof ContinuousScale;
 
         const enabledYKeys = [...seriesItemEnabled.entries()].filter(([, enabled]) => enabled).map(([yKey]) => yKey);
+
         const normaliseTo = normalizedTo && isFinite(normalizedTo) ? normalizedTo : undefined;
+        const extraProps = [];
+        if (normaliseTo) {
+            extraProps.push(normaliseGroupTo(enabledYKeys, normaliseTo, 'sum'));
+        }
 
         this.dataModel = new DataModel<any, any, true>({
             props: [
@@ -244,10 +250,10 @@ export class AreaSeries extends CartesianSeries<AreaSeriesNodeDataContext> {
                     })
                 ),
                 sum(enabledYKeys),
+                ...extraProps,
             ],
             groupByKeys: true,
             dataVisible: this.visible && enabledYKeys.length > 0,
-            normaliseTo,
         });
 
         this.processedData = this.dataModel.processData(data);

--- a/charts-community-modules/ag-charts-community/src/chart/series/cartesian/histogramSeries.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/series/cartesian/histogramSeries.ts
@@ -49,9 +49,9 @@ import {
     fixNumericExtent,
     GroupByFn,
     PropertyDefinition,
-    SORT_DOMAIN_GROUPS,
 } from '../../data/dataModel';
 import { area, groupAverage, groupCount, sum } from '../../data/aggregateFunctions';
+import { SORT_DOMAIN_GROUPS } from '../../data/processors';
 
 const HISTOGRAM_AGGREGATIONS = ['count', 'sum', 'mean'];
 const HISTOGRAM_AGGREGATION = predicateWithMessage(

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/doc-interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/doc-interfaces.AUTO.json
@@ -5614,6 +5614,7 @@
     "meta": { "typeParams": ["K", "Grouped extends boolean | undefined"] }
   },
   "PropertyDefinition": { "meta": { "typeParams": ["K"] } },
+  "ProcessorFn": {},
   "DatumPropertyDefinition": { "meta": { "typeParams": ["K"] } },
   "InternalDatumPropertyDefinition": { "meta": { "typeParams": ["K"] } },
   "AggregatePropertyDefinition": {
@@ -5621,6 +5622,10 @@
       "typeParams": ["D", "K extends keyof D", "R = [number, number]", "R2 = R"]
     }
   },
+  "GroupValueProcessorDefinition": {
+    "meta": { "typeParams": ["D", "K extends keyof D"] }
+  },
+  "PropertyValueProcessorDefinition": { "meta": { "typeParams": ["D"] } },
   "ReducerOutputPropertyDefinition": { "meta": { "typeParams": ["R"] } },
   "ProcessorOutputPropertyDefinition": { "meta": { "typeParams": ["R"] } },
   "Series": {

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
@@ -3690,7 +3690,7 @@
   },
   "DatumPropertyDefinition": {
     "meta": { "isTypeAlias": true, "typeParams": ["K"] },
-    "type": "{ type: 'key' | 'value'; valueType: DatumPropertyType; property: K; invalidValue?: any; missingValue?: any; validation?: (datum: any) => boolean; }"
+    "type": "{ type: 'key' | 'value'; valueType: DatumPropertyType; property: K; invalidValue?: any; missingValue?: any; validation?: (datum: any) => boolean; processor?: (datum: any, previousDatum?: any) => any; }"
   },
   "InternalDatumPropertyDefinition": {
     "meta": { "isTypeAlias": true, "typeParams": ["K"] },

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
@@ -3682,15 +3682,19 @@
       "isTypeAlias": true,
       "typeParams": ["K", "Grouped extends boolean | undefined"]
     },
-    "type": "{ readonly props: PropertyDefinition<K>[]; readonly groupByKeys?: Grouped; readonly groupByFn?: GroupByFn; readonly normaliseTo?: number; readonly dataVisible?: boolean; }"
+    "type": "{ readonly props: PropertyDefinition<K>[]; readonly groupByKeys?: Grouped; readonly groupByFn?: GroupByFn; readonly dataVisible?: boolean; }"
   },
   "PropertyDefinition": {
     "meta": { "isTypeAlias": true, "typeParams": ["K"] },
-    "type": "DatumPropertyDefinition<K> | AggregatePropertyDefinition<any, any, any> | ReducerOutputPropertyDefinition<any> | ProcessorOutputPropertyDefinition<any>"
+    "type": "DatumPropertyDefinition<K> | AggregatePropertyDefinition<any, any, any> | PropertyValueProcessorDefinition<any> | GroupValueProcessorDefinition<any, any> | ReducerOutputPropertyDefinition<any> | ProcessorOutputPropertyDefinition<any>"
+  },
+  "ProcessorFn": {
+    "meta": { "isTypeAlias": true },
+    "type": "(datum: any, previousDatum?: any) => any"
   },
   "DatumPropertyDefinition": {
     "meta": { "isTypeAlias": true, "typeParams": ["K"] },
-    "type": "{ type: 'key' | 'value'; valueType: DatumPropertyType; property: K; invalidValue?: any; missingValue?: any; validation?: (datum: any) => boolean; processor?: (datum: any, previousDatum?: any) => any; }"
+    "type": "{ type: 'key' | 'value'; valueType: DatumPropertyType; property: K; invalidValue?: any; missingValue?: any; validation?: (datum: any) => boolean; processor?: () => ProcessorFn; }"
   },
   "InternalDatumPropertyDefinition": {
     "meta": { "isTypeAlias": true, "typeParams": ["K"] },
@@ -3701,7 +3705,15 @@
       "isTypeAlias": true,
       "typeParams": ["D", "K extends keyof D", "R = [number, number]", "R2 = R"]
     },
-    "type": "{ type: 'aggregate'; aggregateFunction: (values: D[K][], keys?: D[K][]) => R; groupAggregateFunction?: (next?: R, acc?: R2) => R2; finalFunction?: (result: R2) => [ number, number ]; properties: K[]; }"
+    "type": "{ type: 'aggregate'; aggregateFunction: (values: D[K][], keys?: D[K][]) => R; groupAggregateFunction?: (next?: R, acc?: R2) => R2; finalFunction?: (result: R2) => [ number, number ]; properties: (K | number)[]; }"
+  },
+  "GroupValueProcessorDefinition": {
+    "meta": { "isTypeAlias": true, "typeParams": ["D", "K extends keyof D"] },
+    "type": "{ type: 'group-value-processor'; properties: (K | number)[]; adjust: () => (values: D[K][], indexes: number[]) => void; }"
+  },
+  "PropertyValueProcessorDefinition": {
+    "meta": { "isTypeAlias": true, "typeParams": ["D"] },
+    "type": "{ type: 'property-value-processor'; property: string | number; adjust: () => (processedData: ProcessedData<D>, valueIndex: number) => void; }"
   },
   "ReducerOutputPropertyDefinition": {
     "meta": { "isTypeAlias": true, "typeParams": ["R"] },


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-8403

Pre-requisite changes to support the `PieSeries` use-case.

Adds support for:
- Accumulative values across groups (rows - bar+area series stack case) and properties (columns - pie case).
- Normalisation across groups (rows) and properties (columns).
- Rounding to 4 significant figures for aggregate values, to mitigate cumulative error issues.

Refactors:
- Normalisation support to be a set of group/property processors, rather than an explicit built-in behaviour.
- Moved a bunch of processors into `processors.ts` to reduce the scope of `dataModel.ts`.