### PR TITLE
AG-8471 Add bar/column animation of adding, removing and updating data

### DIFF
--- a/charts-community-modules/ag-charts-community/src/chart/interaction/animationManager.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/interaction/animationManager.ts
@@ -100,7 +100,6 @@ export class AnimationManager extends BaseManager<AnimationEventType, AnimationE
 
         if (this.controllers[id]) {
             this.controllers[id].stop();
-            delete this.controllers[id];
         }
 
         this.controllers[id] = controller;
@@ -204,6 +203,8 @@ export class AnimationManager extends BaseManager<AnimationEventType, AnimationE
                     }
                 },
                 stop: () => {
+                    delete this.controllers[id];
+
                     this.updaters = this.updaters.filter(([uid]) => uid !== id);
                     if (this.updaters.length <= 0) {
                         this.cancelAnimationFrame();
@@ -222,9 +223,7 @@ export class AnimationManager extends BaseManager<AnimationEventType, AnimationE
         const frame = (time: number) => {
             this.requestId = requestAnimationFrame(frame);
 
-            if (!this.readyToPlay) {
-                return;
-            }
+            if (!this.readyToPlay) return;
 
             if (this.lastTime === undefined) this.lastTime = time;
             const deltaMs = time - this.lastTime;
@@ -245,5 +244,6 @@ export class AnimationManager extends BaseManager<AnimationEventType, AnimationE
 
         cancelAnimationFrame(this.requestId);
         this.requestId = undefined;
+        this.lastTime = undefined;
     }
 }

--- a/charts-community-modules/ag-charts-community/src/chart/series/cartesian/barSeries.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/series/cartesian/barSeries.ts
@@ -1046,7 +1046,13 @@ export class BarSeries extends CartesianSeries<SeriesNodeDataContext<BarNodeDatu
         });
     }
 
-    animateWaitingUpdateReady({ datumSelections }: { datumSelections: Array<Selection<Rect, BarNodeDatum>> }) {
+    animateWaitingUpdateReady({
+        datumSelections,
+        labelSelections,
+    }: {
+        datumSelections: Array<Selection<Rect, BarNodeDatum>>;
+        labelSelections: Array<Selection<Text, BarNodeDatum>>;
+    }) {
         const { processedData } = this;
 
         const diff = processedData?.reduced?.diff as {
@@ -1064,6 +1070,8 @@ export class BarSeries extends CartesianSeries<SeriesNodeDataContext<BarNodeDatu
         }
 
         const totalDuration = 1000;
+        const labelDuration = 200;
+
         let sectionDuration = totalDuration;
         if (diff.added.length > 0 && diff.removed.length > 0) {
             sectionDuration = Math.floor(totalDuration / 3);
@@ -1142,6 +1150,24 @@ export class BarSeries extends CartesianSeries<SeriesNodeDataContext<BarNodeDatu
 
                 this.animateRect(`${this.id}_ready-update_${rect.id}`, rect, props, duration, delay, () => {
                     if (cleanup) datumSelection.cleanup();
+                });
+            });
+        });
+
+        labelSelections.forEach((labelSelection) => {
+            labelSelection.each((label) => {
+                label.opacity = 0;
+
+                this.animationManager?.animate(`${this.id}_empty-update-ready_${label.id}`, {
+                    from: 0,
+                    to: 1,
+                    delay: totalDuration,
+                    duration: labelDuration,
+                    ease: easing.linear,
+                    repeat: 0,
+                    onUpdate: (opacity) => {
+                        label.opacity = opacity;
+                    },
                 });
             });
         });

--- a/charts-community-modules/ag-charts-community/src/chart/series/cartesian/barSeries.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/series/cartesian/barSeries.ts
@@ -1054,13 +1054,7 @@ export class BarSeries extends CartesianSeries<SeriesNodeDataContext<BarNodeDatu
         labelSelections: Array<Selection<Text, BarNodeDatum>>;
     }) {
         const { processedData } = this;
-
-        const diff = processedData?.reduced?.diff as {
-            changed: boolean;
-            added: string[][];
-            removed: string[][];
-            updated: string[][];
-        };
+        const diff = processedData?.reduced?.diff;
 
         if (!diff?.changed) {
             datumSelections.forEach((datumSelection) => {
@@ -1093,11 +1087,11 @@ export class BarSeries extends CartesianSeries<SeriesNodeDataContext<BarNodeDatu
         const datumIdKey = this.processedData?.defs.keys?.[0];
 
         const addedIds: { [key: string]: boolean } = {};
-        diff.added.forEach((d) => {
+        diff.added.forEach((d: string[]) => {
             addedIds[d[0]] = true;
         });
         const removedIds: { [key: string]: boolean } = {};
-        diff.removed.forEach((d) => {
+        diff.removed.forEach((d: string[]) => {
             removedIds[d[0]] = true;
         });
 

--- a/charts-community-modules/ag-charts-community/src/scene/selection.ts
+++ b/charts-community-modules/ag-charts-community/src/scene/selection.ts
@@ -5,36 +5,66 @@ type NodeFactory<TNode extends Node, TDatum> = (datum: TDatum) => TNode;
 type NodeConstructorOrFactory<TNode extends Node, TDatum> = NodeConstructor<TNode> | NodeFactory<TNode, TDatum>;
 
 export class Selection<TChild extends Node = Node, TDatum = any> {
-    constructor(parent: Node, classOrFactory: NodeConstructorOrFactory<TChild, TDatum>) {
+    constructor(
+        parent: Node,
+        classOrFactory: NodeConstructorOrFactory<TChild, TDatum>,
+        garbageCollection: boolean = true
+    ) {
         this._parent = parent;
         this._factory = Object.prototype.isPrototypeOf.call(Node, classOrFactory)
             ? () => new (classOrFactory as NodeConstructor<TChild>)()
             : (classOrFactory as NodeFactory<TChild, TDatum>);
+        this._garbageCollection = garbageCollection;
     }
 
     static select<TChild extends Node = Node, TDatum = any>(
         parent: Node,
-        classOrFactory: NodeConstructorOrFactory<TChild, TDatum>
+        classOrFactory: NodeConstructorOrFactory<TChild, TDatum>,
+        garbageCollection: boolean = true
     ) {
-        return new Selection(parent, classOrFactory);
+        return new Selection(parent, classOrFactory, garbageCollection);
     }
 
     private _parent: Node;
     private _nodes: TChild[] = [];
     private _data: TDatum[] = [];
+    private _ids: string[] = [];
     private _factory: NodeFactory<TChild, TDatum>;
+
+    // If garbage collection is set to false, you must call `selection.cleanup()` to remove deleted nodes
+    private _garbage: number[] = [];
+    private _garbageCollection: boolean = true;
 
     each(iterate: (node: TChild, datum: TDatum, index: number) => void) {
         this._nodes.forEach((node, i) => iterate(node, node.datum, i));
         return this;
     }
 
-    update(data: TDatum[], init?: (node: TChild) => void) {
+    /**
+     * Update the data in a selection. If an `id()` function is provided, maintain a list of ids related to the nodes.
+     * Otherwise, take the more efficient route of simply creating and destroying nodes at the end of the array.
+     */
+    update(data: TDatum[], init?: (node: TChild) => void, getDatumId?: (datum: TDatum) => string) {
         const old = this._data;
         const parent = this._parent;
         const factory = this._factory;
 
-        if (data.length > old.length) {
+        if (getDatumId) {
+            // Append any new datum ids and nodes to the end of the arrays
+            data.forEach((datum) => {
+                const datumId = getDatumId(datum);
+                if (this._ids.indexOf(datumId) === -1) {
+                    this._ids.push(datumId);
+
+                    const node = factory(datum);
+                    node.datum = datum;
+                    init?.(node);
+                    parent.appendChild(node);
+                    this._nodes.push(node);
+                }
+            });
+        } else if (data.length > old.length) {
+            // Create and append nodes for new data
             data.slice(old.length).forEach((datum) => {
                 const node = factory(datum);
                 node.datum = datum;
@@ -43,14 +73,34 @@ export class Selection<TChild extends Node = Node, TDatum = any> {
                 this._nodes.push(node);
             });
         } else if (data.length < old.length) {
+            // Destroy any nodes that are in excess of the new data
             this._nodes.splice(data.length).forEach((node) => {
                 parent.removeChild(node);
             });
         }
 
+        // Copy the data into a new array to prevent mutation and duplicates
         this._data = data.slice(0);
-        for (let i = 0; i < data.length; i++) {
-            this._nodes[i].datum = this._data[i];
+
+        if (getDatumId) {
+            // Find and update the datum for each node by the index of the id within the set
+            for (let i = 0; i < this._ids.length; i++) {
+                const datum = this._data.find((d) => getDatumId(d) === this._ids[i]);
+                if (datum) {
+                    this._nodes[i].datum = datum;
+                } else {
+                    this._garbage.push(i);
+                }
+            }
+
+            if (this._garbageCollection) {
+                this.cleanup();
+            }
+        } else {
+            // Reset the node data by index
+            for (let i = 0; i < data.length; i++) {
+                this._nodes[i].datum = this._data[i];
+            }
         }
 
         return this;
@@ -59,6 +109,21 @@ export class Selection<TChild extends Node = Node, TDatum = any> {
     clear() {
         this.update([]);
         return this;
+    }
+
+    cleanup() {
+        if (this._garbage.length === 0) return;
+
+        this._nodes = this._nodes.filter((node, index) => {
+            if (this._garbage.indexOf(index) === -1) return true;
+
+            delete this._ids[index];
+            this._parent.removeChild(node);
+            return false;
+        });
+
+        this._ids = this._ids.filter((id) => id !== undefined);
+        this._garbage = [];
     }
 
     static selectAll<T extends Node = Node>(parent: Node, predicate: (node: Node) => boolean): T[] {


### PR DESCRIPTION
PR for https://ag-grid.atlassian.net/browse/AG-8471

This provides a new selection strategy if an optional `getDatumId()` function is provided. This allows the datum id to be tracked against the nodes created for them which in turn allows correct ordering and moving about when nodes are added and removed. If this is provided the series must handle the garbage collection itself by calling the `cleanup()` method on the selection, allowing the series time to animate the removed nodes out of view.

It adds a `diff` post-processor to the data model that can be given the previous data and provide back the list of keys that have been added, updated or removed. The animation handlers can then use this to move those nodes around.

Since a series `update()` method is called whenever a node is highlighted, I've added a special `waiting` animation state that the series goes into whenever the data itself is updated in the `processData()` method. This blocks any other transitions until the `update()` method finishes and transitions with the new processed data. Without this the animation would keep triggering with the new added/updated/removed nodes being re-drawn.