### PR TITLE
Fixed incorrect parameter callback documentation

### DIFF
--- a/grid-packages/ag-grid-docs/documentation/doc-pages/grid-interface/_index-react.md
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/grid-interface/_index-react.md
@@ -89,8 +89,8 @@
 |
 | // access API from callback params object
 | sendToClipboard = params => {
-|     e.api.sizeColumnsToFit();
-|     e.columnApi.resetColumnState();
+|     params.api.sizeColumnsToFit();
+|     params.columnApi.resetColumnState();
 | }
 |
 | &lt;AgGridReact


### PR DESCRIPTION
I happened to notice what appears to be a copy/paste issue in the grid interface react docs, where the body of the function is referencing `e` (presumably copied from the example directly above it), but the provided arg is `params`:

`// access API from callback params object
sendToClipboard = params => {
    e.api.sizeColumnsToFit();
    e.columnApi.resetColumnState();
}`

This change switches the `e` to `params`.