### PR TITLE
AG-8552 Change zoom panning to pan each axis separately

### DIFF
--- a/charts-community-modules/ag-charts-community/src/chart/interaction/zoomManager.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/interaction/zoomManager.ts
@@ -83,6 +83,17 @@ export class ZoomManager extends BaseManager<'zoom-change', ZoomChangeEvent> {
         return this.axes[axisId]?.getZoom();
     }
 
+    public getAxisZooms(): Record<string, { direction: ChartAxisDirection; zoom: ZoomState | undefined }> {
+        const axes: Record<string, { direction: ChartAxisDirection; zoom: ZoomState | undefined }> = {};
+        for (const [axisId, axis] of Object.entries(this.axes)) {
+            axes[axisId] = {
+                direction: axis.direction,
+                zoom: axis.getZoom(),
+            };
+        }
+        return axes;
+    }
+
     private applyStates() {
         const changed = Object.values(this.axes)
             .map((axis) => axis.applyStates())

--- a/charts-enterprise-modules/ag-charts-enterprise/src/zoom/zoom.ts
+++ b/charts-enterprise-modules/ag-charts-enterprise/src/zoom/zoom.ts
@@ -150,15 +150,12 @@ export class Zoom extends _ModuleSupport.BaseModuleInstance implements _ModuleSu
             return;
         }
 
-        if (
-            this.enablePanning &&
-            this.seriesRect &&
-            !this.isMaxZoom(zoom) &&
-            (!this.enableSelecting || this.isPanningKeyPressed(sourceEvent))
-        ) {
-            // Allow panning if not at the maximum zoom and either selection is disabled or the panning key is pressed.
-            const newZoom = this.panner.update(event, this.seriesRect, zoom);
-            this.updateZoom(newZoom);
+        // Allow panning if either selection is disabled or the panning key is pressed.
+        if (this.enablePanning && this.seriesRect && (!this.enableSelecting || this.isPanningKeyPressed(sourceEvent))) {
+            const newZooms = this.panner.update(event, this.seriesRect, this.zoomManager.getAxisZooms());
+            for (const [axisId, { direction, zoom: newZoom }] of Object.entries(newZooms)) {
+                this.updateAxisZoom(axisId, direction, newZoom);
+            }
             this.cursorManager.updateCursor(CURSOR_ID, 'grabbing');
             return;
         }


### PR DESCRIPTION
PR for https://ag-grid.atlassian.net/browse/AG-8552

This changes zoom panning so that it will pan each series together such that they stay at the same relative positions to each other. But then if one series reaches the edge of it’s axis' domain, it will then stop while the others continue to move. Sliding over each other.

Previously it would reset the zoom of all the axes to match the last axis in the array.

https://github.com/ag-grid/ag-grid/assets/3817697/8b43a253-b437-4b21-9bb8-d888bcea2b08

