### PR TITLE
Fix typo in footer

### DIFF
--- a/grid-packages/ag-grid-docs/documentation/src/components/footer/footer-items.json
+++ b/grid-packages/ag-grid-docs/documentation/src/components/footer/footer-items.json
@@ -64,7 +64,7 @@
         "title": "Follow",
         "links": [
             {
-                "name": "Github",
+                "name": "GitHub",
                 "url": "https://github.com/ag-grid/ag-grid",
                 "iconName": "github"
             },


### PR DESCRIPTION
<img width="171" alt="Screenshot 2023-07-15 at 01 31 32" src="https://github.com/ag-grid/ag-grid/assets/3165635/ac5d7363-374d-4a82-a96e-e21212ef01da">
