### PR TITLE
AG-7112 - Add axis title formatter.

### DIFF
--- a/charts-community-modules/ag-charts-community/src/axis.ts
+++ b/charts-community-modules/ag-charts-community/src/axis.ts
@@ -561,7 +561,7 @@ export abstract class Axis<S extends Scale<D, number, TickInterval<S>>, D = any>
         }
     }
 
-    protected title: AxisTitle | undefined = undefined;
+    public title: AxisTitle | undefined = undefined;
     protected _titleCaption = new Caption();
 
     private setDomain() {
@@ -1413,6 +1413,7 @@ export abstract class Axis<S extends Scale<D, number, TickInterval<S>>, D = any>
         _titleCaption.fontSize = title.fontSize;
         _titleCaption.fontStyle = title.fontStyle;
         _titleCaption.fontWeight = title.fontWeight;
+        _titleCaption.color = title.color;
         _titleCaption.wrapping = title.wrapping;
 
         let titleVisible = false;

--- a/charts-community-modules/ag-charts-community/src/chart/agChartOptions.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/agChartOptions.ts
@@ -302,6 +302,15 @@ export interface AgChartCaptionOptions {
 export interface AgChartSubtitleOptions extends AgChartCaptionOptions {}
 export interface AgChartFooterOptions extends AgChartCaptionOptions {}
 
+export interface AgAxisCaptionFormatterParams {
+    /** Default value to be used for the axis title (as specified in chart options or theme). */
+    value?: string;
+    /** Keys bound to the axis the title belongs to. */
+    direction: 'x' | 'y';
+    /** Keys bound to the axis the title belongs to. */
+    keys: string[];
+}
+
 export interface AgAxisCaptionOptions {
     /** Whether or not the title should be shown. */
     enabled?: boolean;
@@ -317,6 +326,8 @@ export interface AgAxisCaptionOptions {
     fontFamily?: FontFamily;
     /** The colour to use for the title. */
     color?: CssColor;
+    /** Formatter to allow dynamic axis title calculation. */
+    formatter?: (params: AgAxisCaptionFormatterParams) => string;
 }
 
 export interface AgNavigatorMaskOptions {

--- a/charts-community-modules/ag-charts-community/src/chart/agChartOptions.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/agChartOptions.ts
@@ -305,7 +305,7 @@ export interface AgChartFooterOptions extends AgChartCaptionOptions {}
 export interface AgAxisCaptionFormatterParams {
     /** Default value to be used for the axis title (as specified in chart options or theme). */
     value?: string;
-    /** Keys bound to the axis the title belongs to. */
+    /** Direction of the axis the title belongs to. */
     direction: 'x' | 'y';
     /** Keys bound to the axis the title belongs to. */
     keys: string[];

--- a/charts-community-modules/ag-charts-community/src/chart/axis/groupedCategoryAxis.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/axis/groupedCategoryAxis.ts
@@ -13,6 +13,7 @@ import { Point } from '../../scene/point';
 import { BOOLEAN, OPT_COLOR_STRING, Validate } from '../../util/validation';
 import { calculateLabelRotation } from '../label';
 import { ModuleContext } from '../../util/module';
+import { AgAxisCaptionFormatterParams } from '../agChartOptions';
 
 class GroupedCategoryAxisLabel extends AxisLabel {
     @Validate(BOOLEAN)
@@ -191,6 +192,9 @@ export class GroupedCategoryAxis extends ChartAxis<BandScale<string | number>> {
             label: { parallel },
             tickScale,
             requestedRange,
+            title,
+            title: { formatter = (p: AgAxisCaptionFormatterParams) => p.value } = {},
+            _titleCaption,
         } = this;
 
         const rangeStart = scale.range[0];
@@ -203,12 +207,9 @@ export class GroupedCategoryAxis extends ChartAxis<BandScale<string | number>> {
 
         this.updatePosition({ rotation, sideFlag });
 
-        const title = this.title;
         // The Text `node` of the Caption is not used to render the title of the grouped category axis.
         // The phantom root of the tree layout is used instead.
-        if (title) {
-            title.node.visible = false;
-        }
+        _titleCaption.node.visible = false;
         const lineHeight = this.lineHeight;
 
         // Render ticks and labels.
@@ -254,7 +255,7 @@ export class GroupedCategoryAxis extends ChartAxis<BandScale<string | number>> {
                 // use the phantom root as the axis title
                 if (title?.enabled && labels.length > 0) {
                     node.visible = true;
-                    node.text = title.text;
+                    node.text = formatter(this.getTitleFormatterParams());
                     node.fontSize = title.fontSize;
                     node.fontStyle = title.fontStyle;
                     node.fontWeight = title.fontWeight;

--- a/charts-community-modules/ag-charts-community/src/chart/chartAxis.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/chartAxis.ts
@@ -180,4 +180,12 @@ export class ChartAxis<S extends Scale<D, number, TickInterval<S>> = Scale<any, 
             delete (this as any)[key];
         }
     }
+
+    protected getTitleFormatterParams() {
+        return {
+            direction: this.direction,
+            keys: this.boundSeries.reduce((acc, next) => [...acc, ...next.getKeys(this.direction)], [] as string[]),
+            value: this.title?.text,
+        };
+    }
 }

--- a/charts-community-modules/ag-charts-community/src/chart/chartOptions.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/chartOptions.ts
@@ -1,3 +1,4 @@
+import { AxisTitle } from '../axis';
 import { Caption } from '../caption';
 import { DropShadow } from '../scene/dropShadow';
 import { JsonApplyParams } from '../util/json';
@@ -16,6 +17,7 @@ const JSON_APPLY_OPTIONS: JsonApplyParams = {
         shadow: DropShadow,
         innerCircle: DoughnutInnerCircle,
         'axes[].crossLines[]': CrossLine,
+        'axes[].title': AxisTitle,
         'series[].innerLabels[]': DoughnutInnerLabel,
     },
     allowedTypes: {

--- a/charts-community-modules/ag-charts-community/src/util/json.ts
+++ b/charts-community-modules/ag-charts-community/src/util/json.ts
@@ -287,7 +287,7 @@ export function jsonApply<Target, Source extends DeepPartial<Target>>(
         const propertyPath = `${path ? path + '.' : ''}${property}`;
         const targetClass = targetAny.constructor;
         const currentValue = targetAny[property];
-        let ctr = constructors[property] ?? constructors[propertyMatcherPath];
+        let ctr = constructors[propertyMatcherPath] ?? constructors[property];
         try {
             const currentValueType = classify(currentValue);
             const newValueType = classify(newValue);


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-7112

Adds support for `axes[].title.formatter` callback function, allowing dynamic chart-axis title calculation. The primary use-case is Integrated Charts customisation.