### PR TITLE
Ag 9265 allow sorting grouprows when groupMaintainOrder = true and groupDisplayType = 'groupRows'

### DIFF
--- a/grid-community-modules/client-side-row-model/src/clientSideRowModel/sortService.ts
+++ b/grid-community-modules/client-side-row-model/src/clientSideRowModel/sortService.ts
@@ -62,14 +62,14 @@ export class SortService extends BeanStub {
             if (skipSortingGroups) {
                 const childrenToBeSorted = rowNode.childrenAfterAggFilter!.slice(0);
                 if (rowNode.childrenAfterSort) {
-                    const indexedOrders: { [key:string]: number } = {};
+                    const indexedOrders: { [key: string]: number } = {};
                     rowNode.childrenAfterSort.forEach((node, idx) => {
                         indexedOrders[node.id!] = idx;
                     });
                     childrenToBeSorted.sort((row1, row2) => (indexedOrders[row1.id!] ?? 0) - (indexedOrders[row2.id!] ?? 0));
                 }
                 rowNode.childrenAfterSort = childrenToBeSorted;
-            } else if(!sortActive || skipSortingPivotLeafs) {
+            } else if (!sortActive || skipSortingPivotLeafs) {
                 // if there's no sort to make, skip this step
                 rowNode.childrenAfterSort = rowNode.childrenAfterAggFilter!.slice(0);
             } else if (useDeltaSort) {
@@ -134,7 +134,7 @@ export class SortService extends BeanStub {
         const touchedRows: RowNode[] = [];
 
         unsortedRows.forEach(row => {
-            if(allTouchedNodes[row.id!] || !changedPath.canSkip(row)) {
+            if (allTouchedNodes[row.id!] || !changedPath.canSkip(row)) {
                 touchedRows.push(row);
             } else {
                 untouchedRowsMap[row.id!] = true;
@@ -142,7 +142,7 @@ export class SortService extends BeanStub {
         });
 
         const sortedUntouchedRows = oldSortedRows.filter(child => untouchedRowsMap[child.id!]);
-        
+
         const mapNodeToSortedNode = (rowNode: RowNode, pos: number): SortedRowNode => (
             { currentPos: pos, rowNode: rowNode }
         );

--- a/grid-community-modules/core/src/ts/entities/rowNode.ts
+++ b/grid-community-modules/core/src/ts/entities/rowNode.ts
@@ -1056,6 +1056,19 @@ export class RowNode<TData = any> implements IEventEmitter, IRowNode<TData> {
         return false;
     }
 
+    /**
+     * Returns a list of ancestor nodes
+     */
+    public getAllOfAncestors(): RowNode[] {
+        const ancestors = [];
+        let parentNode = this.parent;
+        while (parentNode) {
+            ancestors.push(parentNode);
+            parentNode = parentNode.parent;
+        }
+        return ancestors;
+    }
+
     /** Add an event listener. */
     public addEventListener(eventType: RowNodeEventType, listener: Function): void {
         if (!this.eventService) {


### PR DESCRIPTION
AG-9265 For the specific situation of when groupMaintainOrder = true and groupDisplayType = 'groupRows',
Allow sorting of group column, when the column is the underlying data of the group column.
This is achieved by checking to see if all active sorts are present in row node's child, itself or any ancestors