### PR TITLE
AG-7651 - Add support for JSON-path expressions in xKey/yKey etc...

### DIFF
--- a/charts-community-modules/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
@@ -66,7 +66,6 @@ interface MarkerSelectionDatum extends Required<CartesianSeriesNodeDatum> {
     readonly index: number;
     readonly fill?: string;
     readonly stroke?: string;
-    readonly yValue: number;
     readonly cumulativeValue: number;
 }
 
@@ -426,6 +425,7 @@ export class AreaSeries extends CartesianSeries<AreaSeriesNodeDataContext> {
                             nodeMidPoint: { x: point.x, y: point.y },
                             cumulativeValue: cumulativeMarkerValues[datumIdx],
                             yValue: yDatum,
+                            xValue: xDatum,
                             yKey,
                             xKey,
                             point,
@@ -672,16 +672,13 @@ export class AreaSeries extends CartesianSeries<AreaSeriesNodeDataContext> {
 
     getTooltipHtml(nodeDatum: MarkerSelectionDatum): string {
         const { xKey, id: seriesId } = this;
-        const { yKey } = nodeDatum;
+        const { yKey, xValue, yValue, datum } = nodeDatum;
         const yKeyDataIndex = this.dataModel?.resolveProcessedDataIndexById(`yValue-${yKey}`);
 
         if (!(xKey && yKey) || !yKeyDataIndex) {
             return '';
         }
 
-        const datum = nodeDatum.datum;
-        const xValue = datum[xKey];
-        const yValue = datum[yKey];
         const { axes, yKeys } = this;
 
         const xAxis = axes[ChartAxisDirection.X];

--- a/charts-community-modules/ag-charts-community/src/chart/series/cartesian/barSeries.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/series/cartesian/barSeries.ts
@@ -707,7 +707,7 @@ export class BarSeries extends CartesianSeries<SeriesNodeDataContext<BarNodeDatu
         } = this;
         const xAxis = this.getCategoryAxis();
         const yAxis = this.getValueAxis();
-        const { yKey, xValue, yValue } = nodeDatum;
+        const { yKey, xValue, yValue, datum } = nodeDatum;
 
         if (!processedData || !xKey || !yKey || !xAxis || !yAxis) {
             return '';
@@ -728,7 +728,6 @@ export class BarSeries extends CartesianSeries<SeriesNodeDataContext<BarNodeDatu
 
         const { xName, yNames, fills, strokes, tooltip, formatter, id: seriesId } = this;
         const { renderer: tooltipRenderer } = tooltip;
-        const { datum } = nodeDatum.datum;
         const yName = yNames[yKey];
         const stackGroup = this.getStackGroup(yKey);
         const fill = fills[fillIndex % fills.length];

--- a/charts-community-modules/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
@@ -43,6 +43,8 @@ type LabelDataSelection<N extends Node, ContextType extends SeriesNodeDataContex
 export interface CartesianSeriesNodeDatum extends SeriesNodeDatum {
     readonly xKey: string;
     readonly yKey: string;
+    readonly xValue: any;
+    readonly yValue: any;
 }
 
 interface SubGroup<C extends SeriesNodeDataContext, SceneNodeType extends Node> {

--- a/charts-community-modules/ag-charts-community/src/chart/series/cartesian/histogramSeries.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/series/cartesian/histogramSeries.ts
@@ -396,6 +396,8 @@ export class HistogramSeries extends CartesianSeries<SeriesNodeDataContext<Histo
                 xKey,
                 x: xMinPx,
                 y: yMaxPx,
+                xValue: xMinPx,
+                yValue: yMaxPx,
                 width: w,
                 height: h,
                 nodeMidPoint,

--- a/charts-community-modules/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
@@ -246,6 +246,8 @@ export class LineSeries extends CartesianSeries<LineContext> {
                     xKey,
                     point: { x, y, moveTo, size },
                     nodeMidPoint: { x, y },
+                    yValue: yDatum,
+                    xValue: xDatum,
                     label: labelText
                         ? {
                               text: labelText,
@@ -432,9 +434,7 @@ export class LineSeries extends CartesianSeries<LineContext> {
 
         const { xName, yName, tooltip, marker, id: seriesId } = this;
         const { renderer: tooltipRenderer, format: tooltipFormat } = tooltip;
-        const datum = nodeDatum.datum;
-        const xValue = datum[xKey];
-        const yValue = datum[yKey];
+        const { datum, xValue, yValue } = nodeDatum;
         const xString = xAxis.formatDatum(xValue);
         const yString = yAxis.formatDatum(yValue);
         const title = sanitizeHtml(this.title ?? yName);

--- a/charts-community-modules/ag-charts-community/src/chart/series/cartesian/scatterSeries.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/series/cartesian/scatterSeries.ts
@@ -267,6 +267,8 @@ export class ScatterSeries extends CartesianSeries<SeriesNodeDataContext<Scatter
                 yKey,
                 xKey,
                 datum,
+                xValue: xDatum,
+                yValue: yDatum,
                 point: { x, y, size: markerSize },
                 nodeMidPoint: { x, y },
                 fill,
@@ -484,9 +486,7 @@ export class ScatterSeries extends CartesianSeries<SeriesNodeDataContext<Scatter
 
         const color = format?.fill ?? fill ?? 'gray';
         const title = this.title ?? yName;
-        const datum = nodeDatum.datum;
-        const xValue = datum[xKey];
-        const yValue = datum[yKey];
+        const { datum, xValue, yValue } = nodeDatum;
         const xString = sanitizeHtml(xAxis.formatDatum(xValue));
         const yString = sanitizeHtml(yAxis.formatDatum(yValue));
 

--- a/charts-enterprise-modules/ag-charts-enterprise/src/heatmap/heatmapSeries.ts
+++ b/charts-enterprise-modules/ag-charts-enterprise/src/heatmap/heatmapSeries.ts
@@ -218,8 +218,10 @@ export class HeatmapSeries extends _ModuleSupport.CartesianSeries<
         const font = label.getFont();
         let actualLength = 0;
         for (const { values, datum } of this.processedData?.data ?? []) {
-            const x = xScale.convert(values[0]) + xOffset;
-            const y = yScale.convert(values[1]) + yOffset;
+            const xDatum = values[0];
+            const yDatum = values[1];
+            const x = xScale.convert(xDatum) + xOffset;
+            const y = yScale.convert(yDatum) + yOffset;
 
             if (!this.checkRangeXY(x, y, xAxis, yAxis)) {
                 continue;
@@ -236,6 +238,8 @@ export class HeatmapSeries extends _ModuleSupport.CartesianSeries<
                 itemId: yKey,
                 yKey,
                 xKey,
+                xValue: xDatum,
+                yValue: yDatum,
                 datum,
                 point: { x, y, size: 0 },
                 width,
@@ -421,9 +425,7 @@ export class HeatmapSeries extends _ModuleSupport.CartesianSeries<
 
         const color = format?.fill ?? fill ?? 'gray';
         const title = this.title ?? yName;
-        const datum = nodeDatum.datum;
-        const xValue = datum[xKey];
-        const yValue = datum[yKey];
+        const { datum, xValue, yValue } = nodeDatum;
         const xString = sanitizeHtml(xAxis.formatDatum(xValue));
         const yString = sanitizeHtml(yAxis.formatDatum(yValue));
 

--- a/charts-enterprise-modules/ag-charts-enterprise/src/waterfall/waterfallSeries.ts
+++ b/charts-enterprise-modules/ag-charts-enterprise/src/waterfall/waterfallSeries.ts
@@ -49,7 +49,6 @@ type WaterfallNodeLabelDatum = Readonly<_Scene.Point> & {
 
 interface WaterfallNodeDatum extends _ModuleSupport.CartesianSeriesNodeDatum, Readonly<_Scene.Point> {
     readonly index: number;
-    readonly yValue: number;
     readonly cumulativeValue: number;
     readonly width: number;
     readonly height: number;
@@ -307,7 +306,8 @@ export class WaterfallBarSeries extends _ModuleSupport.CartesianSeries<
         const contextIndexMap = new Map<SeriesItemType, number>();
 
         processedData?.data.forEach(({ keys, datum, values }, dataIndex) => {
-            const x = xScale.convert(keys[xIndex]);
+            const xDatum = keys[xIndex];
+            const x = xScale.convert(xDatum);
 
             const rawValue = values[yIndex];
             const isPositive = rawValue >= 0;
@@ -357,6 +357,7 @@ export class WaterfallBarSeries extends _ModuleSupport.CartesianSeries<
                 itemId,
                 datum,
                 cumulativeValue,
+                xValue: xDatum,
                 yValue: rawValue,
                 yKey,
                 xKey,
@@ -498,10 +499,7 @@ export class WaterfallBarSeries extends _ModuleSupport.CartesianSeries<
         }
 
         const { formatter, tooltip, xName, yName, id: seriesId } = this;
-
-        const datum = nodeDatum.datum;
-        const xValue = datum[xKey];
-        const yValue = datum[yKey];
+        const { datum, xValue, yValue } = nodeDatum;
 
         let format: any | undefined = undefined;
 


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-7651

Adds support for paths in `xKey`, `yKey`, `sizeKey`, `angleKey` and `radiusKey` options.

Fixes many `getTooltipHtml()` methods which were directly trying to access datum values via direct property access.