### PR TITLE
AG-8873 Return to flush sync

### DIFF
--- a/grid-community-modules/core/src/ts/gridBodyComp/rowContainer/rowContainerCtrl.ts
+++ b/grid-community-modules/core/src/ts/gridBodyComp/rowContainer/rowContainerCtrl.ts
@@ -113,7 +113,7 @@ const WrapperCssClasses: Map<RowContainerName, string> = convertToMap([
 
 export interface IRowContainerComp {
     setViewportHeight(height: string): void;
-    setRowCtrls(rowCtrls: RowCtrl[]): void;
+    setRowCtrls(rowCtrls: RowCtrl[], useFlushSync: boolean): void;
     setDomOrder(domOrder: boolean): void;
     setContainerWidth(width: string): void;
 }
@@ -288,7 +288,7 @@ export class RowContainerCtrl extends BeanStub {
         this.addManagedListener(this.eventService, Events.EVENT_SCROLL_VISIBILITY_CHANGED, () => this.onScrollVisibilityChanged());
         this.addManagedListener(this.eventService, Events.EVENT_DISPLAYED_COLUMNS_CHANGED, () => this.onDisplayedColumnsChanged());
         this.addManagedListener(this.eventService, Events.EVENT_DISPLAYED_COLUMNS_WIDTH_CHANGED, () => this.onDisplayedColumnsWidthChanged());
-        this.addManagedListener(this.eventService, Events.EVENT_DISPLAYED_ROWS_CHANGED, () => this.onDisplayedRowsChanged());
+        this.addManagedListener(this.eventService, Events.EVENT_DISPLAYED_ROWS_CHANGED, (params: DisplayedRowsChangedEvent) => this.onDisplayedRowsChanged(params.afterScroll));
 
         this.onScrollVisibilityChanged();
         this.onDisplayedColumnsChanged();
@@ -439,7 +439,7 @@ export class RowContainerCtrl extends BeanStub {
         }
     }
 
-    private onDisplayedRowsChanged(): void {
+    private onDisplayedRowsChanged(useFlushSync: boolean = false): void {
         if (this.visible) {
             const printLayout = this.gridOptionsService.isDomLayout('print');
             // this just justifies if the ctrl is in the correct place, this will be fed with zombie rows by the
@@ -458,9 +458,9 @@ export class RowContainerCtrl extends BeanStub {
             // this list contains either all pinned top, center or pinned bottom rows
             // this filters out rows not for this container, eg if it's a full with row, but we are not full with container
             const rowsThisContainer = this.getRowCtrls().filter(doesRowMatch);
-            this.comp.setRowCtrls(rowsThisContainer);
+            this.comp.setRowCtrls(rowsThisContainer, useFlushSync);
         } else {
-            this.comp.setRowCtrls(this.EMPTY_CTRLS);
+            this.comp.setRowCtrls(this.EMPTY_CTRLS, false);
         }
     }
 

--- a/grid-community-modules/core/src/ts/rendering/row/rowCtrl.ts
+++ b/grid-community-modules/core/src/ts/rendering/row/rowCtrl.ts
@@ -254,7 +254,7 @@ export class RowCtrl extends BeanStub {
             this.onRowSelected(gui);
         }
 
-        this.updateColumnLists(!this.useAnimationFrameForCreate, false);
+        this.updateColumnLists(!this.useAnimationFrameForCreate);
 
         const comp = gui.rowComp;
 
@@ -459,7 +459,7 @@ export class RowCtrl extends BeanStub {
         }
     }
 
-    private updateColumnLists(suppressAnimationFrame: boolean, useFlushSync: boolean): void {
+    private updateColumnLists(suppressAnimationFrame = false, useFlushSync = false): void {
 
         if (this.isFullWidth()) { return; }
 
@@ -714,7 +714,7 @@ export class RowCtrl extends BeanStub {
     }
 
     private onColumnMoved(): void {
-        this.updateColumnLists(false, true);
+        this.updateColumnLists();
     }
 
     private addListenersForCellComps(): void {
@@ -813,7 +813,7 @@ export class RowCtrl extends BeanStub {
     private onDisplayedColumnsChanged(): void {
         // we skip animations for onDisplayedColumnChanged, as otherwise the client could remove columns and
         // then set data, and any old valueGetter's (ie from cols that were removed) would still get called.
-        this.updateColumnLists(true, false);
+        this.updateColumnLists(true);
 
         if (this.beans.columnModel.wasAutoRowHeightEverActive()) {
             this.rowNode.checkAutoHeights();
@@ -885,7 +885,7 @@ export class RowCtrl extends BeanStub {
         this.centerCellCtrls = this.removeCellCtrl(this.centerCellCtrls, cellCtrl);
         this.leftCellCtrls = this.removeCellCtrl(this.leftCellCtrls, cellCtrl);
         this.rightCellCtrls = this.removeCellCtrl(this.rightCellCtrls, cellCtrl);
-        this.updateColumnLists(false, false);
+        this.updateColumnLists();
     }
 
     private removeCellCtrl(prev: CellCtrlListAndMap, cellCtrlToRemove: CellCtrl): CellCtrlListAndMap {

--- a/grid-community-modules/react/src/reactUi/cells/cellComp.tsx
+++ b/grid-community-modules/react/src/reactUi/cells/cellComp.tsx
@@ -144,7 +144,7 @@ const CellComp = (props: {
     const cellInstanceId = cellCtrl.getInstanceId();
 
     // Only provide an initial state when not using a Cell Renderer so that we do not display a raw value before the cell renderer is created.
-    const [renderDetails, setRenderDetails] = useState<RenderDetails | undefined>( cellCtrl.getIsCellRenderer() ? undefined : { compDetails: undefined, value: cellCtrl.getValueToDisplay(), force: false });
+    const [renderDetails, setRenderDetails] = useState<RenderDetails | undefined>(() => cellCtrl.getIsCellRenderer() ? undefined : { compDetails: undefined, value: cellCtrl.getValueToDisplay(), force: false });
     const [editDetails, setEditDetails ] = useState<EditDetails>();
     const [renderKey, setRenderKey] = useState<number>(1);
 

--- a/grid-community-modules/react/src/reactUi/rows/rowComp.tsx
+++ b/grid-community-modules/react/src/reactUi/rows/rowComp.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, useState, useMemo, memo, useContext, useLayoutEffect, useCallback } from 'react';
 import { CellCtrl, RowContainerType, IRowComp, RowCtrl, UserCompDetails, ICellRenderer, CssClassManager, RowStyle } from '@ag-grid-community/core';
 import { showJsComp } from '../jsComp';
-import { isComponentStateless, getNextValueIfDifferent } from '../utils';
+import { isComponentStateless, getNextValueIfDifferent, agFlushSync } from '../utils';
 import { BeansContext } from '../beansContext';
 import CellComp from '../cells/cellComp';
 
@@ -15,7 +15,8 @@ const RowComp = (params: { rowCtrl: RowCtrl, containerType: RowContainerType }) 
     const isFullWidth = rowCtrl.isFullWidth();
 
     const [userStyles, setUserStyles] = useState<RowStyle | undefined>(() => rowCtrl.getRowStyles());
-    const [cellCtrls, setCellCtrls] = useState<CellCtrl[] | null>(() => isFullWidth ? null : rowCtrl.getCellCtrlsForContainer(containerType)); //rowCtrl.getCellCtrlsForContainer(containerType)
+   // const [cellCtrls, setCellCtrls] = useState<CellCtrl[] | null>(() => isFullWidth ? null : rowCtrl.getCellCtrlsForContainer(containerType));
+    const [cellCtrls, setCellCtrls] = useState<CellCtrl[] | null>(() => null);
     const [fullWidthCompDetails, setFullWidthCompDetails] = useState<UserCompDetails>();
 
     // these styles have initial values, so element is placed into the DOM with them,
@@ -90,8 +91,10 @@ const RowComp = (params: { rowCtrl: RowCtrl, containerType: RowContainerType }) 
             setUserStyles: (styles: RowStyle | undefined) => setUserStyles(styles),
             // if we don't maintain the order, then cols will be ripped out and into the dom
             // when cols reordered, which would stop the CSS transitions from working
-            setCellCtrls: (next) => {
-                setCellCtrls(prev => getNextValueIfDifferent(prev, next, domOrderRef.current));
+            setCellCtrls: (next, useFlushSync) => {
+                agFlushSync(useFlushSync, () => {
+                    setCellCtrls(prev => getNextValueIfDifferent(prev, next, domOrderRef.current));
+                });
             },
             showFullWidth: compDetails => setFullWidthCompDetails(compDetails),
             getFullWidthCellRenderer: () => fullWidthCompRef.current,

--- a/grid-community-modules/react/src/reactUi/rows/rowComp.tsx
+++ b/grid-community-modules/react/src/reactUi/rows/rowComp.tsx
@@ -147,6 +147,9 @@ const RowComp = (params: { rowCtrl: RowCtrl, containerType: RowContainerType }) 
             ref={setRef}
             role={'row'}
             style={rowStyles}
+            row-index={ rowIndex }
+            row-id={ rowId }
+            row-business-key={ rowBusinessKey }
             tabIndex={tabIndex}
         >
             {showCells && showCellsJsx()}

--- a/grid-community-modules/react/src/reactUi/rows/rowComp.tsx
+++ b/grid-community-modules/react/src/reactUi/rows/rowComp.tsx
@@ -14,14 +14,18 @@ const RowComp = (params: { rowCtrl: RowCtrl, containerType: RowContainerType }) 
     const domOrderRef = useRef<boolean>(rowCtrl.getDomOrder());
     const isFullWidth = rowCtrl.isFullWidth();
 
+    const [rowIndex, setRowIndex] = useState<string>(() => rowCtrl.getRowIndex());
+    const [rowId, setRowId] = useState<string | null>(() => rowCtrl.getRowId());
+    const [rowBusinessKey, setRowBusinessKey] = useState<string | null>(() => rowCtrl.getBusinessKey());
+
     const [userStyles, setUserStyles] = useState<RowStyle | undefined>(() => rowCtrl.getRowStyles());
     const [cellCtrls, setCellCtrls] = useState<CellCtrl[] | null>(() => null);
     const [fullWidthCompDetails, setFullWidthCompDetails] = useState<UserCompDetails>();
 
     // these styles have initial values, so element is placed into the DOM with them,
     // rather than an transition getting applied.
-    const topRef = useRef<string | undefined>(rowCtrl.getInitialRowTop(containerType));
-    const transformRef = useRef<string | undefined>(rowCtrl.getInitialTransform(containerType));
+    const [top, setTop] = useState<string | undefined>(() => rowCtrl.getInitialRowTop(containerType));
+    const [transform, setTransform] = useState<string | undefined>(() => rowCtrl.getInitialTransform(containerType));
 
     const eGui = useRef<HTMLDivElement | null>(null);
     const fullWidthCompRef = useRef<ICellRenderer>();
@@ -70,24 +74,18 @@ const RowComp = (params: { rowCtrl: RowCtrl, containerType: RowContainerType }) 
         const compProxy: IRowComp = {
             // the rowTop is managed by state, instead of direct style manipulation by rowCtrl (like all the other styles)
             // as we need to have an initial value when it's placed into he DOM for the first time, for animation to work.
-            setTop: top => {
-                topRef.current = top;
-                eGui.current!.style.top = top;
-            },
-            setTransform: transform => {
-                eGui.current!.style.transform = transform;
-                transformRef.current = transform;
-            },
+            setTop,
+            setTransform,
 
             // i found using React for managing classes at the row level was to slow, as modifying classes caused a lot of
             // React code to execute, so avoiding React for managing CSS Classes made the grid go much faster.
             addOrRemoveCssClass: (name, on) => cssClassManager.current!.addOrRemoveCssClass(name, on),
 
             setDomOrder: domOrder => domOrderRef.current = domOrder,
-            setRowIndex: rowIndex => eGui.current!.setAttribute('row-index', rowIndex),
-            setRowId: rowId => eGui.current!.setAttribute('row-id', rowId),
-            setRowBusinessKey: businessKey => eGui.current!.setAttribute('row-business-key', businessKey),
-            setUserStyles: (styles: RowStyle | undefined) => setUserStyles(styles),
+            setRowIndex,
+            setRowId,
+            setRowBusinessKey,
+            setUserStyles,
             // if we don't maintain the order, then cols will be ripped out and into the dom
             // when cols reordered, which would stop the CSS transitions from working
             setCellCtrls: (next, useFlushSync) => {
@@ -105,13 +103,11 @@ const RowComp = (params: { rowCtrl: RowCtrl, containerType: RowContainerType }) 
     useLayoutEffect(() => showJsComp(fullWidthCompDetails, context, eGui.current!, fullWidthCompRef), [fullWidthCompDetails]);
 
     const rowStyles = useMemo(() => {
-        // Will use the current values of top / transform so that these are not overridden when userStyles change
-        // We don't need this to update when top / transform are updated as these are directly updated on the DOM
-        const res = { top: topRef.current, transform: transformRef.current };
+        const res = { top, transform };
 
         Object.assign(res, userStyles);
         return res;
-    }, [userStyles]);
+    }, [top, transform, userStyles]);
 
     const showFullWidthFramework = isFullWidth && fullWidthCompDetails && fullWidthCompDetails.componentFromFramework;
     const showCells = !isFullWidth && cellCtrls != null;

--- a/grid-community-modules/react/src/reactUi/rows/rowComp.tsx
+++ b/grid-community-modules/react/src/reactUi/rows/rowComp.tsx
@@ -15,7 +15,6 @@ const RowComp = (params: { rowCtrl: RowCtrl, containerType: RowContainerType }) 
     const isFullWidth = rowCtrl.isFullWidth();
 
     const [userStyles, setUserStyles] = useState<RowStyle | undefined>(() => rowCtrl.getRowStyles());
-   // const [cellCtrls, setCellCtrls] = useState<CellCtrl[] | null>(() => isFullWidth ? null : rowCtrl.getCellCtrlsForContainer(containerType));
     const [cellCtrls, setCellCtrls] = useState<CellCtrl[] | null>(() => null);
     const [fullWidthCompDetails, setFullWidthCompDetails] = useState<UserCompDetails>();
 

--- a/grid-community-modules/react/src/reactUi/rows/rowContainerComp.tsx
+++ b/grid-community-modules/react/src/reactUi/rows/rowContainerComp.tsx
@@ -22,9 +22,9 @@ const RowContainerComp = (params: {name: RowContainerName}) => {
     const rowContainerCtrlRef = useRef<RowContainerCtrl | null>();
 
     const cssClasses = useMemo(() => RowContainerCtrl.getRowContainerCssClasses(name), [name]);
-    const wrapperClasses = useMemo( ()=> classesList(cssClasses.wrapper), []);
-    const viewportClasses = useMemo( ()=> classesList(cssClasses.viewport), []);
-    const containerClasses = useMemo( ()=> classesList(cssClasses.container), []);
+    const wrapperClasses = useMemo( ()=> classesList(cssClasses.wrapper), [cssClasses]);
+    const viewportClasses = useMemo( ()=> classesList(cssClasses.viewport), [cssClasses]);
+    const containerClasses = useMemo( ()=> classesList(cssClasses.container), [cssClasses]);
 
     // no need to useMemo for boolean types
     const template1 = name === RowContainerName.CENTER;

--- a/grid-community-modules/react/src/reactUi/rows/rowContainerComp.tsx
+++ b/grid-community-modules/react/src/reactUi/rows/rowContainerComp.tsx
@@ -1,6 +1,6 @@
 import { getRowContainerTypeForName, IRowContainerComp, RowContainerCtrl, RowContainerName, RowCtrl } from '@ag-grid-community/core';
 import React, { useMemo, useRef, useState, memo, useContext, useCallback } from 'react';
-import { classesList, getNextValueIfDifferent } from '../utils';
+import { agFlushSync, classesList, getNextValueIfDifferent } from '../utils';
 import useReactCommentEffect from '../reactComment';
 import RowComp from './rowComp';
 import { BeansContext } from '../beansContext';
@@ -21,7 +21,7 @@ const RowContainerComp = (params: {name: RowContainerName}) => {
     const orderedRowCtrlsRef = useRef<RowCtrl[]>([]);
     const domOrderRef = useRef<boolean>(false);
     const rowContainerCtrlRef = useRef<RowContainerCtrl | null>();
-    const rowUpdateCallback = useRef<(() => void) | null>();
+    const rowUpdateCallback = useRef<((useFlushSync: boolean) => void) | null>();
 
     const cssClasses = useMemo(() => RowContainerCtrl.getRowContainerCssClasses(name), [name]);
     const wrapperClasses = useMemo( ()=> classesList(cssClasses.wrapper), []);
@@ -67,7 +67,7 @@ const RowContainerComp = (params: {name: RowContainerName}) => {
     // With React 18 this will use the new useSyncExternalStore hook
     // With React 17 this will use the useState hook as the renderer is synchronous anyway.
     let rowCtrlsOrdered: RowCtrl[];
-    if ((React as any).useSyncExternalStore) {
+    if ((React as any).useSyncExternalStore && false) {
         const sub = useCallback((callback: any) => {
             rowUpdateCallback.current = callback;
             return () => {
@@ -78,7 +78,11 @@ const RowContainerComp = (params: {name: RowContainerName}) => {
         rowCtrlsOrdered = React.useSyncExternalStore(sub, () => orderedRowCtrlsRef.current);
     } else {
         const [ctrlsOrdered, setCtrlsOrdered] = useState<RowCtrl[]>(() => []);
-        rowUpdateCallback.current = () => setCtrlsOrdered(orderedRowCtrlsRef.current);
+        rowUpdateCallback.current = (useFlushSync: boolean) => {
+         agFlushSync(useFlushSync,() => {
+            setCtrlsOrdered(orderedRowCtrlsRef.current);
+            });
+        }
         rowCtrlsOrdered = ctrlsOrdered;
     }
 
@@ -89,11 +93,11 @@ const RowContainerComp = (params: {name: RowContainerName}) => {
         }
         if (areElementsReady()) {
 
-            const updateRowCtrlsOrdered = () => {
+            const updateRowCtrlsOrdered = (useFlushSync: boolean) => {
                 const prev = orderedRowCtrlsRef.current;
                 orderedRowCtrlsRef.current = getNextValueIfDifferent(orderedRowCtrlsRef.current, rowCtrlsRef.current, domOrderRef.current)!;
                 if (rowUpdateCallback.current && prev !== orderedRowCtrlsRef.current) {
-                    rowUpdateCallback.current();
+                    rowUpdateCallback.current(useFlushSync);
                 }
             }
 
@@ -103,15 +107,16 @@ const RowContainerComp = (params: {name: RowContainerName}) => {
                         eViewport.current.style.height = height;
                     }
                 },
-                setRowCtrls: (rowCtrls) => {
+                setRowCtrls: (rowCtrls, useFlushSync) => {
                     // Keep a record of the rowCtrls in case we need to reset the Dom order.
+                    const useFlush = useFlushSync && rowCtrlsRef.current.length > 0 && rowCtrls.length > 0;
                     rowCtrlsRef.current = rowCtrls;
-                    updateRowCtrlsOrdered();
+                    updateRowCtrlsOrdered(useFlush);
                 },
                 setDomOrder: domOrder => {
                     if (domOrderRef.current != domOrder) {
                         domOrderRef.current = domOrder;
-                        updateRowCtrlsOrdered();
+                        updateRowCtrlsOrdered(false);
                     }
                 },
                 setContainerWidth: width => {

--- a/grid-community-modules/react/src/reactUi/utils.tsx
+++ b/grid-community-modules/react/src/reactUi/utils.tsx
@@ -1,3 +1,4 @@
+import ReactDOM from "react-dom";
 
 export const classesList = (...list: (string | null | undefined)[]): string => {
     const filtered = list.filter( s => s != null && s !== '');
@@ -43,6 +44,21 @@ export const isComponentStateless = (Component: any) => {
         ) || (typeof Component === 'object' && Component.$$typeof === getMemoType());
 }
 
+// CreateRoot is only available from React 18, which if used requires us to use flushSync.
+const createRootAndFlushSyncAvailable = (ReactDOM as any).createRoot != null && (ReactDOM as any).flushSync != null;
+
+/**
+ * Wrapper around flushSync to provide backwards compatibility with React 16-17
+ * Also allows us to control via the `useFlushSync` param whether we want to use flushSync or not
+ * as we do not want to use flushSync when we are likely to already be in a render cycle
+ */
+export const agFlushSync = (useFlushSync: boolean, fn: () => void) => {
+    if (createRootAndFlushSyncAvailable && useFlushSync) {
+        (ReactDOM as any).flushSync(fn);
+    } else {
+        fn();
+    }
+}
 
 /**
  * The aim of this function is to maintain references to prev or next values where possible.
@@ -102,3 +118,4 @@ export function getNextValueIfDifferent<T extends { getInstanceId: () => string 
     // Spread as we need to combine the old and new values
     return [...oldValues, ...newValues];
 }
+

--- a/grid-packages/ag-grid-react/src/reactUi/rows/rowComp.tsx
+++ b/grid-packages/ag-grid-react/src/reactUi/rows/rowComp.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, useState, useMemo, memo, useContext, useLayoutEffect, useCallback } from 'react';
 import { CellCtrl, RowContainerType, IRowComp, RowCtrl, UserCompDetails, ICellRenderer, CssClassManager, RowStyle } from 'ag-grid-community';
 import { showJsComp } from '../jsComp';
-import { isComponentStateless, getNextValueIfDifferent } from '../utils';
+import { isComponentStateless, getNextValueIfDifferent, agFlushSync } from '../utils';
 import { BeansContext } from '../beansContext';
 import CellComp from '../cells/cellComp';
 
@@ -14,14 +14,18 @@ const RowComp = (params: { rowCtrl: RowCtrl, containerType: RowContainerType }) 
     const domOrderRef = useRef<boolean>(rowCtrl.getDomOrder());
     const isFullWidth = rowCtrl.isFullWidth();
 
+    const [rowIndex, setRowIndex] = useState<string>(() => rowCtrl.getRowIndex());
+    const [rowId, setRowId] = useState<string | null>(() => rowCtrl.getRowId());
+    const [rowBusinessKey, setRowBusinessKey] = useState<string | null>(() => rowCtrl.getBusinessKey());
+
     const [userStyles, setUserStyles] = useState<RowStyle | undefined>(() => rowCtrl.getRowStyles());
-    const [cellCtrls, setCellCtrls] = useState<CellCtrl[] | null>(() => isFullWidth ? null : rowCtrl.getCellCtrlsForContainer(containerType)); //rowCtrl.getCellCtrlsForContainer(containerType)
+    const [cellCtrls, setCellCtrls] = useState<CellCtrl[] | null>(() => null);
     const [fullWidthCompDetails, setFullWidthCompDetails] = useState<UserCompDetails>();
 
     // these styles have initial values, so element is placed into the DOM with them,
     // rather than an transition getting applied.
-    const topRef = useRef<string | undefined>(rowCtrl.getInitialRowTop(containerType));
-    const transformRef = useRef<string | undefined>(rowCtrl.getInitialTransform(containerType));
+    const [top, setTop] = useState<string | undefined>(() => rowCtrl.getInitialRowTop(containerType));
+    const [transform, setTransform] = useState<string | undefined>(() => rowCtrl.getInitialTransform(containerType));
 
     const eGui = useRef<HTMLDivElement | null>(null);
     const fullWidthCompRef = useRef<ICellRenderer>();
@@ -70,28 +74,24 @@ const RowComp = (params: { rowCtrl: RowCtrl, containerType: RowContainerType }) 
         const compProxy: IRowComp = {
             // the rowTop is managed by state, instead of direct style manipulation by rowCtrl (like all the other styles)
             // as we need to have an initial value when it's placed into he DOM for the first time, for animation to work.
-            setTop: top => {
-                topRef.current = top;
-                eGui.current!.style.top = top;
-            },
-            setTransform: transform => {
-                eGui.current!.style.transform = transform;
-                transformRef.current = transform;
-            },
+            setTop,
+            setTransform,
 
             // i found using React for managing classes at the row level was to slow, as modifying classes caused a lot of
             // React code to execute, so avoiding React for managing CSS Classes made the grid go much faster.
             addOrRemoveCssClass: (name, on) => cssClassManager.current!.addOrRemoveCssClass(name, on),
 
             setDomOrder: domOrder => domOrderRef.current = domOrder,
-            setRowIndex: rowIndex => eGui.current!.setAttribute('row-index', rowIndex),
-            setRowId: rowId => eGui.current!.setAttribute('row-id', rowId),
-            setRowBusinessKey: businessKey => eGui.current!.setAttribute('row-business-key', businessKey),
-            setUserStyles: (styles: RowStyle | undefined) => setUserStyles(styles),
+            setRowIndex,
+            setRowId,
+            setRowBusinessKey,
+            setUserStyles,
             // if we don't maintain the order, then cols will be ripped out and into the dom
             // when cols reordered, which would stop the CSS transitions from working
-            setCellCtrls: (next) => {
-                setCellCtrls(prev => getNextValueIfDifferent(prev, next, domOrderRef.current));
+            setCellCtrls: (next, useFlushSync) => {
+                agFlushSync(useFlushSync, () => {
+                    setCellCtrls(prev => getNextValueIfDifferent(prev, next, domOrderRef.current));
+                });
             },
             showFullWidth: compDetails => setFullWidthCompDetails(compDetails),
             getFullWidthCellRenderer: () => fullWidthCompRef.current,
@@ -103,13 +103,11 @@ const RowComp = (params: { rowCtrl: RowCtrl, containerType: RowContainerType }) 
     useLayoutEffect(() => showJsComp(fullWidthCompDetails, context, eGui.current!, fullWidthCompRef), [fullWidthCompDetails]);
 
     const rowStyles = useMemo(() => {
-        // Will use the current values of top / transform so that these are not overridden when userStyles change
-        // We don't need this to update when top / transform are updated as these are directly updated on the DOM
-        const res = { top: topRef.current, transform: transformRef.current };
+        const res = { top, transform };
 
         Object.assign(res, userStyles);
         return res;
-    }, [userStyles]);
+    }, [top, transform, userStyles]);
 
     const showFullWidthFramework = isFullWidth && fullWidthCompDetails && fullWidthCompDetails.componentFromFramework;
     const showCells = !isFullWidth && cellCtrls != null;

--- a/grid-packages/ag-grid-react/src/reactUi/rows/rowComp.tsx
+++ b/grid-packages/ag-grid-react/src/reactUi/rows/rowComp.tsx
@@ -147,6 +147,9 @@ const RowComp = (params: { rowCtrl: RowCtrl, containerType: RowContainerType }) 
             ref={setRef}
             role={'row'}
             style={rowStyles}
+            row-index={ rowIndex }
+            row-id={ rowId }
+            row-business-key={ rowBusinessKey }
             tabIndex={tabIndex}
         >
             {showCells && showCellsJsx()}

--- a/grid-packages/ag-grid-react/src/reactUi/rows/rowContainerComp.tsx
+++ b/grid-packages/ag-grid-react/src/reactUi/rows/rowContainerComp.tsx
@@ -1,6 +1,6 @@
 import { getRowContainerTypeForName, IRowContainerComp, RowContainerCtrl, RowContainerName, RowCtrl } from 'ag-grid-community';
 import React, { useMemo, useRef, useState, memo, useContext, useCallback } from 'react';
-import { classesList, getNextValueIfDifferent } from '../utils';
+import { agFlushSync, classesList, getNextValueIfDifferent } from '../utils';
 import useReactCommentEffect from '../reactComment';
 import RowComp from './rowComp';
 import { BeansContext } from '../beansContext';
@@ -21,7 +21,7 @@ const RowContainerComp = (params: {name: RowContainerName}) => {
     const orderedRowCtrlsRef = useRef<RowCtrl[]>([]);
     const domOrderRef = useRef<boolean>(false);
     const rowContainerCtrlRef = useRef<RowContainerCtrl | null>();
-    const rowUpdateCallback = useRef<(() => void) | null>();
+    const rowUpdateCallback = useRef<((useFlushSync: boolean) => void) | null>();
 
     const cssClasses = useMemo(() => RowContainerCtrl.getRowContainerCssClasses(name), [name]);
     const wrapperClasses = useMemo( ()=> classesList(cssClasses.wrapper), []);
@@ -67,7 +67,7 @@ const RowContainerComp = (params: {name: RowContainerName}) => {
     // With React 18 this will use the new useSyncExternalStore hook
     // With React 17 this will use the useState hook as the renderer is synchronous anyway.
     let rowCtrlsOrdered: RowCtrl[];
-    if ((React as any).useSyncExternalStore) {
+    if ((React as any).useSyncExternalStore && false) {
         const sub = useCallback((callback: any) => {
             rowUpdateCallback.current = callback;
             return () => {
@@ -78,7 +78,11 @@ const RowContainerComp = (params: {name: RowContainerName}) => {
         rowCtrlsOrdered = React.useSyncExternalStore(sub, () => orderedRowCtrlsRef.current);
     } else {
         const [ctrlsOrdered, setCtrlsOrdered] = useState<RowCtrl[]>(() => []);
-        rowUpdateCallback.current = () => setCtrlsOrdered(orderedRowCtrlsRef.current);
+        rowUpdateCallback.current = (useFlushSync: boolean) => {
+         agFlushSync(useFlushSync,() => {
+            setCtrlsOrdered(orderedRowCtrlsRef.current);
+            });
+        }
         rowCtrlsOrdered = ctrlsOrdered;
     }
 
@@ -89,11 +93,11 @@ const RowContainerComp = (params: {name: RowContainerName}) => {
         }
         if (areElementsReady()) {
 
-            const updateRowCtrlsOrdered = () => {
+            const updateRowCtrlsOrdered = (useFlushSync: boolean) => {
                 const prev = orderedRowCtrlsRef.current;
                 orderedRowCtrlsRef.current = getNextValueIfDifferent(orderedRowCtrlsRef.current, rowCtrlsRef.current, domOrderRef.current)!;
                 if (rowUpdateCallback.current && prev !== orderedRowCtrlsRef.current) {
-                    rowUpdateCallback.current();
+                    rowUpdateCallback.current(useFlushSync);
                 }
             }
 
@@ -103,15 +107,16 @@ const RowContainerComp = (params: {name: RowContainerName}) => {
                         eViewport.current.style.height = height;
                     }
                 },
-                setRowCtrls: (rowCtrls) => {
+                setRowCtrls: (rowCtrls, useFlushSync) => {
                     // Keep a record of the rowCtrls in case we need to reset the Dom order.
+                    const useFlush = useFlushSync && rowCtrlsRef.current.length > 0 && rowCtrls.length > 0;
                     rowCtrlsRef.current = rowCtrls;
-                    updateRowCtrlsOrdered();
+                    updateRowCtrlsOrdered(useFlush);
                 },
                 setDomOrder: domOrder => {
                     if (domOrderRef.current != domOrder) {
                         domOrderRef.current = domOrder;
-                        updateRowCtrlsOrdered();
+                        updateRowCtrlsOrdered(false);
                     }
                 },
                 setContainerWidth: width => {

--- a/grid-packages/ag-grid-react/src/reactUi/rows/rowContainerComp.tsx
+++ b/grid-packages/ag-grid-react/src/reactUi/rows/rowContainerComp.tsx
@@ -9,7 +9,6 @@ const RowContainerComp = (params: {name: RowContainerName}) => {
 
     const {context} = useContext(BeansContext);
 
-
     const { name } = params;
     const containerType = useMemo(() => getRowContainerTypeForName(name), [name]);
 

--- a/grid-packages/ag-grid-react/src/reactUi/rows/rowContainerComp.tsx
+++ b/grid-packages/ag-grid-react/src/reactUi/rows/rowContainerComp.tsx
@@ -18,10 +18,9 @@ const RowContainerComp = (params: {name: RowContainerName}) => {
     const eContainer = useRef<HTMLDivElement | null>(null);
 
     const rowCtrlsRef = useRef<RowCtrl[]>([]);
-    const orderedRowCtrlsRef = useRef<RowCtrl[]>([]);
+    const [rowCtrlsOrdered, setRowCtrlsOrdered] = useState<RowCtrl[]>(() => []);
     const domOrderRef = useRef<boolean>(false);
     const rowContainerCtrlRef = useRef<RowContainerCtrl | null>();
-    const rowUpdateCallback = useRef<((useFlushSync: boolean) => void) | null>();
 
     const cssClasses = useMemo(() => RowContainerCtrl.getRowContainerCssClasses(name), [name]);
     const wrapperClasses = useMemo( ()=> classesList(cssClasses.wrapper), []);
@@ -38,7 +37,6 @@ const RowContainerComp = (params: {name: RowContainerName}) => {
     const topLevelRef = template1 ? eWrapper : template2 ? eViewport : eContainer;
 
     useReactCommentEffect(' AG Row Container ' + name + ' ', topLevelRef);
-
 
     const areElementsReady = useCallback(() => {
         if (template1) {
@@ -64,28 +62,6 @@ const RowContainerComp = (params: {name: RowContainerName}) => {
         }
     }, []);
 
-    // With React 18 this will use the new useSyncExternalStore hook
-    // With React 17 this will use the useState hook as the renderer is synchronous anyway.
-    let rowCtrlsOrdered: RowCtrl[];
-    if ((React as any).useSyncExternalStore && false) {
-        const sub = useCallback((callback: any) => {
-            rowUpdateCallback.current = callback;
-            return () => {
-                rowUpdateCallback.current = null;
-            }
-        }, []);
-
-        rowCtrlsOrdered = React.useSyncExternalStore(sub, () => orderedRowCtrlsRef.current);
-    } else {
-        const [ctrlsOrdered, setCtrlsOrdered] = useState<RowCtrl[]>(() => []);
-        rowUpdateCallback.current = (useFlushSync: boolean) => {
-         agFlushSync(useFlushSync,() => {
-            setCtrlsOrdered(orderedRowCtrlsRef.current);
-            });
-        }
-        rowCtrlsOrdered = ctrlsOrdered;
-    }
-
     const setRef = useCallback(() => {
         if (areElementsRemoved()) {
             context.destroyBean(rowContainerCtrlRef.current);
@@ -94,11 +70,9 @@ const RowContainerComp = (params: {name: RowContainerName}) => {
         if (areElementsReady()) {
 
             const updateRowCtrlsOrdered = (useFlushSync: boolean) => {
-                const prev = orderedRowCtrlsRef.current;
-                orderedRowCtrlsRef.current = getNextValueIfDifferent(orderedRowCtrlsRef.current, rowCtrlsRef.current, domOrderRef.current)!;
-                if (rowUpdateCallback.current && prev !== orderedRowCtrlsRef.current) {
-                    rowUpdateCallback.current(useFlushSync);
-                }
+                agFlushSync(useFlushSync, () => {
+                    setRowCtrlsOrdered(prev => getNextValueIfDifferent(prev, rowCtrlsRef.current, domOrderRef.current)!);
+                });
             }
 
             const compProxy: IRowContainerComp = {
@@ -108,8 +82,8 @@ const RowContainerComp = (params: {name: RowContainerName}) => {
                     }
                 },
                 setRowCtrls: (rowCtrls, useFlushSync) => {
-                    // Keep a record of the rowCtrls in case we need to reset the Dom order.
                     const useFlush = useFlushSync && rowCtrlsRef.current.length > 0 && rowCtrls.length > 0;
+                    // Keep a record of the rowCtrls in case we need to reset the Dom order.
                     rowCtrlsRef.current = rowCtrls;
                     updateRowCtrlsOrdered(useFlush);
                 },

--- a/grid-packages/ag-grid-react/src/reactUi/utils.tsx
+++ b/grid-packages/ag-grid-react/src/reactUi/utils.tsx
@@ -1,3 +1,4 @@
+import ReactDOM from "react-dom";
 
 export const classesList = (...list: (string | null | undefined)[]): string => {
     const filtered = list.filter( s => s != null && s !== '');
@@ -43,6 +44,21 @@ export const isComponentStateless = (Component: any) => {
         ) || (typeof Component === 'object' && Component.$$typeof === getMemoType());
 }
 
+// CreateRoot is only available from React 18, which if used requires us to use flushSync.
+const createRootAndFlushSyncAvailable = (ReactDOM as any).createRoot != null && (ReactDOM as any).flushSync != null;
+
+/**
+ * Wrapper around flushSync to provide backwards compatibility with React 16-17
+ * Also allows us to control via the `useFlushSync` param whether we want to use flushSync or not
+ * as we do not want to use flushSync when we are likely to already be in a render cycle
+ */
+export const agFlushSync = (useFlushSync: boolean, fn: () => void) => {
+    if (createRootAndFlushSyncAvailable && useFlushSync) {
+        (ReactDOM as any).flushSync(fn);
+    } else {
+        fn();
+    }
+}
 
 /**
  * The aim of this function is to maintain references to prev or next values where possible.
@@ -102,3 +118,4 @@ export function getNextValueIfDifferent<T extends { getInstanceId: () => string 
     // Spread as we need to combine the old and new values
     return [...oldValues, ...newValues];
 }
+


### PR DESCRIPTION
flushSync enables us to avoid issues with React batching too many slow cell renderers together which block the main thread. Using `flushSync` forces per row rendering and enables it to be interrupted for scrolling. 