### PR TITLE
AG-6613 - Split Bar and Column option typings.

### DIFF
--- a/charts-community-modules/ag-charts-community/src/chart/agChartOptions.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/agChartOptions.ts
@@ -191,7 +191,7 @@ export interface AgCartesianSeriesTheme {
     scatter?: AgScatterSeriesOptions;
     area?: AgAreaSeriesOptions;
     bar?: AgBarSeriesOptions;
-    column?: AgBarSeriesOptions;
+    column?: AgColumnSeriesOptions;
     histogram?: AgHistogramSeriesOptions;
 }
 
@@ -1328,9 +1328,9 @@ export interface AgBarSeriesTooltip extends AgSeriesTooltip {
     renderer?: (params: AgBarSeriesTooltipRendererParams) => string | AgTooltipRendererResult;
 }
 
-/** Configuration for bar/column series. */
+/** Configuration for bar series. */
 export interface AgBarSeriesOptions<DatumType = any> extends AgBaseSeriesOptions<DatumType> {
-    type?: 'bar' | 'column';
+    type?: 'bar';
     /** Whether to show different y-values as separate bars (grouped) or not (stacked). */
     grouped?: boolean;
     /** An option indicating if the bars/columns should be stacked. */
@@ -1371,6 +1371,87 @@ export interface AgBarSeriesOptions<DatumType = any> extends AgBaseSeriesOptions
     tooltip?: AgBarSeriesTooltip;
     /** Function used to return formatting for individual bars/columns, based on the given parameters. If the current bar/column is highlighted, the `highlighted` property will be set to `true`; make sure to check this if you want to differentiate between the highlighted and un-highlighted states. */
     formatter?: (params: AgBarSeriesFormatterParams<DatumType>) => AgBarSeriesFormat;
+    /** A map of event names to event listeners. */
+    listeners?: AgSeriesListeners<DatumType>;
+}
+
+export type AgColumnSeriesLabelPlacement = 'inside' | 'outside';
+
+export interface AgColumnSeriesLabelOptions extends AgCartesianSeriesLabelOptions {
+    /** Where to render series labels relative to the segments. */
+    placement?: AgColumnSeriesLabelPlacement;
+}
+
+export interface AgColumnSeriesFormatterParams<DatumType> {
+    readonly datum: DatumType;
+    readonly fill?: CssColor;
+    readonly stroke?: CssColor;
+    readonly strokeWidth: PixelSize;
+    readonly highlighted: boolean;
+    readonly xKey: string;
+    readonly yKey: string;
+    readonly seriesId: string;
+    readonly stackGroup?: string;
+}
+
+export interface AgColumnSeriesFormat {
+    fill?: CssColor;
+    stroke?: CssColor;
+    strokeWidth?: PixelSize;
+}
+
+export interface AgColumnSeriesTooltipRendererParams extends AgCartesianSeriesTooltipRendererParams {
+    readonly stackGroup?: string;
+}
+
+export interface AgColumnSeriesTooltip extends AgSeriesTooltip {
+    /** Function used to create the content for tooltips. */
+    renderer?: (params: AgColumnSeriesTooltipRendererParams) => string | AgTooltipRendererResult;
+}
+
+/** Configuration for column series. */
+export interface AgColumnSeriesOptions<DatumType = any> extends AgBaseSeriesOptions<DatumType> {
+    type?: 'column';
+    /** Whether to show different y-values as separate bars (grouped) or not (stacked). */
+    grouped?: boolean;
+    /** An option indicating if the bars/columns should be stacked. */
+    stacked?: boolean;
+    /** An ID to be used to group stacked items. */
+    stackGroup?: string;
+    /** The number to normalise the bar stacks to. Has no effect when `grouped` is `true`. For example, if `normalizedTo` is set to `100`, the bar stacks will all be scaled proportionally so that each of their totals is 100. */
+    normalizedTo?: number;
+    /** The key to use to retrieve x-values from the data. */
+    xKey?: string;
+    /** The key to use to retrieve y-values from the data. */
+    yKey?: string;
+    /** A human-readable description of the x-values. If supplied, this will be shown in the default tooltip and passed to the tooltip renderer as one of the parameters. */
+    xName?: string;
+    /** Human-readable description of the y-values. If supplied, a corresponding `yName` will be shown in the default tooltip and passed to the tooltip renderer as one of the parameters. */
+    yName?: string;
+    /** Human-readable description of the y-values. If supplied, matching items with the same value will be toggled together. */
+    legendItemName?: string;
+    /** The colour to use for the fill of the bars. */
+    fill?: CssColor;
+    /** The colours to use for the stroke of the bars. */
+    stroke?: CssColor;
+    /** The width in pixels of the stroke for the bars. */
+    strokeWidth?: PixelSize;
+    /** The opacity of the fill for the bars. */
+    fillOpacity?: Opacity;
+    /** The opacity of the stroke for the bars. */
+    strokeOpacity?: Opacity;
+    /** Defines how the bar/column strokes are rendered. Every number in the array specifies the length in pixels of alternating dashes and gaps. For example, `[6, 3]` means dashes with a length of `6` pixels with gaps between of `3` pixels. */
+    lineDash?: PixelSize[];
+    /** The initial offset of the dashed line in pixels. */
+    lineDashOffset?: PixelSize;
+    /** Configuration for the shadow used behind the chart series. */
+    shadow?: AgDropShadowOptions;
+    /** Configuration for the labels shown on bars. */
+    label?: AgColumnSeriesLabelOptions;
+    /** Series-specific tooltip configuration. */
+    tooltip?: AgColumnSeriesTooltip;
+    /** Function used to return formatting for individual bars/columns, based on the given parameters. If the current bar/column is highlighted, the `highlighted` property will be set to `true`; make sure to check this if you want to differentiate between the highlighted and un-highlighted states. */
+    formatter?: (params: AgColumnSeriesFormatterParams<DatumType>) => AgColumnSeriesFormat;
     /** A map of event names to event listeners. */
     listeners?: AgSeriesListeners<DatumType>;
 }
@@ -1843,6 +1924,7 @@ export type AgCartesianSeriesOptions<TAddon = never> =
     | AgScatterSeriesOptions
     | AgAreaSeriesOptions
     | AgBarSeriesOptions
+    | AgColumnSeriesOptions
     | AgHistogramSeriesOptions
     | TAddon;
 

--- a/charts-community-modules/ag-charts-community/src/chart/agChartV2.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/agChartV2.ts
@@ -11,6 +11,7 @@ import {
     AgTreemapSeriesOptions,
     AgChartInstance,
     AgBaseAxisOptions,
+    AgColumnSeriesOptions,
 } from './agChartOptions';
 import { CartesianChart } from './cartesianChart';
 import { PolarChart } from './polarChart';
@@ -18,7 +19,7 @@ import { HierarchyChart } from './hierarchyChart';
 import { Series } from './series/series';
 import { getSeries } from './factory/seriesTypes';
 import { AreaSeries } from './series/cartesian/areaSeries';
-import { BarSeries } from './series/cartesian/barSeries';
+import { BarSeries, ColumnSeries } from './series/cartesian/barSeries';
 import { HistogramSeries } from './series/cartesian/histogramSeries';
 import { LineSeries } from './series/cartesian/lineSeries';
 import { ScatterSeries } from './series/cartesian/scatterSeries';
@@ -56,6 +57,8 @@ type SeriesOptionType<T extends Series> = T extends LineSeries
     ? AgLineSeriesOptions
     : T extends BarSeries
     ? AgBarSeriesOptions
+    : T extends ColumnSeries
+    ? AgColumnSeriesOptions
     : T extends AreaSeries
     ? AgAreaSeriesOptions
     : T extends ScatterSeries

--- a/charts-community-modules/ag-charts-community/src/chart/chart.test.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/chart.test.ts
@@ -6,9 +6,9 @@ import { Rect } from '../scene/shape/rect';
 import { Sector } from '../scene/shape/sector';
 import {
     AgAreaSeriesOptions,
-    AgBarSeriesOptions,
     AgCartesianChartOptions,
     AgChartInteractionRange,
+    AgColumnSeriesOptions,
     AgLineSeriesOptions,
     AgPieSeriesOptions,
     AgPolarChartOptions,
@@ -309,7 +309,7 @@ describe('Chart', () => {
     describe(`Column Series Pointer Events`, () => {
         testPointerEvents({
             ...cartesianTestParams,
-            seriesOptions: <AgBarSeriesOptions>{
+            seriesOptions: <AgColumnSeriesOptions>{
                 type: 'column',
                 data: datasets.economy.data,
                 xKey: datasets.economy.categoryKey,

--- a/charts-community-modules/ag-charts-community/src/chart/mapping/prepareSeries.test.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/mapping/prepareSeries.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, test } from '@jest/globals';
 import 'jest-canvas-mock';
 import { groupSeriesByType, reduceSeries, processSeriesOptions } from './prepareSeries';
-import { AgBarSeriesOptions, AgLineSeriesOptions } from '../agChartOptions';
+import { AgColumnSeriesOptions, AgLineSeriesOptions } from '../agChartOptions';
 
-const colSeriesIPhone: AgBarSeriesOptions = {
+const colSeriesIPhone: AgColumnSeriesOptions = {
     type: 'column',
     xKey: 'quarter',
     yKey: 'iphone',
@@ -15,7 +15,7 @@ const lineSeriesMac: AgLineSeriesOptions = {
     yKey: 'mac',
     yName: 'Mac',
 };
-const colSeriesMac: AgBarSeriesOptions = {
+const colSeriesMac: AgColumnSeriesOptions = {
     type: 'column',
     xKey: 'quarter',
     yKey: 'mac',
@@ -27,20 +27,20 @@ const lineSeriesIPhone: AgLineSeriesOptions = {
     yKey: 'iphone',
     yName: 'iPhone',
 };
-const colSeriesWearables: AgBarSeriesOptions = {
+const colSeriesWearables: AgColumnSeriesOptions = {
     type: 'column',
     xKey: 'quarter',
     yKey: 'wearables',
     yName: 'Wearables',
 };
-const colSeriesServices: AgBarSeriesOptions = {
+const colSeriesServices: AgColumnSeriesOptions = {
     type: 'column',
     xKey: 'quarter',
     yKey: 'services',
     yName: 'Services',
 };
 
-const seriesOptions: Array<AgBarSeriesOptions | AgLineSeriesOptions> = [
+const seriesOptions: Array<AgColumnSeriesOptions | AgLineSeriesOptions> = [
     {
         ...colSeriesIPhone,
         fill: 'pink',

--- a/charts-community-modules/ag-charts-community/src/chart/mapping/transforms.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/mapping/transforms.ts
@@ -7,6 +7,7 @@ import {
     AgPieSeriesOptions,
     AgScatterSeriesOptions,
     AgTreemapSeriesOptions,
+    AgColumnSeriesOptions,
 } from '../agChartOptions';
 
 type Transforms<
@@ -113,13 +114,27 @@ function barSeriesTransform<T extends AgBarSeriesOptions>(options: T): T {
     }) as T;
 }
 
+function columnSeriesTransform<T extends AgColumnSeriesOptions>(options: T): T {
+    const result = {
+        ...options,
+    };
+    delete result['yKey'];
+    delete result['yName'];
+
+    return transform(result, {
+        yNames: yNamesMapping,
+        yKeys: yKeysMapping,
+        legendItemNames: legendItemNamesMapping,
+    }) as T;
+}
+
 type SeriesTypes = NonNullable<AgChartOptions['series']>[number];
 type SeriesType<T extends SeriesTypes['type']> = T extends 'area'
     ? AgAreaSeriesOptions
     : T extends 'bar'
     ? AgBarSeriesOptions
     : T extends 'column'
-    ? AgBarSeriesOptions
+    ? AgColumnSeriesOptions
     : T extends 'histogram'
     ? AgHistogramSeriesOptions
     : T extends 'line'
@@ -140,7 +155,7 @@ const SERIES_TRANSFORMS: {
 } = {
     area: identityTransform,
     bar: barSeriesTransform,
-    column: barSeriesTransform,
+    column: columnSeriesTransform,
     histogram: identityTransform,
     line: identityTransform,
     pie: identityTransform,

--- a/charts-enterprise-modules/ag-charts-enterprise/src/crosshair/crosshair.test.ts
+++ b/charts-enterprise-modules/ag-charts-enterprise/src/crosshair/crosshair.test.ts
@@ -7,6 +7,7 @@ import {
     AgCartesianAxisOptions,
     AgBarSeriesOptions,
     AgAreaSeriesOptions,
+    AgColumnSeriesOptions,
 } from 'ag-charts-community';
 
 import { AgEnterpriseCharts, _ModuleSupport } from '../main';
@@ -157,7 +158,7 @@ const SIMPLE_LINE_OPTIONS: AgCartesianChartOptions = {
 const SIMPLE_COLUMN_OPTIONS: AgCartesianChartOptions = {
     ...BASE_OPTIONS,
     axes: CATEGORY_AXIS_OPTIONS,
-    series: BASE_OPTIONS.series?.map((s) => ({ ...s, type: 'column' })) as AgBarSeriesOptions[],
+    series: BASE_OPTIONS.series?.map((s) => ({ ...s, type: 'column' })) as AgColumnSeriesOptions[],
 };
 
 const LINE_SECONDARY_AXIS_OPTIONS: AgCartesianChartOptions = {
@@ -168,13 +169,13 @@ const LINE_SECONDARY_AXIS_OPTIONS: AgCartesianChartOptions = {
 const STACKED_COLUMN_OPTIONS: AgCartesianChartOptions = {
     ...BASE_OPTIONS,
     axes: SIMPLE_AXIS_OPTIONS,
-    series: BASE_OPTIONS.series?.map((s) => ({ ...s, type: 'column', stacked: true })) as AgBarSeriesOptions[],
+    series: BASE_OPTIONS.series?.map((s) => ({ ...s, type: 'column', stacked: true })) as AgColumnSeriesOptions[],
 };
 
 const GROUPED_COLUMN_OPTIONS: AgCartesianChartOptions = {
     ...BASE_OPTIONS,
     axes: CATEGORY_AXIS_OPTIONS,
-    series: BASE_OPTIONS.series?.map((s) => ({ ...s, type: 'column', stacked: false })) as AgBarSeriesOptions[],
+    series: BASE_OPTIONS.series?.map((s) => ({ ...s, type: 'column', stacked: false })) as AgColumnSeriesOptions[],
 };
 
 const STACKED_BAR_OPTIONS: AgCartesianChartOptions = {

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api-create-update/index.md
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api-create-update/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Create/Update"
 ---
+
 Learn about creating and updating charts in more detail.
 
 ## Creating and Updating Charts
@@ -36,47 +37,48 @@ to, not a partial configuration. Use `AgChart.updateDelta()` to apply partial up
 See the [Options Reference](/charts-api/) for more detail about the `AgChartOptions` structure.
 
 The following example demonstrates both create and update cases:
+
 - Definition of an `options` object used to create the initial chart state.
 - Buttons that invoke mutations of the `options` and trigger update of the chart state.
 
 <chart-example title='Create and Update with AgChartOptions' name='create-update' type='generated'></chart-example>
 
+## Delta Options Update
+
 <framework-specific-section frameworks="javascript">
-| ## Delta Options Update
-|
 | `AgChart` exposes an `updateDelta()` static method to allow partial updates to a charts options.
-| <api-documentation source='charts-api/doc-interfaces.AUTO.json' section="AgChart" names='["updateDelta"]' config='{ "showSnippets": false, "lookupRoot": "charts-api", "suppressTypes": ["AgChartInstance", "AgChartOptions", "DeepPartial"] }'></api-documentation>
-|
-| To assist with state management, the complete applied options state can be retrieved by calling `getOptions()` on the
-| `AgChartInstance`:
-| <api-documentation source='charts-api/doc-interfaces.AUTO.json' section="AgChartInstance" names='["getOptions"]' config='{ "showSnippets": false, "lookupRoot": "charts-api", "suppressTypes": ["AgChartInstance", "AgChartOptions", "DeepPartial"] }'></api-documentation>
-|
+</framework-specific-section>
+<framework-specific-section frameworks="javascript">
+<api-documentation source='charts-api/doc-interfaces.AUTO.json' section="AgChart" names='["updateDelta"]' config='{ "showSnippets": false, "lookupRoot": "charts-api", "suppressTypes": ["AgChartInstance", "AgChartOptions", "DeepPartial"] }'></api-documentation>
+</framework-specific-section>
+<framework-specific-section frameworks="javascript">
+| To assist with state management, the complete applied options state can be retrieved by calling `getOptions()` on
+e `AgChartInstance`:
+</framework-specific-section>
+<framework-specific-section frameworks="javascript">
+<api-documentation source='charts-api/doc-interfaces.AUTO.json' section="AgChartInstance" names='["getOptions"]' config='{ "showSnippets": false, "lookupRoot": "charts-api", "suppressTypes": ["AgChartInstance", "AgChartOptions", "DeepPartial"] }'></api-documentation>
+</framework-specific-section>
+<framework-specific-section frameworks="javascript">
 | The following example demonstrates:
+| 
 | - Retrieving current Chart configuration via `getOptions()`.
 | - Mutation of the Chart configuration via `updateDelta()`.
 </framework-specific-section>
-
 <framework-specific-section frameworks="javascript">
 <chart-example title='Update with Partial AgChartOptions' name='update-partial' type='typescript'></chart-example>
 </framework-specific-section>
 
 <framework-specific-section frameworks="frameworks">
-| ## Delta Options Update
-|
 | `AgChart` exposes an `updateDelta()` static method to allow partial updates to an existing charts configuration:
 </framework-specific-section>
-<framework-specific-section frameworks="javascript">
+<framework-specific-section frameworks="frameworks">
 <note>
-|`updateDelta()` should not be normally used with the AG Charts component; framework change detection and updates
-|to the chart apply automatically after an options change.
+| `updateDelta()` should not be normally used with the AG Charts component; framework change detection and updates
+| to the chart apply automatically after an options change.
 |
-|However when using [Integrated Charts](../integrated-charts-events/#accessing-chart-instance) it may be
-|necessary to use this API to perform chart updates in Grid callbacks.
+| However when using [Integrated Charts](../integrated-charts-events/#accessing-chart-instance) it may be
+| necessary to use this API to perform chart updates in Grid callbacks.
 </note>
-</framework-specific-section>
-
-<framework-specific-section frameworks="javascript">
-<api-documentation source='charts-api/doc-interfaces.AUTO.json' section="AgChart" names='["updateDelta"]' config='{ "showSnippets": false, "lookupRoot": "charts-api", "suppressTypes": ["AgChartInstance", "AgChartOptions", "DeepPartial"] }'></api-documentation>
 </framework-specific-section>
 
 ## Destroying Charts
@@ -87,7 +89,6 @@ The following example demonstrates both create and update cases:
 <framework-specific-section frameworks="javascript">
 <api-documentation source='charts-api/doc-interfaces.AUTO.json' section="AgChartInstance" names='["destroy"]' config='{ "showSnippets": false, "lookupRoot": "charts-api", "suppressTypes": ["AgChartInstance", "AgChartOptions", "DeepPartial"] }'></api-documentation>
 </framework-specific-section>
-
 
 <framework-specific-section frameworks="frameworks">
 Charts are automatically destroyed when the AG Charts component is removed from the DOM.

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api-create-update/index.md
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api-create-update/index.md
@@ -79,6 +79,7 @@ e `AgChartInstance`:
 | However when using [Integrated Charts](../integrated-charts-events/#accessing-chart-instance) it may be
 | necessary to use this API to perform chart updates in Grid callbacks.
 </note>
+<api-documentation source='charts-api/doc-interfaces.AUTO.json' section="AgChart" names='["updateDelta"]' config='{ "showSnippets": false, "lookupRoot": "charts-api", "suppressTypes": ["AgChartInstance", "AgChartOptions", "DeepPartial"] }'></api-documentation>
 </framework-specific-section>
 
 ## Destroying Charts

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/api.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/api.json
@@ -907,6 +907,95 @@
       }
     }
   },
+  "AgColumnSeriesOptions": {
+    "xKey": {
+      "isRequired": true
+    },
+    "yKey": {
+      "isRequired": true
+    },
+    "grouped": {
+      "default": false
+    },
+    "normalizedTo": {
+      "min": 1,
+      "max": 100
+    },
+    "fillOpacity": {
+      "default": 1,
+      "min": 0,
+      "max": 1,
+      "step": 0.05
+    },
+    "strokeOpacity": {
+      "default": 1,
+      "min": 0,
+      "max": 1,
+      "step": 0.05
+    },
+    "strokeWidth": {
+      "default": 1,
+      "min": 0,
+      "max": 20,
+      "unit": "px"
+    },
+    "shadow": {
+      "enabled": {
+        "default": true
+      },
+      "color": {
+        "default": "rgba(0, 0, 0, 0.5)"
+      },
+      "xOffset": {
+        "default": 0,
+        "min": -20,
+        "max": 20,
+        "unit": "px"
+      },
+      "yOffset": {
+        "default": 0,
+        "min": -20,
+        "max": 20,
+        "unit": "px"
+      },
+      "blur": {
+        "default": 5,
+        "min": 0,
+        "max": 20,
+        "unit": "px"
+      }
+    },
+    "lineDashOffset": {
+      "default": 0,
+      "min": 0,
+      "max": 200,
+      "unit": "px"
+    },
+    "label": {
+      "enabled": {
+        "default": true
+      },
+      "placement": {
+        "default": "inside",
+        "options": ["inside", "outside"]
+      },
+      "color": {
+        "default": "rgba(70, 70, 70, 1)"
+      },
+      "fontStyle": {
+        "default": "normal"
+      },
+      "fontWeight": {
+        "default": "normal"
+      },
+      "fontSize": {
+        "default": 12
+      },
+      "fontFamily": {
+        "default": "Verdana, sans-serif"
+      }
+    }
+  },
   "AgHistogramSeriesOptions": {
     "xKey": {
       "isRequired": true

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-bar-series/index.md
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-bar-series/index.md
@@ -111,11 +111,15 @@ The above formatter produces an attractive chart where the labels don't stick ou
 It's best to avoid using labels with grouped columns (or bars), because columns in grouped mode tend to be narrow and often won't fit a label.
 </note>
 
-To learn more about label configuration please refer to the [API reference](#reference-AgBarSeriesOptions-label) below.
+To learn more about label configuration please refer to the [API reference](#reference-AgColumnSeriesOptions-label) below.
+
+### API Reference
+
+<interface-documentation interfaceName='AgColumnSeriesOptions' overridesrc="charts-api/api.json" config='{ "showSnippets": false, "lookupRoot": "charts-api" }'></interface-documentation>
 
 ## Bar Series
 
-`'bar'` series configuration is exactly the same as `'column'` series configuration and all the same modes (stacked, grouped, normalized) apply to bars just as they do to columns.
+`'bar'` series configuration is similar to the `'column'` series configuration and all the same modes (stacked, grouped, normalized) apply to bars just as they do to columns.
 
 To create a bar chart all you need to do is use `type: 'bar'` instead of `type: 'column'` in the `series` options.
 
@@ -132,6 +136,6 @@ With this simple change we go from [stacked columns](#stacked-columns) to stacke
 
 <chart-example title='Stacked Bar Series' name='stacked-bar' type='generated'></chart-example>
 
-## API Reference
+### API Reference
 
 <interface-documentation interfaceName='AgBarSeriesOptions' overridesrc="charts-api/api.json" config='{ "showSnippets": false, "lookupRoot": "charts-api" }'></interface-documentation>


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-6613

Attempts to give `bar` vs. `column` series types distinct 1st-class typings.