### PR TITLE
AG-9042 - Disable complex object handling for Integrated case.

### DIFF
--- a/charts-community-modules/ag-charts-community/src/chart/chart.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/chart.ts
@@ -759,7 +759,7 @@ export abstract class Chart extends Observable implements AgChartInstance {
             this.assignSeriesToAxes();
         }
 
-        const dataController = new DataController();
+        const dataController = new DataController(this.mode);
         const seriesPromises = this.series.map((s) => s.processData(dataController));
         await dataController.execute();
         await Promise.all(seriesPromises);

--- a/charts-community-modules/ag-charts-community/src/chart/data/dataController.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/data/dataController.ts
@@ -41,7 +41,7 @@ export class DataController {
     private requested: RequestedProcessing<any, any, any>[] = [];
     private status: 'setup' | 'executed' = 'setup';
 
-    public constructor() {}
+    public constructor(private readonly mode: 'standalone' | 'integrated') {}
 
     public async request<
         D extends object,
@@ -72,7 +72,7 @@ export class DataController {
 
         for (const { opts, data, resultCbs, rejects, ids } of merged) {
             try {
-                const dataModel = new DataModel<any>(opts);
+                const dataModel = new DataModel<any>({ ...opts, mode: this.mode });
                 const processedData = dataModel.processData(data);
                 if (processedData && processedData.partialValidDataCount === 0) {
                     resultCbs.forEach((cb) => cb({ dataModel, processedData }));

--- a/charts-community-modules/ag-charts-community/src/chart/data/dataModel.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/data/dataModel.ts
@@ -230,9 +230,15 @@ export class DataModel<
     private readonly propertyProcessors: (PropertyValueProcessorDefinition<D> & InternalDefinition)[];
     private readonly reducers: (ReducerOutputPropertyDefinition<any> & InternalDefinition)[];
     private readonly processors: (ProcessorOutputPropertyDefinition<any> & InternalDefinition)[];
+    private readonly mode: 'standalone' | 'integrated';
 
-    public constructor(opts: DataModelOptions<K, Grouped>) {
-        const { props } = opts;
+    public constructor(
+        opts: DataModelOptions<K, Grouped> & {
+            readonly mode?: 'standalone' | 'integrated';
+        }
+    ) {
+        const { props, mode = 'standalone' } = opts;
+        this.mode = mode;
 
         // Validate that keys appear before values in the definitions, as output ordering depends
         // on configuration ordering, but we process keys before values.
@@ -915,6 +921,8 @@ export class DataModel<
 
     buildAccessors(...defs: { property: string }[]) {
         const result: Record<string, (d: any) => any> = {};
+        if (this.mode === 'integrated') return result;
+
         for (const def of defs) {
             const isPath = def.property.indexOf('.') >= 0 || def.property.indexOf('[') >= 0;
             if (!isPath) continue;


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-9042

Workaround so that Grid complex objects don't break Integrated Charts, by disabling key expressions in Charts for Integrated Charts use-cases.