### PR TITLE
Fix chart animation resize handling

### DIFF
--- a/charts-community-modules/ag-charts-community/src/chart/chart.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/chart.ts
@@ -81,25 +81,15 @@ export abstract class Chart extends Observable implements AgChartInstance {
 
     private extraDebugStats: Record<string, number> = {};
 
-    private _container: OptionalHTMLElement = undefined;
-    set container(value: OptionalHTMLElement) {
-        if (this._container !== value) {
-            const { parentNode } = this.element;
-
-            if (parentNode != null) {
-                parentNode.removeChild(this.element);
-            }
-
-            if (value && !this.destroyed) {
-                value.appendChild(this.element);
-            }
-
-            this._container = value;
-        }
-    }
-    get container(): OptionalHTMLElement {
-        return this._container;
-    }
+    @ActionOnSet<Chart>({
+        newValue(value) {
+            value.appendChild(this.element);
+        },
+        oldValue(value) {
+            value.removeChild(this.element);
+        },
+    })
+    container: OptionalHTMLElement = undefined;
 
     @ActionOnSet<Chart>({
         newValue(value) {
@@ -513,21 +503,7 @@ export abstract class Chart extends Observable implements AgChartInstance {
                 splits.push(performance.now());
             // eslint-disable-next-line no-fallthrough
             case ChartUpdateType.PERFORM_LAYOUT:
-                if (this.autoSize && !this._lastAutoSize) {
-                    const count = this._performUpdateNoRenderCount++;
-
-                    if (count < 5) {
-                        // Reschedule if canvas size hasn't been set yet to avoid a race.
-                        this._performUpdateType = ChartUpdateType.PERFORM_LAYOUT;
-                        this.performUpdateTrigger.schedule();
-                        break;
-                    }
-
-                    // After several failed passes, continue and accept there maybe a redundant
-                    // render. Sometimes this case happens when we already have the correct
-                    // width/height, and we end up never rendering the chart in that scenario.
-                }
-                this._performUpdateNoRenderCount = 0;
+                if (!this.checkFirstAutoSize()) break;
 
                 await this.performLayout();
                 this.handleOverlays();
@@ -565,6 +541,30 @@ export abstract class Chart extends Observable implements AgChartInstance {
             count,
             performUpdateType: ChartUpdateType[performUpdateType],
         });
+    }
+
+    private checkFirstAutoSize() {
+        if (this.autoSize && !this._lastAutoSize) {
+            const count = this._performUpdateNoRenderCount++;
+            const backOffMs = (count ^ 2) * 10;
+
+            if (count < 5) {
+                // Reschedule if canvas size hasn't been set yet to avoid a race.
+                this._performUpdateType = ChartUpdateType.PERFORM_LAYOUT;
+                this.performUpdateTrigger.schedule(backOffMs);
+
+                this.log('Chart.checkFirstAutoSize() - backing off until first size update', backOffMs);
+                return false;
+            }
+
+            // After several failed passes, continue and accept there maybe a redundant
+            // render. Sometimes this case happens when we already have the correct
+            // width/height, and we end up never rendering the chart in that scenario.
+            this.log('Chart.checkFirstAutoSize() - timeout for first size update.');
+        }
+        this._performUpdateNoRenderCount = 0;
+
+        return true;
     }
 
     readonly element: HTMLElement;

--- a/charts-community-modules/ag-charts-community/src/chart/chart.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/chart.ts
@@ -83,6 +83,8 @@ export abstract class Chart extends Observable implements AgChartInstance {
 
     @ActionOnSet<Chart>({
         newValue(value) {
+            if (this.destroyed) return;
+
             value.appendChild(this.element);
         },
         oldValue(value) {

--- a/charts-community-modules/ag-charts-community/src/util/render.ts
+++ b/charts-community-modules/ag-charts-community/src/util/render.ts
@@ -5,15 +5,15 @@ type Callback = (params: { count: number }) => Promise<void> | void;
  * after the first schedule() call, and subsequent schedule() calls will be ignored until the
  * animation callback executes.
  */
-export function debouncedAnimationFrame(cb: Callback): { schedule(): void; await(): Promise<void> } {
-    return buildScheduler((cb) => requestAnimationFrame(cb), cb);
+export function debouncedAnimationFrame(cb: Callback): { schedule(delayMs?: number): void; await(): Promise<void> } {
+    return buildScheduler((cb, _delayMs) => requestAnimationFrame(cb), cb);
 }
 
-export function debouncedCallback(cb: Callback): { schedule(): void; await(): Promise<void> } {
-    return buildScheduler((cb) => setTimeout(cb, 0), cb);
+export function debouncedCallback(cb: Callback): { schedule(delayMs?: number): void; await(): Promise<void> } {
+    return buildScheduler((cb, delayMs = 0) => setTimeout(cb, delayMs), cb);
 }
 
-function buildScheduler(scheduleFn: (cb: () => void) => void, cb: Callback) {
+function buildScheduler(scheduleFn: (cb: () => void, delayMs?: number) => void, cb: Callback) {
     let scheduleCount = 0;
     let promiseRunning = false;
     let awaitingPromise: Promise<void> | undefined;
@@ -51,9 +51,9 @@ function buildScheduler(scheduleFn: (cb: () => void) => void, cb: Callback) {
     };
 
     return {
-        schedule() {
+        schedule(delayMs?: number) {
             if (scheduleCount === 0 && !busy()) {
-                scheduleFn(scheduleCb);
+                scheduleFn(scheduleCb, delayMs);
             }
             scheduleCount++;
         },


### PR DESCRIPTION
Fixes animation resize using stale `contextNodeData`.

Bonus: Cleaned-up resize handling.