### PR TITLE
AG-8561 Add animation.duration option

### DIFF
--- a/charts-community-modules/ag-charts-community/src/chart/interaction/animationManager.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/interaction/animationManager.ts
@@ -41,6 +41,7 @@ export class AnimationManager extends BaseManager<AnimationEventType, AnimationE
 
     private interactionManager: InteractionManager;
 
+    public defaultOptions: Partial<Pick<AnimationOptions<any>, 'duration'>> = {};
     public skipAnimations = false;
 
     constructor(interactionManager: InteractionManager) {

--- a/charts-community-modules/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
@@ -849,7 +849,7 @@ export class AreaSeries extends CartesianSeries<AreaSeriesNodeDataContext> {
         contextData.forEach(({ fillSelectionData, strokeSelectionData, itemId }, seriesIdx) => {
             const [fill, stroke] = paths[seriesIdx];
 
-            const duration = 1000;
+            const duration = this.animationManager?.defaultOptions.duration ?? 1000;
             const markerDuration = 200;
 
             const animationOptions = {

--- a/charts-community-modules/ag-charts-community/src/chart/series/cartesian/barSeries.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/series/cartesian/barSeries.ts
@@ -984,7 +984,7 @@ export class BarSeries extends CartesianSeries<SeriesNodeDataContext<BarNodeDatu
         datumSelections: Array<Selection<Rect, BarNodeDatum>>;
         labelSelections: Array<Selection<Text, BarNodeDatum>>;
     }) {
-        const duration = 1000;
+        const duration = this.animationManager?.defaultOptions.duration ?? 1000;
         const labelDuration = 200;
 
         let startingX = Infinity;
@@ -1066,7 +1066,7 @@ export class BarSeries extends CartesianSeries<SeriesNodeDataContext<BarNodeDatu
             return;
         }
 
-        const totalDuration = 1000;
+        const totalDuration = this.animationManager?.defaultOptions.duration ?? 1000;
         const labelDuration = 200;
 
         let sectionDuration = totalDuration;

--- a/charts-community-modules/ag-charts-community/src/chart/series/cartesian/histogramSeries.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/series/cartesian/histogramSeries.ts
@@ -603,7 +603,7 @@ export class HistogramSeries extends CartesianSeries<SeriesNodeDataContext<Histo
         datumSelections: Array<Selection<Rect, HistogramNodeDatum>>;
         labelSelections: Array<Selection<Text, HistogramNodeDatum>>;
     }) {
-        const duration = 1000;
+        const duration = this.animationManager?.defaultOptions.duration ?? 1000;
         const labelDuration = 200;
 
         let startingY = 0;
@@ -685,7 +685,7 @@ export class HistogramSeries extends CartesianSeries<SeriesNodeDataContext<Histo
             return;
         }
 
-        const totalDuration = 1000;
+        const totalDuration = this.animationManager?.defaultOptions.duration ?? 1000;
         const labelDuration = 200;
 
         let sectionDuration = totalDuration;

--- a/charts-community-modules/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
@@ -566,7 +566,7 @@ export class LineSeries extends CartesianSeries<LineContext> {
             lineNode.lineDash = this.lineDash;
             lineNode.lineDashOffset = this.lineDashOffset;
 
-            const duration = 1000;
+            const duration = this.animationManager?.defaultOptions.duration ?? 1000;
             const markerDuration = 200;
 
             const animationOptions = {

--- a/charts-community-modules/ag-charts-community/src/chart/series/cartesian/scatterSeries.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/series/cartesian/scatterSeries.ts
@@ -583,7 +583,7 @@ export class ScatterSeries extends CartesianSeries<SeriesNodeDataContext<Scatter
         markerSelections: Array<Selection<Marker, ScatterNodeDatum>>;
         labelSelections: Array<Selection<Text, ScatterNodeDatum>>;
     }) {
-        const duration = 1000;
+        const duration = this.animationManager?.defaultOptions.duration ?? 1000;
         const labelDuration = 200;
 
         markerSelections.forEach((markerSelection) => {

--- a/charts-community-modules/ag-charts-community/src/chart/series/polar/pieSeries.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/series/polar/pieSeries.ts
@@ -1588,7 +1588,7 @@ export class PieSeries extends PolarSeries<PieNodeDatum> {
     }
 
     animateEmptyUpdateReady() {
-        const duration = 1000;
+        const duration = this.animationManager?.defaultOptions.duration ?? 1000;
         const labelDuration = 200;
 
         const rotation = Math.PI / -2 + toRadians(this.rotation);

--- a/charts-enterprise-modules/ag-charts-enterprise/src/animation/animation.ts
+++ b/charts-enterprise-modules/ag-charts-enterprise/src/animation/animation.ts
@@ -1,6 +1,6 @@
 import { _ModuleSupport, _Scene } from 'ag-charts-community';
 
-const { BOOLEAN, ActionOnSet, Validate } = _ModuleSupport;
+const { BOOLEAN, NUMBER, ActionOnSet, Validate } = _ModuleSupport;
 
 export class Animation extends _ModuleSupport.BaseModuleInstance implements _ModuleSupport.ModuleInstance {
     @Validate(BOOLEAN)
@@ -11,6 +11,15 @@ export class Animation extends _ModuleSupport.BaseModuleInstance implements _Mod
         },
     })
     public enabled = true;
+
+    @Validate(NUMBER(0))
+    @ActionOnSet<Animation>({
+        newValue(value: number | undefined) {
+            if (!this.animationManager) return;
+            this.animationManager.defaultOptions.duration = value;
+        },
+    })
+    public duration?: number;
 
     animationManager: _ModuleSupport.AnimationManager;
 

--- a/charts-enterprise-modules/ag-charts-enterprise/src/animation/animationModule.ts
+++ b/charts-enterprise-modules/ag-charts-enterprise/src/animation/animationModule.ts
@@ -12,4 +12,6 @@ export const AnimationModule: _ModuleSupport.Module = {
 export interface AgAnimationOptions {
     /** Set to true to enable the animation module. */
     enabled?: boolean;
+    /** The total duration of the animation for each series on initial load and updates */
+    duration?: number;
 }

--- a/charts-enterprise-modules/ag-charts-enterprise/src/main.ts
+++ b/charts-enterprise-modules/ag-charts-enterprise/src/main.ts
@@ -115,6 +115,7 @@ declare module 'ag-charts-community' {
     export type AgPolarAxisOptions = AgAngleCategoryAxisOptions | AgRadiusNumberAxisOptions;
 
     export interface AgPolarChartOptions {
+        animation?: AgAnimationOptions;
         contextMenu?: AgContextMenuOptions;
         /** Axis configurations. */
         axes?: AgPolarAxisOptions[];

--- a/charts-enterprise-modules/ag-charts-enterprise/src/waterfall/waterfallSeries.ts
+++ b/charts-enterprise-modules/ag-charts-enterprise/src/waterfall/waterfallSeries.ts
@@ -757,7 +757,7 @@ export class WaterfallBarSeries extends _ModuleSupport.CartesianSeries<
         paths: Array<Array<_Scene.Path>>;
         seriesRect?: _Scene.BBox;
     }) {
-        const duration = 1000;
+        const duration = this.animationManager?.defaultOptions.duration ?? 1000;
 
         contextData.forEach(({ pointData }, contextDataIndex) => {
             this.animateRects(datumSelections[contextDataIndex], duration);


### PR DESCRIPTION
PR for https://ag-grid.atlassian.net/browse/AG-8561

This only adds a basic version of the `animation.duration` option for the total duration, mostly for QA purposes.