### PR TITLE
AG-8471 Add animation throttling to bar updates

### DIFF
--- a/charts-community-modules/ag-charts-community/src/axis.ts
+++ b/charts-community-modules/ag-charts-community/src/axis.ts
@@ -1446,16 +1446,18 @@ export abstract class Axis<S extends Scale<D, number, TickInterval<S>> = Scale<a
             duration: sectionDuration,
         };
 
+        const animationGroup = `${this.id}_${Math.random()}`;
+
         tickLabelGroupSelection.each((node, datum) => {
-            this.animateSelectionNode(tickLabelGroupSelection, diff, options, node, datum);
+            this.animateSelectionNode(tickLabelGroupSelection, diff, options, node, datum, animationGroup);
         });
 
         gridLineGroupSelection.each((node, datum) => {
-            this.animateSelectionNode(gridLineGroupSelection, diff, options, node, datum);
+            this.animateSelectionNode(gridLineGroupSelection, diff, options, node, datum, animationGroup);
         });
 
         tickLineGroupSelection.each((node, datum) => {
-            this.animateSelectionNode(tickLineGroupSelection, diff, options, node, datum);
+            this.animateSelectionNode(tickLineGroupSelection, diff, options, node, datum, animationGroup);
         });
     }
 
@@ -1464,7 +1466,8 @@ export abstract class Axis<S extends Scale<D, number, TickInterval<S>> = Scale<a
         diff: AxisUpdateDiff,
         options: { delay: number; duration: number },
         node: Text | Line,
-        datum: TickDatum
+        datum: TickDatum,
+        animationGroup: string
     ) {
         const roundedTranslationY = Math.round(datum.translationY);
         let translate = { from: node.translationY, to: roundedTranslationY };
@@ -1491,6 +1494,7 @@ export abstract class Axis<S extends Scale<D, number, TickInterval<S>> = Scale<a
             duration,
             ease: easing.easeOut,
             throttleId: this.id,
+            throttleGroup: animationGroup,
             onUpdate([translationY, opacity]) {
                 node.translationY = translationY;
                 node.opacity = opacity;

--- a/charts-community-modules/ag-charts-community/src/chart/series/cartesian/barSeries.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/series/cartesian/barSeries.ts
@@ -675,29 +675,6 @@ export class BarSeries extends CartesianSeries<SeriesNodeDataContext<BarNodeDatu
         return legendData;
     }
 
-    animateRect(
-        id: string,
-        rect: Rect,
-        props: Array<{ from: number; to: number }>,
-        duration: number,
-        delay: number = 0,
-        onComplete?: () => void
-    ) {
-        this.ctx.animationManager?.animateManyWithThrottle(id, props, {
-            delay,
-            duration,
-            ease: easing.easeOut,
-            throttleId: this.id,
-            onUpdate([x, width, y, height]) {
-                rect.x = x;
-                rect.width = width;
-                rect.y = y;
-                rect.height = height;
-            },
-            onComplete,
-        });
-    }
-
     animateEmptyUpdateReady({
         datumSelections,
         labelSelections,
@@ -731,18 +708,26 @@ export class BarSeries extends CartesianSeries<SeriesNodeDataContext<BarNodeDatu
                     { from: contextHeight, to: datum.height },
                 ];
 
-                this.animateRect(`${this.id}_empty-update-ready_${rect.id}`, rect, props, duration);
+                this.ctx.animationManager?.animateMany(`${this.id}_empty-update-ready_${rect.id}`, props, {
+                    duration,
+                    ease: easing.easeOut,
+                    onUpdate([x, width, y, height]) {
+                        rect.x = x;
+                        rect.width = width;
+                        rect.y = y;
+                        rect.height = height;
+                    },
+                });
             });
         });
 
         labelSelections.forEach((labelSelection) => {
             labelSelection.each((label) => {
-                this.ctx.animationManager?.animateWithThrottle(`${this.id}_empty-update-ready_${label.id}`, {
+                this.ctx.animationManager?.animate(`${this.id}_empty-update-ready_${label.id}`, {
                     from: 0,
                     to: 1,
                     delay: duration,
                     duration: labelDuration,
-                    throttleId: this.id,
                     onUpdate: (opacity) => {
                         label.opacity = opacity;
                     },
@@ -800,6 +785,9 @@ export class BarSeries extends CartesianSeries<SeriesNodeDataContext<BarNodeDatu
             removedIds[d[0]] = true;
         });
 
+        const rectThrottleGroup = `${this.id}_${Math.random()}`;
+        const labelThrottleGroup = `${this.id}_${Math.random()}`;
+
         datumSelections.forEach((datumSelection) => {
             datumSelection.each((rect, datum) => {
                 let props = [
@@ -826,7 +814,10 @@ export class BarSeries extends CartesianSeries<SeriesNodeDataContext<BarNodeDatu
                     contextHeight = 0;
                 }
 
-                if (datumId !== undefined && addedIds[datumId] !== undefined) {
+                const isAdded = datumId !== undefined && addedIds[datumId] !== undefined;
+                const isRemoved = datumId !== undefined && removedIds[datumId] !== undefined;
+
+                if (isAdded) {
                     props = [
                         { from: contextX, to: datum.x },
                         { from: contextWidth, to: datum.width },
@@ -834,7 +825,7 @@ export class BarSeries extends CartesianSeries<SeriesNodeDataContext<BarNodeDatu
                         { from: contextHeight, to: datum.height },
                     ];
                     duration = sectionDuration;
-                } else if (datumId !== undefined && removedIds[datumId] !== undefined) {
+                } else if (isRemoved) {
                     props = [
                         { from: datum.x, to: contextX },
                         { from: datum.width, to: contextWidth },
@@ -846,9 +837,26 @@ export class BarSeries extends CartesianSeries<SeriesNodeDataContext<BarNodeDatu
                     cleanup = true;
                 }
 
-                this.animateRect(`${this.id}_waiting-update-ready_${rect.id}`, rect, props, duration, delay, () => {
-                    if (cleanup) datumSelection.cleanup();
-                });
+                this.ctx.animationManager?.animateManyWithThrottle(
+                    `${this.id}_waiting-update-ready_${rect.id}`,
+                    props,
+                    {
+                        delay,
+                        duration,
+                        ease: easing.easeOut,
+                        throttleId: `${this.id}_rects`,
+                        throttleGroup: rectThrottleGroup,
+                        onUpdate([x, width, y, height]) {
+                            rect.x = x;
+                            rect.width = width;
+                            rect.y = y;
+                            rect.height = height;
+                        },
+                        onComplete() {
+                            if (cleanup) datumSelection.cleanup();
+                        },
+                    }
+                );
             });
         });
 
@@ -861,7 +869,8 @@ export class BarSeries extends CartesianSeries<SeriesNodeDataContext<BarNodeDatu
                     to: 1,
                     delay: totalDuration,
                     duration: labelDuration,
-                    throttleId: this.id,
+                    throttleId: `${this.id}_labels`,
+                    throttleGroup: labelThrottleGroup,
                     onUpdate: (opacity) => {
                         label.opacity = opacity;
                     },


### PR DESCRIPTION
PR for https://ag-grid.atlassian.net/browse/AG-8471

With the previous solution, bars after the first would have their animation cancelled. This solution creates animation throttle groups that signal that these animations should not throttle each other.

Using a `throttleGroup` in combination with a `throttleId` allows batches of animations to run normally but throttle later batches.

So in this example, each time the update animation is triggered a new `throttleGroup` is created for the whole datum selection, but the series always shared a single `throttleId` across all animations.


https://github.com/ag-grid/ag-grid/assets/3817697/4b617c67-8bff-4899-94e2-bbbf3942762f

