### PR TITLE
AG-7933 - Implement DataModel reduction/merging.

### DIFF
--- a/charts-community-modules/ag-charts-community/src/chart/data/__snapshots__/dataModel.test.ts.snap
+++ b/charts-community-modules/ag-charts-community/src/chart/data/__snapshots__/dataModel.test.ts.snap
@@ -59,17 +59,6 @@ exports[`DataModel empty data set processing should generated the expected resul
       [],
     ],
   },
-  "indices": {
-    "keys": {
-      "year": 0,
-    },
-    "values": {
-      "chrome": 1,
-      "firefox": 2,
-      "ie": 0,
-      "safari": 3,
-    },
-  },
   "time": Any<Number>,
   "type": "ungrouped",
 }
@@ -301,14 +290,6 @@ exports[`DataModel grouped processing - calculated grouping should generated the
         3505,
       ],
     ],
-  },
-  "indices": {
-    "keys": {
-      "curb-weight": 0,
-    },
-    "values": {
-      "curb-weight": 0,
-    },
   },
   "reduced": {
     "sortedGroupDomain": [
@@ -580,14 +561,6 @@ exports[`DataModel grouped processing - calculated grouping should generated the
       ],
     ],
   },
-  "indices": {
-    "keys": {
-      "engine-size": 0,
-    },
-    "values": {
-      "highway-mpg": 0,
-    },
-  },
   "reduced": {
     "sortedGroupDomain": [
       [
@@ -780,12 +753,6 @@ exports[`DataModel grouped processing - calculated grouping should generated the
       ],
     ],
     "values": [],
-  },
-  "indices": {
-    "keys": {
-      "engine-size": 0,
-    },
-    "values": {},
   },
   "reduced": {
     "sortedGroupDomain": [
@@ -1057,15 +1024,6 @@ exports[`DataModel grouped processing - grouped example should generated the exp
         4.2,
       ],
     ],
-  },
-  "indices": {
-    "keys": {
-      "type": 0,
-    },
-    "values": {
-      "regular": 1,
-      "total": 0,
-    },
   },
   "time": Any<Number>,
   "type": "grouped",
@@ -1621,19 +1579,6 @@ exports[`DataModel grouped processing - stacked and normalised example should ge
       ],
     ],
   },
-  "indices": {
-    "keys": {
-      "month": 0,
-    },
-    "values": {
-      "bioenergyWaste": 2,
-      "imported": 5,
-      "naturalGas": 1,
-      "nuclear": 3,
-      "petroleum": 0,
-      "windSolarHydro": 4,
-    },
-  },
   "reduced": {
     "aggValuesExtent": [
       0,
@@ -1929,19 +1874,6 @@ exports[`DataModel grouped processing - stacked and normalised example should ge
         95064,
       ],
     ],
-  },
-  "indices": {
-    "keys": {
-      "type": 0,
-    },
-    "values": {
-      "asian": 2,
-      "black": 3,
-      "chinese": 4,
-      "mixed": 1,
-      "other": 5,
-      "white": 0,
-    },
   },
   "reduced": {
     "aggValuesExtent": [
@@ -2290,17 +2222,6 @@ exports[`DataModel grouped processing - stacked example should generated the exp
         919,
       ],
     ],
-  },
-  "indices": {
-    "keys": {
-      "type": 0,
-    },
-    "values": {
-      "housingAssociation": 3,
-      "localAuthority": 2,
-      "ownerOccupied": 0,
-      "privateRented": 1,
-    },
   },
   "reduced": {
     "aggValuesExtent": [
@@ -2654,17 +2575,6 @@ exports[`DataModel grouped processing - stacked with accumulation and normalised
       ],
     ],
   },
-  "indices": {
-    "keys": {
-      "type": 0,
-    },
-    "values": {
-      "housingAssociation": 3,
-      "localAuthority": 2,
-      "ownerOccupied": 0,
-      "privateRented": 1,
-    },
-  },
   "reduced": {
     "aggValuesExtent": [
       23.7745,
@@ -2963,17 +2873,6 @@ exports[`DataModel grouped processing - stacked with accumulation example should
       ],
     ],
   },
-  "indices": {
-    "keys": {
-      "type": 0,
-    },
-    "values": {
-      "housingAssociation": 3,
-      "localAuthority": 2,
-      "ownerOccupied": 0,
-      "privateRented": 1,
-    },
-  },
   "time": Any<Number>,
   "type": "grouped",
 }
@@ -3262,17 +3161,6 @@ exports[`DataModel missing and invalid data processing should generated the expe
       ],
     ],
   },
-  "indices": {
-    "keys": {
-      "year": 0,
-    },
-    "values": {
-      "chrome": 1,
-      "firefox": 2,
-      "ie": 0,
-      "safari": 3,
-    },
-  },
   "time": Any<Number>,
   "type": "ungrouped",
 }
@@ -3360,6 +3248,9 @@ exports[`DataModel repeated property processing should generated the expected re
         "missing": false,
         "processor": [Function],
         "property": "share",
+        "scopes": [
+          "test",
+        ],
         "type": "value",
         "validation": [Function],
         "valueType": "range",
@@ -3378,12 +3269,6 @@ exports[`DataModel repeated property processing should generated the expected re
         0.6869,
       ],
     ],
-  },
-  "indices": {
-    "keys": {},
-    "values": {
-      "share": 1,
-    },
   },
   "time": Any<Number>,
   "type": "ungrouped",
@@ -3541,13 +3426,6 @@ exports[`DataModel ungrouped processing - accumulated and normalised properties 
         8666000,
       ],
     ],
-  },
-  "indices": {
-    "keys": {},
-    "values": {
-      "population": 2,
-      "religion": 1,
-    },
   },
   "time": Any<Number>,
   "type": "ungrouped",
@@ -4332,15 +4210,6 @@ exports[`DataModel ungrouped processing should generated the expected results 1`
         136.45,
       ],
     ],
-  },
-  "indices": {
-    "keys": {
-      "date": 0,
-    },
-    "values": {
-      "diesel": 1,
-      "petrol": 0,
-    },
   },
   "time": Any<Number>,
   "type": "ungrouped",

--- a/charts-community-modules/ag-charts-community/src/chart/data/__snapshots__/dataModel.test.ts.snap
+++ b/charts-community-modules/ag-charts-community/src/chart/data/__snapshots__/dataModel.test.ts.snap
@@ -4,6 +4,7 @@ exports[`DataModel empty data set processing should generated the expected resul
 {
   "data": [],
   "defs": {
+    "allScopesHaveSameDefs": true,
     "keys": [
       {
         "index": 0,
@@ -74,6 +75,7 @@ exports[`DataModel empty data set processing should generated the expected resul
       [],
     ],
   },
+  "partialValidDataCount": 0,
   "time": Any<Number>,
   "type": "ungrouped",
 }
@@ -131,6 +133,7 @@ exports[`DataModel grouped processing - calculated grouping should generated the
         2000,
         3000,
       ],
+      "validScopes": undefined,
       "values": [
         [
           2548,
@@ -201,6 +204,7 @@ exports[`DataModel grouped processing - calculated grouping should generated the
         3000,
         4500,
       ],
+      "validScopes": undefined,
       "values": [
         [
           3086,
@@ -241,6 +245,7 @@ exports[`DataModel grouped processing - calculated grouping should generated the
         0,
         2000,
       ],
+      "validScopes": undefined,
       "values": [
         [
           1488,
@@ -252,6 +257,7 @@ exports[`DataModel grouped processing - calculated grouping should generated the
     },
   ],
   "defs": {
+    "allScopesHaveSameDefs": false,
     "keys": [
       {
         "index": 0,
@@ -310,6 +316,7 @@ exports[`DataModel grouped processing - calculated grouping should generated the
       ],
     ],
   },
+  "partialValidDataCount": 0,
   "reduced": {
     "sortedGroupDomain": [
       [
@@ -390,6 +397,7 @@ exports[`DataModel grouped processing - calculated grouping should generated the
       "keys": [
         "100 - 150",
       ],
+      "validScopes": undefined,
       "values": [
         [
           27,
@@ -466,6 +474,7 @@ exports[`DataModel grouped processing - calculated grouping should generated the
       "keys": [
         ">150",
       ],
+      "validScopes": undefined,
       "values": [
         [
           26,
@@ -510,6 +519,7 @@ exports[`DataModel grouped processing - calculated grouping should generated the
       "keys": [
         "<100",
       ],
+      "validScopes": undefined,
       "values": [
         [
           53,
@@ -521,6 +531,7 @@ exports[`DataModel grouped processing - calculated grouping should generated the
     },
   ],
   "defs": {
+    "allScopesHaveSameDefs": true,
     "keys": [
       {
         "index": 0,
@@ -586,6 +597,7 @@ exports[`DataModel grouped processing - calculated grouping should generated the
       ],
     ],
   },
+  "partialValidDataCount": 0,
   "reduced": {
     "sortedGroupDomain": [
       [
@@ -652,6 +664,7 @@ exports[`DataModel grouped processing - calculated grouping should generated the
       "keys": [
         "100 - 150",
       ],
+      "validScopes": undefined,
       "values": [
         undefined,
         undefined,
@@ -699,6 +712,7 @@ exports[`DataModel grouped processing - calculated grouping should generated the
       "keys": [
         ">150",
       ],
+      "validScopes": undefined,
       "values": [
         undefined,
         undefined,
@@ -727,6 +741,7 @@ exports[`DataModel grouped processing - calculated grouping should generated the
       "keys": [
         "<100",
       ],
+      "validScopes": undefined,
       "values": [
         undefined,
         undefined,
@@ -734,6 +749,7 @@ exports[`DataModel grouped processing - calculated grouping should generated the
     },
   ],
   "defs": {
+    "allScopesHaveSameDefs": true,
     "keys": [
       {
         "index": 0,
@@ -782,6 +798,7 @@ exports[`DataModel grouped processing - calculated grouping should generated the
     ],
     "values": [],
   },
+  "partialValidDataCount": 0,
   "reduced": {
     "sortedGroupDomain": [
       [
@@ -820,6 +837,7 @@ exports[`DataModel grouped processing - grouped example should generated the exp
       "keys": [
         "Whole economy",
       ],
+      "validScopes": undefined,
       "values": [
         [
           2.9,
@@ -844,6 +862,7 @@ exports[`DataModel grouped processing - grouped example should generated the exp
       "keys": [
         "Finance and business services",
       ],
+      "validScopes": undefined,
       "values": [
         [
           3.7,
@@ -868,6 +887,7 @@ exports[`DataModel grouped processing - grouped example should generated the exp
       "keys": [
         "Public sector",
       ],
+      "validScopes": undefined,
       "values": [
         [
           3.3,
@@ -892,6 +912,7 @@ exports[`DataModel grouped processing - grouped example should generated the exp
       "keys": [
         "Construction",
       ],
+      "validScopes": undefined,
       "values": [
         [
           3.2,
@@ -916,6 +937,7 @@ exports[`DataModel grouped processing - grouped example should generated the exp
       "keys": [
         "Private sector",
       ],
+      "validScopes": undefined,
       "values": [
         [
           2.7,
@@ -940,6 +962,7 @@ exports[`DataModel grouped processing - grouped example should generated the exp
       "keys": [
         "Manufacturing",
       ],
+      "validScopes": undefined,
       "values": [
         [
           2.7,
@@ -964,6 +987,7 @@ exports[`DataModel grouped processing - grouped example should generated the exp
       "keys": [
         "Wholesaling, retailing, hotels and restaurants",
       ],
+      "validScopes": undefined,
       "values": [
         [
           1.1,
@@ -973,6 +997,7 @@ exports[`DataModel grouped processing - grouped example should generated the exp
     },
   ],
   "defs": {
+    "allScopesHaveSameDefs": true,
     "keys": [
       {
         "index": 0,
@@ -1062,6 +1087,7 @@ exports[`DataModel grouped processing - grouped example should generated the exp
       ],
     ],
   },
+  "partialValidDataCount": 0,
   "time": Any<Number>,
   "type": "grouped",
 }
@@ -1092,6 +1118,7 @@ exports[`DataModel grouped processing - stacked and normalised example should ge
       "keys": [
         "Jan",
       ],
+      "validScopes": undefined,
       "values": [
         [
           29.946524064171125,
@@ -1125,6 +1152,7 @@ exports[`DataModel grouped processing - stacked and normalised example should ge
       "keys": [
         "Feb",
       ],
+      "validScopes": undefined,
       "values": [
         [
           31.46067415730337,
@@ -1158,6 +1186,7 @@ exports[`DataModel grouped processing - stacked and normalised example should ge
       "keys": [
         "Mar",
       ],
+      "validScopes": undefined,
       "values": [
         [
           30.167597765363126,
@@ -1191,6 +1220,7 @@ exports[`DataModel grouped processing - stacked and normalised example should ge
       "keys": [
         "Apr",
       ],
+      "validScopes": undefined,
       "values": [
         [
           38.56209150326798,
@@ -1224,6 +1254,7 @@ exports[`DataModel grouped processing - stacked and normalised example should ge
       "keys": [
         "May",
       ],
+      "validScopes": undefined,
       "values": [
         [
           42.10526315789474,
@@ -1257,6 +1288,7 @@ exports[`DataModel grouped processing - stacked and normalised example should ge
       "keys": [
         "Jun",
       ],
+      "validScopes": undefined,
       "values": [
         [
           46.03174603174603,
@@ -1290,6 +1322,7 @@ exports[`DataModel grouped processing - stacked and normalised example should ge
       "keys": [
         "Jul",
       ],
+      "validScopes": undefined,
       "values": [
         [
           44.44444444444444,
@@ -1323,6 +1356,7 @@ exports[`DataModel grouped processing - stacked and normalised example should ge
       "keys": [
         "Aug",
       ],
+      "validScopes": undefined,
       "values": [
         [
           46.456692913385815,
@@ -1356,6 +1390,7 @@ exports[`DataModel grouped processing - stacked and normalised example should ge
       "keys": [
         "Sep",
       ],
+      "validScopes": undefined,
       "values": [
         [
           44.27480916030535,
@@ -1389,6 +1424,7 @@ exports[`DataModel grouped processing - stacked and normalised example should ge
       "keys": [
         "Oct",
       ],
+      "validScopes": undefined,
       "values": [
         [
           37.41496598639456,
@@ -1422,6 +1458,7 @@ exports[`DataModel grouped processing - stacked and normalised example should ge
       "keys": [
         "Nov",
       ],
+      "validScopes": undefined,
       "values": [
         [
           35.54216867469879,
@@ -1455,6 +1492,7 @@ exports[`DataModel grouped processing - stacked and normalised example should ge
       "keys": [
         "Dec",
       ],
+      "validScopes": undefined,
       "values": [
         [
           33.33333333333333,
@@ -1468,6 +1506,7 @@ exports[`DataModel grouped processing - stacked and normalised example should ge
     },
   ],
   "defs": {
+    "allScopesHaveSameDefs": true,
     "keys": [
       {
         "index": 0,
@@ -1637,6 +1676,7 @@ exports[`DataModel grouped processing - stacked and normalised example should ge
       ],
     ],
   },
+  "partialValidDataCount": 0,
   "reduced": {
     "aggValuesExtent": [
       0,
@@ -1672,6 +1712,7 @@ exports[`DataModel grouped processing - stacked and normalised example should ge
       "keys": [
         "Nursery",
       ],
+      "validScopes": undefined,
       "values": [
         [
           59.712524678576585,
@@ -1704,6 +1745,7 @@ exports[`DataModel grouped processing - stacked and normalised example should ge
       "keys": [
         "Primary",
       ],
+      "validScopes": undefined,
       "values": [
         [
           74.28693389376268,
@@ -1736,6 +1778,7 @@ exports[`DataModel grouped processing - stacked and normalised example should ge
       "keys": [
         "Secondary",
       ],
+      "validScopes": undefined,
       "values": [
         [
           74.49944393701765,
@@ -1768,6 +1811,7 @@ exports[`DataModel grouped processing - stacked and normalised example should ge
       "keys": [
         "Special",
       ],
+      "validScopes": undefined,
       "values": [
         [
           74.84837848647854,
@@ -1800,6 +1844,7 @@ exports[`DataModel grouped processing - stacked and normalised example should ge
       "keys": [
         "Referral units",
       ],
+      "validScopes": undefined,
       "values": [
         [
           78.45841011628646,
@@ -1813,6 +1858,7 @@ exports[`DataModel grouped processing - stacked and normalised example should ge
     },
   ],
   "defs": {
+    "allScopesHaveSameDefs": true,
     "keys": [
       {
         "index": 0,
@@ -1954,6 +2000,7 @@ exports[`DataModel grouped processing - stacked and normalised example should ge
       ],
     ],
   },
+  "partialValidDataCount": 0,
   "reduced": {
     "aggValuesExtent": [
       0,
@@ -1987,6 +2034,7 @@ exports[`DataModel grouped processing - stacked example should generated the exp
       "keys": [
         "Semi-detached house",
       ],
+      "validScopes": undefined,
       "values": [
         [
           4567,
@@ -2015,6 +2063,7 @@ exports[`DataModel grouped processing - stacked example should generated the exp
       "keys": [
         "Medium/large terraced house",
       ],
+      "validScopes": undefined,
       "values": [
         [
           2842,
@@ -2043,6 +2092,7 @@ exports[`DataModel grouped processing - stacked example should generated the exp
       "keys": [
         "Detached house",
       ],
+      "validScopes": undefined,
       "values": [
         [
           3655,
@@ -2071,6 +2121,7 @@ exports[`DataModel grouped processing - stacked example should generated the exp
       "keys": [
         "Purpose-built flat low rise",
       ],
+      "validScopes": undefined,
       "values": [
         [
           905,
@@ -2099,6 +2150,7 @@ exports[`DataModel grouped processing - stacked example should generated the exp
       "keys": [
         "Small terraced house",
       ],
+      "validScopes": undefined,
       "values": [
         [
           1013,
@@ -2127,6 +2179,7 @@ exports[`DataModel grouped processing - stacked example should generated the exp
       "keys": [
         "Bungalow",
       ],
+      "validScopes": undefined,
       "values": [
         [
           1486,
@@ -2155,6 +2208,7 @@ exports[`DataModel grouped processing - stacked example should generated the exp
       "keys": [
         "Converted flat",
       ],
+      "validScopes": undefined,
       "values": [
         [
           252,
@@ -2183,6 +2237,7 @@ exports[`DataModel grouped processing - stacked example should generated the exp
       "keys": [
         "Purpose-built flat high rise",
       ],
+      "validScopes": undefined,
       "values": [
         [
           97,
@@ -2194,6 +2249,7 @@ exports[`DataModel grouped processing - stacked example should generated the exp
     },
   ],
   "defs": {
+    "allScopesHaveSameDefs": true,
     "keys": [
       {
         "index": 0,
@@ -2317,6 +2373,7 @@ exports[`DataModel grouped processing - stacked example should generated the exp
       ],
     ],
   },
+  "partialValidDataCount": 0,
   "reduced": {
     "aggValuesExtent": [
       0,
@@ -2350,6 +2407,7 @@ exports[`DataModel grouped processing - stacked with accumulation and normalised
       "keys": [
         "Semi-detached house",
       ],
+      "validScopes": undefined,
       "values": [
         [
           76.09130289903365,
@@ -2378,6 +2436,7 @@ exports[`DataModel grouped processing - stacked with accumulation and normalised
       "keys": [
         "Medium/large terraced house",
       ],
+      "validScopes": undefined,
       "values": [
         [
           64.11008346492217,
@@ -2406,6 +2465,7 @@ exports[`DataModel grouped processing - stacked with accumulation and normalised
       "keys": [
         "Detached house",
       ],
+      "validScopes": undefined,
       "values": [
         [
           92.01913393756294,
@@ -2434,6 +2494,7 @@ exports[`DataModel grouped processing - stacked with accumulation and normalised
       "keys": [
         "Purpose-built flat low rise",
       ],
+      "validScopes": undefined,
       "values": [
         [
           25.251116071428573,
@@ -2462,6 +2523,7 @@ exports[`DataModel grouped processing - stacked with accumulation and normalised
       "keys": [
         "Small terraced house",
       ],
+      "validScopes": undefined,
       "values": [
         [
           44.081810269799824,
@@ -2490,6 +2552,7 @@ exports[`DataModel grouped processing - stacked with accumulation and normalised
       "keys": [
         "Bungalow",
       ],
+      "validScopes": undefined,
       "values": [
         [
           70.4933586337761,
@@ -2518,6 +2581,7 @@ exports[`DataModel grouped processing - stacked with accumulation and normalised
       "keys": [
         "Converted flat",
       ],
+      "validScopes": undefined,
       "values": [
         [
           27.155172413793103,
@@ -2546,6 +2610,7 @@ exports[`DataModel grouped processing - stacked with accumulation and normalised
       "keys": [
         "Purpose-built flat high rise",
       ],
+      "validScopes": undefined,
       "values": [
         [
           23.774509803921568,
@@ -2557,6 +2622,7 @@ exports[`DataModel grouped processing - stacked with accumulation and normalised
     },
   ],
   "defs": {
+    "allScopesHaveSameDefs": true,
     "keys": [
       {
         "index": 0,
@@ -2684,6 +2750,7 @@ exports[`DataModel grouped processing - stacked with accumulation and normalised
       ],
     ],
   },
+  "partialValidDataCount": 0,
   "reduced": {
     "aggValuesExtent": [
       23.7745,
@@ -2711,6 +2778,7 @@ exports[`DataModel grouped processing - stacked with accumulation example should
       "keys": [
         "Semi-detached house",
       ],
+      "validScopes": undefined,
       "values": [
         [
           4567,
@@ -2733,6 +2801,7 @@ exports[`DataModel grouped processing - stacked with accumulation example should
       "keys": [
         "Medium/large terraced house",
       ],
+      "validScopes": undefined,
       "values": [
         [
           2842,
@@ -2755,6 +2824,7 @@ exports[`DataModel grouped processing - stacked with accumulation example should
       "keys": [
         "Detached house",
       ],
+      "validScopes": undefined,
       "values": [
         [
           3655,
@@ -2777,6 +2847,7 @@ exports[`DataModel grouped processing - stacked with accumulation example should
       "keys": [
         "Purpose-built flat low rise",
       ],
+      "validScopes": undefined,
       "values": [
         [
           905,
@@ -2799,6 +2870,7 @@ exports[`DataModel grouped processing - stacked with accumulation example should
       "keys": [
         "Small terraced house",
       ],
+      "validScopes": undefined,
       "values": [
         [
           1013,
@@ -2821,6 +2893,7 @@ exports[`DataModel grouped processing - stacked with accumulation example should
       "keys": [
         "Bungalow",
       ],
+      "validScopes": undefined,
       "values": [
         [
           1486,
@@ -2843,6 +2916,7 @@ exports[`DataModel grouped processing - stacked with accumulation example should
       "keys": [
         "Converted flat",
       ],
+      "validScopes": undefined,
       "values": [
         [
           252,
@@ -2865,6 +2939,7 @@ exports[`DataModel grouped processing - stacked with accumulation example should
       "keys": [
         "Purpose-built flat high rise",
       ],
+      "validScopes": undefined,
       "values": [
         [
           97,
@@ -2876,6 +2951,7 @@ exports[`DataModel grouped processing - stacked with accumulation example should
     },
   ],
   "defs": {
+    "allScopesHaveSameDefs": true,
     "keys": [
       {
         "index": 0,
@@ -2997,8 +3073,306 @@ exports[`DataModel grouped processing - stacked with accumulation example should
       ],
     ],
   },
+  "partialValidDataCount": 0,
   "time": Any<Number>,
   "type": "grouped",
+}
+`;
+
+exports[`DataModel missing and invalid data processing - multiple scopes should generated the expected results 1`] = `
+{
+  "data": [
+    {
+      "datum": {
+        "chrome": "illegal value",
+        "firefox": 26.85,
+        "safari": 2.79,
+        "year": "2009",
+      },
+      "keys": [
+        "2009",
+      ],
+      "validScopes": [
+        "series-b",
+        "series-c",
+      ],
+      "values": [
+        null,
+        ,
+        26.85,
+        2.79,
+      ],
+    },
+    {
+      "datum": {
+        "firefox": 31.15,
+        "ie": 54.39,
+        "safari": 4.22,
+        "year": "2010",
+      },
+      "keys": [
+        "2010",
+      ],
+      "values": [
+        54.39,
+        null,
+        31.15,
+        4.22,
+      ],
+    },
+    {
+      "datum": {
+        "chrome": 15.01,
+        "ie": 44.03,
+        "safari": 5.94,
+        "year": "2011",
+      },
+      "keys": [
+        "2011",
+      ],
+      "values": [
+        44.03,
+        15.01,
+        null,
+        5.94,
+      ],
+    },
+    {
+      "datum": {
+        "chrome": 31.71,
+        "firefox": undefined,
+        "safari": undefined,
+        "year": "2013",
+      },
+      "keys": [
+        "2013",
+      ],
+      "validScopes": [
+        "series-a",
+      ],
+      "values": [
+        null,
+        31.71,
+        ,
+        ,
+      ],
+    },
+    {
+      "datum": {
+        "firefox": 14.77,
+        "ie": 17.75,
+        "safari": 12.63,
+        "year": "2014",
+      },
+      "keys": [
+        "2014",
+      ],
+      "values": [
+        17.75,
+        null,
+        14.77,
+        12.63,
+      ],
+    },
+    {
+      "datum": {
+        "chrome": 42.27,
+        "ie": -13.3,
+        "safari": "illegal value",
+        "year": "2015",
+      },
+      "keys": [
+        "2015",
+      ],
+      "validScopes": [
+        "series-a",
+        "series-b",
+      ],
+      "values": [
+        -13.3,
+        42.27,
+        null,
+        ,
+      ],
+    },
+    {
+      "datum": {
+        "chrome": 47.79,
+        "firefox": 8.97,
+        "ie": -8.94,
+        "year": "2016",
+      },
+      "keys": [
+        "2016",
+      ],
+      "values": [
+        -8.94,
+        47.79,
+        8.97,
+        null,
+      ],
+    },
+    {
+      "datum": {
+        "chrome": 51.76,
+        "firefox": 6.75,
+        "safari": 14.54,
+        "year": "2017",
+      },
+      "keys": [
+        "2017",
+      ],
+      "values": [
+        null,
+        51.76,
+        6.75,
+        14.54,
+      ],
+    },
+    {
+      "datum": {
+        "firefox": "illegal value",
+        "ie": 3.2,
+        "safari": 14.44,
+        "year": "2018",
+      },
+      "keys": [
+        "2018",
+      ],
+      "validScopes": [
+        "series-a",
+        "series-c",
+      ],
+      "values": [
+        3.2,
+        null,
+        ,
+        14.44,
+      ],
+    },
+    {
+      "datum": {
+        "chrome": 61.72,
+        "ie": 2.7,
+        "safari": 15.23,
+        "year": "2019",
+      },
+      "keys": [
+        "2019",
+      ],
+      "values": [
+        2.7,
+        61.72,
+        null,
+        15.23,
+      ],
+    },
+  ],
+  "defs": {
+    "allScopesHaveSameDefs": false,
+    "keys": [
+      {
+        "index": 0,
+        "missing": false,
+        "property": "year",
+        "scopes": [
+          "test",
+        ],
+        "type": "key",
+        "valueType": "category",
+      },
+    ],
+    "values": [
+      {
+        "id": undefined,
+        "index": 0,
+        "missing": false,
+        "missingValue": null,
+        "property": "ie",
+        "scopes": undefined,
+        "type": "value",
+        "validation": [Function],
+        "valueType": "range",
+      },
+      {
+        "id": undefined,
+        "index": 1,
+        "missing": false,
+        "missingValue": null,
+        "property": "chrome",
+        "scopes": [
+          "series-a",
+        ],
+        "type": "value",
+        "validation": [Function],
+        "valueType": "range",
+      },
+      {
+        "id": undefined,
+        "index": 2,
+        "missing": false,
+        "missingValue": null,
+        "property": "firefox",
+        "scopes": [
+          "series-b",
+        ],
+        "type": "value",
+        "validation": [Function],
+        "valueType": "range",
+      },
+      {
+        "id": undefined,
+        "index": 3,
+        "missing": false,
+        "missingValue": null,
+        "property": "safari",
+        "scopes": [
+          "series-c",
+        ],
+        "type": "value",
+        "validation": [Function],
+        "valueType": "range",
+      },
+    ],
+  },
+  "domain": {
+    "keys": [
+      [
+        "2009",
+        "2010",
+        "2011",
+        "2012",
+        "2013",
+        "2014",
+        "2015",
+        "2016",
+        "2017",
+        "2018",
+        "2019",
+      ],
+    ],
+    "values": [
+      [
+        -13.3,
+        54.39,
+      ],
+      [
+        null,
+        61.72,
+      ],
+      [
+        null,
+        31.15,
+      ],
+      [
+        null,
+        15.23,
+      ],
+    ],
+  },
+  "partialValidDataCount": 4,
+  "time": Any<Number>,
+  "type": "ungrouped",
 }
 `;
 
@@ -3194,6 +3568,7 @@ exports[`DataModel missing and invalid data processing should generated the expe
     },
   ],
   "defs": {
+    "allScopesHaveSameDefs": true,
     "keys": [
       {
         "index": 0,
@@ -3300,6 +3675,7 @@ exports[`DataModel missing and invalid data processing should generated the expe
       ],
     ],
   },
+  "partialValidDataCount": 0,
   "time": Any<Number>,
   "type": "ungrouped",
 }
@@ -3370,6 +3746,7 @@ exports[`DataModel repeated property processing should generated the expected re
     },
   ],
   "defs": {
+    "allScopesHaveSameDefs": true,
     "keys": [],
     "values": [
       {
@@ -3412,6 +3789,7 @@ exports[`DataModel repeated property processing should generated the expected re
       ],
     ],
   },
+  "partialValidDataCount": 0,
   "time": Any<Number>,
   "type": "ungrouped",
 }
@@ -3518,6 +3896,7 @@ exports[`DataModel ungrouped processing - accumulated and normalised properties 
     },
   ],
   "defs": {
+    "allScopesHaveSameDefs": true,
     "keys": [],
     "values": [
       {
@@ -3578,6 +3957,7 @@ exports[`DataModel ungrouped processing - accumulated and normalised properties 
       ],
     ],
   },
+  "partialValidDataCount": 0,
   "time": Any<Number>,
   "type": "ungrouped",
 }
@@ -4316,6 +4696,7 @@ exports[`DataModel ungrouped processing should generated the expected results 1`
     },
   ],
   "defs": {
+    "allScopesHaveSameDefs": false,
     "keys": [
       {
         "index": 0,
@@ -4369,6 +4750,7 @@ exports[`DataModel ungrouped processing should generated the expected results 1`
       ],
     ],
   },
+  "partialValidDataCount": 0,
   "time": Any<Number>,
   "type": "ungrouped",
 }

--- a/charts-community-modules/ag-charts-community/src/chart/data/__snapshots__/dataModel.test.ts.snap
+++ b/charts-community-modules/ag-charts-community/src/chart/data/__snapshots__/dataModel.test.ts.snap
@@ -9,6 +9,9 @@ exports[`DataModel empty data set processing should generated the expected resul
         "index": 0,
         "missing": false,
         "property": "year",
+        "scopes": [
+          "test",
+        ],
         "type": "key",
         "valueType": "category",
       },
@@ -19,6 +22,9 @@ exports[`DataModel empty data set processing should generated the expected resul
         "index": 0,
         "missing": false,
         "property": "ie",
+        "scopes": [
+          "test",
+        ],
         "type": "value",
         "valueType": "range",
       },
@@ -27,6 +33,9 @@ exports[`DataModel empty data set processing should generated the expected resul
         "index": 1,
         "missing": false,
         "property": "chrome",
+        "scopes": [
+          "test",
+        ],
         "type": "value",
         "valueType": "range",
       },
@@ -35,6 +44,9 @@ exports[`DataModel empty data set processing should generated the expected resul
         "index": 2,
         "missing": false,
         "property": "firefox",
+        "scopes": [
+          "test",
+        ],
         "type": "value",
         "valueType": "range",
       },
@@ -43,6 +55,9 @@ exports[`DataModel empty data set processing should generated the expected resul
         "index": 3,
         "missing": false,
         "property": "safari",
+        "scopes": [
+          "test",
+        ],
         "type": "value",
         "valueType": "range",
       },
@@ -242,6 +257,7 @@ exports[`DataModel grouped processing - calculated grouping should generated the
         "index": 0,
         "missing": false,
         "property": "curb-weight",
+        "scope": "test",
         "type": "key",
         "valueType": "range",
       },
@@ -252,6 +268,9 @@ exports[`DataModel grouped processing - calculated grouping should generated the
         "index": 0,
         "missing": false,
         "property": "curb-weight",
+        "scopes": [
+          "test",
+        ],
         "type": "value",
         "valueType": "range",
       },
@@ -507,6 +526,9 @@ exports[`DataModel grouped processing - calculated grouping should generated the
         "index": 0,
         "missing": false,
         "property": "engine-size",
+        "scopes": [
+          "test",
+        ],
         "type": "key",
         "valueType": "category",
       },
@@ -517,6 +539,9 @@ exports[`DataModel grouped processing - calculated grouping should generated the
         "index": 0,
         "missing": false,
         "property": "highway-mpg",
+        "scopes": [
+          "test",
+        ],
         "type": "value",
         "valueType": "range",
       },
@@ -714,6 +739,9 @@ exports[`DataModel grouped processing - calculated grouping should generated the
         "index": 0,
         "missing": false,
         "property": "engine-size",
+        "scopes": [
+          "test",
+        ],
         "type": "key",
         "valueType": "category",
       },
@@ -950,6 +978,9 @@ exports[`DataModel grouped processing - grouped example should generated the exp
         "index": 0,
         "missing": false,
         "property": "type",
+        "scopes": [
+          "test",
+        ],
         "type": "key",
         "valueType": "category",
       },
@@ -960,6 +991,9 @@ exports[`DataModel grouped processing - grouped example should generated the exp
         "index": 0,
         "missing": false,
         "property": "total",
+        "scopes": [
+          "test",
+        ],
         "type": "value",
         "valueType": "range",
       },
@@ -968,6 +1002,9 @@ exports[`DataModel grouped processing - grouped example should generated the exp
         "index": 1,
         "missing": false,
         "property": "regular",
+        "scopes": [
+          "test",
+        ],
         "type": "value",
         "valueType": "range",
       },
@@ -1436,6 +1473,9 @@ exports[`DataModel grouped processing - stacked and normalised example should ge
         "index": 0,
         "missing": false,
         "property": "month",
+        "scopes": [
+          "test",
+        ],
         "type": "key",
         "valueType": "category",
       },
@@ -1446,6 +1486,9 @@ exports[`DataModel grouped processing - stacked and normalised example should ge
         "index": 0,
         "missing": false,
         "property": "petroleum",
+        "scopes": [
+          "test",
+        ],
         "type": "value",
         "valueType": "range",
       },
@@ -1454,6 +1497,9 @@ exports[`DataModel grouped processing - stacked and normalised example should ge
         "index": 1,
         "missing": false,
         "property": "naturalGas",
+        "scopes": [
+          "test",
+        ],
         "type": "value",
         "valueType": "range",
       },
@@ -1462,6 +1508,9 @@ exports[`DataModel grouped processing - stacked and normalised example should ge
         "index": 2,
         "missing": false,
         "property": "bioenergyWaste",
+        "scopes": [
+          "test",
+        ],
         "type": "value",
         "valueType": "range",
       },
@@ -1470,6 +1519,9 @@ exports[`DataModel grouped processing - stacked and normalised example should ge
         "index": 3,
         "missing": false,
         "property": "nuclear",
+        "scopes": [
+          "test",
+        ],
         "type": "value",
         "valueType": "range",
       },
@@ -1478,6 +1530,9 @@ exports[`DataModel grouped processing - stacked and normalised example should ge
         "index": 4,
         "missing": false,
         "property": "windSolarHydro",
+        "scopes": [
+          "test",
+        ],
         "type": "value",
         "valueType": "range",
       },
@@ -1486,6 +1541,9 @@ exports[`DataModel grouped processing - stacked and normalised example should ge
         "index": 5,
         "missing": false,
         "property": "imported",
+        "scopes": [
+          "test",
+        ],
         "type": "value",
         "valueType": "range",
       },
@@ -1760,6 +1818,9 @@ exports[`DataModel grouped processing - stacked and normalised example should ge
         "index": 0,
         "missing": false,
         "property": "type",
+        "scopes": [
+          "test",
+        ],
         "type": "key",
         "valueType": "category",
       },
@@ -1770,6 +1831,9 @@ exports[`DataModel grouped processing - stacked and normalised example should ge
         "index": 0,
         "missing": false,
         "property": "white",
+        "scopes": [
+          "test",
+        ],
         "type": "value",
         "valueType": "range",
       },
@@ -1778,6 +1842,9 @@ exports[`DataModel grouped processing - stacked and normalised example should ge
         "index": 1,
         "missing": false,
         "property": "mixed",
+        "scopes": [
+          "test",
+        ],
         "type": "value",
         "valueType": "range",
       },
@@ -1786,6 +1853,9 @@ exports[`DataModel grouped processing - stacked and normalised example should ge
         "index": 2,
         "missing": false,
         "property": "asian",
+        "scopes": [
+          "test",
+        ],
         "type": "value",
         "valueType": "range",
       },
@@ -1794,6 +1864,9 @@ exports[`DataModel grouped processing - stacked and normalised example should ge
         "index": 3,
         "missing": false,
         "property": "black",
+        "scopes": [
+          "test",
+        ],
         "type": "value",
         "valueType": "range",
       },
@@ -1802,6 +1875,9 @@ exports[`DataModel grouped processing - stacked and normalised example should ge
         "index": 4,
         "missing": false,
         "property": "chinese",
+        "scopes": [
+          "test",
+        ],
         "type": "value",
         "valueType": "range",
       },
@@ -1810,6 +1886,9 @@ exports[`DataModel grouped processing - stacked and normalised example should ge
         "index": 5,
         "missing": false,
         "property": "other",
+        "scopes": [
+          "test",
+        ],
         "type": "value",
         "valueType": "range",
       },
@@ -2120,6 +2199,9 @@ exports[`DataModel grouped processing - stacked example should generated the exp
         "index": 0,
         "missing": false,
         "property": "type",
+        "scopes": [
+          "test",
+        ],
         "type": "key",
         "valueType": "category",
       },
@@ -2130,6 +2212,9 @@ exports[`DataModel grouped processing - stacked example should generated the exp
         "index": 0,
         "missing": false,
         "property": "ownerOccupied",
+        "scopes": [
+          "test",
+        ],
         "type": "value",
         "valueType": "range",
       },
@@ -2138,6 +2223,9 @@ exports[`DataModel grouped processing - stacked example should generated the exp
         "index": 1,
         "missing": false,
         "property": "privateRented",
+        "scopes": [
+          "test",
+        ],
         "type": "value",
         "valueType": "range",
       },
@@ -2146,6 +2234,9 @@ exports[`DataModel grouped processing - stacked example should generated the exp
         "index": 2,
         "missing": false,
         "property": "localAuthority",
+        "scopes": [
+          "test",
+        ],
         "type": "value",
         "valueType": "range",
       },
@@ -2154,6 +2245,9 @@ exports[`DataModel grouped processing - stacked example should generated the exp
         "index": 3,
         "missing": false,
         "property": "housingAssociation",
+        "scopes": [
+          "test",
+        ],
         "type": "value",
         "valueType": "range",
       },
@@ -2468,6 +2562,9 @@ exports[`DataModel grouped processing - stacked with accumulation and normalised
         "index": 0,
         "missing": false,
         "property": "type",
+        "scopes": [
+          "test",
+        ],
         "type": "key",
         "valueType": "category",
       },
@@ -2479,6 +2576,9 @@ exports[`DataModel grouped processing - stacked with accumulation and normalised
         "missing": false,
         "processor": [Function],
         "property": "ownerOccupied",
+        "scopes": [
+          "test",
+        ],
         "type": "value",
         "valueType": "range",
       },
@@ -2488,6 +2588,9 @@ exports[`DataModel grouped processing - stacked with accumulation and normalised
         "missing": false,
         "processor": [Function],
         "property": "privateRented",
+        "scopes": [
+          "test",
+        ],
         "type": "value",
         "valueType": "range",
       },
@@ -2497,6 +2600,9 @@ exports[`DataModel grouped processing - stacked with accumulation and normalised
         "missing": false,
         "processor": [Function],
         "property": "localAuthority",
+        "scopes": [
+          "test",
+        ],
         "type": "value",
         "valueType": "range",
       },
@@ -2506,6 +2612,9 @@ exports[`DataModel grouped processing - stacked with accumulation and normalised
         "missing": false,
         "processor": [Function],
         "property": "housingAssociation",
+        "scopes": [
+          "test",
+        ],
         "type": "value",
         "valueType": "range",
       },
@@ -2772,6 +2881,9 @@ exports[`DataModel grouped processing - stacked with accumulation example should
         "index": 0,
         "missing": false,
         "property": "type",
+        "scopes": [
+          "test",
+        ],
         "type": "key",
         "valueType": "category",
       },
@@ -2783,6 +2895,9 @@ exports[`DataModel grouped processing - stacked with accumulation example should
         "missing": false,
         "processor": [Function],
         "property": "ownerOccupied",
+        "scopes": [
+          "test",
+        ],
         "type": "value",
         "valueType": "range",
       },
@@ -2792,6 +2907,9 @@ exports[`DataModel grouped processing - stacked with accumulation example should
         "missing": false,
         "processor": [Function],
         "property": "privateRented",
+        "scopes": [
+          "test",
+        ],
         "type": "value",
         "valueType": "range",
       },
@@ -2801,6 +2919,9 @@ exports[`DataModel grouped processing - stacked with accumulation example should
         "missing": false,
         "processor": [Function],
         "property": "localAuthority",
+        "scopes": [
+          "test",
+        ],
         "type": "value",
         "valueType": "range",
       },
@@ -2810,6 +2931,9 @@ exports[`DataModel grouped processing - stacked with accumulation example should
         "missing": false,
         "processor": [Function],
         "property": "housingAssociation",
+        "scopes": [
+          "test",
+        ],
         "type": "value",
         "valueType": "range",
       },
@@ -3075,6 +3199,9 @@ exports[`DataModel missing and invalid data processing should generated the expe
         "index": 0,
         "missing": false,
         "property": "year",
+        "scopes": [
+          "test",
+        ],
         "type": "key",
         "valueType": "category",
       },
@@ -3087,6 +3214,9 @@ exports[`DataModel missing and invalid data processing should generated the expe
         "missing": false,
         "missingValue": null,
         "property": "ie",
+        "scopes": [
+          "test",
+        ],
         "type": "value",
         "validation": [Function],
         "valueType": "range",
@@ -3098,6 +3228,9 @@ exports[`DataModel missing and invalid data processing should generated the expe
         "missing": false,
         "missingValue": null,
         "property": "chrome",
+        "scopes": [
+          "test",
+        ],
         "type": "value",
         "validation": [Function],
         "valueType": "range",
@@ -3109,6 +3242,9 @@ exports[`DataModel missing and invalid data processing should generated the expe
         "missing": false,
         "missingValue": null,
         "property": "firefox",
+        "scopes": [
+          "test",
+        ],
         "type": "value",
         "validation": [Function],
         "valueType": "range",
@@ -3120,6 +3256,9 @@ exports[`DataModel missing and invalid data processing should generated the expe
         "missing": false,
         "missingValue": null,
         "property": "safari",
+        "scopes": [
+          "test",
+        ],
         "type": "value",
         "validation": [Function],
         "valueType": "range",
@@ -3239,6 +3378,9 @@ exports[`DataModel repeated property processing should generated the expected re
         "missing": false,
         "processor": [Function],
         "property": "share",
+        "scopes": [
+          "test",
+        ],
         "type": "value",
         "valueType": "range",
       },
@@ -3285,7 +3427,7 @@ exports[`DataModel ungrouped processing - accumulated and normalised properties 
       },
       "keys": [],
       "values": [
-        2.978445409938555,
+        0,
         "Christian",
         4159000,
       ],
@@ -3297,7 +3439,7 @@ exports[`DataModel ungrouped processing - accumulated and normalised properties 
       },
       "keys": [],
       "values": [
-        3.049570275710106,
+        0.1352271965379232,
         "Buddhist",
         97000,
       ],
@@ -3309,7 +3451,7 @@ exports[`DataModel ungrouped processing - accumulated and normalised properties 
       },
       "keys": [],
       "values": [
-        3.383930469440284,
+        0.7709344297471291,
         "Hindu",
         456000,
       ],
@@ -3321,7 +3463,7 @@ exports[`DataModel ungrouped processing - accumulated and normalised properties 
       },
       "keys": [],
       "values": [
-        3.507115803972454,
+        1.0051423577715735,
         "Jewish",
         168000,
       ],
@@ -3333,7 +3475,7 @@ exports[`DataModel ungrouped processing - accumulated and normalised properties 
       },
       "keys": [],
       "values": [
-        4.398009741214046,
+        2.698967551519787,
         "Muslim",
         1215000,
       ],
@@ -3345,7 +3487,7 @@ exports[`DataModel ungrouped processing - accumulated and normalised properties 
       },
       "keys": [],
       "values": [
-        4.488199003996527,
+        2.8704412131091117,
         "Sikh",
         123000,
       ],
@@ -3357,7 +3499,7 @@ exports[`DataModel ungrouped processing - accumulated and normalised properties 
       },
       "keys": [],
       "values": [
-        4.61578381476199,
+        3.1130137099915722,
         "Other",
         174000,
       ],
@@ -3384,6 +3526,9 @@ exports[`DataModel ungrouped processing - accumulated and normalised properties 
         "missing": false,
         "processor": [Function],
         "property": "population",
+        "scopes": [
+          "test",
+        ],
         "type": "value",
         "valueType": "range",
       },
@@ -3391,6 +3536,9 @@ exports[`DataModel ungrouped processing - accumulated and normalised properties 
         "index": 1,
         "missing": false,
         "property": "religion",
+        "scopes": [
+          "test",
+        ],
         "type": "value",
         "valueType": "category",
       },
@@ -3399,6 +3547,9 @@ exports[`DataModel ungrouped processing - accumulated and normalised properties 
         "index": 2,
         "missing": false,
         "property": "population",
+        "scopes": [
+          "test",
+        ],
         "type": "value",
         "valueType": "range",
       },
@@ -3423,7 +3574,7 @@ exports[`DataModel ungrouped processing - accumulated and normalised properties 
       ],
       [
         97000,
-        8666000,
+        4159000,
       ],
     ],
   },
@@ -4170,6 +4321,7 @@ exports[`DataModel ungrouped processing should generated the expected results 1`
         "index": 0,
         "missing": false,
         "property": "date",
+        "scope": "test",
         "type": "key",
         "valueType": "range",
       },
@@ -4180,6 +4332,9 @@ exports[`DataModel ungrouped processing should generated the expected results 1`
         "index": 0,
         "missing": false,
         "property": "petrol",
+        "scopes": [
+          "test",
+        ],
         "type": "value",
         "valueType": "range",
       },
@@ -4188,6 +4343,9 @@ exports[`DataModel ungrouped processing should generated the expected results 1`
         "index": 1,
         "missing": false,
         "property": "diesel",
+        "scopes": [
+          "test",
+        ],
         "type": "value",
         "valueType": "range",
       },

--- a/charts-community-modules/ag-charts-community/src/chart/data/aggregateFunctions.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/data/aggregateFunctions.ts
@@ -1,4 +1,4 @@
-import { AggregatePropertyDefinition, DatumPropertyDefinition } from './dataModel';
+import { AggregatePropertyDefinition, DatumPropertyDefinition, ScopeProvider } from './dataModel';
 import { extendDomain } from './utilFunctions';
 
 type ContinuousDomain<T extends number | Date> = [T, T];
@@ -19,8 +19,10 @@ function sumValues(values: any[], accumulator = [0, 0] as ContinuousDomain<numbe
     return accumulator;
 }
 
-export function sum<K>(props: K[]) {
+export function sum<K>(scope: ScopeProvider, id: string, props: K[]) {
     const result: AggregatePropertyDefinition<any, any> = {
+        id,
+        scopes: [scope.id],
         properties: props,
         type: 'aggregate',
         aggregateFunction: (values) => sumValues(values),
@@ -29,8 +31,14 @@ export function sum<K>(props: K[]) {
     return result;
 }
 
-export function groupSum<K>(props: K[]): AggregatePropertyDefinition<any, any, [number, number]> {
+export function groupSum<K>(
+    scope: ScopeProvider,
+    id: string,
+    props: K[]
+): AggregatePropertyDefinition<any, any, [number, number]> {
     return {
+        id,
+        scopes: [scope.id],
         type: 'aggregate',
         properties: props,
         aggregateFunction: (values) => sumValues(values),
@@ -42,8 +50,10 @@ export function groupSum<K>(props: K[]): AggregatePropertyDefinition<any, any, [
     };
 }
 
-export function range<K>(props: K[]) {
+export function range<K>(scope: ScopeProvider, id: string, props: K[]) {
     const result: AggregatePropertyDefinition<any, any> = {
+        id,
+        scopes: [scope.id],
         properties: props,
         type: 'aggregate',
         aggregateFunction: (values) => extendDomain(values),
@@ -52,8 +62,10 @@ export function range<K>(props: K[]) {
     return result;
 }
 
-export function count() {
+export function count(scope: ScopeProvider, id: string) {
     const result: AggregatePropertyDefinition<any, any> = {
+        id,
+        scopes: [scope.id],
         properties: [],
         type: 'aggregate',
         aggregateFunction: () => [0, 1],
@@ -62,8 +74,10 @@ export function count() {
     return result;
 }
 
-export function groupCount(): AggregatePropertyDefinition<any, any, [number, number]> {
+export function groupCount(scope: ScopeProvider, id: string): AggregatePropertyDefinition<any, any, [number, number]> {
     return {
+        id,
+        scopes: [scope.id],
         type: 'aggregate',
         properties: [],
         aggregateFunction: () => [0, 1],
@@ -75,8 +89,10 @@ export function groupCount(): AggregatePropertyDefinition<any, any, [number, num
     };
 }
 
-export function average<K>(props: K[]) {
+export function average<K>(scope: ScopeProvider, id: string, props: K[]) {
     const result: AggregatePropertyDefinition<any, any> = {
+        id,
+        scopes: [scope.id],
         properties: props,
         type: 'aggregate',
         aggregateFunction: (values) => sumValues(values).map((v) => v / values.length) as [number, number],
@@ -85,8 +101,10 @@ export function average<K>(props: K[]) {
     return result;
 }
 
-export function groupAverage<K>(props: K[]) {
+export function groupAverage<K>(scope: ScopeProvider, id: string, props: K[]) {
     const result: AggregatePropertyDefinition<any, any, [number, number], [number, number, number]> = {
+        id,
+        scopes: [scope.id],
         properties: props,
         type: 'aggregate',
         aggregateFunction: (values) => sumValues(values),
@@ -108,8 +126,10 @@ export function groupAverage<K>(props: K[]) {
     return result;
 }
 
-export function area<K>(props: K[], aggFn: AggregatePropertyDefinition<any, any>) {
+export function area<K>(scope: ScopeProvider, id: string, props: K[], aggFn: AggregatePropertyDefinition<any, any>) {
     const result: AggregatePropertyDefinition<any, any> = {
+        id,
+        scopes: [scope.id],
         properties: props,
         type: 'aggregate',
         aggregateFunction: (values, keyRange = []) => {

--- a/charts-community-modules/ag-charts-community/src/chart/data/dataController.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/data/dataController.ts
@@ -1,4 +1,6 @@
 import { jsonDiff } from '../../util/json';
+import { Logger } from '../../util/logger';
+import { windowValue } from '../../util/window';
 import { DataModel, DataModelOptions, DatumPropertyDefinition, ProcessedData, PropertyDefinition } from './dataModel';
 
 interface RequestedProcessing<
@@ -33,6 +35,8 @@ type Result<
 
 /** Implements cross-series data model coordination. */
 export class DataController {
+    static DEBUG = () => [true, 'data-model'].includes(windowValue('agChartsDebug') as string) ?? false;
+
     private requested: RequestedProcessing<any, any, any>[] = [];
     private status: 'setup' | 'executed' = 'setup';
 
@@ -61,7 +65,9 @@ export class DataController {
 
         this.status = 'executed';
 
+        if (DataController.DEBUG()) Logger.debug('DataController.execute() - requested', this.requested);
         const merged = this.mergeRequested();
+        if (DataController.DEBUG()) Logger.debug('DataController.execute() - merged', merged);
 
         for (const { opts, data, resultCbs, rejects } of merged) {
             try {

--- a/charts-community-modules/ag-charts-community/src/chart/data/dataController.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/data/dataController.ts
@@ -1,4 +1,5 @@
-import { DataModel, DataModelOptions, ProcessedData } from './dataModel';
+import { jsonDiff } from '../../util/json';
+import { DataModel, DataModelOptions, DatumPropertyDefinition, ProcessedData, PropertyDefinition } from './dataModel';
 
 interface RequestedProcessing<
     D extends object,
@@ -10,6 +11,18 @@ interface RequestedProcessing<
     data: D[];
     resultCb: (result: Result<D, K, G>) => void;
     reject: (reason?: any) => void;
+}
+
+interface MergedRequests<
+    D extends object,
+    K extends keyof D & string = keyof D & string,
+    G extends boolean | undefined = undefined
+> {
+    ids: string[];
+    opts: DataModelOptions<K, any>;
+    data: D[];
+    resultCbs: ((result: Result<D, K, G>) => void)[];
+    rejects: ((reason?: any) => void)[];
 }
 
 type Result<
@@ -48,18 +61,95 @@ export class DataController {
 
         this.status = 'executed';
 
-        for (const { opts, data, resultCb, reject } of this.requested) {
+        const merged = this.mergeRequested();
+
+        for (const { opts, data, resultCbs, rejects } of merged) {
             try {
                 const dataModel = new DataModel<any>(opts);
                 const processedData = dataModel.processData(data);
                 if (processedData) {
-                    resultCb({ dataModel, processedData });
+                    resultCbs.forEach((cb) => cb({ dataModel, processedData }));
                 } else {
-                    reject(new Error(`AG Charts - no processed data generated`));
+                    rejects.forEach((cb) => cb(new Error(`AG Charts - no processed data generated`)));
                 }
             } catch (error) {
-                reject(error);
+                rejects.forEach((cb) => cb(error));
             }
         }
+    }
+
+    private mergeRequested(): MergedRequests<any, any, any>[] {
+        const grouped: RequestedProcessing<any, any, any>[][] = [];
+        const keys = (props: PropertyDefinition<any>[]) => {
+            return props
+                .filter((p): p is DatumPropertyDefinition<any> => p.type === 'key')
+                .map((p) => p.property)
+                .join(';');
+        };
+
+        const groupMatch =
+            ({ opts, data }: RequestedProcessing<any, any, any>) =>
+            (gr: RequestedProcessing<any, any, any>[]) => {
+                return (
+                    gr[0].data === data &&
+                    gr[0].opts.groupByKeys === opts.groupByKeys &&
+                    gr[0].opts.dataVisible === opts.dataVisible &&
+                    gr[0].opts.groupByFn === opts.groupByFn &&
+                    keys(gr[0].opts.props) === keys(opts.props)
+                );
+            };
+
+        const propMatch = (prop: PropertyDefinition<any>) => (existing: PropertyDefinition<any>) => {
+            if (existing.type !== prop.type) return false;
+            if (existing.id !== prop.id) return false;
+
+            const diff = jsonDiff(existing, prop) ?? {};
+            delete diff['scopes'];
+
+            return Object.keys(diff).length === 0;
+        };
+
+        const mergeOpts = (opts: DataModelOptions<any, any>[]): DataModelOptions<any, any> => {
+            return {
+                ...opts[0],
+                props: opts.reduce((result, next) => {
+                    for (const prop of next.props) {
+                        const match = result.find(propMatch(prop));
+
+                        if (match) {
+                            match.scopes ??= [];
+                            match.scopes.push(...(prop.scopes ?? []), ...(next.scopes ?? []));
+                            continue;
+                        }
+
+                        result.push(prop);
+                    }
+
+                    return result;
+                }, [] as PropertyDefinition<any>[]),
+            };
+        };
+
+        const merge = (props: RequestedProcessing<any, any, any>[]): MergedRequests<any, any, any> => {
+            return {
+                ids: props.map(({ id }) => id),
+                resultCbs: props.map(({ resultCb }) => resultCb),
+                rejects: props.map(({ reject }) => reject),
+                data: props[0].data,
+                opts: mergeOpts(props.map(({ opts }) => opts)),
+            };
+        };
+
+        for (const request of this.requested) {
+            const match = grouped.find(groupMatch(request));
+
+            if (match) {
+                match.push(request);
+            } else {
+                grouped.push([request]);
+            }
+        }
+
+        return grouped.map(merge);
     }
 }

--- a/charts-community-modules/ag-charts-community/src/chart/data/dataModel.test.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/data/dataModel.test.ts
@@ -4,8 +4,15 @@ import { DATA_BROWSER_MARKET_SHARE } from '../test/data';
 
 import * as examples from '../test/examples';
 
-import { DataModel, GroupByFn } from './dataModel';
-import { area, groupAverage, groupCount, range, sum, accumulatedValue } from './aggregateFunctions';
+import { AggregatePropertyDefinition, DataModel, GroupByFn } from './dataModel';
+import {
+    area as actualArea,
+    groupAverage as actualGroupAverage,
+    groupCount as actualGroupCount,
+    range as actualRange,
+    sum as actualSum,
+    accumulatedValue,
+} from './aggregateFunctions';
 import {
     AGG_VALUES_EXTENT,
     normaliseGroupTo,
@@ -32,6 +39,12 @@ const accumulatedPropertyValue = (property: string, id?: string) => ({
     ...value(property, id),
     processor: accumulatedValue(),
 });
+const sum = (props: string[]) => actualSum({ id: 'test' }, `sum-${props.join('-')}`, props);
+const range = (props: string[]) => actualRange({ id: 'test' }, `range-${props.join('-')}`, props);
+const groupAverage = (props: string[]) => actualGroupAverage({ id: 'test' }, `groupAverage-${props.join('-')}`, props);
+const groupCount = () => actualGroupCount({ id: 'test' }, `groupCount`);
+const area = (props: string[], aggFn: AggregatePropertyDefinition<any, any>) =>
+    actualArea({ id: 'test' }, `area-${props.join('-')}`, props, aggFn);
 
 describe('DataModel', () => {
     describe('ungrouped processing', () => {
@@ -980,7 +993,7 @@ describe('DataModel', () => {
             const dataModel = new DataModel<any, any>({
                 props: [
                     accumulatedPropertyValue('share', 'angle'),
-                    rangedValueProperty('share', { id: 'radius', min: 0.05, max: 0.7 }),
+                    rangedValueProperty({ id: 'test' }, 'share', { id: 'radius', min: 0.05, max: 0.7 }),
                     normalisePropertyTo({ id: 'angle' }, [0, 1]),
                 ],
             });

--- a/charts-community-modules/ag-charts-community/src/chart/data/dataModel.test.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/data/dataModel.test.ts
@@ -4,7 +4,7 @@ import { DATA_BROWSER_MARKET_SHARE } from '../test/data';
 
 import * as examples from '../test/examples';
 
-import { AggregatePropertyDefinition, DataModel, GroupByFn } from './dataModel';
+import { AggregatePropertyDefinition, DataModel, GroupByFn, PropertyId } from './dataModel';
 import {
     area as actualArea,
     groupAverage as actualGroupAverage,
@@ -15,22 +15,33 @@ import {
 } from './aggregateFunctions';
 import {
     AGG_VALUES_EXTENT,
-    normaliseGroupTo,
-    normalisePropertyTo,
+    normaliseGroupTo as actualNormaliseGroupTo,
+    normalisePropertyTo as actualNormalisePropertyTo,
     SMALLEST_KEY_INTERVAL,
     SORT_DOMAIN_GROUPS,
 } from './processors';
 import { rangedValueProperty } from '../series/series';
 
-const rangeKey = (property: string) => ({ property, type: 'key' as const, valueType: 'range' as const });
-const categoryKey = (property: string) => ({ property, type: 'key' as const, valueType: 'category' as const });
+const rangeKey = (property: string) => ({ scope: 'test', property, type: 'key' as const, valueType: 'range' as const });
+const categoryKey = (property: string) => ({
+    scopes: ['test'],
+    property,
+    type: 'key' as const,
+    valueType: 'category' as const,
+});
 const value = (property: string, id?: string) => ({
+    scopes: ['test'],
     property,
     type: 'value' as const,
     valueType: 'range' as const,
     id,
 });
-const categoryValue = (property: string) => ({ property, type: 'value' as const, valueType: 'category' as const });
+const categoryValue = (property: string) => ({
+    scopes: ['test'],
+    property,
+    type: 'value' as const,
+    valueType: 'category' as const,
+});
 const accumulatedGroupValue = (property: string, id?: string) => ({
     ...value(property, id),
     processor: () => (next, total) => next + (total ?? 0),
@@ -45,6 +56,10 @@ const groupAverage = (props: string[]) => actualGroupAverage({ id: 'test' }, `gr
 const groupCount = () => actualGroupCount({ id: 'test' }, `groupCount`);
 const area = (props: string[], aggFn: AggregatePropertyDefinition<any, any>) =>
     actualArea({ id: 'test' }, `area-${props.join('-')}`, props, aggFn);
+const normaliseGroupTo = (props: string[], normaliseTo: number, mode?: 'sum' | 'range') =>
+    actualNormaliseGroupTo({ id: 'test' }, props, normaliseTo, mode);
+const normalisePropertyTo = (prop: PropertyId<any>, normaliseTo: [number, number]) =>
+    actualNormalisePropertyTo({ id: 'test' }, prop, normaliseTo);
 
 describe('DataModel', () => {
     describe('ungrouped processing', () => {

--- a/charts-community-modules/ag-charts-community/src/chart/data/processors.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/data/processors.ts
@@ -5,6 +5,7 @@ import {
     PropertyValueProcessorDefinition,
     ReducerOutputPropertyDefinition,
     ProcessedData,
+    ScopeProvider,
 } from './dataModel';
 
 export const SMALLEST_KEY_INTERVAL: ReducerOutputPropertyDefinition<number> = {
@@ -64,6 +65,7 @@ export const SORT_DOMAIN_GROUPS: ProcessorOutputPropertyDefinition<any> = {
 };
 
 export function normaliseGroupTo(
+    scope: ScopeProvider,
     properties: PropertyId<any>[],
     normaliseTo: number,
     mode: 'sum' | 'range' = 'sum'
@@ -77,6 +79,7 @@ export function normaliseGroupTo(
     };
 
     return {
+        scopes: [scope.id],
         type: 'group-value-processor',
         properties,
         adjust: () => (values: any[], valueIndexes: number[]) => {
@@ -102,6 +105,7 @@ export function normaliseGroupTo(
 }
 
 export function normalisePropertyTo(
+    scope: ScopeProvider,
     property: PropertyId<any>,
     normaliseTo: [number, number],
     rangeMin?: number,
@@ -118,6 +122,7 @@ export function normalisePropertyTo(
     };
 
     return {
+        scopes: [scope.id],
         type: 'property-value-processor',
         property,
         adjust: () => (pData, pIdx) => {

--- a/charts-community-modules/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
@@ -239,7 +239,7 @@ export class AreaSeries extends CartesianSeries<AreaSeriesNodeDataContext> {
         const normaliseTo = normalizedTo && isFinite(normalizedTo) ? normalizedTo : undefined;
         const extraProps = [];
         if (normaliseTo) {
-            extraProps.push(normaliseGroupTo(enabledYKeys, normaliseTo, 'sum'));
+            extraProps.push(normaliseGroupTo(this, enabledYKeys, normaliseTo, 'sum'));
         }
 
         const { dataModel, processedData } = await dataController.request<any, any, true>(this.id, data, {

--- a/charts-community-modules/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
@@ -51,6 +51,7 @@ import { normaliseGroupTo } from '../../data/processors';
 import { LegendItemDoubleClickChartEvent } from '../../interaction/chartEventManager';
 import { ModuleContext } from '../../../util/moduleContext';
 import { DataController } from '../../data/dataController';
+import { ContinuousDomain } from '../../data/utilFunctions';
 
 interface FillSelectionDatum {
     readonly itemId: string;
@@ -270,17 +271,10 @@ export class AreaSeries extends CartesianSeries<AreaSeriesNodeDataContext> {
         const xAxis = axes[ChartAxisDirection.X];
         const yAxis = axes[ChartAxisDirection.Y];
 
-        const {
-            domain: {
-                values: [yExtent],
-                aggValues: [ySumExtent] = [],
-            },
-        } = processedData;
-
         const keyDef = dataModel.resolveProcessedDataDefById(this, `xValue`);
         const keys = dataModel.getDomain(this, `xValue`, 'key', processedData);
-        // const yExtent = dataModel.getDomain(``);
-        // const ySumExtent = dataModel.getDomain(``);
+        const yExtent = dataModel.getDomain(this, /yValue-.*/, 'value', processedData);
+        const ySumExtent = dataModel.getDomain(this, `sum`, 'aggregate', processedData) as ContinuousDomain<number>;
 
         if (direction === ChartAxisDirection.X) {
             if (keyDef?.def.type === 'key' && keyDef.def.valueType === 'category') {

--- a/charts-community-modules/ag-charts-community/src/chart/series/cartesian/barSeries.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/series/cartesian/barSeries.ts
@@ -324,7 +324,7 @@ export class BarSeries extends CartesianSeries<SeriesNodeDataContext<BarNodeDatu
         const normaliseTo = normalizedToAbs && isFinite(normalizedToAbs) ? normalizedToAbs : undefined;
         const extraProps = [];
         if (normaliseTo) {
-            extraProps.push(normaliseGroupTo(activeSeriesItems, normaliseTo, 'sum'));
+            extraProps.push(normaliseGroupTo(this, activeSeriesItems, normaliseTo, 'sum'));
         }
 
         if (!this.animationManager?.skipAnimations && this.processedData) {

--- a/charts-community-modules/ag-charts-community/src/chart/series/cartesian/barSeries.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/series/cartesian/barSeries.ts
@@ -362,9 +362,6 @@ export class BarSeries extends CartesianSeries<SeriesNodeDataContext<BarNodeDatu
         if (!processedData || !dataModel) return [];
 
         const {
-            domain: {
-                values: [yExtent],
-            },
             reduced: { [SMALLEST_KEY_INTERVAL.property]: smallestX, [AGG_VALUES_EXTENT.property]: ySumExtent } = {},
         } = processedData;
 
@@ -373,6 +370,7 @@ export class BarSeries extends CartesianSeries<SeriesNodeDataContext<BarNodeDatu
 
         const keyDef = dataModel.resolveProcessedDataDefById(this, `xValue`);
         const keys = dataModel.getDomain(this, `xValue`, 'key', processedData);
+        const yExtent = dataModel.getDomain(this, /yValue-.*/, 'value', processedData);
 
         if (direction === this.getCategoryDirection()) {
             if (keyDef?.def.type === 'key' && keyDef?.def.valueType === 'category') {

--- a/charts-community-modules/ag-charts-community/src/chart/series/cartesian/histogramSeries.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/series/cartesian/histogramSeries.ts
@@ -290,13 +290,11 @@ export class HistogramSeries extends CartesianSeries<SeriesNodeDataContext<Histo
     }
 
     getDomain(direction: ChartAxisDirection): any[] {
-        const { processedData } = this;
+        const { processedData, dataModel } = this;
 
-        if (!processedData) return [];
+        if (!processedData || !dataModel) return [];
 
-        const {
-            domain: { aggValues: [yDomain] = [] },
-        } = processedData;
+        const yDomain = dataModel.getDomain(this, `groupAgg`, 'aggregate', processedData);
         const xDomainMin = this.calculatedBins?.[0][0];
         const xDomainMax = this.calculatedBins?.[(this.calculatedBins?.length ?? 0) - 1][1];
         if (direction === ChartAxisDirection.X) {

--- a/charts-community-modules/ag-charts-community/src/chart/series/cartesian/histogramSeries.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/series/cartesian/histogramSeries.ts
@@ -220,26 +220,26 @@ export class HistogramSeries extends CartesianSeries<SeriesNodeDataContext<Histo
     async processData(dataController: DataController) {
         const { xKey, yKey, data, areaPlot, aggregation } = this;
 
-        const props: PropertyDefinition<any>[] = [keyProperty(xKey, true), SORT_DOMAIN_GROUPS];
+        const props: PropertyDefinition<any>[] = [keyProperty(this, xKey, true), SORT_DOMAIN_GROUPS];
         if (yKey) {
-            let aggProp: AggregatePropertyDefinition<any, any, any> = groupCount();
+            let aggProp: AggregatePropertyDefinition<any, any, any> = groupCount(this, 'groupCount');
 
             if (aggregation === 'count') {
                 // Nothing to do.
             } else if (aggregation === 'sum') {
-                aggProp = groupSum([yKey]);
+                aggProp = groupSum(this, 'groupAgg', [yKey]);
             } else if (aggregation === 'mean') {
-                aggProp = groupAverage([yKey]);
+                aggProp = groupAverage(this, 'groupAgg', [yKey]);
             }
             if (areaPlot) {
-                aggProp = area([yKey], aggProp);
+                aggProp = area(this, 'groupAgg', [yKey], aggProp);
             }
-            props.push(valueProperty(yKey, true, { invalidValue: undefined }), aggProp);
+            props.push(valueProperty(this, yKey, true, { invalidValue: undefined }), aggProp);
         } else {
-            let aggProp = groupCount();
+            let aggProp = groupCount(this, 'groupAgg');
 
             if (areaPlot) {
-                aggProp = area([], aggProp);
+                aggProp = area(this, 'groupAgg', [], aggProp);
             }
             props.push(aggProp);
         }

--- a/charts-community-modules/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
@@ -206,6 +206,7 @@ export class LineSeries extends CartesianSeries<LineContext> {
                 if (isNaN(x)) {
                     prevXInRange = undefined;
                     moveTo = true;
+                    nextPoint = undefined;
                     continue;
                 }
                 const tolerance = (xScale.bandwidth ?? markerSize * 0.5 + (strokeWidth ?? 0)) + 1;

--- a/charts-community-modules/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
@@ -132,8 +132,8 @@ export class LineSeries extends CartesianSeries<LineContext> {
 
         const { dataModel, processedData } = await dataController.request<any>(this.id, data ?? [], {
             props: [
-                valueProperty(xKey, isContinuousX, { id: 'xValue' }),
-                valueProperty(yKey, isContinuousY, { id: 'yValue', invalidValue: undefined }),
+                valueProperty(this, xKey, isContinuousX, { id: 'xValue' }),
+                valueProperty(this, yKey, isContinuousY, { id: 'yValue', invalidValue: undefined }),
             ],
             dataVisible: this.visible,
         });
@@ -148,16 +148,16 @@ export class LineSeries extends CartesianSeries<LineContext> {
         const xAxis = axes[ChartAxisDirection.X];
         const yAxis = axes[ChartAxisDirection.Y];
 
-        const xDef = dataModel.resolveProcessedDataDefById(`xValue`);
+        const xDef = dataModel.resolveProcessedDataDefById(this, `xValue`);
         if (direction === ChartAxisDirection.X) {
-            const domain = dataModel.getDomain(`xValue`, processedData);
-            if (xDef?.valueType === 'category') {
+            const domain = dataModel.getDomain(this, `xValue`, 'value', processedData);
+            if (xDef?.def.type === 'value' && xDef.def.valueType === 'category') {
                 return domain;
             }
 
             return this.fixNumericExtent(extent(domain), xAxis);
         } else {
-            const domain = dataModel.getDomain(`yValue`, processedData);
+            const domain = dataModel.getDomain(this, `yValue`, 'value', processedData);
             return this.fixNumericExtent(domain as any, yAxis);
         }
     }
@@ -186,8 +186,8 @@ export class LineSeries extends CartesianSeries<LineContext> {
         const nodeData: LineNodeDatum[] = new Array(processedData.data.length);
         const size = markerEnabled ? markerSize : 0;
 
-        const xIdx = this.dataModel?.resolveProcessedDataIndexById(`xValue`)?.index ?? -1;
-        const yIdx = this.dataModel?.resolveProcessedDataIndexById(`yValue`)?.index ?? -1;
+        const xIdx = dataModel.resolveProcessedDataIndexById(this, `xValue`).index;
+        const yIdx = dataModel.resolveProcessedDataIndexById(this, `yValue`).index;
 
         let moveTo = true;
         let prevXInRange: undefined | -1 | 0 | 1 = undefined;

--- a/charts-community-modules/ag-charts-community/src/chart/series/hierarchy/treemapSeries.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/series/hierarchy/treemapSeries.ts
@@ -791,8 +791,6 @@ export class TreemapSeries extends HierarchySeries<TreemapNodeDatum> {
             let labelStyle: Label;
             let wrappedText = '';
             if (datum.isLeaf) {
-                labelStyle = labels.small;
-
                 const pickStyle = () => {
                     const availHeight = availTextHeight - (valueText ? valueStyle.fontSize + valueMargin : 0);
                     const labelStyles = [labels.large, labels.medium, labels.small];

--- a/charts-community-modules/ag-charts-community/src/chart/series/polar/pieSeries.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/series/polar/pieSeries.ts
@@ -410,7 +410,7 @@ export class PieSeries extends PolarSeries<PieNodeDatum> {
                     max: this.radiusMax,
                 }),
                 valueProperty(this, radiusKey, true, { id: `radiusRaw` }), // Raw value pass-through.
-                normalisePropertyTo({ id: 'radiusValue' }, [0, 1], this.radiusMin ?? 0, this.radiusMax)
+                normalisePropertyTo(this, { id: 'radiusValue' }, [0, 1], this.radiusMin ?? 0, this.radiusMax)
             );
             extraProps.push();
         }
@@ -430,7 +430,7 @@ export class PieSeries extends PolarSeries<PieNodeDatum> {
             props: [
                 accumulativeValueProperty(this, angleKey, true, { id: `angleValue` }),
                 valueProperty(this, angleKey, true, { id: `angleRaw` }), // Raw value pass-through.
-                normalisePropertyTo({ id: 'angleValue' }, [0, 1], 0),
+                normalisePropertyTo(this, { id: 'angleValue' }, [0, 1], 0),
                 ...extraProps,
             ],
         });

--- a/charts-community-modules/ag-charts-community/src/chart/test/examples.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/test/examples.ts
@@ -57,13 +57,14 @@ export function loadExampleOptions(name: string, evalFn = 'options'): any {
     const dataFileContent = dataFileExists ? cleanJs(fs.readFileSync(dataFile)) : [];
     const exampleFileLines = cleanJs(fs.readFileSync(exampleFile));
 
-    const evalExpr = `${dataFileContent.join('\n')} \n ${exampleFileLines.join('\n')}; ${evalFn};`;
+    const evalExpr = `${dataFileContent.join('\n')} \n ${exampleFileLines.join('\n')}; return ${evalFn};`;
     // @ts-ignore - used in the eval() call.
     const agCharts = require('../../main');
     // @ts-ignore - used in the eval() call.
     const { AgChart, time, Marker } = agCharts;
     try {
-        return eval(evalExpr);
+        const exampleRunFn = new Function('agCharts', 'AgChart', 'time', 'Marker', evalExpr);
+        return exampleRunFn(agCharts, AgChart, time, Marker);
     } catch (error) {
         Logger.error(`unable to read example data for [${name}]; error: ${error.message}`);
         Logger.debug(evalExpr);

--- a/charts-enterprise-modules/ag-charts-enterprise/src/polar-series/radar-line/radarLineSeries.ts
+++ b/charts-enterprise-modules/ag-charts-enterprise/src/polar-series/radar-line/radarLineSeries.ts
@@ -223,9 +223,9 @@ export class RadarLineSeries extends _ModuleSupport.PolarSeries<RadarLineNodeDat
         if (!processedData || !dataModel) return [];
 
         if (direction === ChartAxisDirection.X) {
-            return dataModel.getDomain(`angleValue`, processedData);
+            return dataModel.getDomain(this, `angleValue`, 'value', processedData);
         } else {
-            const domain = dataModel.getDomain(`radiusValue`, processedData);
+            const domain = dataModel.getDomain(this, `radiusValue`, 'value', processedData);
             return this.fixNumericExtent(extent([0].concat(domain)));
         }
     }
@@ -238,8 +238,8 @@ export class RadarLineSeries extends _ModuleSupport.PolarSeries<RadarLineNodeDat
 
         const { dataModel, processedData } = await dataController.request<any, any, true>(this.id, data, {
             props: [
-                valueProperty(angleKey, false, { id: 'angleValue' }),
-                valueProperty(radiusKey, false, { id: 'radiusValue', invalidValue: undefined }),
+                valueProperty(this, angleKey, false, { id: 'angleValue' }),
+                valueProperty(this, radiusKey, false, { id: 'radiusValue', invalidValue: undefined }),
             ],
         });
         this.dataModel = dataModel;
@@ -285,8 +285,8 @@ export class RadarLineSeries extends _ModuleSupport.PolarSeries<RadarLineNodeDat
             return [];
         }
 
-        const angleIdx = dataModel.resolveProcessedDataIndexById(`angleValue`)?.index ?? -1;
-        const radiusIdx = dataModel.resolveProcessedDataIndexById(`radiusValue`)?.index ?? -1;
+        const angleIdx = dataModel.resolveProcessedDataIndexById(this, `angleValue`, 'value').index;
+        const radiusIdx = dataModel.resolveProcessedDataIndexById(this, `radiusValue`, 'value').index;
 
         const { label, marker, id: seriesId } = this;
         const { size: markerSize } = this.marker;

--- a/charts-enterprise-modules/ag-charts-enterprise/src/waterfall/waterfallSeries.ts
+++ b/charts-enterprise-modules/ag-charts-enterprise/src/waterfall/waterfallSeries.ts
@@ -271,11 +271,11 @@ export class WaterfallBarSeries extends _ModuleSupport.CartesianSeries<
 
         const { dataModel, processedData } = await dataController.request<any, any, true>(this.id, data, {
             props: [
-                keyProperty(xKey, isContinuousX),
-                accumulativeValueProperty(yKey, true, { id: `yCurrent`, validation }),
-                trailingAccumulatedValueProperty(yKey, true, { id: `yPrevious`, validation }),
-                valueProperty(yKey, true, { id: `yRaw` }), // Raw value pass-through.
-                ...(typeKey ? [valueProperty(typeKey, false, { id: `typeValue`, missingValue: undefined })] : []),
+                keyProperty(this, xKey, isContinuousX, { id: `xKey` }),
+                accumulativeValueProperty(this, yKey, true, { id: `yCurrent`, validation }),
+                trailingAccumulatedValueProperty(this, yKey, true, { id: `yPrevious`, validation }),
+                valueProperty(this, yKey, true, { id: `yRaw` }), // Raw value pass-through.
+                ...(typeKey ? [valueProperty(this, typeKey, false, { id: `typeValue`, missingValue: undefined })] : []),
             ],
             dataVisible: this.visible,
         });
@@ -347,16 +347,16 @@ export class WaterfallBarSeries extends _ModuleSupport.CartesianSeries<
         const offsetDirection = barAlongX ? -1 : 1;
         const offset = offsetDirection * halfLineWidth;
 
-        const { yKey = '', xKey = '', typeKey = '', processedData } = this;
+        const { yKey = '', xKey = '', processedData } = this;
         if (processedData?.type !== 'ungrouped') return [];
 
         const contexts: WaterfallContext[] = [];
 
-        const yIndex = processedData?.indices.values[yKey] ?? -1;
-        const xIndex = processedData?.indices.keys[xKey] ?? -1;
-        const typeKeyIndex = processedData?.indices.values[typeKey] ?? -1;
-        const yCurrIndex = dataModel.resolveProcessedDataIndexById('yCurrent')?.index ?? -1;
-        const yPrevIndex = dataModel.resolveProcessedDataIndexById('yPrevious')?.index ?? -1;
+        const yRawIndex = dataModel.resolveProcessedDataIndexById(this, `yRaw`).index;
+        const xIndex = dataModel.resolveProcessedDataIndexById(this, `xKey`).index;
+        const yCurrIndex = dataModel.resolveProcessedDataIndexById(this, 'yCurrent').index;
+        const yPrevIndex = dataModel.resolveProcessedDataIndexById(this, 'yPrevious').index;
+        const typeKeyIndex = this.typeKey ? dataModel.resolveProcessedDataIndexById(this, `typeValue`).index : -1;
 
         const contextIndexMap = new Map<SeriesItemType, number>();
 
@@ -372,7 +372,7 @@ export class WaterfallBarSeries extends _ModuleSupport.CartesianSeries<
             const xDatum = keys[xIndex];
             const x = xScale.convert(xDatum);
 
-            const rawValue = values[yIndex];
+            const rawValue = values[yRawIndex];
             const cumulativeValue = values[yCurrIndex];
             const trailingValue = isTotalOrSubtotal ? 0 : values[yPrevIndex];
 


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-7933

Implements merging of all series-specified `DataModel` `PropertyDefinition[]` so all processing is performed by the minimum number of `DataModel` instances.

Some things to note:
- `scope` has been introduced as an additional concept, which alongside `id` allows identification of which series originated a `PropertyDefinition` after reduction (and its subsequent output values in `ProcessedData`).
- Validation state is tracked per `scope`, and if there are mismatches in the set of valid rows per `scope` there is a final step to split results appropriately.
- `ProcessedData` no longer contains property->index information, since there is no longer a trivial mapping - `DataModel` exposes methods to allow indexes to be obtained in a correct manner.

Bonus:
- Cleaned up some of the APIs to be more consistent WRT argument ordering.