### PR TITLE
AG-8543 AG-8544 Fix no data overlay to re-use existing component

### DIFF
--- a/charts-community-modules/ag-charts-community/src/chart/chart.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/chart.ts
@@ -367,6 +367,7 @@ export abstract class Chart extends Observable implements AgChartInstance {
         this.tooltipManager.destroy();
         this.tooltip.destroy();
         this.legend?.destroy();
+        this.overlays.noData.hide();
         SizeMonitor.unobserve(this.element);
 
         for (const [key, module] of Object.entries(this.modules)) {


### PR DESCRIPTION
PR for https://ag-grid.atlassian.net/browse/AG-8543 and https://ag-grid.atlassian.net/browse/AG-8544

The issue was that when `updateDelta()` is called it runs the chart constructor again so the overlays manager loses track of the no data overlay element. This fixes that by finding it each time from the class as a child of the parent.