### PR TITLE
AG-8603 - Fix legend toggle corrupting seriesItemEnabled tracking.

### DIFF
--- a/charts-community-modules/ag-charts-community/src/chart/axis/axisExamples.test.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/axis/axisExamples.test.ts
@@ -406,7 +406,7 @@ describe('Axis Examples', () => {
                 const reference = await snapshot();
 
                 chart.series.forEach((s) => {
-                    s.toggleSeriesItem(s.getKeys(ChartAxisDirection.Y)[0], true);
+                    (s as any).toggleSeriesItem(s.getKeys(ChartAxisDirection.Y)[0], true);
                 });
                 chart.update(ChartUpdateType.FULL);
 
@@ -414,7 +414,7 @@ describe('Axis Examples', () => {
                 (expect(afterUpdate) as any).not.toMatchImage(reference);
 
                 chart.series.forEach((s) => {
-                    s.toggleSeriesItem(s.getKeys(ChartAxisDirection.Y)[0], false);
+                    (s as any).toggleSeriesItem(s.getKeys(ChartAxisDirection.Y)[0], false);
                 });
                 chart.update(ChartUpdateType.FULL);
 
@@ -440,14 +440,14 @@ describe('Axis Examples', () => {
             expect(chart.series[1].getKeys(ChartAxisDirection.Y)).toEqual(['exportedTonnes']);
 
             // Hide series bound to secondary axis.
-            chart.series[1].toggleSeriesItem('exportedTonnes', false);
+            (chart.series[1] as any).toggleSeriesItem('exportedTonnes', false);
             chart.update(ChartUpdateType.FULL);
 
             const afterUpdate = await snapshot();
             (expect(afterUpdate) as any).not.toMatchImage(reference);
 
             // Show series bound to secondary axis.
-            chart.series[1].toggleSeriesItem('exportedTonnes', true);
+            (chart.series[1] as any).toggleSeriesItem('exportedTonnes', true);
             chart.update(ChartUpdateType.FULL);
 
             const afterFinalUpdate = await snapshot();

--- a/charts-community-modules/ag-charts-community/src/chart/chartAxis.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/chartAxis.ts
@@ -95,11 +95,10 @@ export class ChartAxis<S extends Scale<D, number, TickInterval<S>> = Scale<any, 
             this.dataDomain = this.linkedTo.dataDomain;
         } else {
             const domains: any[][] = [];
-            boundSeries
-                .filter((s) => includeInvisibleDomains || s.isEnabled())
-                .forEach((series) => {
-                    domains.push(series.getDomain(direction));
-                });
+            const visibleSeries = boundSeries.filter((s) => includeInvisibleDomains || s.isEnabled());
+            for (const series of visibleSeries) {
+                domains.push(series.getDomain(direction));
+            }
 
             const domain = new Array<any>().concat(...domains);
             this.dataDomain = this.normaliseDataDomain(domain);

--- a/charts-community-modules/ag-charts-community/src/chart/dataService.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/dataService.ts
@@ -1,7 +1,6 @@
 interface Series {
     id: string;
     type: string;
-    toggleSeriesItem(itemId: string, enabled: boolean): void;
     getLegendData(): any[];
 }
 

--- a/charts-community-modules/ag-charts-community/src/chart/series/cartesian/barSeries.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/series/cartesian/barSeries.ts
@@ -910,8 +910,9 @@ export class BarSeries extends CartesianSeries<SeriesNodeDataContext<BarNodeDatu
     }
 
     onLegendItemClick(event: LegendItemClickChartEvent) {
-        const { itemId, enabled } = event;
+        const { itemId, enabled, series } = event;
 
+        if (series.id !== this.id) return;
         super.toggleSeriesItem(itemId, enabled);
 
         // Toggle items where the legendItemName matches the legendItemName of the clicked item
@@ -927,8 +928,9 @@ export class BarSeries extends CartesianSeries<SeriesNodeDataContext<BarNodeDatu
     }
 
     onLegendItemDoubleClick(event: LegendItemDoubleClickChartEvent) {
-        const { enabled, itemId, numVisibleItems } = event;
+        const { enabled, itemId, numVisibleItems, series } = event;
 
+        if (series.id !== this.id) return;
         const totalVisibleItems = Object.values(numVisibleItems).reduce((p, v) => p + v, 0);
         const singleEnabledInEachSeries =
             Object.values(numVisibleItems).filter((v) => v === 1).length === Object.keys(numVisibleItems).length;

--- a/charts-community-modules/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
@@ -602,14 +602,14 @@ export abstract class CartesianSeries<
     onLegendItemClick(event: LegendItemClickChartEvent) {
         const { enabled, itemId, series } = event;
 
-        if (series.id === this.id) {
-            this.toggleSeriesItem(itemId, enabled);
-        }
+        if (series.id !== this.id) return;
+        this.toggleSeriesItem(itemId, enabled);
     }
 
     onLegendItemDoubleClick(event: LegendItemDoubleClickChartEvent) {
         const { enabled, itemId, series, numVisibleItems } = event;
 
+        if (series.id !== this.id) return;
         const totalVisibleItems = Object.values(numVisibleItems).reduce((p, v) => p + v, 0);
 
         const wasClicked = series.id === this.id;
@@ -618,7 +618,7 @@ export abstract class CartesianSeries<
         this.toggleSeriesItem(itemId, newEnabled);
     }
 
-    toggleSeriesItem(itemId: string, enabled: boolean): void {
+    protected toggleSeriesItem(itemId: string, enabled: boolean): void {
         if (this.seriesItemEnabled.size > 0) {
             this.seriesItemEnabled.set(itemId, enabled);
             this.nodeDataRefresh = true;

--- a/charts-community-modules/ag-charts-community/src/chart/series/polar/pieSeries.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/series/polar/pieSeries.ts
@@ -1452,7 +1452,7 @@ export class PieSeries extends PolarSeries<PieNodeDatum> {
         });
     }
 
-    toggleSeriesItem(itemId: number, enabled: boolean): void {
+    protected toggleSeriesItem(itemId: number, enabled: boolean): void {
         this.seriesItemEnabled[itemId] = enabled;
         this.nodeDataRefresh = true;
     }

--- a/charts-community-modules/ag-charts-community/src/chart/series/polar/polarSeries.test.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/series/polar/polarSeries.test.ts
@@ -153,7 +153,7 @@ describe('PolarSeries', () => {
             const reference = await snapshot();
 
             options.data?.forEach((_, idx) => {
-                chart.series[0].toggleSeriesItem(idx, false);
+                (chart.series[0] as any).toggleSeriesItem(idx, false);
             });
             chart.update(ChartUpdateType.FULL);
 
@@ -161,7 +161,7 @@ describe('PolarSeries', () => {
             (expect(afterUpdate) as any).not.toMatchImage(reference);
 
             options.data?.forEach((_, idx) => {
-                chart.series[0].toggleSeriesItem(idx, true);
+                (chart.series[0] as any).toggleSeriesItem(idx, true);
             });
             chart.update(ChartUpdateType.FULL);
 

--- a/charts-community-modules/ag-charts-community/src/chart/series/series.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/series/series.ts
@@ -561,7 +561,7 @@ export abstract class Series<C extends SeriesNodeDataContext = SeriesNodeDataCon
 
     abstract getLegendData(): ChartLegendDatum[];
 
-    toggleSeriesItem(_itemId: any, enabled: boolean): void {
+    protected toggleSeriesItem(_itemId: any, enabled: boolean): void {
         this.visible = enabled;
         this.nodeDataRefresh = true;
     }

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/doc-interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/doc-interfaces.AUTO.json
@@ -5642,13 +5642,6 @@
   "Series": {
     "id": { "type": { "returnType": "string", "optional": false } },
     "type": { "type": { "returnType": "string", "optional": false } },
-    "toggleSeriesItem": {
-      "type": {
-        "arguments": { "itemId": "string", "enabled": "boolean" },
-        "returnType": "void",
-        "optional": false
-      }
-    },
     "getLegendData": {
       "type": { "arguments": {}, "returnType": "any[]", "optional": false }
     }

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
@@ -3746,12 +3746,7 @@
   },
   "Series": {
     "meta": {},
-    "type": {
-      "id": "string",
-      "type": "string",
-      "toggleSeriesItem(itemId: string, enabled: boolean)": "void",
-      "getLegendData()": "any[]"
-    }
+    "type": { "id": "string", "type": "string", "getLegendData()": "any[]" }
   },
   "SeriesGetter": { "meta": { "isTypeAlias": true }, "type": "() => Series[]" },
   "ChartType": {


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-8603

Fixes corruption of `Series.seriesItemsEnabled` on legend toggle, which leads to side-effects such as axis labels being displayed even when there are no bound-series displayed.

Bonus:
- I made `Series.toggleSeriesItem()` protected since it no longer need to be exposed to `Legend`, a couple of tests use it but I'd rather lock it down and workaround in those situations.