### PR TITLE
Charts debug logging improvements.

### DIFF
--- a/charts-community-modules/ag-charts-community/src/chart/agChartV2.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/agChartV2.ts
@@ -226,7 +226,7 @@ abstract class AgChartInternal {
     ) {
         AgChartInternal.initialiseModules();
 
-        debug('>>> createOrUpdate() user options', userOptions);
+        debug('>>> AgChartV2.createOrUpdate() user options', userOptions);
         const mixinOpts: any = {};
         if (AgChartInternal.DEBUG() === true) {
             mixinOpts['debug'] = true;
@@ -281,8 +281,8 @@ abstract class AgChartInternal {
 
         const lastUpdateOptions = queuedUserOptions[queuedUserOptions.length - 1] ?? chart.userOptions;
         const userOptions = jsonMerge([lastUpdateOptions, deltaOptions]);
-        debug('>>> updateUserDelta() user delta', deltaOptions);
-        debug('base options', lastUpdateOptions);
+        debug('>>> AgChartV2.updateUserDelta() user delta', deltaOptions);
+        debug('AgChartV2.updateUserDelta() - base options', lastUpdateOptions);
         AgChartInternal.createOrUpdate(userOptions as any, proxy);
     }
 
@@ -388,7 +388,7 @@ abstract class AgChartInternal {
 
         if (chart.destroyed) return;
 
-        debug('applying delta', processedOptions);
+        debug('AgChartV2.updateDelta() - applying delta', processedOptions);
         applyChartOptions(chart, processedOptions, userOptions);
     }
 }
@@ -452,7 +452,7 @@ function applyChartOptions(chart: Chart, processedOptions: Partial<AgChartOption
 
     const majorChange = forceNodeDataRefresh || modulesChanged;
     const updateType = majorChange ? ChartUpdateType.PROCESS_DATA : ChartUpdateType.PERFORM_LAYOUT;
-    debug('chart update type', { updateType: ChartUpdateType[updateType] });
+    debug('AgChartV2.applyChartOptions() - update type', ChartUpdateType[updateType]);
     chart.update(updateType, { forceNodeDataRefresh });
 }
 
@@ -503,7 +503,7 @@ function applySeries(chart: Chart, options: AgChartOptions) {
                 return;
             }
 
-            debug(`applying series diff idx ${i}`, seriesDiff);
+            debug(`AgChartV2.applySeries() - applying series diff idx ${i}`, seriesDiff);
 
             applySeriesValues(s as any, seriesDiff, { path: `series[${i}]`, index: i });
             s.markNodeDataDirty();
@@ -532,7 +532,7 @@ function applyAxes(chart: Chart, options: AgCartesianChartOptions) {
                 const previousOpts = oldOpts.axes?.[i] ?? {};
                 const axisDiff = jsonDiff(previousOpts, optAxes[i]) as any;
 
-                debug(`applying axis diff idx ${i}`, axisDiff);
+                debug(`AgChartV2.applyAxes() - applying axis diff idx ${i}`, axisDiff);
 
                 const path = `axes[${i}]`;
                 const skip = ['axes[].type'];

--- a/charts-community-modules/ag-charts-community/src/chart/data/dataModel.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/data/dataModel.ts
@@ -675,14 +675,14 @@ function logProcessedData(processedData: ProcessedData<any>) {
     const log = (name: string, data: any[]) => {
         if (data.length > 0) {
             // eslint-disable-next-line no-console
-            console.log(name);
+            console.log(`DataModel.processData() - ${name}`);
             // eslint-disable-next-line no-console
             console.table(data);
         }
     };
 
     // eslint-disable-next-line no-console
-    console.log({ processedData });
+    console.log('DataModel.processData() - processedData', processedData);
     log('Key Domains', processedData.domain.keys);
     log('Group Domains', processedData.domain.groups ?? []);
     log('Value Domains', processedData.domain.values);

--- a/charts-community-modules/ag-charts-community/src/chart/interaction/animationManager.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/interaction/animationManager.ts
@@ -9,6 +9,7 @@ import {
     TweenControls,
     TweenOptions,
 } from '../../motion/animate';
+import { Logger } from '../../util/logger';
 
 type AnimationId = string;
 type AnimationEventType = 'animation-frame';
@@ -42,6 +43,7 @@ export class AnimationManager extends BaseManager<AnimationEventType, AnimationE
     private interactionManager: InteractionManager;
 
     public skipAnimations = false;
+    public debug = false;
 
     constructor(interactionManager: InteractionManager) {
         super();
@@ -63,6 +65,10 @@ export class AnimationManager extends BaseManager<AnimationEventType, AnimationE
 
         this.isPlaying = true;
 
+        if (this.debug) {
+            Logger.debug('AnimationManager.play()');
+        }
+
         for (const id in this.controllers) {
             this.controllers[id].play();
         }
@@ -76,6 +82,10 @@ export class AnimationManager extends BaseManager<AnimationEventType, AnimationE
         this.isPlaying = false;
         this.cancelAnimationFrame();
 
+        if (this.debug) {
+            Logger.debug('AnimationManager.pause()');
+        }
+
         for (const id in this.controllers) {
             this.controllers[id].pause();
         }
@@ -84,6 +94,10 @@ export class AnimationManager extends BaseManager<AnimationEventType, AnimationE
     public stop() {
         this.isPlaying = false;
         this.cancelAnimationFrame();
+
+        if (this.debug) {
+            Logger.debug('AnimationManager.stop()');
+        }
 
         for (const id in this.controllers) {
             this.controllers[id].stop();
@@ -232,9 +246,11 @@ export class AnimationManager extends BaseManager<AnimationEventType, AnimationE
             const deltaMs = time - this.lastTime;
             this.lastTime = time;
 
-            this.updaters.forEach(([_, update]) => {
-                update(deltaMs);
-            });
+            if (this.debug) {
+                Logger.debug('AnimationManager - frame()', { updaterCount: this.updaters.length });
+            }
+
+            this.updaters.forEach(([_, update]) => update(deltaMs));
 
             this.listeners.dispatch('animation-frame', { type: 'animation-frame', deltaMs });
         };

--- a/charts-community-modules/ag-charts-community/src/chart/series/series.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/series/series.ts
@@ -235,6 +235,7 @@ export abstract class Series<C extends SeriesNodeDataContext = SeriesNodeDataCon
     // Package-level visibility, not meant to be set by the user.
     chart?: {
         mode: 'standalone' | 'integrated';
+        debug: boolean;
         placeLabels(): Map<Series<any>, PlacedLabel[]>;
         getSeriesRect(): Readonly<BBox> | undefined;
     };

--- a/charts-community-modules/ag-charts-community/src/scene/scene.ts
+++ b/charts-community-modules/ag-charts-community/src/scene/scene.ts
@@ -1,11 +1,11 @@
 import { HdpiCanvas, Size } from '../canvas/hdpiCanvas';
-import { Node, RedrawType, RenderContext } from './node';
+import { Node, RedrawType, RenderContext, ZIndexSubOrder } from './node';
 import { createId } from '../util/id';
 import { Group } from './group';
 import { HdpiOffscreenCanvas } from '../canvas/hdpiOffscreenCanvas';
 import { windowValue } from '../util/window';
 import { ascendingStringNumberUndefined, compoundAscending } from '../util/compare';
-import { SceneDebugOptions } from './sceneDebugOptions';
+import { SceneDebugLevel, SceneDebugOptions } from './sceneDebugOptions';
 import { Logger } from '../util/logger';
 
 interface SceneOptions {
@@ -17,7 +17,7 @@ interface SceneLayer {
     id: number;
     name?: string;
     zIndex: number;
-    zIndexSubOrder?: [string, number];
+    zIndexSubOrder?: ZIndexSubOrder;
     canvas: HdpiOffscreenCanvas | HdpiCanvas;
     getComputedOpacity: () => number;
     getVisibility: () => boolean;
@@ -70,7 +70,10 @@ export class Scene {
         this.overrideDevicePixelRatio = overrideDevicePixelRatio;
 
         this.opts = { document, mode };
-        this.debug.consoleLog = windowValue('agChartsDebug') === true;
+        this.debug.consoleLog = [true, 'scene'].includes(windowValue('agChartsDebug') as any);
+        this.debug.level = ['scene'].includes(windowValue('agChartsDebug') as any)
+            ? SceneDebugLevel.DETAILED
+            : SceneDebugLevel.SUMMARY;
         this.debug.stats = (windowValue('agChartsSceneStats') as any) ?? false;
         this.debug.dirtyTree = (windowValue('agChartsSceneDirtyTree') as boolean) ?? false;
         this.debug.sceneNodeHighlight = buildSceneNodeHighlight();
@@ -125,7 +128,7 @@ export class Scene {
     private _nextLayerId = 0;
     addLayer(opts: {
         zIndex?: number;
-        zIndexSubOrder?: [string, number];
+        zIndexSubOrder?: ZIndexSubOrder;
         name?: string;
         getComputedOpacity: () => number;
         getVisibility: () => boolean;
@@ -183,7 +186,7 @@ export class Scene {
         }
 
         if (this.debug.consoleLog) {
-            Logger.debug({ layers: this.layers });
+            Logger.debug('Scene.addLayer() - layers', this.layers);
         }
 
         return newLayer.canvas;
@@ -198,12 +201,12 @@ export class Scene {
             this.markDirty();
 
             if (this.debug.consoleLog) {
-                Logger.debug({ layers: this.layers });
+                Logger.debug('Scene.removeLayer() -  layers', this.layers);
             }
         }
     }
 
-    moveLayer(canvas: HdpiCanvas | HdpiOffscreenCanvas, newZIndex: number, newZIndexSubOrder?: [string, number]) {
+    moveLayer(canvas: HdpiCanvas | HdpiOffscreenCanvas, newZIndex: number, newZIndexSubOrder?: ZIndexSubOrder) {
         const layer = this.layers.find((l) => l.canvas === canvas);
 
         if (layer) {
@@ -213,7 +216,7 @@ export class Scene {
             this.markDirty();
 
             if (this.debug.consoleLog) {
-                Logger.debug({ layers: this.layers });
+                Logger.debug('Scene.moveLayer() -  layers', this.layers);
             }
         }
     }
@@ -253,7 +256,17 @@ export class Scene {
             if (node.parent === null && node.layerManager && node.layerManager !== this) {
                 (node.layerManager as Scene).root = null;
             }
-            node._setLayerManager(this);
+            node._setLayerManager({
+                addLayer: (opts) => this.addLayer(opts),
+                moveLayer: (...opts) => this.moveLayer(...opts),
+                removeLayer: (...opts) => this.removeLayer(...opts),
+                markDirty: () => this.markDirty(),
+                canvas: this.canvas,
+                debug: {
+                    ...this.debug,
+                    consoleLog: this.debug.level >= SceneDebugLevel.DETAILED,
+                },
+            });
         }
 
         this.markDirty();
@@ -267,6 +280,7 @@ export class Scene {
         stats: false,
         renderBoundingBoxes: false,
         consoleLog: false,
+        level: SceneDebugLevel.SUMMARY,
         sceneNodeHighlight: [],
     };
 
@@ -318,7 +332,7 @@ export class Scene {
 
         if (root && !this.dirty) {
             if (this.debug.consoleLog) {
-                Logger.debug('no-op', {
+                Logger.debug('Scene.render() - no-op', {
                     redrawType: RedrawType[root.dirty],
                     tree: this.buildTree(root),
                 });
@@ -347,12 +361,12 @@ export class Scene {
 
         if (root && this.debug.dirtyTree) {
             const { dirtyTree, paths } = this.buildDirtyTree(root);
-            Logger.debug({ dirtyTree, paths });
+            Logger.debug('Scene.render() - dirtyTree', { dirtyTree, paths });
         }
 
         if (root && canvasCleared) {
             if (this.debug.consoleLog) {
-                Logger.debug('before', {
+                Logger.debug('Scene.render() - before', {
                     redrawType: RedrawType[root.dirty],
                     canvasCleared,
                     tree: this.buildTree(root),
@@ -390,7 +404,11 @@ export class Scene {
         this.debugSceneNodeHighlight(ctx, this.debug.sceneNodeHighlight, renderCtx.debugNodes);
 
         if (root && this.debug.consoleLog) {
-            Logger.debug('after', { redrawType: RedrawType[root.dirty], canvasCleared, tree: this.buildTree(root) });
+            Logger.debug('Scene.render() - after', {
+                redrawType: RedrawType[root.dirty],
+                canvasCleared,
+                tree: this.buildTree(root),
+            });
         }
     }
 
@@ -473,7 +491,7 @@ export class Scene {
             const predicate = typeof next === 'string' ? stringPredicate(next) : regexpPredicate(next);
             const nodes = this.root?.findNodes(predicate);
             if (!nodes || nodes.length === 0) {
-                Logger.debug(`no debugging node with id [${next}] in scene graph.`);
+                Logger.debug(`Scene.render() - no debugging node with id [${next}] in scene graph.`);
                 continue;
             }
 
@@ -492,7 +510,7 @@ export class Scene {
             const bbox = node.computeTransformedBBox();
 
             if (!bbox) {
-                Logger.debug(`no bbox for debugged node [${name}].`);
+                Logger.debug(`Scene.render() - no bbox for debugged node [${name}].`);
                 continue;
             }
 

--- a/charts-community-modules/ag-charts-community/src/scene/sceneDebugOptions.ts
+++ b/charts-community-modules/ag-charts-community/src/scene/sceneDebugOptions.ts
@@ -1,7 +1,13 @@
+export enum SceneDebugLevel {
+    SUMMARY,
+    DETAILED,
+}
+
 export interface SceneDebugOptions {
     stats: false | 'basic' | 'detailed';
     dirtyTree: boolean;
     renderBoundingBoxes: boolean;
     consoleLog: boolean;
+    level: SceneDebugLevel;
     sceneNodeHighlight: (string | RegExp)[];
 }


### PR DESCRIPTION
Improves the readability of console output as a result of setting `window.agChartsDebug = true`:
- Removes low-level rendering debug output.
- Adds class-name + method-name prefixes.

Adds `window.agChartsDebug = 'scene'` to re-enable mode details scene rendering logging.

Also adds a few more strategic log messages to allow control-flow tracing for major processing steps.