### PR TITLE
AG-8403 - Integrated DataModel into  PieSeries

### DIFF
--- a/charts-community-modules/ag-charts-community/src/chart/data/__snapshots__/dataModel.test.ts.snap
+++ b/charts-community-modules/ag-charts-community/src/chart/data/__snapshots__/dataModel.test.ts.snap
@@ -15,6 +15,7 @@ Object {
     ],
     "values": Array [
       Object {
+        "id": undefined,
         "index": 0,
         "missing": false,
         "property": "ie",
@@ -22,6 +23,7 @@ Object {
         "valueType": "range",
       },
       Object {
+        "id": undefined,
         "index": 1,
         "missing": false,
         "property": "chrome",
@@ -29,6 +31,7 @@ Object {
         "valueType": "range",
       },
       Object {
+        "id": undefined,
         "index": 2,
         "missing": false,
         "property": "firefox",
@@ -36,6 +39,7 @@ Object {
         "valueType": "range",
       },
       Object {
+        "id": undefined,
         "index": 3,
         "missing": false,
         "property": "safari",
@@ -255,6 +259,7 @@ Object {
     ],
     "values": Array [
       Object {
+        "id": undefined,
         "index": 0,
         "missing": false,
         "property": "curb-weight",
@@ -527,6 +532,7 @@ Object {
     ],
     "values": Array [
       Object {
+        "id": undefined,
         "index": 0,
         "missing": false,
         "property": "highway-mpg",
@@ -983,6 +989,7 @@ Object {
     ],
     "values": Array [
       Object {
+        "id": undefined,
         "index": 0,
         "missing": false,
         "property": "total",
@@ -990,6 +997,7 @@ Object {
         "valueType": "range",
       },
       Object {
+        "id": undefined,
         "index": 1,
         "missing": false,
         "property": "regular",
@@ -1476,6 +1484,7 @@ Object {
     ],
     "values": Array [
       Object {
+        "id": undefined,
         "index": 0,
         "missing": false,
         "property": "petroleum",
@@ -1483,6 +1492,7 @@ Object {
         "valueType": "range",
       },
       Object {
+        "id": undefined,
         "index": 1,
         "missing": false,
         "property": "naturalGas",
@@ -1490,6 +1500,7 @@ Object {
         "valueType": "range",
       },
       Object {
+        "id": undefined,
         "index": 2,
         "missing": false,
         "property": "bioenergyWaste",
@@ -1497,6 +1508,7 @@ Object {
         "valueType": "range",
       },
       Object {
+        "id": undefined,
         "index": 3,
         "missing": false,
         "property": "nuclear",
@@ -1504,6 +1516,7 @@ Object {
         "valueType": "range",
       },
       Object {
+        "id": undefined,
         "index": 4,
         "missing": false,
         "property": "windSolarHydro",
@@ -1511,6 +1524,7 @@ Object {
         "valueType": "range",
       },
       Object {
+        "id": undefined,
         "index": 5,
         "missing": false,
         "property": "imported",
@@ -1807,6 +1821,7 @@ Object {
     ],
     "values": Array [
       Object {
+        "id": undefined,
         "index": 0,
         "missing": false,
         "property": "white",
@@ -1814,6 +1829,7 @@ Object {
         "valueType": "range",
       },
       Object {
+        "id": undefined,
         "index": 1,
         "missing": false,
         "property": "mixed",
@@ -1821,6 +1837,7 @@ Object {
         "valueType": "range",
       },
       Object {
+        "id": undefined,
         "index": 2,
         "missing": false,
         "property": "asian",
@@ -1828,6 +1845,7 @@ Object {
         "valueType": "range",
       },
       Object {
+        "id": undefined,
         "index": 3,
         "missing": false,
         "property": "black",
@@ -1835,6 +1853,7 @@ Object {
         "valueType": "range",
       },
       Object {
+        "id": undefined,
         "index": 4,
         "missing": false,
         "property": "chinese",
@@ -1842,6 +1861,7 @@ Object {
         "valueType": "range",
       },
       Object {
+        "id": undefined,
         "index": 5,
         "missing": false,
         "property": "other",
@@ -2174,6 +2194,7 @@ Object {
     ],
     "values": Array [
       Object {
+        "id": undefined,
         "index": 0,
         "missing": false,
         "property": "ownerOccupied",
@@ -2181,6 +2202,7 @@ Object {
         "valueType": "range",
       },
       Object {
+        "id": undefined,
         "index": 1,
         "missing": false,
         "property": "privateRented",
@@ -2188,6 +2210,7 @@ Object {
         "valueType": "range",
       },
       Object {
+        "id": undefined,
         "index": 2,
         "missing": false,
         "property": "localAuthority",
@@ -2195,6 +2218,7 @@ Object {
         "valueType": "range",
       },
       Object {
+        "id": undefined,
         "index": 3,
         "missing": false,
         "property": "housingAssociation",
@@ -2529,6 +2553,7 @@ Object {
     ],
     "values": Array [
       Object {
+        "id": undefined,
         "index": 0,
         "missing": false,
         "processor": [Function],
@@ -2537,6 +2562,7 @@ Object {
         "valueType": "range",
       },
       Object {
+        "id": undefined,
         "index": 1,
         "missing": false,
         "processor": [Function],
@@ -2545,6 +2571,7 @@ Object {
         "valueType": "range",
       },
       Object {
+        "id": undefined,
         "index": 2,
         "missing": false,
         "processor": [Function],
@@ -2553,6 +2580,7 @@ Object {
         "valueType": "range",
       },
       Object {
+        "id": undefined,
         "index": 3,
         "missing": false,
         "processor": [Function],
@@ -2840,6 +2868,7 @@ Object {
     ],
     "values": Array [
       Object {
+        "id": undefined,
         "index": 0,
         "missing": false,
         "processor": [Function],
@@ -2848,6 +2877,7 @@ Object {
         "valueType": "range",
       },
       Object {
+        "id": undefined,
         "index": 1,
         "missing": false,
         "processor": [Function],
@@ -2856,6 +2886,7 @@ Object {
         "valueType": "range",
       },
       Object {
+        "id": undefined,
         "index": 2,
         "missing": false,
         "processor": [Function],
@@ -2864,6 +2895,7 @@ Object {
         "valueType": "range",
       },
       Object {
+        "id": undefined,
         "index": 3,
         "missing": false,
         "processor": [Function],
@@ -3150,6 +3182,7 @@ Object {
     ],
     "values": Array [
       Object {
+        "id": undefined,
         "index": 0,
         "invalidValue": NaN,
         "missing": false,
@@ -3160,6 +3193,7 @@ Object {
         "valueType": "range",
       },
       Object {
+        "id": undefined,
         "index": 1,
         "invalidValue": NaN,
         "missing": false,
@@ -3170,6 +3204,7 @@ Object {
         "valueType": "range",
       },
       Object {
+        "id": undefined,
         "index": 2,
         "invalidValue": NaN,
         "missing": false,
@@ -3180,6 +3215,7 @@ Object {
         "valueType": "range",
       },
       Object {
+        "id": undefined,
         "index": 3,
         "invalidValue": NaN,
         "missing": false,
@@ -3242,6 +3278,118 @@ Object {
 }
 `;
 
+exports[`DataModel repeated property processing should generated the expected results 1`] = `
+Object {
+  "data": Array [
+    Object {
+      "datum": Object {
+        "browser": "Chrome",
+        "share": 0.6869,
+        "year": 2020,
+      },
+      "keys": Array [],
+      "values": Array [
+        0,
+        0.6869,
+      ],
+    },
+    Object {
+      "datum": Object {
+        "browser": "Edge",
+        "share": 0.0463,
+        "year": 2020,
+      },
+      "keys": Array [],
+      "values": Array [
+        0.1478760779303737,
+        0.05,
+      ],
+    },
+    Object {
+      "datum": Object {
+        "browser": "Safari",
+        "share": 0.087,
+        "year": 2020,
+      },
+      "keys": Array [],
+      "values": Array [
+        0.4257425742574256,
+        0.087,
+      ],
+    },
+    Object {
+      "datum": Object {
+        "browser": "Firefox",
+        "share": 0.0955,
+        "year": 2020,
+      },
+      "keys": Array [],
+      "values": Array [
+        0.7307569466624081,
+        0.0955,
+      ],
+    },
+    Object {
+      "datum": Object {
+        "browser": "Other",
+        "share": 0.0843,
+        "year": 2020,
+      },
+      "keys": Array [],
+      "values": Array [
+        1,
+        0.0843,
+      ],
+    },
+  ],
+  "defs": Object {
+    "keys": Array [],
+    "values": Array [
+      Object {
+        "id": "angle",
+        "index": 0,
+        "missing": false,
+        "processor": [Function],
+        "property": "share",
+        "type": "value",
+        "valueType": "range",
+      },
+      Object {
+        "id": "radius",
+        "index": 1,
+        "missing": false,
+        "processor": [Function],
+        "property": "share",
+        "type": "value",
+        "validation": [Function],
+        "valueType": "range",
+      },
+    ],
+  },
+  "domain": Object {
+    "keys": Array [],
+    "values": Array [
+      Array [
+        0,
+        1,
+      ],
+      Array [
+        0.05,
+        0.6869,
+      ],
+    ],
+  },
+  "indices": Object {
+    "keys": Object {},
+    "values": Object {
+      "share": 1,
+    },
+  },
+  "time": Any<Number>,
+  "type": "ungrouped",
+}
+`;
+
 exports[`DataModel ungrouped processing - accumulated and normalised properties should generated the expected results 1`] = `
 Object {
   "data": Array [
@@ -3252,7 +3400,7 @@ Object {
       },
       "keys": Array [],
       "values": Array [
-        3.01543592113546,
+        2.978445409938555,
         "Christian",
         4159000,
       ],
@@ -3264,7 +3412,7 @@ Object {
       },
       "keys": Array [],
       "values": Array [
-        3.0857646742852896,
+        3.049570275710106,
         "Buddhist",
         97000,
       ],
@@ -3276,7 +3424,7 @@ Object {
       },
       "keys": Array [],
       "values": Array [
-        3.4163823179587136,
+        3.383930469440284,
         "Hindu",
         456000,
       ],
@@ -3288,7 +3436,7 @@ Object {
       },
       "keys": Array [],
       "values": Array [
-        3.5381888182594485,
+        3.507115803972454,
         "Jewish",
         168000,
       ],
@@ -3300,7 +3448,7 @@ Object {
       },
       "keys": Array [],
       "values": Array [
-        4.419110829362979,
+        4.398009741214046,
         "Muslim",
         1215000,
       ],
@@ -3312,7 +3460,7 @@ Object {
       },
       "keys": Array [],
       "values": Array [
-        4.5082905885117315,
+        4.488199003996527,
         "Sikh",
         123000,
       ],
@@ -3324,7 +3472,7 @@ Object {
       },
       "keys": Array [],
       "values": Array [
-        4.634447320966064,
+        4.61578381476199,
         "Other",
         174000,
       ],
@@ -3346,6 +3494,7 @@ Object {
     "keys": Array [],
     "values": Array [
       Object {
+        "id": undefined,
         "index": 0,
         "missing": false,
         "processor": [Function],
@@ -3361,6 +3510,7 @@ Object {
         "valueType": "category",
       },
       Object {
+        "id": undefined,
         "index": 2,
         "missing": false,
         "property": "population",
@@ -3373,7 +3523,7 @@ Object {
     "keys": Array [],
     "values": Array [
       Array [
-        0.0703287531498292,
+        0,
         6.283185307179586,
       ],
       Array [
@@ -4148,6 +4298,7 @@ Object {
     ],
     "values": Array [
       Object {
+        "id": undefined,
         "index": 0,
         "missing": false,
         "property": "petrol",
@@ -4155,6 +4306,7 @@ Object {
         "valueType": "range",
       },
       Object {
+        "id": undefined,
         "index": 1,
         "missing": false,
         "property": "diesel",

--- a/charts-community-modules/ag-charts-community/src/chart/data/aggregateFunctions.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/data/aggregateFunctions.ts
@@ -130,6 +130,9 @@ export function accumulatedValue(): DatumPropertyDefinition<any>['processor'] {
         let value = 0;
 
         return (datum: any) => {
+            if (typeof datum !== 'number') return datum;
+            if (isNaN(datum)) return datum;
+
             value += datum;
             return value;
         };

--- a/charts-community-modules/ag-charts-community/src/chart/data/processors.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/data/processors.ts
@@ -1,6 +1,7 @@
 import {
     GroupValueProcessorDefinition,
     ProcessorOutputPropertyDefinition,
+    PropertyId,
     PropertyValueProcessorDefinition,
     ReducerOutputPropertyDefinition,
 } from './dataModel';
@@ -62,7 +63,7 @@ export const SORT_DOMAIN_GROUPS: ProcessorOutputPropertyDefinition<any> = {
 };
 
 export function normaliseGroupTo(
-    properties: (string | number)[],
+    properties: PropertyId<any>[],
     normaliseTo: number,
     mode: 'sum' | 'range' = 'sum'
 ): GroupValueProcessorDefinition<any, any> {
@@ -100,7 +101,7 @@ export function normaliseGroupTo(
 }
 
 export function normalisePropertyTo(
-    property: string | number,
+    property: PropertyId<any>,
     normaliseTo: [number, number],
     rangeMin?: number,
     rangeMax?: number
@@ -109,7 +110,8 @@ export function normalisePropertyTo(
     const normalise = (val: number, start: number, span: number) => {
         const result = normaliseTo[0] + ((val - start) / span) * normaliseSpan;
 
-        if (result > normaliseTo[1]) return normaliseTo[1];
+        if (span === 0) return normaliseTo[1];
+        if (result >= normaliseTo[1]) return normaliseTo[1];
         if (result < normaliseTo[0]) return normaliseTo[0];
         return result;
     };

--- a/charts-community-modules/ag-charts-community/src/chart/polarChart.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/polarChart.ts
@@ -19,7 +19,7 @@ export class PolarChart extends Chart {
 
         const fullSeriesRect = shrinkRect.clone();
         this.computeSeriesRect(shrinkRect);
-        await this.computeCircle();
+        this.computeCircle();
 
         const hoverRectPadding = 20;
         const hoverRect = shrinkRect.clone().grow(hoverRectPadding);
@@ -46,7 +46,7 @@ export class PolarChart extends Chart {
         this.seriesRect = shrinkRect;
     }
 
-    private async computeCircle() {
+    private computeCircle() {
         const seriesBox = this.seriesRect!;
         const polarSeries = this.series.filter((series) => {
             return series instanceof PolarSeries;
@@ -69,7 +69,7 @@ export class PolarChart extends Chart {
         const shake = async ({ hideWhenNecessary = false } = {}) => {
             const labelBoxes = [];
             for (const series of polarSeries) {
-                const box = await series.computeLabelsBBox({ hideWhenNecessary }, seriesBox);
+                const box = series.computeLabelsBBox({ hideWhenNecessary }, seriesBox);
                 if (box == null) continue;
 
                 labelBoxes.push(box);
@@ -91,11 +91,11 @@ export class PolarChart extends Chart {
             radius = refined.radius;
         };
 
-        await shake(); // Initial attempt
-        await shake(); // Precise attempt
-        await shake(); // Just in case
-        await shake({ hideWhenNecessary: true }); // Hide unnecessary labels
-        await shake({ hideWhenNecessary: true }); // Final result
+        shake(); // Initial attempt
+        shake(); // Precise attempt
+        shake(); // Just in case
+        shake({ hideWhenNecessary: true }); // Hide unnecessary labels
+        shake({ hideWhenNecessary: true }); // Final result
     }
 
     private refineCircle(labelsBox: BBox, radius: number) {

--- a/charts-community-modules/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
@@ -242,9 +242,10 @@ export class AreaSeries extends CartesianSeries<AreaSeriesNodeDataContext> {
 
         this.dataModel = new DataModel<any, any, true>({
             props: [
-                keyProperty(xKey, isContinuousX),
+                keyProperty(xKey, isContinuousX, { id: 'xValue' }),
                 ...enabledYKeys.map((yKey) =>
                     valueProperty(yKey, isContinuousY, {
+                        id: `yValue-${yKey}`,
                         missingValue: NaN,
                         invalidValue: undefined,
                     })
@@ -353,7 +354,7 @@ export class AreaSeries extends CartesianSeries<AreaSeriesNodeDataContext> {
         };
 
         yKeys.forEach((yKey, seriesIdx) => {
-            const yKeyDataIndex = this.dataModel?.resolveProcessedDataIndex(yKey);
+            const yKeyDataIndex = this.dataModel?.resolveProcessedDataIndexById(`yValue-${yKey}`);
             const labelSelectionData: LabelSelectionDatum[] = [];
             const markerSelectionData: MarkerSelectionDatum[] = [];
             const strokeSelectionData: StrokeSelectionDatum = { itemId: yKey, points: [], yValues: [] };
@@ -751,7 +752,7 @@ export class AreaSeries extends CartesianSeries<AreaSeriesNodeDataContext> {
     getTooltipHtml(nodeDatum: MarkerSelectionDatum): string {
         const { xKey, id: seriesId } = this;
         const { yKey } = nodeDatum;
-        const yKeyDataIndex = this.dataModel?.resolveProcessedDataIndex(yKey);
+        const yKeyDataIndex = this.dataModel?.resolveProcessedDataIndexById(`yValue-${yKey}`);
 
         if (!(xKey && yKey) || !yKeyDataIndex) {
             return '';

--- a/charts-community-modules/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
@@ -149,8 +149,8 @@ export class LineSeries extends CartesianSeries<LineContext> {
 
         this.dataModel = new DataModel<any>({
             props: [
-                valueProperty(xKey, isContinuousX),
-                valueProperty(yKey, isContinuousY, { invalidValue: undefined }),
+                valueProperty(xKey, isContinuousX, { id: 'xValue' }),
+                valueProperty(yKey, isContinuousY, { id: 'yValue', invalidValue: undefined }),
             ],
             dataVisible: this.visible,
         });
@@ -158,19 +158,19 @@ export class LineSeries extends CartesianSeries<LineContext> {
     }
 
     getDomain(direction: ChartAxisDirection): any[] {
-        const { xKey, yKey, xAxis, yAxis, dataModel, processedData } = this;
+        const { xAxis, yAxis, dataModel, processedData } = this;
         if (!processedData || !dataModel) return [];
 
-        const xDef = dataModel.resolveProcessedDataDef(xKey);
+        const xDef = dataModel.resolveProcessedDataDefById(`xValue`);
         if (direction === ChartAxisDirection.X) {
-            const domain = dataModel.getDomain(xKey, processedData);
+            const domain = dataModel.getDomain(`xValue`, processedData);
             if (xDef?.valueType === 'category') {
                 return domain;
             }
 
             return this.fixNumericExtent(extent(domain), xAxis);
         } else {
-            const domain = dataModel.getDomain(yKey, processedData);
+            const domain = dataModel.getDomain(`yValue`, processedData);
             return this.fixNumericExtent(domain as any, yAxis);
         }
     }
@@ -196,8 +196,8 @@ export class LineSeries extends CartesianSeries<LineContext> {
         const nodeData: LineNodeDatum[] = new Array(processedData.data.length);
         const size = markerEnabled ? markerSize : 0;
 
-        const xIdx = this.dataModel?.resolveProcessedDataIndex(xKey)?.index ?? -1;
-        const yIdx = this.dataModel?.resolveProcessedDataIndex(yKey)?.index ?? -1;
+        const xIdx = this.dataModel?.resolveProcessedDataIndexById(`xValue`)?.index ?? -1;
+        const yIdx = this.dataModel?.resolveProcessedDataIndexById(`yValue`)?.index ?? -1;
 
         let moveTo = true;
         let prevXInRange: undefined | -1 | 0 | 1 = undefined;

--- a/charts-community-modules/ag-charts-community/src/chart/series/cartesian/scatterSeries.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/series/cartesian/scatterSeries.ts
@@ -175,23 +175,23 @@ export class ScatterSeries extends CartesianSeries<SeriesNodeDataContext<Scatter
 
         this.dataModel = new DataModel<any>({
             props: [
-                valueProperty(xKey, isContinuousX),
-                valueProperty(yKey, isContinuousY),
-                ...(sizeKey ? [valueProperty(sizeKey, true)] : []),
-                ...(colorKey ? [valueProperty(colorKey, true)] : []),
+                valueProperty(xKey, isContinuousX, { id: `xValue` }),
+                valueProperty(yKey, isContinuousY, { id: `yValue` }),
+                ...(sizeKey ? [valueProperty(sizeKey, true, { id: `sizeValue` })] : []),
+                ...(colorKey ? [valueProperty(colorKey, true, { id: `colorValue` })] : []),
             ],
             dataVisible: this.visible,
         });
         this.processedData = this.dataModel.processData(data ?? []);
 
         if (sizeKey) {
-            const sizeKeyIdx = this.dataModel.resolveProcessedDataIndex(sizeKey)?.index ?? -1;
+            const sizeKeyIdx = this.dataModel.resolveProcessedDataIndexById(`sizeValue`)?.index ?? -1;
             const processedSize = this.processedData?.domain.values[sizeKeyIdx] ?? [];
             this.sizeScale.domain = marker.domain ? marker.domain : processedSize;
         }
 
         if (colorKey) {
-            const colorKeyIdx = this.dataModel.resolveProcessedDataIndex(colorKey)?.index ?? -1;
+            const colorKeyIdx = this.dataModel.resolveProcessedDataIndexById(`colorValue`)?.index ?? -1;
             colorScale.domain = colorDomain ?? this.processedData!.domain.values[colorKeyIdx];
             colorScale.range = colorRange;
         }
@@ -201,9 +201,9 @@ export class ScatterSeries extends CartesianSeries<SeriesNodeDataContext<Scatter
         const { dataModel, processedData } = this;
         if (!processedData || !dataModel) return [];
 
-        const key = direction === ChartAxisDirection.X ? this.xKey : this.yKey;
-        const dataDef = dataModel.resolveProcessedDataDef(key);
-        const domain = dataModel.getDomain(key, processedData);
+        const id = direction === ChartAxisDirection.X ? `xValue` : `yValue`;
+        const dataDef = dataModel.resolveProcessedDataDefById(id);
+        const domain = dataModel.getDomain(id, processedData);
         if (dataDef?.valueType === 'category') {
             return domain;
         }
@@ -222,8 +222,8 @@ export class ScatterSeries extends CartesianSeries<SeriesNodeDataContext<Scatter
     async createNodeData() {
         const { visible, xAxis, yAxis, yKey, xKey, label, labelKey } = this;
 
-        const xDataIdx = this.dataModel?.resolveProcessedDataIndex(xKey);
-        const yDataIdx = this.dataModel?.resolveProcessedDataIndex(yKey);
+        const xDataIdx = this.dataModel?.resolveProcessedDataIndexById(`xValue`);
+        const yDataIdx = this.dataModel?.resolveProcessedDataIndexById(`yValue`);
 
         if (!(xDataIdx && yDataIdx && visible && xAxis && yAxis)) {
             return [];

--- a/charts-community-modules/ag-charts-community/src/chart/series/polar/pieSeries.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/series/polar/pieSeries.ts
@@ -419,14 +419,18 @@ export class PieSeries extends PolarSeries<PieNodeDatum> {
         this.processedData = this.dataModel.processData(data);
     }
 
-    async maybeRefreshNodeData() {
+    maybeRefreshNodeData() {
         if (!this.nodeDataRefresh) return;
-        const [{ nodeData = [] } = {}] = await this.createNodeData();
+        const [{ nodeData = [] } = {}] = this._createNodeData();
         this.nodeData = nodeData;
         this.nodeDataRefresh = false;
     }
 
     async createNodeData() {
+        return this._createNodeData();
+    }
+
+    private _createNodeData() {
         const { id: seriesId, processedData, dataModel, rotation, angleScale } = this;
 
         if (!processedData || !dataModel || processedData.type !== 'ungrouped') return [];
@@ -654,7 +658,7 @@ export class PieSeries extends PolarSeries<PieNodeDatum> {
     async update({ seriesRect }: { seriesRect: BBox }) {
         const { title } = this;
 
-        await this.maybeRefreshNodeData();
+        this.maybeRefreshNodeData();
         this.updateTitleNodes();
         this.updateRadiusScale();
         this.updateInnerCircleNodes();
@@ -1075,12 +1079,12 @@ export class PieSeries extends PolarSeries<PieNodeDatum> {
         });
     }
 
-    async computeLabelsBBox(options: { hideWhenNecessary: boolean }, seriesRect: BBox) {
+    computeLabelsBBox(options: { hideWhenNecessary: boolean }, seriesRect: BBox) {
         const { radiusScale, calloutLabel, calloutLine } = this;
         const calloutLength = calloutLine.length;
         const { offset, maxCollisionOffset } = calloutLabel;
 
-        await this.maybeRefreshNodeData();
+        this.maybeRefreshNodeData();
 
         this.updateRadiusScale();
         this.computeCalloutLabelCollisionOffsets();

--- a/charts-community-modules/ag-charts-community/src/chart/series/polar/pieSeries.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/series/polar/pieSeries.ts
@@ -7,7 +7,14 @@ import { DropShadow } from '../../../scene/dropShadow';
 import { LinearScale } from '../../../scale/linearScale';
 import { Sector } from '../../../scene/shape/sector';
 import { BBox } from '../../../scene/bbox';
-import { SeriesNodeDatum, HighlightStyle, SeriesTooltip, SeriesNodeBaseClickEvent } from './../series';
+import {
+    SeriesNodeDatum,
+    HighlightStyle,
+    SeriesTooltip,
+    SeriesNodeBaseClickEvent,
+    valueProperty,
+    accumulativeValueProperty,
+} from './../series';
 import { Label } from '../../label';
 import { PointerEvents } from '../../../scene/node';
 import { normalizeAngle180, toRadians } from '../../../util/angle';
@@ -42,6 +49,8 @@ import {
 import { LegendItemClickChartEvent, LegendItemDoubleClickChartEvent } from '../../interaction/chartEventManager';
 import { StateMachine } from '../../../motion/states';
 import * as easing from '../../../motion/easing';
+import { DataModel } from '../../data/dataModel';
+import { normalisePropertyTo } from '../../data/processors';
 
 class PieSeriesNodeBaseClickEvent extends SeriesNodeBaseClickEvent<any> {
     readonly angleKey: string;
@@ -77,6 +86,8 @@ class PieSeriesNodeDoubleClickEvent extends PieSeriesNodeBaseClickEvent {
 interface PieNodeDatum extends SeriesNodeDatum {
     readonly index: number;
     readonly radius: number; // in the [0, 1] range
+    readonly angleValue: number;
+    readonly radiusValue?: number;
     readonly startAngle: number;
     readonly endAngle: number;
     readonly midAngle: number;
@@ -97,7 +108,8 @@ interface PieNodeDatum extends SeriesNodeDatum {
         readonly text: string;
     };
 
-    readonly sectorFormat: AgPieSeriesFormat;
+    readonly sectorFormat: Required<AgPieSeriesFormat>;
+    readonly legendItemKey?: string;
 }
 
 enum PieNodeTag {
@@ -189,12 +201,7 @@ export class PieSeries extends PolarSeries<PieNodeDatum> {
     // The group node that contains the background graphics.
     readonly backgroundGroup: Group;
 
-    /**
-     * The processed data that gets visualized.
-     */
-    private groupSelectionData: PieNodeDatum[] = [];
-    private sectorFormatData: AgPieSeriesFormat[] = [];
-
+    private nodeData: PieNodeDatum[] = [];
     private angleScale: LinearScale;
 
     // When a user toggles a series item (e.g. from the legend), its boolean state is recorded here.
@@ -383,97 +390,177 @@ export class PieSeries extends PolarSeries<PieNodeDatum> {
     }
 
     async processData() {
-        const {
-            angleKey,
-            radiusKey,
-            seriesItemEnabled,
-            angleScale,
-            groupSelectionData,
-            sectorFormatData,
-            calloutLabel,
-            sectorLabel,
-            id: seriesId,
-        } = this;
-        const data = angleKey && this.data ? this.data : [];
+        let { data = [] } = this;
+        const { angleKey, radiusKey, seriesItemEnabled } = this;
 
-        const angleData: number[] = data.map(
-            (datum, index) => (seriesItemEnabled[index] && Math.abs(+datum[angleKey])) || 0
-        );
-        const angleDataTotal = angleData.reduce((a, b) => a + b, 0);
+        if (!angleKey) return;
 
-        // The ratios (in [0, 1] interval) used to calculate the end angle value for every pie sector.
-        // Each sector starts where the previous one ends, so we only keep the ratios for end angles.
-        const angleDataRatios = (() => {
-            let sum = 0;
-            return angleData.map((datum) => (sum += datum / angleDataTotal));
-        })();
-
-        const labelFormatter = calloutLabel.formatter;
-        const labelKey = calloutLabel.enabled ? this.calloutLabelKey : undefined;
-        const sectorLabelKey = sectorLabel.enabled ? this.sectorLabelKey : undefined;
-        let labelData: string[] = [];
-        let sectorLabelData: string[] = [];
-        let radiusData: number[] = [];
-
-        const getLabelFormatterParams = (datum: any): AgPieSeriesLabelFormatterParams<any> => {
-            return {
-                datum,
-                angleKey,
-                angleValue: datum[angleKey],
-                angleName: this.angleName,
-                radiusKey,
-                radiusValue: radiusKey ? datum[radiusKey] : undefined,
-                radiusName: this.radiusName,
-                calloutLabelKey: labelKey,
-                calloutLabelValue: labelKey ? datum[labelKey] : undefined,
-                calloutLabelName: this.calloutLabelName,
-                sectorLabelKey,
-                sectorLabelValue: sectorLabelKey ? datum[sectorLabelKey] : undefined,
-                sectorLabelName: this.sectorLabelName,
-                seriesId,
-            };
-        };
-
-        if (labelKey) {
-            if (labelFormatter) {
-                labelData = data.map((datum) => labelFormatter(getLabelFormatterParams(datum)));
-            } else {
-                labelData = data.map((datum) => String(datum[labelKey]));
-            }
-        }
-
-        const sectorLabelFormatter = sectorLabel.formatter;
-
-        if (sectorLabelKey) {
-            if (sectorLabelFormatter) {
-                sectorLabelData = data.map((datum) => {
-                    const formatterParams = getLabelFormatterParams(datum);
-                    return sectorLabelFormatter(formatterParams);
-                });
-            } else {
-                sectorLabelData = data.map((datum) => String(datum[sectorLabelKey]));
-            }
-        }
-
+        const extraProps = [];
         if (radiusKey) {
-            const { radiusMin, radiusMax } = this;
-            const radii = data.map((datum) => Math.abs(datum[radiusKey]));
-            const min = radiusMin ?? 0;
-            const max = radiusMax ? radiusMax : Math.max(...radii);
-            const delta = max - min;
-
-            radiusData = radii.map((value) => (delta ? (value - min) / delta : 1));
+            extraProps.push(
+                valueProperty(radiusKey, true),
+                valueProperty(radiusKey, true), // Raw value pass-through.
+                normalisePropertyTo(radiusKey, 1)
+            );
+            extraProps.push();
         }
 
-        groupSelectionData.length = 0;
-        sectorFormatData.length = 0;
-        sectorFormatData.push(...data.map((datum, datumIdx) => this.getSectorFormat(datum, datumIdx, datumIdx, false)));
+        data = data.map((d, idx) => (seriesItemEnabled[idx] ? d : {}));
 
-        const rotation = toRadians(this.rotation);
-        const halfPi = Math.PI / 2;
+        this.dataModel = new DataModel<any, any, true>({
+            props: [
+                accumulativeValueProperty(angleKey, true),
+                valueProperty(angleKey, true), // Raw value pass-through.
+                normalisePropertyTo(angleKey, 1),
+                ...extraProps,
+            ],
+        });
+        this.processedData = this.dataModel.processData(data);
+    }
 
-        let datumIndex = 0;
+    async maybeRefreshNodeData() {
+        if (!this.nodeDataRefresh) return;
+        const [{ nodeData = [] } = {}] = await this.createNodeData();
+        this.nodeData = nodeData;
+        this.nodeDataRefresh = false;
+    }
 
+    async createNodeData() {
+        const { id: seriesId, processedData, dataModel, rotation, radiusKey, angleScale } = this;
+
+        if (!processedData || !dataModel || processedData.type !== 'ungrouped') return [];
+
+        const angleIdx = dataModel.resolveProcessedDataIndex(this.angleKey)?.index ?? -1;
+        const radiusIdx = dataModel.resolveProcessedDataIndex(radiusKey || '')?.index ?? -1;
+
+        if (angleIdx < 0) return [];
+
+        let currentStart = 0;
+        const nodeData = processedData.data.map((group, index): PieNodeDatum => {
+            const { datum, values } = group;
+
+            const startAngle = angleScale.convert(currentStart) + toRadians(rotation);
+            currentStart = values[angleIdx];
+            const endAngle = angleScale.convert(currentStart) + toRadians(rotation);
+            const span = Math.abs(endAngle - startAngle);
+            const midAngle = startAngle + span / 2;
+
+            const angleValue = values[angleIdx + 1];
+            const radius = radiusIdx >= 0 ? values[radiusIdx] ?? 1 : 1;
+            const radiusValue = radiusIdx >= 0 ? values[radiusIdx + 1] : undefined;
+
+            const labels = this.getLabels(datum, midAngle, span);
+            const sectorFormat = this.getSectorFormat(datum, index, index, false);
+
+            return {
+                itemId: index,
+                series: this,
+                datum,
+                index,
+                angleValue,
+                midAngle,
+                midCos: Math.cos(midAngle),
+                midSin: Math.sin(midAngle),
+                startAngle,
+                endAngle,
+                sectorFormat,
+                radius,
+                radiusValue,
+                ...labels,
+            };
+        });
+
+        return [
+            {
+                itemId: seriesId,
+                nodeData,
+                labelData: nodeData,
+            },
+        ];
+    }
+
+    private getLabels(datum: any, midAngle: number, span: number) {
+        const { calloutLabel, sectorLabel, legendItemKey } = this;
+
+        const calloutLabelKey = calloutLabel.enabled ? this.calloutLabelKey : undefined;
+        const sectorLabelKey = sectorLabel.enabled ? this.sectorLabelKey : undefined;
+
+        if (!calloutLabelKey && !sectorLabelKey) return {};
+
+        const labelFormatterParams = this.getLabelFormatterParams(datum);
+
+        let calloutLabelText;
+        if (calloutLabelKey) {
+            const calloutLabelMinAngle = toRadians(calloutLabel.minAngle);
+            const calloutLabelVisible = span > calloutLabelMinAngle;
+
+            if (!calloutLabelVisible) {
+                calloutLabelText = undefined;
+            } else if (calloutLabel.formatter) {
+                calloutLabelText = calloutLabel.formatter(labelFormatterParams);
+            } else {
+                calloutLabelText = String(datum[calloutLabelKey]);
+            }
+        }
+
+        let sectorLabelText;
+        if (sectorLabelKey) {
+            if (sectorLabel.formatter) {
+                sectorLabelText = sectorLabel.formatter(labelFormatterParams);
+            } else {
+                sectorLabelText = String(datum[sectorLabelKey]);
+            }
+        }
+
+        return {
+            ...(calloutLabelText != null
+                ? {
+                      calloutLabel: {
+                          ...this.getTextAlignment(midAngle),
+                          text: calloutLabelText,
+                          hidden: false,
+                          collisionTextAlign: undefined,
+                          collisionOffsetY: 0,
+                          box: undefined,
+                      },
+                  }
+                : {}),
+            ...(sectorLabelText != null ? { sectorLabel: { text: sectorLabelText } } : {}),
+            ...(legendItemKey != null ? { legendItemKey: datum[legendItemKey] } : {}),
+        };
+    }
+
+    private getLabelFormatterParams(datum: any): AgPieSeriesLabelFormatterParams<any> {
+        const {
+            id: seriesId,
+            radiusKey,
+            radiusName,
+            angleKey,
+            angleName,
+            calloutLabelKey,
+            calloutLabelName,
+            sectorLabelKey,
+            sectorLabelName,
+        } = this;
+        return {
+            datum,
+            angleKey,
+            angleValue: datum[angleKey],
+            angleName,
+            radiusKey,
+            radiusValue: radiusKey ? datum[radiusKey] : undefined,
+            radiusName,
+            calloutLabelKey,
+            calloutLabelValue: calloutLabelKey ? datum[calloutLabelKey] : undefined,
+            calloutLabelName,
+            sectorLabelKey,
+            sectorLabelValue: sectorLabelKey ? datum[sectorLabelKey] : undefined,
+            sectorLabelName,
+            seriesId,
+        };
+    }
+
+    private getTextAlignment(midAngle: number) {
         const quadrantTextOpts: { textAlign: CanvasTextAlign; textBaseline: CanvasTextBaseline }[] = [
             { textAlign: 'center', textBaseline: 'bottom' },
             { textAlign: 'left', textBaseline: 'middle' },
@@ -481,72 +568,18 @@ export class PieSeries extends PolarSeries<PieNodeDatum> {
             { textAlign: 'right', textBaseline: 'middle' },
         ];
 
-        // Process sectors.
-        let end = 0;
-        angleDataRatios.forEach((start) => {
-            if (isNaN(start)) {
-                return;
-            } // No sectors displayed - nothing to do.
+        const midAngle180 = normalizeAngle180(midAngle);
 
-            const radius = radiusKey ? radiusData[datumIndex] : 1;
-            const startAngle = angleScale.convert(start) + rotation;
-            const endAngle = angleScale.convert(end) + rotation;
+        // Split the circle into quadrants like so: ⊗
+        const quadrantStart = (-3 * Math.PI) / 4; // same as `normalizeAngle180(toRadians(-135))`
+        const quadrantOffset = midAngle180 - quadrantStart;
+        const quadrant = Math.floor(quadrantOffset / (Math.PI / 2));
+        const quadrantIndex = mod(quadrant, quadrantTextOpts.length);
 
-            const midAngle = (startAngle + endAngle) / 2;
-            const span = Math.abs(endAngle - startAngle);
-            const midCos = Math.cos(midAngle);
-            const midSin = Math.sin(midAngle);
-
-            const labelMinAngle = toRadians(calloutLabel.minAngle);
-            const labelVisible = labelKey && span > labelMinAngle;
-            const midAngle180 = normalizeAngle180(midAngle);
-
-            // Split the circle into quadrants like so: ⊗
-            const quadrantStart = (-3 * Math.PI) / 4; // same as `normalizeAngle180(toRadians(-135))`
-            const quadrantOffset = midAngle180 - quadrantStart;
-            const quadrant = Math.floor(quadrantOffset / halfPi);
-            const quadrantIndex = mod(quadrant, quadrantTextOpts.length);
-
-            const { textAlign, textBaseline } = quadrantTextOpts[quadrantIndex];
-            const datum = data[datumIndex];
-            const itemId = datumIndex;
-
-            groupSelectionData.push({
-                series: this,
-                datum,
-                itemId,
-                index: datumIndex,
-                radius,
-                startAngle,
-                endAngle,
-                midAngle,
-                midCos,
-                midSin,
-                calloutLabel: labelVisible
-                    ? {
-                          text: labelData[datumIndex],
-                          textAlign,
-                          textBaseline,
-                          hidden: false,
-                          collisionTextAlign: undefined,
-                          collisionOffsetY: 0,
-                          box: undefined,
-                      }
-                    : undefined,
-                sectorLabel: sectorLabelKey
-                    ? {
-                          text: sectorLabelData[datumIndex],
-                      }
-                    : undefined,
-                sectorFormat: sectorFormatData[datumIndex],
-            });
-
-            datumIndex++;
-            end = start; // Update for next iteration.
-        });
+        return quadrantTextOpts[quadrantIndex];
     }
 
-    private getSectorFormat(datum: any, itemId: any, index: number, highlight: any): AgPieSeriesFormat {
+    private getSectorFormat(datum: any, itemId: any, index: number, highlight: any) {
         const { angleKey, radiusKey, fills, strokes, fillOpacity: seriesFillOpacity, formatter, id: seriesId } = this;
 
         const highlightedDatum = this.highlightManager?.getActiveHighlight();
@@ -580,10 +613,6 @@ export class PieSeries extends PolarSeries<PieNodeDatum> {
         };
     }
 
-    async createNodeData() {
-        return [];
-    }
-
     private getInnerRadius() {
         const { radius, innerRadiusRatio, innerRadiusOffset } = this;
         const innerRadius = radius * (innerRadiusRatio ?? 1) + (innerRadiusOffset ? innerRadiusOffset : 0);
@@ -615,14 +644,15 @@ export class PieSeries extends PolarSeries<PieNodeDatum> {
         }
         const spacing = this.title?.spacing ?? 0;
         const titleOffset = 2 + spacing;
-        const minLabelY = Math.min(0, ...this.groupSelectionData.map((d) => d.calloutLabel?.box?.y || 0));
+        const minLabelY = Math.min(0, ...this.nodeData.map((d) => d.calloutLabel?.box?.y || 0));
         const dy = Math.max(0, -outerRadius - minLabelY);
         return -outerRadius - titleOffset - dy;
     }
 
-    async update() {
+    async update({ seriesRect }: { seriesRect: BBox }) {
         const { title } = this;
 
+        await this.maybeRefreshNodeData();
         this.updateTitleNodes();
         this.updateRadiusScale();
         this.updateInnerCircleNodes();
@@ -643,7 +673,7 @@ export class PieSeries extends PolarSeries<PieNodeDatum> {
         this.updateNodeMidPoint();
 
         await this.updateSelections();
-        await this.updateNodes();
+        await this.updateNodes(seriesRect);
     }
 
     private updateTitleNodes() {
@@ -684,7 +714,7 @@ export class PieSeries extends PolarSeries<PieNodeDatum> {
     }
 
     private updateNodeMidPoint() {
-        this.groupSelectionData.forEach((d) => {
+        this.nodeData.forEach((d) => {
             const radius = this.radiusScale.convert(d.radius);
             d.nodeMidPoint = {
                 x: d.midCos * Math.max(0, radius / 2),
@@ -707,7 +737,7 @@ export class PieSeries extends PolarSeries<PieNodeDatum> {
         } = this;
 
         const update = (selection: typeof groupSelection) => {
-            return selection.update(this.groupSelectionData, (group) => {
+            return selection.update(this.nodeData, (group) => {
                 const sector = new Sector();
                 sector.tag = PieNodeTag.Sector;
                 group.appendChild(sector);
@@ -717,7 +747,7 @@ export class PieSeries extends PolarSeries<PieNodeDatum> {
         this.groupSelection = update(groupSelection);
         this.highlightSelection = update(highlightSelection);
 
-        calloutLabelSelection.update(this.groupSelectionData, (group) => {
+        calloutLabelSelection.update(this.nodeData, (group) => {
             const line = new Line();
             line.tag = PieNodeTag.Callout;
             line.pointerEvents = PointerEvents.None;
@@ -729,7 +759,7 @@ export class PieSeries extends PolarSeries<PieNodeDatum> {
             group.appendChild(text);
         });
 
-        sectorLabelSelection.update(this.groupSelectionData, (node) => {
+        sectorLabelSelection.update(this.nodeData, (node) => {
             node.pointerEvents = PointerEvents.None;
         });
 
@@ -738,14 +768,7 @@ export class PieSeries extends PolarSeries<PieNodeDatum> {
         });
     }
 
-    private datumSectorRefs = new WeakMap<PieNodeDatum, Sector>();
-
-    private async updateNodes() {
-        const seriesBox = this.chart?.getSeriesRect();
-        if (seriesBox == null) {
-            return;
-        }
-
+    private async updateNodes(seriesRect: BBox) {
         const highlightedDatum = this.highlightManager?.getActiveHighlight();
         const isVisible = this.seriesItemEnabled.indexOf(true) >= 0;
         this.rootGroup.visible = isVisible;
@@ -792,8 +815,6 @@ export class PieSeries extends PolarSeries<PieNodeDatum> {
             sector.fillShadow = this.shadow;
             sector.lineJoin = 'round';
             sector.visible = this.seriesItemEnabled[index];
-
-            this.datumSectorRefs.set(datum, sector);
         };
 
         this.groupSelection
@@ -812,7 +833,7 @@ export class PieSeries extends PolarSeries<PieNodeDatum> {
         this.animationStates.transition('update');
 
         this.updateCalloutLineNodes();
-        this.updateCalloutLabelNodes(seriesBox);
+        this.updateCalloutLabelNodes(seriesRect);
         this.updateSectorLabelNodes();
         this.updateInnerLabelNodes();
     }
@@ -898,8 +919,8 @@ export class PieSeries extends PolarSeries<PieNodeDatum> {
             return !label || outerRadius === 0;
         };
 
-        const fullData = this.groupSelectionData;
-        const data = this.groupSelectionData.filter((text) => !shouldSkip(text));
+        const fullData = this.nodeData;
+        const data = this.nodeData.filter((text) => !shouldSkip(text));
         data.forEach((datum) => {
             const label = datum.calloutLabel!;
             label.hidden = false;
@@ -1052,15 +1073,18 @@ export class PieSeries extends PolarSeries<PieNodeDatum> {
         });
     }
 
-    computeLabelsBBox(options: { hideWhenNecessary: boolean }, seriesRect: BBox): BBox | null {
+    async computeLabelsBBox(options: { hideWhenNecessary: boolean }, seriesRect: BBox) {
         const { radiusScale, calloutLabel, calloutLine } = this;
         const calloutLength = calloutLine.length;
         const { offset, maxCollisionOffset } = calloutLabel;
+
+        await this.maybeRefreshNodeData();
+
         this.updateRadiusScale();
         this.computeCalloutLabelCollisionOffsets();
 
         const text = new Text();
-        const textBoxes = this.groupSelectionData
+        const textBoxes = this.nodeData
             .map((datum) => {
                 const label = datum.calloutLabel;
                 const radius = radiusScale.convert(datum.radius);
@@ -1169,20 +1193,17 @@ export class PieSeries extends PolarSeries<PieNodeDatum> {
                 text.textAlign = 'center';
                 text.textBaseline = 'middle';
 
-                const sector = this.datumSectorRefs.get(datum);
-                if (sector) {
-                    const bbox = text.computeBBox();
-                    const corners = [
-                        [bbox.x, bbox.y],
-                        [bbox.x + bbox.width, bbox.y],
-                        [bbox.x + bbox.width, bbox.y + bbox.height],
-                        [bbox.x, bbox.y + bbox.height],
-                    ];
-                    const { startAngle, endAngle } = datum;
-                    const sectorBounds = { startAngle, endAngle, innerRadius, outerRadius };
-                    if (corners.every(([x, y]) => isPointInSector(x, y, sectorBounds))) {
-                        isTextVisible = true;
-                    }
+                const bbox = text.computeBBox();
+                const corners = [
+                    [bbox.x, bbox.y],
+                    [bbox.x + bbox.width, bbox.y],
+                    [bbox.x + bbox.width, bbox.y + bbox.height],
+                    [bbox.x, bbox.y + bbox.height],
+                ];
+                const { startAngle, endAngle } = datum;
+                const sectorBounds = { startAngle, endAngle, innerRadius, outerRadius };
+                if (corners.every(([x, y]) => isPointInSector(x, y, sectorBounds))) {
+                    isTextVisible = true;
                 }
             }
             text.visible = isTextVisible;
@@ -1289,13 +1310,16 @@ export class PieSeries extends PolarSeries<PieNodeDatum> {
         } = this;
 
         const { renderer: tooltipRenderer } = tooltip;
-        const color = nodeDatum.sectorFormat.fill;
-        const datum = nodeDatum.datum;
-        const label = calloutLabelKey ? `${datum[calloutLabelKey]}: ` : '';
-        const angleValue = datum[angleKey];
-        const formattedAngleValue = typeof angleValue === 'number' ? toFixed(angleValue) : angleValue.toString();
+        const {
+            datum,
+            angleValue,
+            radiusValue,
+            sectorFormat: { fill: color },
+            calloutLabel: { text: label = '' } = {},
+        } = nodeDatum;
+        const formattedAngleValue = typeof angleValue === 'number' ? toFixed(angleValue) : String(angleValue);
         const title = this.title ? this.title.text : undefined;
-        const content = label + formattedAngleValue;
+        const content = `${label}: ${formattedAngleValue}`;
         const defaults: AgTooltipRendererResult = {
             title,
             backgroundColor: color,
@@ -1310,7 +1334,7 @@ export class PieSeries extends PolarSeries<PieNodeDatum> {
                     angleValue,
                     angleName,
                     radiusKey,
-                    radiusValue: radiusKey ? datum[radiusKey] : undefined,
+                    radiusValue,
                     radiusName,
                     calloutLabelKey,
                     calloutLabelName,
@@ -1328,20 +1352,26 @@ export class PieSeries extends PolarSeries<PieNodeDatum> {
     }
 
     getLegendData(): ChartLegendDatum[] {
-        const { calloutLabelKey, legendItemKey, data, id, sectorFormatData } = this;
+        const { calloutLabelKey, legendItemKey, id, data } = this;
 
-        if (!data || data.length === 0 || (!legendItemKey && !calloutLabelKey)) return [];
+        if (!data || data.length === 0) return [];
+
+        if (!legendItemKey && !calloutLabelKey) return [];
 
         const titleText = this.title && this.title.showInLegend && this.title.text;
         const legendData: CategoryLegendDatum[] = data.map((datum, index) => {
             const labelParts = [];
-            titleText && labelParts.push(titleText);
+            if (titleText) {
+                labelParts.push(titleText);
+            }
+            const labels = this.getLabels(datum, 2 * Math.PI, 2 * Math.PI);
             if (legendItemKey) {
-                labelParts.push(String(datum[legendItemKey]));
+                labelParts.push(String(labels.legendItemKey));
             } else if (calloutLabelKey) {
-                labelParts.push(String(datum[calloutLabelKey]));
+                labelParts.push(labels.calloutLabel?.text);
             }
 
+            const sectorFormat = this.getSectorFormat(datum, index, index, false);
             return {
                 legendType: 'category',
                 id,
@@ -1352,8 +1382,8 @@ export class PieSeries extends PolarSeries<PieNodeDatum> {
                     text: labelParts.join(' - '),
                 },
                 marker: {
-                    fill: sectorFormatData[index].fill!,
-                    stroke: sectorFormatData[index].stroke!,
+                    fill: sectorFormat.fill,
+                    stroke: sectorFormat.stroke,
                     fillOpacity: this.fillOpacity,
                     strokeOpacity: this.strokeOpacity,
                 },
@@ -1427,7 +1457,7 @@ export class PieSeries extends PolarSeries<PieNodeDatum> {
         const rotation = Math.PI / -2 + toRadians(this.rotation);
 
         this.groupSelection.selectByTag<Sector>(PieNodeTag.Sector).forEach((node) => {
-            const { datum } = node;
+            const datum: PieNodeDatum = node.datum;
 
             this.animationManager?.animateMany<number>(
                 `${this.id}_empty-update-ready_${node.id}`,

--- a/charts-community-modules/ag-charts-community/src/chart/series/polar/pieSeries.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/series/polar/pieSeries.ts
@@ -399,9 +399,9 @@ export class PieSeries extends PolarSeries<PieNodeDatum> {
         const extraProps = [];
         if (radiusKey) {
             extraProps.push(
-                rangedValueProperty(radiusKey, { min: this.radiusMin, max: this.radiusMax }),
-                valueProperty(radiusKey, true), // Raw value pass-through.
-                normalisePropertyTo(radiusKey, [0, 1], this.radiusMin, this.radiusMax)
+                rangedValueProperty(radiusKey, { id: 'radiusValue', min: this.radiusMin ?? 0, max: this.radiusMax }),
+                valueProperty(radiusKey, true, { id: `radiusRaw` }), // Raw value pass-through.
+                normalisePropertyTo({ id: 'radiusValue' }, [0, 1], this.radiusMin ?? 0, this.radiusMax)
             );
             extraProps.push();
         }
@@ -410,9 +410,9 @@ export class PieSeries extends PolarSeries<PieNodeDatum> {
 
         this.dataModel = new DataModel<any, any, true>({
             props: [
-                accumulativeValueProperty(angleKey, true),
-                valueProperty(angleKey, true), // Raw value pass-through.
-                normalisePropertyTo(angleKey, [0, 1]),
+                accumulativeValueProperty(angleKey, true, { id: `angleValue` }),
+                valueProperty(angleKey, true, { id: `angleRaw` }), // Raw value pass-through.
+                normalisePropertyTo({ id: 'angleValue' }, [0, 1], 0),
                 ...extraProps,
             ],
         });
@@ -427,12 +427,12 @@ export class PieSeries extends PolarSeries<PieNodeDatum> {
     }
 
     async createNodeData() {
-        const { id: seriesId, processedData, dataModel, rotation, radiusKey, angleScale } = this;
+        const { id: seriesId, processedData, dataModel, rotation, angleScale } = this;
 
         if (!processedData || !dataModel || processedData.type !== 'ungrouped') return [];
 
-        const angleIdx = dataModel.resolveProcessedDataIndex(this.angleKey)?.index ?? -1;
-        const radiusIdx = dataModel.resolveProcessedDataIndex(radiusKey || '')?.index ?? -1;
+        const angleIdx = dataModel.resolveProcessedDataIndexById(`angleValue`)?.index ?? -1;
+        const radiusIdx = dataModel.resolveProcessedDataIndexById(`radiusValue`)?.index ?? -1;
 
         if (angleIdx < 0) return [];
 

--- a/charts-community-modules/ag-charts-community/src/chart/series/polar/polarSeries.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/series/polar/polarSeries.ts
@@ -2,6 +2,7 @@ import { Series, SeriesNodeDatum, SeriesNodeDataContext, SeriesNodePickMode } fr
 import { BBox } from '../../../scene/bbox';
 import { ChartAxisDirection } from '../../chartAxisDirection';
 import { PointLabelDatum } from '../../../util/labelPlacement';
+import { DataModel, ProcessedData } from '../../data/dataModel';
 
 export abstract class PolarSeries<S extends SeriesNodeDatum> extends Series<SeriesNodeDataContext<S>> {
     /**
@@ -20,6 +21,9 @@ export abstract class PolarSeries<S extends SeriesNodeDatum> extends Series<Seri
      */
     radius: number = 0;
 
+    protected dataModel?: DataModel<any, any, any>;
+    protected processedData?: ProcessedData<any>;
+
     constructor({ useLabelLayer = false }) {
         super({
             useLabelLayer,
@@ -35,7 +39,7 @@ export abstract class PolarSeries<S extends SeriesNodeDatum> extends Series<Seri
         return [];
     }
 
-    computeLabelsBBox(_options: { hideWhenNecessary: boolean }, _seriesRect: BBox): BBox | null {
+    async computeLabelsBBox(_options: { hideWhenNecessary: boolean }, _seriesRect: BBox): Promise<BBox | null> {
         return null;
     }
 }

--- a/charts-community-modules/ag-charts-community/src/chart/series/polar/polarSeries.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/series/polar/polarSeries.ts
@@ -39,7 +39,7 @@ export abstract class PolarSeries<S extends SeriesNodeDatum> extends Series<Seri
         return [];
     }
 
-    async computeLabelsBBox(_options: { hideWhenNecessary: boolean }, _seriesRect: BBox): Promise<BBox | null> {
+    computeLabelsBBox(_options: { hideWhenNecessary: boolean }, _seriesRect: BBox): BBox | null {
         return null;
     }
 }

--- a/charts-community-modules/ag-charts-community/src/chart/series/series.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/series/series.ts
@@ -84,8 +84,9 @@ export function valueProperty<K>(propName: K, continuous: boolean, opts = {} as 
 
 export function rangedValueProperty<K>(
     propName: K,
-    { min = -Infinity, max = Infinity }: { min?: number; max?: number }
+    opts = {} as Partial<DatumPropertyDefinition<K>> & { min?: number; max?: number }
 ): DatumPropertyDefinition<K> {
+    const { min = -Infinity, max = Infinity, ...defOpts } = opts;
     return {
         type: 'value',
         property: propName,
@@ -97,6 +98,7 @@ export function rangedValueProperty<K>(
 
             return Math.min(Math.max(datum, min), max);
         },
+        ...defOpts,
     };
 }
 

--- a/charts-community-modules/ag-charts-community/src/chart/series/series.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/series/series.ts
@@ -24,6 +24,7 @@ import { ChartAxisDirection } from '../chartAxisDirection';
 import { AgChartInteractionRange } from '../agChartOptions';
 import { DatumPropertyDefinition, fixNumericExtent } from '../data/dataModel';
 import { TooltipPosition } from '../tooltip/tooltip';
+import { accumulatedValue } from '../data/aggregateFunctions';
 
 /**
  * Processed series datum used in node selections,
@@ -77,6 +78,18 @@ export function valueProperty<K>(propName: K, continuous: boolean, opts = {} as 
         type: 'value',
         valueType: continuous ? 'range' : 'category',
         validation: (v) => checkDatum(v, continuous) != null,
+    };
+    return result;
+}
+
+export function accumulativeValueProperty<K>(
+    propName: K,
+    continuous: boolean,
+    opts = {} as Partial<DatumPropertyDefinition<K>>
+) {
+    const result: DatumPropertyDefinition<K> = {
+        ...valueProperty(propName, continuous, opts),
+        processor: accumulatedValue(),
     };
     return result;
 }

--- a/charts-community-modules/ag-charts-community/src/chart/series/series.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/series/series.ts
@@ -82,6 +82,24 @@ export function valueProperty<K>(propName: K, continuous: boolean, opts = {} as 
     return result;
 }
 
+export function rangedValueProperty<K>(
+    propName: K,
+    { min = -Infinity, max = Infinity }: { min?: number; max?: number }
+): DatumPropertyDefinition<K> {
+    return {
+        type: 'value',
+        property: propName,
+        valueType: 'range',
+        validation: (v) => checkDatum(v, true) != null,
+        processor: () => (datum) => {
+            if (typeof datum !== 'number') return datum;
+            if (isNaN(datum)) return datum;
+
+            return Math.min(Math.max(datum, min), max);
+        },
+    };
+}
+
 export function accumulativeValueProperty<K>(
     propName: K,
     continuous: boolean,

--- a/charts-community-modules/ag-charts-community/src/util/sector.ts
+++ b/charts-community-modules/ag-charts-community/src/util/sector.ts
@@ -33,7 +33,7 @@ export function isPointInSector(x: number, y: number, sector: SectorBoundaries) 
     if (startAngle === (3 * Math.PI) / 2) {
         return angle > endAngle;
     }
-    return angle >= endAngle && angle <= startAngle;
+    return angle <= endAngle && angle >= startAngle;
 }
 
 function lineCollidesSector(line: LineCoordinates, sector: SectorBoundaries) {

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/doc-interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/doc-interfaces.AUTO.json
@@ -5619,15 +5619,21 @@
   },
   "PropertyDefinition": { "meta": { "typeParams": ["K"] } },
   "ProcessorFn": {},
+  "PropertyId": { "meta": { "typeParams": ["K extends string"] } },
   "DatumPropertyDefinition": { "meta": { "typeParams": ["K"] } },
   "InternalDatumPropertyDefinition": { "meta": { "typeParams": ["K"] } },
   "AggregatePropertyDefinition": {
     "meta": {
-      "typeParams": ["D", "K extends keyof D", "R = [number, number]", "R2 = R"]
+      "typeParams": [
+        "D",
+        "K extends keyof D & string",
+        "R = [number, number]",
+        "R2 = R"
+      ]
     }
   },
   "GroupValueProcessorDefinition": {
-    "meta": { "typeParams": ["D", "K extends keyof D"] }
+    "meta": { "typeParams": ["D", "K extends keyof D & string"] }
   },
   "PropertyValueProcessorDefinition": { "meta": { "typeParams": ["D"] } },
   "ReducerOutputPropertyDefinition": { "meta": { "typeParams": ["R"] } },

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/doc-interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/doc-interfaces.AUTO.json
@@ -6195,6 +6195,8 @@
   "PieNodeDatum": {
     "index": { "type": { "returnType": "number", "optional": false } },
     "radius": { "type": { "returnType": "number", "optional": false } },
+    "angleValue": { "type": { "returnType": "number", "optional": false } },
+    "radiusValue": { "type": { "returnType": "number", "optional": true } },
     "startAngle": { "type": { "returnType": "number", "optional": false } },
     "endAngle": { "type": { "returnType": "number", "optional": false } },
     "midAngle": { "type": { "returnType": "number", "optional": false } },
@@ -6213,8 +6215,9 @@
       }
     },
     "sectorFormat": {
-      "type": { "returnType": "AgPieSeriesFormat", "optional": false }
+      "type": { "returnType": "Required<AgPieSeriesFormat>", "optional": false }
     },
+    "legendItemKey": { "type": { "returnType": "string", "optional": true } },
     "series": { "type": { "returnType": "Series<any>", "optional": false } },
     "itemId": { "type": { "returnType": "any", "optional": true } },
     "datum": { "type": { "returnType": "any", "optional": false } },

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
@@ -3697,9 +3697,13 @@
     "meta": { "isTypeAlias": true },
     "type": "(datum: any, previousDatum?: any) => any"
   },
+  "PropertyId": {
+    "meta": { "isTypeAlias": true, "typeParams": ["K extends string"] },
+    "type": "K | { id: string; }"
+  },
   "DatumPropertyDefinition": {
     "meta": { "isTypeAlias": true, "typeParams": ["K"] },
-    "type": "{ type: 'key' | 'value'; valueType: DatumPropertyType; property: K; invalidValue?: any; missingValue?: any; validation?: (datum: any) => boolean; processor?: () => ProcessorFn; }"
+    "type": "{ id?: string; type: 'key' | 'value'; valueType: DatumPropertyType; property: K; invalidValue?: any; missingValue?: any; validation?: (datum: any) => boolean; processor?: () => ProcessorFn; }"
   },
   "InternalDatumPropertyDefinition": {
     "meta": { "isTypeAlias": true, "typeParams": ["K"] },
@@ -3708,25 +3712,33 @@
   "AggregatePropertyDefinition": {
     "meta": {
       "isTypeAlias": true,
-      "typeParams": ["D", "K extends keyof D", "R = [number, number]", "R2 = R"]
+      "typeParams": [
+        "D",
+        "K extends keyof D & string",
+        "R = [number, number]",
+        "R2 = R"
+      ]
     },
-    "type": "{ type: 'aggregate'; aggregateFunction: (values: D[K][], keys?: D[K][]) => R; groupAggregateFunction?: (next?: R, acc?: R2) => R2; finalFunction?: (result: R2) => [ number, number ]; properties: (K | number)[]; }"
+    "type": "{ id?: string; type: 'aggregate'; aggregateFunction: (values: D[K][], keys?: D[K][]) => R; groupAggregateFunction?: (next?: R, acc?: R2) => R2; finalFunction?: (result: R2) => [ number, number ]; properties: PropertyId<K>[]; }"
   },
   "GroupValueProcessorDefinition": {
-    "meta": { "isTypeAlias": true, "typeParams": ["D", "K extends keyof D"] },
-    "type": "{ type: 'group-value-processor'; properties: (K | number)[]; adjust: () => (values: D[K][], indexes: number[]) => void; }"
+    "meta": {
+      "isTypeAlias": true,
+      "typeParams": ["D", "K extends keyof D & string"]
+    },
+    "type": "{ id?: string; type: 'group-value-processor'; properties: PropertyId<K>[]; adjust: () => (values: D[K][], indexes: number[]) => void; }"
   },
   "PropertyValueProcessorDefinition": {
     "meta": { "isTypeAlias": true, "typeParams": ["D"] },
-    "type": "{ type: 'property-value-processor'; property: string | number; adjust: () => (processedData: ProcessedData<D>, valueIndex: number) => void; }"
+    "type": "{ id?: string; type: 'property-value-processor'; property: PropertyId<keyof D & string>; adjust: () => (processedData: ProcessedData<D>, valueIndex: number) => void; }"
   },
   "ReducerOutputPropertyDefinition": {
     "meta": { "isTypeAlias": true, "typeParams": ["R"] },
-    "type": "{ type: 'reducer'; property: string; initialValue?: R; reducer: () => (acc: R, next: UngroupedDataItem<any, any>) => R; }"
+    "type": "{ id?: string; type: 'reducer'; property: string; initialValue?: R; reducer: () => (acc: R, next: UngroupedDataItem<any, any>) => R; }"
   },
   "ProcessorOutputPropertyDefinition": {
     "meta": { "isTypeAlias": true, "typeParams": ["R"] },
-    "type": "{ type: 'processor'; property: string; calculate: (data: ProcessedData<any>) => R; }"
+    "type": "{ id?: string; type: 'processor'; property: string; calculate: (data: ProcessedData<any>) => R; }"
   },
   "Series": {
     "meta": {},

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
@@ -4298,6 +4298,8 @@
     "type": {
       "index": "number",
       "radius": "number",
+      "angleValue": "number",
+      "radiusValue?": "number",
       "startAngle": "number",
       "endAngle": "number",
       "midAngle": "number",
@@ -4305,7 +4307,8 @@
       "midSin": "number",
       "calloutLabel?": "{ readonly text: string; readonly textAlign: CanvasTextAlign; readonly textBaseline: CanvasTextBaseline; hidden: boolean; collisionTextAlign?: CanvasTextAlign; collisionOffsetY: number; box?: BBox; }",
       "sectorLabel?": "{ readonly text: string; }",
-      "sectorFormat": "AgPieSeriesFormat",
+      "sectorFormat": "Required<AgPieSeriesFormat>",
+      "legendItemKey?": "string",
       "series": "Series<any>",
       "itemId?": "any",
       "datum": "any",


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-8403

Integrated use of `DataModel` into `PieSeries`.

Required several `DataModel` improvements:
- Reworked normalisation support to allow for non-zero-based domains (min and max specified by users).
- Updated property references to use ids rather than property keys, allowing multiple uses of the same property key with different aggregation or normalisation functions.
- Debugging of `ProcessedData` via `window.agChartsDebug = 'data-model'`.