### PR TITLE
AG-8552 Add zoom axis dragging

### DIFF
--- a/charts-community-modules/ag-charts-community/src/chart/cartesianChart.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/cartesianChart.ts
@@ -367,7 +367,7 @@ export class CartesianChart extends Chart {
                 break;
         }
 
-        const zoom = this.zoomManager.getZoom()?.[axis.direction];
+        const zoom = this.zoomManager.getAxisZoom(axis.id);
         const { min = 0, max = 1 } = zoom ?? {};
         axis.visibleRange = [min, max];
 

--- a/charts-community-modules/ag-charts-community/src/chart/chart.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/chart.ts
@@ -581,6 +581,7 @@ export abstract class Chart extends Observable implements AgChartInstance {
             axis.attachAxis(this.axisGroup);
             removedAxes.delete(axis);
         });
+        this.zoomManager.updateAxes(this._axes);
 
         removedAxes.forEach((axis) => axis.destroy());
     }
@@ -741,7 +742,6 @@ export abstract class Chart extends Observable implements AgChartInstance {
         if (this.axes.length > 0) {
             this.assignAxesToSeries();
             this.assignSeriesToAxes();
-            this.zoomManager.updateAxes(this.axes);
         }
 
         await Promise.all(this.series.map((s) => s.processData()));

--- a/charts-community-modules/ag-charts-community/src/chart/chart.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/chart.ts
@@ -741,6 +741,7 @@ export abstract class Chart extends Observable implements AgChartInstance {
         if (this.axes.length > 0) {
             this.assignAxesToSeries();
             this.assignSeriesToAxes();
+            this.zoomManager.updateAxes(this.axes);
         }
 
         await Promise.all(this.series.map((s) => s.processData()));

--- a/charts-community-modules/ag-charts-community/src/chart/chartAxis.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/chartAxis.ts
@@ -28,7 +28,7 @@ export interface ChartAxis {
     dataDomain: any[];
     destroy(): void;
     detachAxis(node: Node): void;
-    direction: 'x' | 'y';
+    direction: ChartAxisDirection;
     formatDatum(datum: any): string;
     getLayoutState(): AxisLayout;
     gridLength: number;

--- a/charts-community-modules/ag-charts-community/src/chart/interaction/chartEventManager.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/interaction/chartEventManager.ts
@@ -1,7 +1,8 @@
 import { BaseManager } from './baseManager';
+import { ChartAxisDirection } from '../chartAxisDirection';
 
-type ChartEventType = 'legend-item-click' | 'legend-item-double-click';
-type ChartEvents = LegendItemClickChartEvent | LegendItemDoubleClickChartEvent;
+type ChartEventType = 'legend-item-click' | 'legend-item-double-click' | 'axis-hover';
+type ChartEvents = LegendItemClickChartEvent | LegendItemDoubleClickChartEvent | AxisHoverChartEvent;
 
 interface ChartEvent<ChartEventType> {
     type: ChartEventType;
@@ -18,6 +19,11 @@ export interface LegendItemDoubleClickChartEvent extends ChartEvent<'legend-item
     itemId: any;
     enabled: boolean;
     numVisibleItems: { [key: string]: number };
+}
+
+export interface AxisHoverChartEvent extends ChartEvent<'axis-hover'> {
+    axisId: string;
+    direction: ChartAxisDirection;
 }
 
 export class ChartEventManager extends BaseManager<ChartEventType, ChartEvents> {
@@ -42,5 +48,15 @@ export class ChartEventManager extends BaseManager<ChartEventType, ChartEvents> 
         };
 
         this.listeners.dispatch('legend-item-double-click', event);
+    }
+
+    axisHover(axisId: string, direction: ChartAxisDirection) {
+        const event: AxisHoverChartEvent = {
+            type: 'axis-hover',
+            axisId,
+            direction,
+        };
+
+        this.listeners.dispatch('axis-hover', event);
     }
 }

--- a/charts-community-modules/ag-charts-community/src/chart/interaction/zoomManager.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/interaction/zoomManager.ts
@@ -22,6 +22,7 @@ export interface ZoomChangeEvent extends AxisZoomState {
  */
 export class ZoomManager extends BaseManager<'zoom-change', ZoomChangeEvent> {
     private axes: Record<string, AxisZoomManager> = {};
+    private initialZoom?: { callerId: string; newZoom?: AxisZoomState };
 
     public updateAxes(axes: Array<{ id: string; direction: ChartAxisDirection }>) {
         const removedAxes = new Set(Object.keys(this.axes));
@@ -34,9 +35,19 @@ export class ZoomManager extends BaseManager<'zoom-change', ZoomChangeEvent> {
         removedAxes.forEach((axisId) => {
             delete this.axes[axisId];
         });
+
+        if (this.initialZoom) {
+            this.updateZoom(this.initialZoom.callerId, this.initialZoom.newZoom);
+            this.initialZoom = undefined;
+        }
     }
 
     public updateZoom(callerId: string, newZoom?: AxisZoomState) {
+        if (Object.keys(this.axes).length === 0) {
+            this.initialZoom = { callerId, newZoom };
+            return;
+        }
+
         Object.values(this.axes).forEach((axis) => {
             axis.updateZoom(callerId, newZoom?.[axis.direction]);
         });

--- a/charts-community-modules/ag-charts-community/src/chart/interaction/zoomManager.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/interaction/zoomManager.ts
@@ -1,4 +1,3 @@
-import { ChartAxis } from '../chartAxis';
 import { ChartAxisDirection } from '../chartAxisDirection';
 import { BaseManager } from './baseManager';
 
@@ -24,9 +23,16 @@ export interface ZoomChangeEvent extends AxisZoomState {
 export class ZoomManager extends BaseManager<'zoom-change', ZoomChangeEvent> {
     private axes: Record<string, AxisZoomManager> = {};
 
-    public updateAxes(axes: Array<ChartAxis>) {
+    public updateAxes(axes: Array<{ id: string; direction: ChartAxisDirection }>) {
+        const removedAxes = new Set(Object.keys(this.axes));
+
         axes.forEach((axis) => {
-            this.axes[axis.id] = this.axes[axis.id] ?? new AxisZoomManager(axis.direction);
+            removedAxes.delete(axis.id);
+            this.axes[axis.id] ??= new AxisZoomManager(axis.direction);
+        });
+
+        removedAxes.forEach((axisId) => {
+            delete this.axes[axisId];
         });
     }
 

--- a/charts-community-modules/ag-charts-community/src/chart/interaction/zoomManager.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/interaction/zoomManager.ts
@@ -1,3 +1,5 @@
+import { ChartAxis } from '../chartAxis';
+import { ChartAxisDirection } from '../chartAxisDirection';
 import { BaseManager } from './baseManager';
 
 interface ZoomState {
@@ -14,61 +16,103 @@ export interface ZoomChangeEvent extends AxisZoomState {
     type: 'zoom-change';
 }
 
-function isEqual(a?: AxisZoomState, b?: AxisZoomState) {
-    if (a === b) return true;
-    if (a?.x?.min !== b?.x?.min) return false;
-    if (a?.x?.max !== b?.x?.max) return false;
-    if (a?.y?.max !== b?.y?.max) return false;
-    if (a?.y?.min !== b?.y?.min) return false;
-
-    return true;
-}
-
 /**
  * Manages the current zoom state for a chart. Tracks the requested zoom from distinct dependents
  * and handles conflicting zoom requests.
  */
 export class ZoomManager extends BaseManager<'zoom-change', ZoomChangeEvent> {
-    private readonly states: Record<string, AxisZoomState> = {};
-    private currentZoom?: AxisZoomState = undefined;
+    private axes: Record<string, AxisZoomManager> = {};
 
-    public constructor() {
-        super();
+    public updateAxes(axes: Array<ChartAxis>) {
+        axes.forEach((axis) => {
+            this.axes[axis.id] = this.axes[axis.id] ?? new AxisZoomManager(axis.direction);
+        });
     }
 
     public updateZoom(callerId: string, newZoom?: AxisZoomState) {
-        delete this.states[callerId];
-
-        if (newZoom != null) {
-            this.states[callerId] = { ...newZoom };
-        }
+        Object.values(this.axes).forEach((axis) => {
+            axis.updateZoom(callerId, newZoom?.[axis.direction]);
+        });
 
         this.applyStates();
     }
 
+    public updateAxisZoom(callerId: string, axisId: string, newZoom?: ZoomState) {
+        this.axes[axisId]?.updateZoom(callerId, newZoom);
+
+        this.applyStates();
+
+        // TODO: fire event?
+    }
+
     public getZoom(): AxisZoomState | undefined {
-        return this.currentZoom;
+        let x: ZoomState | undefined;
+        let y: ZoomState | undefined;
+
+        // TODO: this only works when there is a single axis on each direction as it gets the last of each
+        Object.values(this.axes).forEach((axis) => {
+            if (axis.direction === ChartAxisDirection.X) {
+                x = axis.getZoom();
+            } else if (axis.direction === ChartAxisDirection.Y) {
+                y = axis.getZoom();
+            }
+        });
+
+        if (x || y) {
+            return { x, y };
+        }
+    }
+
+    public getAxisZoom(axisId: string): ZoomState | undefined {
+        return this.axes[axisId]?.getZoom();
     }
 
     private applyStates() {
-        const currentZoom = this.currentZoom;
-        const zoomToApply: AxisZoomState = {};
-
-        // Last added entry wins.
-        for (const [_, { x, y }] of Object.entries(this.states)) {
-            zoomToApply.x = x ?? zoomToApply.x;
-            zoomToApply.y = y ?? zoomToApply.y;
-        }
-        this.currentZoom = zoomToApply.x != null || zoomToApply.y != null ? zoomToApply : undefined;
-
-        const changed = !isEqual(currentZoom, this.currentZoom);
+        const changed = Object.values(this.axes)
+            .map((axis) => axis.applyStates())
+            .some(Boolean);
         if (!changed) {
             return;
         }
+        const currentZoom = this.getZoom();
         const event: ZoomChangeEvent = {
             type: 'zoom-change',
             ...(currentZoom ?? {}),
         };
         this.listeners.dispatch('zoom-change', event);
+    }
+}
+
+class AxisZoomManager {
+    private readonly states: Record<string, ZoomState> = {};
+    private currentZoom?: ZoomState = undefined;
+
+    public direction: ChartAxisDirection;
+
+    constructor(direction: ChartAxisDirection) {
+        this.direction = direction;
+    }
+
+    public updateZoom(callerId: string, newZoom?: ZoomState) {
+        delete this.states[callerId];
+
+        if (newZoom != null) {
+            this.states[callerId] = { ...newZoom };
+        }
+    }
+
+    public getZoom(): ZoomState | undefined {
+        return this.currentZoom;
+    }
+
+    public applyStates(): boolean {
+        const prevZoom = this.currentZoom;
+        const last = Object.keys(this.states)[Object.keys(this.states).length - 1];
+
+        this.currentZoom = { ...this.states[last] };
+
+        const changed = prevZoom?.min !== this.currentZoom?.min || prevZoom?.max !== this.currentZoom?.max;
+
+        return changed;
     }
 }

--- a/charts-enterprise-modules/ag-charts-enterprise/src/zoom/zoomAxisDragger.ts
+++ b/charts-enterprise-modules/ag-charts-enterprise/src/zoom/zoomAxisDragger.ts
@@ -1,0 +1,74 @@
+import { _ModuleSupport, _Scene } from 'ag-charts-community';
+
+import { constrainZoom, definedZoomState, pointToRatio } from './zoomTransformers';
+import { DefinedZoomState, ZoomCoords } from './zoomTypes';
+
+export class ZoomAxisDragger {
+    public isAxisDragging: boolean = false;
+
+    private coords?: ZoomCoords;
+    private oldZoom?: DefinedZoomState;
+
+    update(
+        event: _ModuleSupport.InteractionEvent<'drag'>,
+        axis: _ModuleSupport.ChartAxisDirection,
+        bbox: _Scene.BBox,
+        zoom?: _ModuleSupport.AxisZoomState
+    ): DefinedZoomState {
+        this.isAxisDragging = true;
+        if (this.oldZoom == null) {
+            this.oldZoom = definedZoomState(zoom);
+        }
+
+        this.updateCoords(event.offsetX, event.offsetY);
+        const newZoom = this.updateZoom(axis, bbox);
+
+        return newZoom;
+    }
+
+    stop() {
+        this.isAxisDragging = false;
+        this.coords = undefined;
+        this.oldZoom = undefined;
+    }
+
+    private updateCoords(x: number, y: number): void {
+        if (!this.coords) {
+            this.coords = { x1: x, y1: y, x2: x, y2: y };
+        } else {
+            this.coords.x2 = x;
+            this.coords.y2 = y;
+        }
+    }
+
+    private updateZoom(axis: _ModuleSupport.ChartAxisDirection, bbox: _Scene.BBox): DefinedZoomState {
+        const { coords, oldZoom } = this;
+
+        let newZoom = definedZoomState(oldZoom);
+
+        if (!coords || !oldZoom) return newZoom;
+
+        const origin = pointToRatio(bbox, coords.x1, coords.y1);
+        const target = pointToRatio(bbox, coords.x2, coords.y2);
+
+        if (axis === _ModuleSupport.ChartAxisDirection.X) {
+            const scaleX = target.x - origin.x;
+
+            newZoom.x.max += scaleX;
+
+            newZoom.x.min = oldZoom.x.max - (newZoom.x.max - newZoom.x.min);
+            newZoom.x.max = oldZoom.x.max;
+        } else {
+            const scaleY = target.y - origin.y;
+
+            newZoom.y.max += scaleY;
+
+            newZoom.y.min = oldZoom.y.max - (newZoom.y.max - newZoom.y.min);
+            newZoom.y.max = oldZoom.y.max;
+        }
+
+        newZoom = constrainZoom(newZoom);
+
+        return newZoom;
+    }
+}

--- a/charts-enterprise-modules/ag-charts-enterprise/src/zoom/zoomModule.ts
+++ b/charts-enterprise-modules/ag-charts-enterprise/src/zoom/zoomModule.ts
@@ -18,6 +18,8 @@ export interface AgZoomOptions {
     axes?: AgZoomAxes;
     /** Set to true to enable the zoom module. */
     enabled?: boolean;
+    /** Set to true to enable dragging an axis to zoom series attached to that axis, defaults to true. */
+    enableAxisDragging?: boolean;
     /** Set to true to enable panning while zoomed, defaults to true. */
     enablePanning?: boolean;
     /** Set to true to enable zooming with the mouse wheel, defaults to true. */


### PR DESCRIPTION
PR for https://ag-grid.atlassian.net/browse/AG-8552

The `ZoomManager` now tracks the zoom state for each axis separately. If using the existing api, i.e. `zoomManager.updateZoom()` it will update all the axis zooms to match, keeping the existing behaviour.

There are some further ux considerations to be discussed at a later date.

https://github.com/ag-grid/ag-grid/assets/3817697/9ae285e3-3e7e-4ac8-b40b-241784867d3a