### PR TITLE
AG-7933 - More z-index fixes - keep highlight with series layer.

### DIFF
--- a/charts-community-modules/ag-charts-community/src/chart/interaction/chartEventManager.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/interaction/chartEventManager.ts
@@ -12,12 +12,14 @@ export interface LegendItemClickChartEvent extends ChartEvent<'legend-item-click
     series: any;
     itemId: any;
     enabled: boolean;
+    legendItemName?: string;
 }
 
 export interface LegendItemDoubleClickChartEvent extends ChartEvent<'legend-item-double-click'> {
     series: any;
     itemId: any;
     enabled: boolean;
+    legendItemName?: string;
     numVisibleItems: { [key: string]: number };
 }
 
@@ -27,23 +29,31 @@ export interface AxisHoverChartEvent extends ChartEvent<'axis-hover'> {
 }
 
 export class ChartEventManager extends BaseManager<ChartEventType, ChartEvents> {
-    legendItemClick(series: any, itemId: any, enabled: boolean) {
+    legendItemClick(series: any, itemId: any, enabled: boolean, legendItemName?: string) {
         const event: LegendItemClickChartEvent = {
             type: 'legend-item-click',
             series,
             itemId,
             enabled,
+            legendItemName,
         };
 
         this.listeners.dispatch('legend-item-click', event);
     }
 
-    legendItemDoubleClick(series: any, itemId: any, enabled: boolean, numVisibleItems: { [key: string]: number }) {
+    legendItemDoubleClick(
+        series: any,
+        itemId: any,
+        enabled: boolean,
+        numVisibleItems: { [key: string]: number },
+        legendItemName?: string
+    ) {
         const event: LegendItemDoubleClickChartEvent = {
             type: 'legend-item-double-click',
             series,
             itemId,
             enabled,
+            legendItemName,
             numVisibleItems,
         };
 

--- a/charts-community-modules/ag-charts-community/src/chart/legend.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/legend.ts
@@ -744,7 +744,7 @@ export class Legend {
         let newEnabled = enabled;
         if (toggleSeriesVisible) {
             newEnabled = !enabled;
-            this.ctx.chartEventManager.legendItemClick(series, itemId, newEnabled);
+            this.ctx.chartEventManager.legendItemClick(series, itemId, newEnabled, datum.legendItemName);
         }
 
         if (!newEnabled) {
@@ -793,7 +793,7 @@ export class Legend {
         event.consume();
 
         if (toggleSeriesVisible) {
-            const legendData: CategoryLegendDatum[] = chartSeries.reduce(
+            const legendData = chartSeries.reduce(
                 (ls, s) => [
                     ...ls,
                     ...s.getLegendData().filter((d): d is CategoryLegendDatum => d.legendType === 'category'),
@@ -812,7 +812,8 @@ export class Legend {
                 series,
                 itemId,
                 clickedItem?.enabled ?? false,
-                numVisibleItems
+                numVisibleItems,
+                clickedItem?.legendItemName
             );
         }
 

--- a/charts-community-modules/ag-charts-community/src/chart/legendDatum.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/legendDatum.ts
@@ -33,6 +33,8 @@ export interface CategoryLegendDatum extends ChartLegendDatum {
         fillOpacity: number;
         strokeOpacity: number;
     };
+    /** Optional deduplication id - used to coordinate synced toggling of multiple items. */
+    legendItemName?: string;
     label: {
         text: string; // display name for the sub-component
     };

--- a/charts-community-modules/ag-charts-community/src/chart/series/cartesian/barSeries.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/series/cartesian/barSeries.ts
@@ -169,9 +169,6 @@ export class BarSeries extends CartesianSeries<SeriesNodeDataContext<BarNodeDatu
     @Validate(OPT_STRING)
     stackGroup?: string = undefined;
 
-    @Validate(OPT_STRING)
-    legendItemName?: string = undefined;
-
     @Validate(OPT_NUMBER())
     normalizedTo?: number;
 
@@ -636,9 +633,22 @@ export class BarSeries extends CartesianSeries<SeriesNodeDataContext<BarNodeDatu
     }
 
     getLegendData(): ChartLegendDatum[] {
-        const { id, data, xKey, yKey, yName, legendItemName, fill, stroke, fillOpacity, strokeOpacity, visible } = this;
+        const {
+            id,
+            data,
+            xKey,
+            yKey,
+            yName,
+            legendItemName,
+            fill,
+            stroke,
+            fillOpacity,
+            strokeOpacity,
+            visible,
+            showInLegend,
+        } = this;
 
-        if (!data?.length || !xKey || !yKey) {
+        if (!showInLegend || !data?.length || !xKey || !yKey) {
             return [];
         }
 
@@ -653,6 +663,7 @@ export class BarSeries extends CartesianSeries<SeriesNodeDataContext<BarNodeDatu
             label: {
                 text: legendItemName ?? yName ?? yKey,
             },
+            legendItemName,
             marker: {
                 fill,
                 stroke,

--- a/charts-community-modules/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
@@ -392,13 +392,17 @@ export abstract class CartesianSeries<
 
     getGroupZIndexSubOrder(
         type: 'data' | 'labels' | 'highlight' | 'path' | 'marker' | 'paths',
-        subIndex?: number
+        subIndex = 0
     ): ZIndexSubOrder {
         const result = super.getGroupZIndexSubOrder(type, subIndex);
         switch (type) {
             case 'paths':
-                if (typeof result[0] === 'number') {
-                    result[0] += this.opts.pathsZIndexSubOrderOffset[subIndex ?? 0] ?? 0;
+                const pathOffset = this.opts.pathsZIndexSubOrderOffset[subIndex] ?? 0;
+                const superFn = result[0];
+                if (typeof superFn === 'function') {
+                    result[0] = () => +superFn() + pathOffset;
+                } else {
+                    result[0] = +superFn + this.opts.pathsZIndexSubOrderOffset[subIndex] ?? 0;
                 }
                 break;
         }

--- a/charts-community-modules/ag-charts-community/src/chart/series/series.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/series/series.ts
@@ -350,6 +350,7 @@ export abstract class Series<C extends SeriesNodeDataContext = SeriesNodeDataCon
             rootGroup,
             type,
             _declarationOrder,
+            getGroupZIndexSubOrder: (type) => this.getGroupZIndexSubOrder(type),
         });
     }
 
@@ -425,27 +426,26 @@ export abstract class Series<C extends SeriesNodeDataContext = SeriesNodeDataCon
 
     getGroupZIndexSubOrder(
         type: 'data' | 'labels' | 'highlight' | 'path' | 'marker' | 'paths',
-        subIndex?: number
+        subIndex = 0
     ): ZIndexSubOrder {
-        let main = 0;
+        let mainAdjust = 0;
         switch (type) {
             case 'data':
-                main = 0;
-                break;
             case 'paths':
-                main = 0;
                 break;
             case 'labels':
-                main += 20000;
-                break;
-            case 'highlight':
-                main += 15000;
+                mainAdjust += 20000;
                 break;
             case 'marker':
-                main += 10000;
+                mainAdjust += 10000;
+                break;
+            // Following cases are in their own layer, so need to be careful to respect declarationOrder.
+            case 'highlight':
+                subIndex += 15000;
                 break;
         }
-        return [main, () => this._declarationOrder + (subIndex ?? 0)];
+        const main = () => this._declarationOrder + mainAdjust;
+        return [main, subIndex];
     }
 
     addChartEventListeners(): void {

--- a/charts-community-modules/ag-charts-community/src/chart/series/seriesLayerManager.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/series/seriesLayerManager.ts
@@ -1,6 +1,19 @@
 import { Group } from '../../scene/group';
+import type { ZIndexSubOrder } from '../../scene/node';
 import { Layers } from '../layers';
 import type { SeriesGrouping } from './seriesStateManager';
+
+export type SeriesConfig = {
+    id: string;
+    seriesGrouping?: SeriesGrouping;
+    rootGroup: Group;
+    type: string;
+    _declarationOrder: number;
+    getGroupZIndexSubOrder(
+        type: 'data' | 'labels' | 'highlight' | 'path' | 'marker' | 'paths',
+        subIndex?: number
+    ): ZIndexSubOrder;
+};
 
 export class SeriesLayerManager {
     private readonly rootGroup: Group;
@@ -18,13 +31,7 @@ export class SeriesLayerManager {
         this.rootGroup = rootGroup;
     }
 
-    public requestGroup(opts: {
-        id: string;
-        seriesGrouping?: SeriesGrouping;
-        rootGroup: Group;
-        type: string;
-        _declarationOrder: number;
-    }) {
+    public requestGroup(opts: SeriesConfig) {
         const { id, seriesGrouping, type, rootGroup } = opts;
         const { groupIndex = id } = seriesGrouping ?? {};
 
@@ -38,7 +45,8 @@ export class SeriesLayerManager {
                         name: `${type}-content`,
                         layer: true,
                         zIndex: Layers.SERIES_LAYER_ZINDEX,
-                        zIndexSubOrder: [() => opts._declarationOrder, 0],
+                        // zIndexSubOrder: [() => opts._declarationOrder, 0],
+                        zIndexSubOrder: opts.getGroupZIndexSubOrder('data'),
                     })
                 ),
             };
@@ -56,14 +64,8 @@ export class SeriesLayerManager {
         rootGroup,
         oldGrouping,
         _declarationOrder,
-    }: {
-        id: string;
-        seriesGrouping?: SeriesGrouping;
-        oldGrouping?: SeriesGrouping;
-        rootGroup: Group;
-        type: string;
-        _declarationOrder: number;
-    }) {
+        getGroupZIndexSubOrder,
+    }: SeriesConfig & { oldGrouping?: SeriesGrouping }) {
         const { groupIndex = id } = seriesGrouping ?? {};
 
         if (this.groups[type]?.[groupIndex]?.seriesIds.includes(id)) {
@@ -72,7 +74,7 @@ export class SeriesLayerManager {
         }
 
         this.releaseGroup({ id, seriesGrouping: oldGrouping, type, rootGroup });
-        this.requestGroup({ id, seriesGrouping, type, rootGroup, _declarationOrder });
+        this.requestGroup({ id, seriesGrouping, type, rootGroup, _declarationOrder, getGroupZIndexSubOrder });
     }
 
     public releaseGroup({

--- a/charts-community-modules/ag-charts-community/src/chart/series/seriesLayerManager.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/series/seriesLayerManager.ts
@@ -45,7 +45,6 @@ export class SeriesLayerManager {
                         name: `${type}-content`,
                         layer: true,
                         zIndex: Layers.SERIES_LAYER_ZINDEX,
-                        // zIndexSubOrder: [() => opts._declarationOrder, 0],
                         zIndexSubOrder: opts.getGroupZIndexSubOrder('data'),
                     })
                 ),


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-7933

Fixes:
- Some more subtle z-index issues - series highlight is now kept at the same depth as the series content, so series obscured by other series also have their highlight obscured.
- `legendItemName` handling now works correctly for `BarSeries`.