### PR TITLE
AG-3479 Zoom panning fixes

### DIFF
--- a/charts-community-modules/ag-charts-community/src/chart/interaction/tooltipManager.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/interaction/tooltipManager.ts
@@ -31,11 +31,7 @@ export class TooltipManager {
             content = this.states[callerId]?.content;
         }
 
-        if (!content) {
-            delete this.states[callerId];
-        } else {
-            this.states[callerId] = { content, meta };
-        }
+        this.states[callerId] = { content, meta };
 
         this.applyStates();
     }

--- a/charts-community-modules/ag-charts-community/src/chart/tooltip/tooltip.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/tooltip/tooltip.ts
@@ -296,6 +296,7 @@ export class Tooltip {
         if (html !== undefined) {
             element.innerHTML = html;
         } else if (!element.innerHTML) {
+            this.toggle(false);
             return;
         }
 

--- a/charts-enterprise-modules/ag-charts-enterprise/src/zoom/zoom.ts
+++ b/charts-enterprise-modules/ag-charts-enterprise/src/zoom/zoom.ts
@@ -18,6 +18,11 @@ const CURSOR_ID = 'zoom-cursor';
 const TOOLTIP_ID = 'zoom-tooltip';
 const ZOOM_ID = 'zoom';
 
+const round = (n: number, sf: number) => {
+    const pow = Math.pow(10, sf);
+    return Math.round(n * pow) / pow;
+};
+
 export class Zoom extends _ModuleSupport.BaseModuleInstance implements _ModuleSupport.ModuleInstance {
     @Validate(BOOLEAN)
     public enabled = true;
@@ -342,8 +347,8 @@ export class Zoom extends _ModuleSupport.BaseModuleInstance implements _ModuleSu
     }
 
     private updateZoom(zoom: DefinedZoomState) {
-        const dx = Math.round((zoom.x.max - zoom.x.min) * 100) / 100;
-        const dy = Math.round((zoom.y.max - zoom.y.min) * 100) / 100;
+        const dx = round(zoom.x.max - zoom.x.min, 2);
+        const dy = round(zoom.y.max - zoom.y.min, 2);
 
         // Discard the zoom update if it would take us below either min ratio
         if (dx < this.minXRatio || dy < this.minYRatio) {
@@ -374,7 +379,10 @@ export class Zoom extends _ModuleSupport.BaseModuleInstance implements _ModuleSu
     ) {
         if (!partialZoom) return;
 
-        const d = Math.round((partialZoom.max - partialZoom.min) * 100) / 100;
+        partialZoom.min = round(partialZoom.min, 3);
+        partialZoom.max = round(partialZoom.max, 3);
+
+        const d = round(partialZoom.max - partialZoom.min, 2);
 
         // Discard the zoom update if it would take us below either min ratio
         if ((direction === ChartAxisDirection.X && d < this.minXRatio) || d < this.minYRatio) {

--- a/charts-enterprise-modules/ag-charts-enterprise/src/zoom/zoom.ts
+++ b/charts-enterprise-modules/ag-charts-enterprise/src/zoom/zoom.ts
@@ -15,6 +15,7 @@ const { BOOLEAN, NUMBER, STRING_UNION, ChartAxisDirection, ChartUpdateType, Vali
 const CONTEXT_ZOOM_ACTION_ID = 'zoom-action';
 const CONTEXT_PAN_ACTION_ID = 'pan-action';
 const CURSOR_ID = 'zoom-cursor';
+const TOOLTIP_ID = 'zoom-tooltip';
 const ZOOM_ID = 'zoom';
 
 export class Zoom extends _ModuleSupport.BaseModuleInstance implements _ModuleSupport.ModuleInstance {
@@ -57,6 +58,7 @@ export class Zoom extends _ModuleSupport.BaseModuleInstance implements _ModuleSu
 
     // Module context
     private readonly cursorManager: _ModuleSupport.CursorManager;
+    private readonly tooltipManager: _ModuleSupport.TooltipManager;
     private readonly zoomManager: _ModuleSupport.ZoomManager;
     private readonly updateService: _ModuleSupport.UpdateService;
 
@@ -75,6 +77,7 @@ export class Zoom extends _ModuleSupport.BaseModuleInstance implements _ModuleSu
 
         this.scene = ctx.scene;
         this.cursorManager = ctx.cursorManager;
+        this.tooltipManager = ctx.tooltipManager;
         this.zoomManager = ctx.zoomManager;
         this.updateService = ctx.updateService;
 
@@ -140,6 +143,7 @@ export class Zoom extends _ModuleSupport.BaseModuleInstance implements _ModuleSu
         if (!isPrimaryMouseButton) return;
 
         this.isDragging = true;
+        this.tooltipManager.updateTooltip(TOOLTIP_ID);
 
         const zoom = definedZoomState(this.zoomManager.getZoom());
 
@@ -204,6 +208,7 @@ export class Zoom extends _ModuleSupport.BaseModuleInstance implements _ModuleSu
         }
 
         this.isDragging = false;
+        this.tooltipManager.removeTooltip(TOOLTIP_ID);
     }
 
     private onWheel(event: _ModuleSupport.InteractionEvent<'wheel'>) {


### PR DESCRIPTION
PR for https://ag-grid.atlassian.net/browse/AG-3479

This reverts https://github.com/ag-grid/ag-grid/commit/a75f7b95ac7ce5f378b0392c985b59d0ef5fe12c from https://ag-grid.atlassian.net/browse/RTI-1465

That change broke a couple of things that rely on overriding the tooltip with an empty instance to hide it. With the intention of using `removeTooltip()` to remove that instance from the stack. Namely zoom and context menu.