### PR TITLE
AG-8460 Add disableInteractions option on animation manager

### DIFF
--- a/charts-community-modules/ag-charts-community/src/chart/chart.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/chart.ts
@@ -243,7 +243,6 @@ export abstract class Chart extends Observable implements AgChartInstance {
         this.scene.container = element;
         this.autoSize = true;
 
-        this.animationManager = new AnimationManager();
         this.chartEventManager = new ChartEventManager();
         this.cursorManager = new CursorManager(element);
         this.highlightManager = new HighlightManager();
@@ -253,6 +252,7 @@ export abstract class Chart extends Observable implements AgChartInstance {
         this.layoutService = new LayoutService();
         this.updateService = new UpdateService((type = ChartUpdateType.FULL) => this.update(type));
 
+        this.animationManager = new AnimationManager(this.interactionManager);
         this.animationManager.skipAnimations = true;
         this.animationManager.play();
 

--- a/charts-community-modules/ag-charts-community/src/chart/interaction/animationManager.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/interaction/animationManager.ts
@@ -40,7 +40,6 @@ export class AnimationManager extends BaseManager<AnimationEventType, AnimationE
     private readyToPlay = false;
 
     private interactionManager: InteractionManager;
-    private interactionDisablers: Array<AnimationId> = [];
 
     public skipAnimations = false;
 
@@ -194,8 +193,7 @@ export class AnimationManager extends BaseManager<AnimationEventType, AnimationE
                     }
 
                     if (disableInteractions) {
-                        this.interactionManager.disable();
-                        this.interactionDisablers.push(id);
+                        this.interactionManager.pause(`animation_${id}`);
                     }
                 },
                 stop: () => {
@@ -204,9 +202,8 @@ export class AnimationManager extends BaseManager<AnimationEventType, AnimationE
                         this.cancelAnimationFrame();
                     }
 
-                    this.interactionDisablers = this.interactionDisablers.filter((did) => did !== id);
-                    if (this.interactionDisablers.length <= 0) {
-                        this.interactionManager.enable();
+                    if (disableInteractions) {
+                        this.interactionManager.resume(`animation_${id}`);
                     }
                 },
                 reset: () => {},

--- a/charts-community-modules/ag-charts-community/src/chart/interaction/interactionManager.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/interaction/interactionManager.ts
@@ -86,6 +86,8 @@ export class InteractionManager extends BaseManager<InteractionTypes, Interactio
     private touchDown = false;
     private dragStartElement?: HTMLElement;
 
+    private enabled = true;
+
     public constructor(element: HTMLElement, doc = document) {
         super();
 
@@ -126,10 +128,18 @@ export class InteractionManager extends BaseManager<InteractionTypes, Interactio
         }
     }
 
+    enable() {
+        this.enabled = true;
+    }
+
+    disable() {
+        this.enabled = false;
+    }
+
     private processEvent(event: SupportedEvent) {
         const types: InteractionTypes[] = this.decideInteractionEventTypes(event);
 
-        if (types.length > 0) {
+        if (types.length > 0 && this.enabled) {
             // Async dispatch to avoid blocking the event-processing thread.
             this.dispatchEvent(event, types);
         }

--- a/charts-community-modules/ag-charts-community/src/chart/interaction/interactionManager.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/interaction/interactionManager.ts
@@ -87,6 +87,7 @@ export class InteractionManager extends BaseManager<InteractionTypes, Interactio
     private dragStartElement?: HTMLElement;
 
     private enabled = true;
+    private pausers: String[] = [];
 
     public constructor(element: HTMLElement, doc = document) {
         super();
@@ -128,12 +129,16 @@ export class InteractionManager extends BaseManager<InteractionTypes, Interactio
         }
     }
 
-    enable() {
-        this.enabled = true;
+    resume(callerId: string) {
+        this.pausers = this.pausers.filter((id) => id !== callerId);
+        this.enabled = this.pausers.length <= 0;
+
+        return this.enabled;
     }
 
-    disable() {
+    pause(callerId: string) {
         this.enabled = false;
+        this.pausers.push(callerId);
     }
 
     private processEvent(event: SupportedEvent) {

--- a/charts-community-modules/ag-charts-community/src/chart/series/cartesian/barSeries.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/series/cartesian/barSeries.ts
@@ -1007,6 +1007,7 @@ export class BarSeries extends CartesianSeries<SeriesNodeDataContext<BarNodeDatu
                             { from: 0, to: datum.width },
                         ],
                         {
+                            disableInteractions: true,
                             duration: 1000,
                             ease: easing.linear,
                             repeat: 0,
@@ -1027,6 +1028,7 @@ export class BarSeries extends CartesianSeries<SeriesNodeDataContext<BarNodeDatu
                             { from: 0, to: datum.height },
                         ],
                         {
+                            disableInteractions: true,
                             duration: 1000,
                             ease: easing.linear,
                             repeat: 0,

--- a/charts-community-modules/ag-charts-community/src/chart/series/polar/pieSeries.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/series/polar/pieSeries.ts
@@ -1436,9 +1436,10 @@ export class PieSeries extends PolarSeries<PieNodeDatum> {
                     { from: rotation, to: datum.endAngle },
                 ],
                 {
+                    disableInteractions: true,
                     duration: 1000,
-                    repeat: 0,
                     ease: easing.linear,
+                    repeat: 0,
                     onUpdate([startAngle, endAngle]) {
                         node.startAngle = startAngle;
                         node.endAngle = endAngle;


### PR DESCRIPTION
PR for https://ag-grid.atlassian.net/browse/AG-8460

This adds the `disableInteractions: true` option when animating, which disables/enables interactions while that animation is running. With the intent on queueing some types of interaction to be run when re-enabled in the future.