### PR TITLE
AG-7112 - Extend axis formatter params

### DIFF
--- a/charts-community-modules/ag-charts-community/src/axis.ts
+++ b/charts-community-modules/ag-charts-community/src/axis.ts
@@ -1384,7 +1384,7 @@ export abstract class Axis<S extends Scale<D, number, TickInterval<S>>, D = any>
     }
 
     private updateTitle({ anyTickVisible, sideFlag }: { anyTickVisible: boolean; sideFlag: Flag }): void {
-        const identityFormatter = (params: { value?: string }) => params.value;
+        const identityFormatter = (params: AgAxisCaptionFormatterParams) => params.defaultValue;
         const { rotation, title, _titleCaption, lineNode, range: requestedRange, tickLineGroup, tickLabelGroup } = this;
         const { formatter = identityFormatter } = this.title ?? {};
 

--- a/charts-community-modules/ag-charts-community/src/chart/agChartOptions.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/agChartOptions.ts
@@ -306,7 +306,7 @@ export interface AgChartFooterOptions extends AgChartCaptionOptions {}
 export interface AgAxisBoundSeries {
     /** Key used by the series for values on the related axis. */
     key: string;
-    /** Optional name used by the series for values on the enclosing axis. */
+    /** Optional name used by the series for values on the related axis. */
     name?: string;
 }
 

--- a/charts-community-modules/ag-charts-community/src/chart/agChartOptions.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/agChartOptions.ts
@@ -302,13 +302,21 @@ export interface AgChartCaptionOptions {
 export interface AgChartSubtitleOptions extends AgChartCaptionOptions {}
 export interface AgChartFooterOptions extends AgChartCaptionOptions {}
 
+/** Metadata about a series bound to an axis. */
+export interface AgAxisBoundSeries {
+    /** Key used by the series for values on the related axis. */
+    key: string;
+    /** Optional name used by the series for values on the enclosing axis. */
+    name?: string;
+}
+
 export interface AgAxisCaptionFormatterParams {
     /** Default value to be used for the axis title (as specified in chart options or theme). */
-    value?: string;
+    defaultValue?: string;
     /** Direction of the axis the title belongs to. */
     direction: 'x' | 'y';
-    /** Keys bound to the axis the title belongs to. */
-    keys: string[];
+    /** Metadata about series bound to the axis the title belongs to. */
+    boundSeries: AgAxisBoundSeries[];
 }
 
 export interface AgAxisCaptionOptions {

--- a/charts-community-modules/ag-charts-community/src/chart/axis/groupedCategoryAxis.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/axis/groupedCategoryAxis.ts
@@ -187,7 +187,7 @@ export class GroupedCategoryAxis extends ChartAxis<BandScale<string | number>> {
             tickScale,
             range: requestedRange,
             title,
-            title: { formatter = (p: AgAxisCaptionFormatterParams) => p.value } = {},
+            title: { formatter = (p: AgAxisCaptionFormatterParams) => p.defaultValue } = {},
             _titleCaption,
         } = this;
 

--- a/charts-community-modules/ag-charts-community/src/chart/chartAxis.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/chartAxis.ts
@@ -4,7 +4,7 @@ import { ChartAxisDirection } from './chartAxisDirection';
 import { LinearScale } from '../scale/linearScale';
 import { ContinuousScale } from '../scale/continuousScale';
 import { POSITION, STRING_ARRAY, Validate } from '../util/validation';
-import { AgCartesianAxisPosition, AgCartesianAxisType } from './agChartOptions';
+import { AgAxisCaptionFormatterParams, AgCartesianAxisPosition, AgCartesianAxisType } from './agChartOptions';
 import { AxisLayout } from './layout/layoutService';
 import { AxisContext, AxisModule, ModuleContext, ModuleInstance } from '../util/module';
 
@@ -13,6 +13,7 @@ interface BoundSeries {
     getDomain(direction: ChartAxisDirection): any[];
     isEnabled(): boolean;
     getKeys(direction: ChartAxisDirection): string[];
+    getNames(direction: ChartAxisDirection): (string | undefined)[];
     visible: boolean;
     getBandScalePadding?(): { inner: number; outer: number };
 }
@@ -182,10 +183,21 @@ export class ChartAxis<S extends Scale<D, number, TickInterval<S>> = Scale<any, 
     }
 
     protected getTitleFormatterParams() {
+        const boundSeries = this.boundSeries.reduce((acc, next) => {
+            const keys = next.getKeys(this.direction);
+            const names = next.getNames(this.direction);
+            for (let idx = 0; idx < keys.length; idx++) {
+                acc.push({
+                    key: keys[idx],
+                    name: names[idx],
+                });
+            }
+            return acc;
+        }, [] as AgAxisCaptionFormatterParams['boundSeries']);
         return {
             direction: this.direction,
-            keys: this.boundSeries.reduce((acc, next) => [...acc, ...next.getKeys(this.direction)], [] as string[]),
-            value: this.title?.text,
+            boundSeries,
+            defaultValue: this.title?.text,
         };
     }
 }

--- a/charts-community-modules/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
@@ -146,8 +146,12 @@ export class AreaSeries extends CartesianSeries<AreaSeriesNodeDataContext> {
             pathsZIndexSubOrderOffset: [0, 1000],
             hasMarkers: true,
             directionKeys: {
-                x: ['xKey'],
-                y: ['yKeys'],
+                [ChartAxisDirection.X]: ['xKey'],
+                [ChartAxisDirection.Y]: ['yKeys'],
+            },
+            directionNames: {
+                [ChartAxisDirection.X]: ['xName'],
+                [ChartAxisDirection.Y]: ['yNames'],
             },
         });
 

--- a/charts-community-modules/ag-charts-community/src/chart/series/cartesian/barSeries.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/series/cartesian/barSeries.ts
@@ -142,6 +142,10 @@ export class BarSeries extends CartesianSeries<SeriesNodeDataContext<BarNodeDatu
                 [ChartAxisDirection.X]: ['xKey'],
                 [ChartAxisDirection.Y]: ['yKeys'],
             },
+            directionNames: {
+                [ChartAxisDirection.X]: ['xName'],
+                [ChartAxisDirection.Y]: ['yNames'],
+            },
         });
 
         this.label.enabled = false;

--- a/charts-community-modules/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
@@ -64,6 +64,11 @@ const DEFAULT_DIRECTION_KEYS: { [key in ChartAxisDirection]?: string[] } = {
     [ChartAxisDirection.Y]: ['yKey'],
 };
 
+const DEFAULT_DIRECTION_NAMES: { [key in ChartAxisDirection]?: string[] } = {
+    [ChartAxisDirection.X]: ['xName'],
+    [ChartAxisDirection.Y]: ['yName'],
+};
+
 export class CartesianSeriesNodeBaseClickEvent<Datum extends { datum: any }> extends SeriesNodeBaseClickEvent<Datum> {
     readonly xKey: string;
     readonly yKey: string;
@@ -127,12 +132,14 @@ export abstract class CartesianSeries<
         opts: Partial<SeriesOpts> & {
             pickModes?: SeriesNodePickMode[];
             directionKeys?: { [key in ChartAxisDirection]?: string[] };
+            directionNames?: { [key in ChartAxisDirection]?: string[] };
         } = {}
     ) {
         super({
             useSeriesGroupLayer: true,
             pickModes: opts.pickModes,
             directionKeys: opts.directionKeys ?? DEFAULT_DIRECTION_KEYS,
+            directionNames: opts.directionNames ?? DEFAULT_DIRECTION_NAMES,
         });
 
         const { pathsPerSeries = 1, hasMarkers = false, pathsZIndexSubOrderOffset = [] } = opts;

--- a/charts-community-modules/ag-charts-community/src/chart/series/polar/polarSeries.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/series/polar/polarSeries.ts
@@ -32,6 +32,10 @@ export abstract class PolarSeries<S extends SeriesNodeDatum> extends Series<Seri
                 [ChartAxisDirection.X]: ['angleKey'],
                 [ChartAxisDirection.Y]: ['radiusKey'],
             },
+            directionNames: {
+                [ChartAxisDirection.X]: ['angleName'],
+                [ChartAxisDirection.Y]: ['radiusName'],
+            },
         });
     }
 

--- a/charts-enterprise-modules/ag-charts-enterprise/src/waterfall/waterfallSeries.ts
+++ b/charts-enterprise-modules/ag-charts-enterprise/src/waterfall/waterfallSeries.ts
@@ -160,6 +160,10 @@ export class WaterfallSeries extends _ModuleSupport.CartesianSeries<
                 [ChartAxisDirection.X]: ['xKey'],
                 [ChartAxisDirection.Y]: ['yKey'],
             },
+            directionNames: {
+                [ChartAxisDirection.X]: ['xName'],
+                [ChartAxisDirection.Y]: ['yName'],
+            },
         });
 
         this.label.enabled = false;


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-7112

Adds `xName` + `yName` to title formatter params, restructures params to better accommodate this.

Bonus: Fix for Docker test execution response to `ctrl+c`.