### PR TITLE
AG-9273 Two pass reactive props

### DIFF
--- a/grid-community-modules/client-side-row-model/src/clientSideRowModel/clientSideNodeManager.ts
+++ b/grid-community-modules/client-side-row-model/src/clientSideRowModel/clientSideNodeManager.ts
@@ -66,8 +66,8 @@ export class ClientSideNodeManager {
         // func below doesn't have 'this' pointer, so need to pull out these bits
         this.suppressParentsInRowNodes = this.gridOptionsService.is('suppressParentsInRowNodes');
         this.isRowMasterFunc = this.gridOptionsService.get('isRowMaster');
-        this.doingTreeData = this.gridOptionsService.isTreeData();
-        this.doingMasterDetail = this.gridOptionsService.isMasterDetail();
+        this.doingTreeData = this.gridOptionsService.is('treeData');
+        this.doingMasterDetail = this.gridOptionsService.is('masterDetail');
     }
 
     public getCopyOfNodesMap(): { [id: string]: RowNode } {

--- a/grid-community-modules/client-side-row-model/src/clientSideRowModel/clientSideRowModel.ts
+++ b/grid-community-modules/client-side-row-model/src/clientSideRowModel/clientSideRowModel.ts
@@ -397,7 +397,7 @@ export class ClientSideRowModel extends BeanStub implements IClientSideRowModel 
 
         const changedPath = new ChangedPath(false, this.rootNode);
 
-        if (noTransactions || this.gridOptionsService.isTreeData()) {
+        if (noTransactions || this.gridOptionsService.is('treeData')) {
             changedPath.setInactive();
         }
 
@@ -763,7 +763,7 @@ export class ClientSideRowModel extends BeanStub implements IClientSideRowModel 
     // + gridApi.expandAll()
     // + gridApi.collapseAll()
     public expandOrCollapseAll(expand: boolean): void {
-        const usingTreeData = this.gridOptionsService.isTreeData();
+        const usingTreeData = this.gridOptionsService.is('treeData');
         const usingPivotMode = this.columnModel.isPivotActive();
 
         const recursiveExpandOrCollapse = (rowNodes: RowNode[] | null): void => {

--- a/grid-community-modules/client-side-row-model/src/clientSideRowModel/filterService.ts
+++ b/grid-community-modules/client-side-row-model/src/clientSideRowModel/filterService.ts
@@ -86,6 +86,6 @@ export class FilterService extends BeanStub {
     }
 
     private doingTreeDataFiltering() {
-        return this.gridOptionsService.isTreeData() && !this.gridOptionsService.is('excludeChildrenWhenTreeDataFiltering');
+        return this.gridOptionsService.is('treeData') && !this.gridOptionsService.is('excludeChildrenWhenTreeDataFiltering');
     }
 }

--- a/grid-community-modules/client-side-row-model/src/clientSideRowModel/flattenStage.ts
+++ b/grid-community-modules/client-side-row-model/src/clientSideRowModel/flattenStage.ts
@@ -7,8 +7,19 @@ import {
     IRowNodeStage,
     RowNode,
     StageExecuteParams,
-    Beans
+    Beans,
+    WithoutGridCommon,
+    GetGroupIncludeFooterParams
 } from "@ag-grid-community/core";
+
+interface FlattenDetails {
+    hideOpenParents: boolean;
+    groupRemoveSingleChildren: boolean;
+    groupRemoveLowestSingleChildren: boolean;
+    groupIncludeTotalFooter: boolean;
+    isGroupMultiAutoColumn: boolean;
+    getGroupIncludeFooter: (params: WithoutGridCommon<GetGroupIncludeFooterParams<any, any>>) => boolean;
+}
 
 @Bean('flattenStage')
 export class FlattenStage extends BeanStub implements IRowNodeStage {
@@ -22,15 +33,15 @@ export class FlattenStage extends BeanStub implements IRowNodeStage {
         // even if not doing grouping, we do the mapping, as the client might
         // of passed in data that already has a grouping in it somewhere
         const result: RowNode[] = [];
-        // putting value into a wrapper so it's passed by reference
-        const nextRowTop: NumberWrapper = {value: 0};
         const skipLeafNodes = this.columnModel.isPivotMode();
         // if we are reducing, and not grouping, then we want to show the root node, as that
         // is where the pivot values are
         const showRootNode = skipLeafNodes && rootNode.leafGroup;
         const topList = showRootNode ? [rootNode] : rootNode.childrenAfterSort;
 
-        this.recursivelyAddToRowsToDisplay(topList, result, nextRowTop, skipLeafNodes, 0);
+        const details = this.getFlattenDetails();
+
+        this.recursivelyAddToRowsToDisplay(details, topList, result, skipLeafNodes, 0);
 
         // we do not want the footer total if the gris is empty
         const atLeastOneRowPresent = result.length > 0;
@@ -38,29 +49,41 @@ export class FlattenStage extends BeanStub implements IRowNodeStage {
         const includeGroupTotalFooter = !showRootNode
             // don't show total footer when showRootNode is true (i.e. in pivot mode and no groups)
             && atLeastOneRowPresent
-            && this.gridOptionsService.is('groupIncludeTotalFooter');
+            && details.groupIncludeTotalFooter;
 
         if (includeGroupTotalFooter) {
             rootNode.createFooter();
-            this.addRowNodeToRowsToDisplay(rootNode.sibling, result, nextRowTop, 0);
+            this.addRowNodeToRowsToDisplay(details, rootNode.sibling, result, 0);
         }
 
         return result;
     }
 
-    private recursivelyAddToRowsToDisplay(
-        rowsToFlatten: RowNode[] | null,
-        result: RowNode[],
-        nextRowTop: NumberWrapper,
-        skipLeafNodes: boolean,
-        uiLevel: number
-    ) {
-        if (_.missingOrEmpty(rowsToFlatten)) { return; }
-        const getGroupIncludeFooter = this.gridOptionsService.getGroupIncludeFooter();
-        const hideOpenParents = this.gridOptionsService.is('groupHideOpenParents');
+    private getFlattenDetails(): FlattenDetails {
         // these two are mutually exclusive, so if first set, we don't set the second
         const groupRemoveSingleChildren = this.gridOptionsService.is('groupRemoveSingleChildren');
         const groupRemoveLowestSingleChildren = !groupRemoveSingleChildren && this.gridOptionsService.is('groupRemoveLowestSingleChildren');
+
+        return {
+            groupRemoveLowestSingleChildren,
+            groupRemoveSingleChildren,
+            isGroupMultiAutoColumn: this.gridOptionsService.isGroupMultiAutoColumn(),
+            hideOpenParents : this.gridOptionsService.is('groupHideOpenParents'),
+            groupIncludeTotalFooter : this.gridOptionsService.is('groupIncludeTotalFooter'),
+            getGroupIncludeFooter : this.gridOptionsService.getGroupIncludeFooter(),
+        };
+    }
+
+    private recursivelyAddToRowsToDisplay(
+        details: FlattenDetails,
+        rowsToFlatten: RowNode[] | null,
+        result: RowNode[],
+        skipLeafNodes: boolean,
+        uiLevel: number
+    ) {
+        if (_.missingOrEmpty(rowsToFlatten)) {
+            return;
+        }
 
         for (let i = 0; i < rowsToFlatten!.length; i++) {
             const rowNode = rowsToFlatten![i];
@@ -69,11 +92,11 @@ export class FlattenStage extends BeanStub implements IRowNodeStage {
 
             const isSkippedLeafNode = skipLeafNodes && !isParent;
 
-            const isRemovedSingleChildrenGroup = groupRemoveSingleChildren &&
-                isParent &&
-                rowNode.childrenAfterGroup!.length === 1;
+            const isRemovedSingleChildrenGroup =
+                details.groupRemoveSingleChildren && isParent && rowNode.childrenAfterGroup!.length === 1;
 
-            const isRemovedLowestSingleChildrenGroup = groupRemoveLowestSingleChildren &&
+            const isRemovedLowestSingleChildrenGroup =
+                details.groupRemoveLowestSingleChildren &&
                 isParent &&
                 rowNode.leafGroup &&
                 rowNode.childrenAfterGroup!.length === 1;
@@ -83,13 +106,13 @@ export class FlattenStage extends BeanStub implements IRowNodeStage {
             // the UI will never allow expanding leaf  groups, however the user might via the API (or menu option 'expand all row groups')
             const neverAllowToExpand = skipLeafNodes && rowNode.leafGroup;
 
-            const isHiddenOpenParent = hideOpenParents && rowNode.expanded && !rowNode.master && (!neverAllowToExpand);
+            const isHiddenOpenParent = details.hideOpenParents && rowNode.expanded && !rowNode.master && !neverAllowToExpand;
 
             const thisRowShouldBeRendered = !isSkippedLeafNode && !isHiddenOpenParent &&
                 !isRemovedSingleChildrenGroup && !isRemovedLowestSingleChildrenGroup;
 
             if (thisRowShouldBeRendered) {
-                this.addRowNodeToRowsToDisplay(rowNode, result, nextRowTop, uiLevel);
+                this.addRowNodeToRowsToDisplay(details, rowNode, result, uiLevel);
             }
 
             // if we are pivoting, we never map below the leaf group
@@ -103,28 +126,36 @@ export class FlattenStage extends BeanStub implements IRowNodeStage {
                 if (rowNode.expanded || excludedParent) {
                     // if the parent was excluded, then ui level is that of the parent
                     const uiLevelForChildren = excludedParent ? uiLevel : uiLevel + 1;
-                    this.recursivelyAddToRowsToDisplay(rowNode.childrenAfterSort, result,
-                        nextRowTop, skipLeafNodes, uiLevelForChildren);
+                    this.recursivelyAddToRowsToDisplay(
+                        details,
+                        rowNode.childrenAfterSort,
+                        result,
+                        skipLeafNodes,
+                        uiLevelForChildren
+                    );
 
                     // put a footer in if user is looking for it
-                    const doesRowShowFooter = getGroupIncludeFooter({ node: rowNode });
+                    const doesRowShowFooter = details.getGroupIncludeFooter({ node: rowNode });
                     if (doesRowShowFooter) {
-                        this.addRowNodeToRowsToDisplay(rowNode.sibling, result, nextRowTop, uiLevelForChildren);
+                        this.addRowNodeToRowsToDisplay(details, rowNode.sibling, result, uiLevelForChildren);
                     }
                 }
             } else if (rowNode.master && rowNode.expanded) {
                 const detailNode = this.createDetailNode(rowNode);
-                this.addRowNodeToRowsToDisplay(detailNode, result, nextRowTop, uiLevel);
+                this.addRowNodeToRowsToDisplay(details, detailNode, result, uiLevel);
             }
         }
     }
 
     // duplicated method, it's also in floatingRowModel
-    private addRowNodeToRowsToDisplay(rowNode: RowNode, result: RowNode[], nextRowTop: NumberWrapper, uiLevel: number): void {
-        const isGroupMultiAutoColumn = this.gridOptionsService.isGroupMultiAutoColumn();
-
+    private addRowNodeToRowsToDisplay(
+        details: FlattenDetails,
+        rowNode: RowNode,
+        result: RowNode[],
+        uiLevel: number
+    ): void {
         result.push(rowNode);
-        rowNode.setUiLevel(isGroupMultiAutoColumn ? 0 : uiLevel);
+        rowNode.setUiLevel(details.isGroupMultiAutoColumn ? 0 : uiLevel);
     }
 
     private createDetailNode(masterNode: RowNode): RowNode {
@@ -146,8 +177,4 @@ export class FlattenStage extends BeanStub implements IRowNodeStage {
 
         return detailNode;
     }
-}
-
-interface NumberWrapper {
-    value: number;
 }

--- a/grid-community-modules/client-side-row-model/src/clientSideRowModel/sortService.ts
+++ b/grid-community-modules/client-side-row-model/src/clientSideRowModel/sortService.ts
@@ -214,7 +214,7 @@ export class SortService extends BeanStub {
             return;
         }
 
-        if (this.gridOptionsService.isTreeData()) {
+        if (this.gridOptionsService.is('treeData')) {
             const msg = `AG Grid: The property hideOpenParents dose not work with Tree Data. This is because Tree Data has values at the group level, it doesn't make sense to hide them (as opposed to Row Grouping, which only has Aggregated Values at the group level).`;
             _.doOnce(() => console.warn(msg), 'sortService.hideOpenParentsWithTreeData');
             return false;

--- a/grid-community-modules/core/src/ts/columns/autoGroupColService.ts
+++ b/grid-community-modules/core/src/ts/columns/autoGroupColService.ts
@@ -17,7 +17,7 @@ export class AutoGroupColService extends BeanStub {
     public createAutoGroupColumns(rowGroupColumns: Column[]): Column[] {
         const groupAutoColumns: Column[] = [];
 
-        const doingTreeData = this.gridOptionsService.isTreeData();
+        const doingTreeData = this.gridOptionsService.is('treeData');
         let doingMultiAutoColumn = this.gridOptionsService.isGroupMultiAutoColumn();
 
         if (doingTreeData && doingMultiAutoColumn) {
@@ -83,7 +83,7 @@ export class AutoGroupColService extends BeanStub {
         res = this.columnFactory.addColumnDefaultAndTypes(res, colId);
 
         // For tree data the filter is always allowed
-        if (!this.gridOptionsService.isTreeData()) {
+        if (!this.gridOptionsService.is('treeData')) {
             // we would only allow filter if the user has provided field or value getter. otherwise the filter
             // would not be able to work.
             const noFieldOrValueGetter =

--- a/grid-community-modules/core/src/ts/columns/columnModel.ts
+++ b/grid-community-modules/core/src/ts/columns/columnModel.ts
@@ -272,7 +272,7 @@ export class ColumnModel extends BeanStub {
             this.pivotMode = pivotMode;
         }
 
-        this.usingTreeData = this.gridOptionsService.isTreeData();
+        this.usingTreeData = this.gridOptionsService.is('treeData');
 
         this.addManagedPropertyListener<ColDefPropertyChangedEvent>('groupDisplayType', () => this.onGroupDisplayTypeChanged());
         this.addManagedPropertyListener<ColDefPropertyChangedEvent>('autoGroupColumnDef', () => this.onAutoGroupColumnDefChanged());
@@ -498,7 +498,7 @@ export class ColumnModel extends BeanStub {
     }
 
     private isPivotSettingAllowed(pivot: boolean): boolean {
-        if (pivot && this.gridOptionsService.isTreeData()) {
+        if (pivot && this.gridOptionsService.is('treeData')) {
             console.warn("AG Grid: Pivot mode not available in conjunction Tree Data i.e. 'gridOptions.treeData: true'");
             return false;
         }

--- a/grid-community-modules/core/src/ts/components/componentUtil.ts
+++ b/grid-community-modules/core/src/ts/components/componentUtil.ts
@@ -6,7 +6,7 @@ import { iterateObject } from '../utils/object';
 import { includes } from '../utils/array';
 import { values } from '../utils/generic';
 import { WithoutGridCommon } from '../interfaces/iCommon';
-import { ColDefPropertyChangedEvent } from '../columns/columnModel';
+
 export class ComponentUtil {
 
     // all events
@@ -72,6 +72,8 @@ export class ComponentUtil {
     public static FUNCTION_PROPERTIES = PropertyKeys.FUNCTION_PROPERTIES;
     public static ALL_PROPERTIES = PropertyKeys.ALL_PROPERTIES;
     public static ALL_PROPERTIES_SET = new Set(PropertyKeys.ALL_PROPERTIES);
+
+    private static changeSetId = 0;
 
     private static getCoercionLookup() {
         let coercionLookup = {} as any;
@@ -155,7 +157,7 @@ export class ComponentUtil {
         if (!changes || Object.keys(changes).length === 0) {
             return;
         }
-
+        this.changeSetId++;
         const changesToApply = { ...changes };
 
         // We manually call these updates so that we can provide a different source of gridOptionsChanged
@@ -177,12 +179,18 @@ export class ComponentUtil {
             delete changesToApply.columnDefs;
         }
 
-        Object.keys(changesToApply).forEach(key => {
+        // Update all the properties on GridOptions first so that we can optimise updates
+        // and so that any update logic triggered off events is only run after all the
+        // props have been updated. This avoids potential sync issues
+        const updates = Object.keys(changesToApply).map(key => {
             const gridKey = key as keyof GridOptions;
-
             const coercedValue = ComponentUtil.getValue(gridKey, changesToApply[gridKey].currentValue);
-            api.__setProperty(gridKey, coercedValue);
+            // Use isChanged to control event via force option as by the time we call __updateProperty the gridOptions[key] will already contain the new value.
+            const isChanged = api.__setPropertyOnly(gridKey, coercedValue);
+            return {gridKey, coercedValue, isChanged}
         });
+        // Then cause any property change event listeners to be fired.
+        updates.forEach((u) => api.__updateProperty(u.gridKey, u.coercedValue, u.isChanged, this.changeSetId));
 
         // copy changes into an event for dispatch
         const event: WithoutGridCommon<ComponentStateChangedEvent> = {

--- a/grid-community-modules/core/src/ts/entities/column.ts
+++ b/grid-community-modules/core/src/ts/entities/column.ts
@@ -356,7 +356,7 @@ export class Column<TValue = any> implements IHeaderColumn<TValue>, IProvidedCol
             ModuleRegistry.__assertRegistered(ModuleNames.RichSelectModule, this.colDef.cellEditor, this.gridOptionsService.getGridId());
         }
 
-        if (this.gridOptionsService.isTreeData()) {
+        if (this.gridOptionsService.is('treeData')) {
             const itemsNotAllowedWithTreeData: (keyof ColDef)[] = ['rowGroup', 'rowGroupIndex', 'pivot', 'pivotIndex'];
             const itemsUsed = itemsNotAllowedWithTreeData.filter(x => exists(colDefAny[x]));
             if (itemsUsed.length > 0) {

--- a/grid-community-modules/core/src/ts/entities/rowNode.ts
+++ b/grid-community-modules/core/src/ts/entities/rowNode.ts
@@ -837,7 +837,7 @@ export class RowNode<TData = any> implements IEventEmitter, IRowNode<TData> {
 
         const isSsrm = this.beans.gridOptionsService.isRowModelType('serverSide');
         if (isSsrm) {
-            const isTreeData = this.beans.gridOptionsService.isTreeData();
+            const isTreeData = this.beans.gridOptionsService.is('treeData');
             const isGroupFunc = this.beans.gridOptionsService.get('isServerSideGroup');
             // stubs and footers can never have children, as they're grid rows. if tree data the presence of children
             // is determined by the isServerSideGroup callback, if not tree data then the rows group property will be set.

--- a/grid-community-modules/core/src/ts/gridApi.ts
+++ b/grid-community-modules/core/src/ts/gridApi.ts
@@ -249,15 +249,23 @@ export class GridApi<TData = any> {
     }
 
     /** Used internally by grid. Not intended to be used by the client. Interface may change between releases. */
-    public __setProperty<K extends keyof GridOptions>(propertyName: K, value: GridOptions[K]) {
-
+    public __setPropertyOnly<K extends keyof GridOptions>(propertyName: K, value: GridOptions[K]): boolean {
+        return this.gos.__setPropertyOnly(propertyName, value);
+    }
+    /** Used internally by grid. Not intended to be used by the client. Interface may change between releases. */
+    public __updateProperty<K extends keyof GridOptions>(
+        propertyName: K,
+        value: GridOptions[K],
+        force: boolean,
+        changeSetId: number
+    ) {
         // Ensure the GridOptions property gets updated and fires the change event as we
         // cannot assume that the dynamic Api call will updated GridOptions.
-        this.gos.set(propertyName, value);
-        // If the dynamic api does update GridOptions then change detection in the 
+        this.gos.set(propertyName, value, force, {}, changeSetId);
+        // If the dynamic api does update GridOptions then change detection in the
         // GridOptionsService will prevent the event being fired twice.
         const setterName = this.getSetterMethod(propertyName);
-        const dynamicApi = (this as any);
+        const dynamicApi = this as any;
         if (dynamicApi[setterName]) {
             dynamicApi[setterName](value);
         }

--- a/grid-community-modules/core/src/ts/gridBodyComp/rowContainer/dragListenerFeature.ts
+++ b/grid-community-modules/core/src/ts/gridBodyComp/rowContainer/dragListenerFeature.ts
@@ -19,7 +19,7 @@ export class DragListenerFeature extends BeanStub {
     @PostConstruct
     private postConstruct(): void {
         if (
-            !this.gridOptionsService.isEnableRangeSelection() || // no range selection if no property
+            !this.gridOptionsService.is('enableRangeSelection') || // no range selection if no property
             missing(this.rangeService) // no range selection if not enterprise version
         ) {
             return;

--- a/grid-community-modules/core/src/ts/gridOptionsService.ts
+++ b/grid-community-modules/core/src/ts/gridOptionsService.ts
@@ -43,6 +43,10 @@ export interface PropertyChangedEvent extends AgEvent {
     type: keyof GridOptions,
     currentValue: any;
     previousValue: any;
+    /** Unique id which can be used to link changes of multiple properties that were updated together.
+     * i.e a user updated multiple properties at the same time.
+     */
+    changeSetId: number;
 }
 
 export type PropertyChangedListener<T extends PropertyChangedEvent> = (event: T) => void
@@ -175,13 +179,41 @@ export class GridOptionsService {
     }
 
     /**
+     * DO NOT USE - only for use for ComponentUtil applyChanges via GridApi.
+     * Use `set` method instead.
+     * Only update the property value, don't fire any events. This enables all properties
+     * that have been updated together to be updated before any events get triggered to avoid
+     * out of sync issues.
+     * @param key - key of the GridOption property to update
+     * @param newValue - new value for this property
+     * @returns The `true` if the previous value is not equal to the new value.
+     */
+    public __setPropertyOnly<K extends keyof GridOptions>(
+        key: K,
+        newValue: GridOptions[K]
+    ): boolean {
+        const previousValue = this.gridOptions[key];
+        if (this.gridOptionLookup.has(key)) {
+            this.gridOptions[key] = newValue;
+        }
+        return previousValue !== newValue;
+    }
+
+    /**
      *
      * @param key - key of the GridOption property to update
      * @param newValue - new value for this property
      * @param force - force the property change Event to be fired even if the value has not changed
      * @param eventParams - additional params to merge into the property changed event
+     * @param changeSetId - Change set id used to identify keys that have been updated in the same framework lifecycle update. 
      */
-    public set<K extends keyof GridOptions>(key: K, newValue: GridOptions[K], force = false, eventParams: object = {}): void {
+    public set<K extends keyof GridOptions>(
+        key: K,
+        newValue: GridOptions[K],
+        force = false,
+        eventParams: object = {},
+        changeSetId = -1
+    ): void {
         if (this.gridOptionLookup.has(key)) {
             const previousValue = this.gridOptions[key];
             if (force || previousValue !== newValue) {
@@ -190,7 +222,8 @@ export class GridOptionsService {
                     type: key,
                     currentValue: newValue,
                     previousValue: previousValue,
-                    ...eventParams
+                    changeSetId,
+                    ...eventParams,
                 };
                 this.propertyEventService.dispatchEvent(event);
             }

--- a/grid-community-modules/core/src/ts/gridOptionsService.ts
+++ b/grid-community-modules/core/src/ts/gridOptionsService.ts
@@ -441,20 +441,10 @@ export class GridOptionsService {
         return true;
     }
 
-    public isTreeData(): boolean {
-        return this.is('treeData') && ModuleRegistry.__assertRegistered(ModuleNames.RowGroupingModule, 'Tree Data', this.api.getGridId());
-    }
-    public isMasterDetail() {
-        return this.is('masterDetail') && ModuleRegistry.__assertRegistered(ModuleNames.MasterDetailModule, 'masterDetail', this.api.getGridId());
-    }
-    public isEnableRangeSelection(): boolean {
-        return this.is('enableRangeSelection') && ModuleRegistry.__isRegistered(ModuleNames.RangeSelectionModule, this.api.getGridId());
-    }
-
     public isColumnsSortingCoupledToGroup(): boolean {
         const autoGroupColumnDef = this.gridOptions.autoGroupColumnDef;
         const isClientSideRowModel = this.isRowModelType('clientSide');
-        return isClientSideRowModel && !autoGroupColumnDef?.comparator && !this.isTreeData();
+        return isClientSideRowModel && !autoGroupColumnDef?.comparator && !this.is('treeData');
     }
 
     public getGroupAggFiltering(): ((params: WithoutGridCommon<GetGroupAggFilteringParams>) => boolean) | undefined {

--- a/grid-community-modules/core/src/ts/gridOptionsValidator.ts
+++ b/grid-community-modules/core/src/ts/gridOptionsValidator.ts
@@ -88,6 +88,9 @@ export class GridOptionsValidator {
         validateRegistered('getContextMenuItems', ModuleNames.MenuModule);
         validateRegistered('allowContextMenuWithControlKey', ModuleNames.MenuModule);
         validateRegistered('enableAdvancedFilter', ModuleNames.AdvancedFilterModule);
+        validateRegistered('treeData', ModuleNames.RowGroupingModule);
+        validateRegistered('enableRangeSelection', ModuleNames.RangeSelectionModule);
+        validateRegistered('masterDetail', ModuleNames.MasterDetailModule);
     }
 
     private checkColumnDefProperties() {

--- a/grid-community-modules/core/src/ts/rendering/beans.ts
+++ b/grid-community-modules/core/src/ts/rendering/beans.ts
@@ -106,7 +106,7 @@ export class Beans {
 
     @PostConstruct
     private postConstruct(): void {
-        this.doingMasterDetail = this.gridOptionsService.isMasterDetail();
+        this.doingMasterDetail = this.gridOptionsService.is('masterDetail');
 
         if (this.gridOptionsService.isRowModelType('clientSide')) {
             this.clientSideRowModel = this.rowModel as IClientSideRowModel;

--- a/grid-community-modules/core/src/ts/rendering/cell/cellCtrl.ts
+++ b/grid-community-modules/core/src/ts/rendering/cell/cellCtrl.ts
@@ -149,7 +149,7 @@ export class CellCtrl extends BeanStub {
         this.cellKeyboardListenerFeature = new CellKeyboardListenerFeature(this, this.beans, this.column, this.rowNode, this.rowCtrl);
         this.addDestroyFunc(() => { this.cellKeyboardListenerFeature?.destroy(); this.cellKeyboardListenerFeature = null; });
 
-        const rangeSelectionEnabled = this.beans.rangeService && this.beans.gridOptionsService.isEnableRangeSelection();
+        const rangeSelectionEnabled = this.beans.rangeService && this.beans.gridOptionsService.is('enableRangeSelection');
         if (rangeSelectionEnabled) {
             this.cellRangeFeature = new CellRangeFeature(this.beans, this);
             this.addDestroyFunc(() => { this.cellRangeFeature?.destroy(); this.cellRangeFeature = null; });

--- a/grid-community-modules/core/src/ts/rendering/cell/cellKeyboardListenerFeature.ts
+++ b/grid-community-modules/core/src/ts/rendering/cell/cellKeyboardListenerFeature.ts
@@ -94,7 +94,7 @@ export class CellKeyboardListenerFeature extends BeanStub {
         eventService.dispatchEvent({ type: Events.EVENT_KEY_SHORTCUT_CHANGED_CELL_START });
 
         if (isDeleteKey(key, gridOptionsService.is('enableCellEditingOnBackspace'))) {
-            if (rangeService && gridOptionsService.isEnableRangeSelection()) {
+            if (rangeService && gridOptionsService.is('enableRangeSelection')) {
                 rangeService.clearCellRangeCellValues({ dispatchWrapperEvents: true, wrapperEventSource: 'deleteKey' });
             } else if (cellCtrl.isCellEditable()) {
                 rowNode.setDataValue(cellCtrl.getColumn(), null, 'cellClear');

--- a/grid-community-modules/core/src/ts/rendering/cellRenderers/groupCellRendererCtrl.ts
+++ b/grid-community-modules/core/src/ts/rendering/cellRenderers/groupCellRendererCtrl.ts
@@ -465,7 +465,7 @@ export class GroupCellRendererCtrl extends BeanStub {
     }
 
     private isShowRowGroupForThisRow(): boolean {
-        if (this.gridOptionsService.isTreeData()) { return true; }
+        if (this.gridOptionsService.is('treeData')) { return true; }
 
         const rowGroupColumn = this.displayedGroupNode.rowGroupColumn;
 
@@ -630,7 +630,7 @@ export class GroupCellRendererCtrl extends BeanStub {
         const rowNode: IRowNode = params.node;
         // if we are only showing one group column, we don't want to be indenting based on level
         const fullWithRow = !!params.colDef;
-        const treeData = this.gridOptionsService.isTreeData();
+        const treeData = this.gridOptionsService.is('treeData');
         const manyDimensionThisColumn = !fullWithRow || treeData || params.colDef!.showRowGroup === true;
         const paddingCount = manyDimensionThisColumn ? rowNode.uiLevel : 0;
 

--- a/grid-community-modules/core/src/ts/rendering/row/rowCtrl.ts
+++ b/grid-community-modules/core/src/ts/rendering/row/rowCtrl.ts
@@ -358,7 +358,7 @@ export class RowCtrl extends BeanStub {
     }
 
     private addRowDraggerToRow(gui: RowGui) {
-        if (this.gridOptionsService.isEnableRangeSelection()) {
+        if (this.gridOptionsService.is('enableRangeSelection')) {
             doOnce(() => {
                 console.warn('AG Grid: Setting `rowDragEntireRow: true` in the gridOptions doesn\'t work with `enableRangeSelection: true`');
             }, 'rowDragAndRangeSelectionEnabled');

--- a/grid-community-modules/core/src/ts/rendering/row/rowDragComp.ts
+++ b/grid-community-modules/core/src/ts/rendering/row/rowDragComp.ts
@@ -71,7 +71,7 @@ export class RowDragComp extends Component {
     // returns true if all compatibility items work out
     private checkCompatibility(): void {
         const managed = this.gridOptionsService.is('rowDragManaged');
-        const treeData = this.gridOptionsService.isTreeData();
+        const treeData = this.gridOptionsService.is('treeData');
 
         if (treeData && managed) {
             doOnce(() =>

--- a/grid-community-modules/core/src/ts/rendering/rowRenderer.ts
+++ b/grid-community-modules/core/src/ts/rendering/rowRenderer.ts
@@ -239,7 +239,7 @@ export class RowRenderer extends BeanStub {
             }
         });
 
-        const rangeSelectionEnabled = this.gridOptionsService.isEnableRangeSelection();
+        const rangeSelectionEnabled = this.gridOptionsService.is('enableRangeSelection');
         if (rangeSelectionEnabled) {
 
             this.addManagedListener(this.eventService, Events.EVENT_RANGE_SELECTION_CHANGED, () => {

--- a/grid-community-modules/core/src/ts/undoRedo/undoRedoService.ts
+++ b/grid-community-modules/core/src/ts/undoRedo/undoRedoService.ts
@@ -329,7 +329,7 @@ export class UndoRedoService extends BeanStub {
 
         this.addManagedListener(this.eventService, Events.EVENT_KEY_SHORTCUT_CHANGED_CELL_END, () => {
             let action: UndoRedoAction;
-            if (this.rangeService && this.gridOptionsService.isEnableRangeSelection()) {
+            if (this.rangeService && this.gridOptionsService.is('enableRangeSelection')) {
                 action = new RangeUndoRedoAction(this.cellValueChanges, undefined, undefined, [...this.rangeService.getCellRanges()]);
             } else {
                 action = new UndoRedoAction(this.cellValueChanges);

--- a/grid-community-modules/csv-export/src/csvExport/gridSerializer.ts
+++ b/grid-community-modules/csv-export/src/csvExport/gridSerializer.ts
@@ -315,7 +315,7 @@ export class GridSerializer extends BeanStub {
 
         if (allColumns && !isPivotMode) {
             // add auto group column for tree data
-            const columns = this.gridOptionsService.isTreeData()
+            const columns = this.gridOptionsService.is('treeData')
                 ? this.columnModel.getGridColumns([GROUP_AUTO_COLUMN_ID])
                 : [];
 

--- a/grid-enterprise-modules/charts/src/charts/chartComp/model/chartDataModel.ts
+++ b/grid-enterprise-modules/charts/src/charts/chartComp/model/chartDataModel.ts
@@ -194,7 +194,7 @@ export class ChartDataModel extends BeanStub {
     }
 
     public isGrouping(): boolean {
-        const usingTreeData = this.gridOptionsService.isTreeData();
+        const usingTreeData = this.gridOptionsService.is('treeData');
         const groupedCols = usingTreeData ? null : this.chartColumnService.getRowGroupColumns();
         const isGroupActive = usingTreeData || (groupedCols && groupedCols.length > 0);
 

--- a/grid-enterprise-modules/clipboard/src/clipboard/clipboardService.ts
+++ b/grid-enterprise-modules/clipboard/src/clipboard/clipboardService.ts
@@ -560,7 +560,7 @@ export class ClipboardService extends BeanStub implements IClipboardService {
 
         // if doing CSRM and NOT tree data, then it means groups are aggregates, which are read only,
         // so we should skip them when doing paste operations.
-        const skipGroupRows = this.clientSideRowModel != null && !this.gridOptionsService.is('enableGroupEdit') && !this.gridOptionsService.isTreeData();
+        const skipGroupRows = this.clientSideRowModel != null && !this.gridOptionsService.is('enableGroupEdit') && !this.gridOptionsService.is('treeData');
 
         const getNextGoodRowNode = () => {
             while (true) {

--- a/grid-enterprise-modules/menu/src/menu/enterpriseMenu.ts
+++ b/grid-enterprise-modules/menu/src/menu/enterpriseMenu.ts
@@ -427,7 +427,7 @@ export class EnterpriseMenu extends BeanStub {
 
         const isInMemoryRowModel = this.rowModel.getType() === 'clientSide';
 
-        const usingTreeData = this.gridOptionsService.isTreeData();
+        const usingTreeData = this.gridOptionsService.is('treeData');
 
         const allowValueAgg =
             // if primary, then only allow aggValue if grouping and it's a value columns

--- a/grid-enterprise-modules/range-selection/src/rangeSelection/rangeService.ts
+++ b/grid-enterprise-modules/range-selection/src/rangeSelection/rangeService.ts
@@ -173,7 +173,7 @@ export class RangeService extends BeanStub implements IRangeService {
     }
 
     public setRangeToCell(cell: CellPosition, appendRange = false): void {
-        if (!this.gridOptionsService.isEnableRangeSelection()) { return; }
+        if (!this.gridOptionsService.is('enableRangeSelection')) { return; }
 
         const columns = this.calculateColumnsBetween(cell.column, cell.column);
 
@@ -308,7 +308,7 @@ export class RangeService extends BeanStub implements IRangeService {
     }
 
     public setCellRange(params: CellRangeParams): void {
-        if (!this.gridOptionsService.isEnableRangeSelection()) {
+        if (!this.gridOptionsService.is('enableRangeSelection')) {
             return;
         }
 
@@ -423,7 +423,7 @@ export class RangeService extends BeanStub implements IRangeService {
     }
 
     public addCellRange(params: CellRangeParams): void {
-        if (!this.gridOptionsService.isEnableRangeSelection()) {
+        if (!this.gridOptionsService.is('enableRangeSelection')) {
             return;
         }
 
@@ -606,7 +606,7 @@ export class RangeService extends BeanStub implements IRangeService {
     }
 
     public onDragStart(mouseEvent: MouseEvent): void {
-        if (!this.gridOptionsService.isEnableRangeSelection()) { return; }
+        if (!this.gridOptionsService.is('enableRangeSelection')) { return; }
 
         const { ctrlKey, metaKey, shiftKey } = mouseEvent;
 

--- a/grid-enterprise-modules/row-grouping/src/rowGrouping/filterAggregatesStage.ts
+++ b/grid-enterprise-modules/row-grouping/src/rowGrouping/filterAggregatesStage.ts
@@ -106,7 +106,7 @@ export class FilterAggregatesStage extends BeanStub implements IRowNodeStage {
             return;
         }
 
-        if (this.gridOptionsService.isTreeData()) {
+        if (this.gridOptionsService.is('treeData')) {
             this.setAllChildrenCountTreeData(rowNode);
         } else {
             this.setAllChildrenCountGridGrouping(rowNode);

--- a/grid-enterprise-modules/row-grouping/src/rowGrouping/groupStage.ts
+++ b/grid-enterprise-modules/row-grouping/src/rowGrouping/groupStage.ts
@@ -10,7 +10,6 @@ import {
     IRowNodeStage,
     IsGroupOpenByDefaultParams,
     NumberSequence,
-    PostConstruct,
     RowNode,
     RowNodeTransaction,
     SelectableService,
@@ -39,6 +38,14 @@ interface GroupingDetails {
     groupedColCount: number;
     transactions: RowNodeTransaction[];
     rowNodeOrder: { [id: string]: number; };
+    
+    groupAllowUnbalanced: boolean;
+    isGroupOpenByDefault: (params: WithoutGridCommon<IsGroupOpenByDefaultParams>) => boolean;
+    initialGroupOrderComparator: (params: WithoutGridCommon<InitialGroupOrderComparatorParams>) => number;
+    createGroupFooter: boolean;
+    
+    usingTreeData: boolean;
+    getDataPath: GetDataPath | undefined;
 }
 
 @Bean('groupStage')
@@ -49,13 +56,6 @@ export class GroupStage extends BeanStub implements IRowNodeStage {
     @Autowired('valueService') private valueService: ValueService;
     @Autowired('beans') private beans: Beans;
     @Autowired('selectionService') private selectionService: ISelectionService;
-
-    // if doing tree data, this is true. we set this at create time - as our code does not
-    // cater for the scenario where this is switched on / off dynamically
-    private usingTreeData: boolean;
-    private getDataPath: GetDataPath | undefined;
-
-    private createGroupFooter: boolean;
 
     // we use a sequence variable so that each time we do a grouping, we don't
     // reuse the ids - otherwise the rowRenderer will confuse rowNodes between redraws
@@ -71,18 +71,6 @@ export class GroupStage extends BeanStub implements IRowNodeStage {
     private oldGroupingDetails: GroupingDetails;
     private oldGroupDisplayColIds: string;
 
-    @PostConstruct
-    private postConstruct(): void {
-        this.usingTreeData = this.gridOptionsService.is('treeData');
-        if (this.usingTreeData) {
-            this.getDataPath = this.gridOptionsService.get('getDataPath');
-        }
-        this.createGroupFooter = this.beans.gridOptionsService.isGroupIncludeFooterTrueOrCallback();
-        this.addManagedPropertyListener('groupIncludeFooter', () => {
-            this.createGroupFooter = this.beans.gridOptionsService.isGroupIncludeFooterTrueOrCallback();
-        });
-    }
-
     public execute(params: StageExecuteParams): void {
 
         const details = this.createGroupingDetails(params);
@@ -94,16 +82,16 @@ export class GroupStage extends BeanStub implements IRowNodeStage {
             this.shotgunResetEverything(details, afterColsChanged);
         }
 
-        this.positionLeafsAndGroups(params.changedPath!);
-        this.orderGroups(details.rootNode);
+        if(!details.usingTreeData){
+            // we don't do group sorting for tree data
+            this.positionLeafsAndGroups(params.changedPath!);
+            this.orderGroups(details);
+        }
 
         this.selectableService.updateSelectableAfterGrouping(details.rootNode);
     }
 
     private positionLeafsAndGroups(changedPath: ChangedPath) {
-        // we don't do group sorting for tree data
-        if (this.usingTreeData) { return; }
-        
         changedPath.forEachChangedNodeDepthFirst(group => {
             if (group.childrenAfterGroup) {
                 const leafNodes: RowNode[] = [];
@@ -134,23 +122,29 @@ export class GroupStage extends BeanStub implements IRowNodeStage {
     private createGroupingDetails(params: StageExecuteParams): GroupingDetails {
         const { rowNode, changedPath, rowNodeTransactions, rowNodeOrder } = params;
 
-        const groupedCols = this.usingTreeData ? null : this.columnModel.getRowGroupColumns();
+        const usingTreeData = this.gridOptionsService.is('treeData');
+
+        const groupedCols = usingTreeData ? null : this.columnModel.getRowGroupColumns();
 
         const details: GroupingDetails = {
             // someone complained that the parent attribute was causing some change detection
-            // to break is some angular add-on - which i never used. taking the parent out breaks
-            // a cyclic dependency, hence this flag got introduced.
+            // to break in an angular add-on.  Taking the parent out breaks a cyclic dependency, hence this flag got introduced.
             includeParents: !this.gridOptionsService.is('suppressParentsInRowNodes'),
             expandByDefault: this.gridOptionsService.getNum('groupDefaultExpanded')!,
             groupedCols: groupedCols!,
             rootNode: rowNode,
             pivotMode: this.columnModel.isPivotMode(),
-            groupedColCount: this.usingTreeData || !groupedCols ? 0 : groupedCols.length,
+            groupedColCount: usingTreeData || !groupedCols ? 0 : groupedCols.length,
             rowNodeOrder: rowNodeOrder!,
             transactions: rowNodeTransactions!,
-
             // if no transaction, then it's shotgun, changed path would be 'not active' at this point anyway
-            changedPath: changedPath!
+            changedPath: changedPath!,
+            groupAllowUnbalanced:  this.gridOptionsService.is('groupAllowUnbalanced'),
+            isGroupOpenByDefault: this.gridOptionsService.getCallback('isGroupOpenByDefault') as any,
+            initialGroupOrderComparator: this.gridOptionsService.getCallback('initialGroupOrderComparator') as any,
+            createGroupFooter: this.gridOptionsService.isGroupIncludeFooterTrueOrCallback(),
+            usingTreeData: usingTreeData,
+            getDataPath: usingTreeData ? this.gridOptionsService.get('getDataPath') : undefined
         };
 
         return details;
@@ -164,7 +158,7 @@ export class GroupStage extends BeanStub implements IRowNodeStage {
             // and moving. if we want to Batch Remover working with tree data then would need
             // to consider how Filler Nodes would be impacted (it's possible that it can be easily
             // modified to work, however for now I don't have the brain energy to work it all out).
-            const batchRemover = !this.usingTreeData ? new BatchRemover() : undefined;
+            const batchRemover = !details.usingTreeData ? new BatchRemover() : undefined;
 
             // the order here of [add, remove, update] needs to be the same as in ClientSideNodeManager,
             // as the order is important when a record with the same id is added and removed in the same
@@ -206,12 +200,9 @@ export class GroupStage extends BeanStub implements IRowNodeStage {
         }, false, true);
     }
 
-    private orderGroups(rootNode: RowNode): void {
-        // we don't do group sorting for tree data
-        if (this.usingTreeData) { return; }
-
-        const comparator = this.gridOptionsService.getCallback('initialGroupOrderComparator');
-        if (_.exists(comparator)) { recursiveSort(rootNode); }
+    private orderGroups(details: GroupingDetails): void {
+        const comparator = details.initialGroupOrderComparator;
+        if (_.exists(comparator)) { recursiveSort(details.rootNode); }
 
         function recursiveSort(rowNode: RowNode): void {
             const doSort = _.exists(rowNode.childrenAfterGroup) &&
@@ -230,7 +221,7 @@ export class GroupStage extends BeanStub implements IRowNodeStage {
 
         // when doing tree data, the node is part of the path,
         // but when doing grid grouping, the node is not part of the path so we start with the parent.
-        let pointer = this.usingTreeData ? node : node.parent;
+        let pointer = details.usingTreeData ? node : node.parent;
         while (pointer && pointer !== details.rootNode) {
             res.push({
                 key: pointer.key!,
@@ -293,7 +284,7 @@ export class GroupStage extends BeanStub implements IRowNodeStage {
 
     private removeNodesInStages(leafRowNodes: RowNode[], details: GroupingDetails, batchRemover: BatchRemover | undefined): void {
         this.removeNodesFromParents(leafRowNodes, details, batchRemover);
-        if (this.usingTreeData) {
+        if (details.usingTreeData) {
             this.postRemoveCreateFillerNodes(leafRowNodes, details);
 
             // When not TreeData, then removeEmptyGroups is called just before the BatchRemover is flushed.
@@ -446,14 +437,14 @@ export class GroupStage extends BeanStub implements IRowNodeStage {
         const recurse = (rowNodes: RowNode[] | null) => {
             if (!rowNodes) { return; }
             rowNodes.forEach(rowNode => {
-                const isLeafNode = !this.usingTreeData && !rowNode.group;
+                const isLeafNode = !details.usingTreeData && !rowNode.group;
                 if (isLeafNode) { return; }
                 const groupInfo: GroupInfo = {
                     field: rowNode.field,
                     key: rowNode.key!,
                     rowGroupColumn: rowNode.rowGroupColumn
                 };
-                this.setGroupData(rowNode, groupInfo);
+                this.setGroupData(rowNode, groupInfo, details);
                 recurse(rowNode.childrenAfterGroup);
             });
         };
@@ -475,7 +466,7 @@ export class GroupStage extends BeanStub implements IRowNodeStage {
         // here to change leafGroup once.
         // we set .leafGroup to false for tree data, as .leafGroup is only used when pivoting, and pivoting
         // isn't allowed with treeData, so the grid never actually use .leafGroup when doing treeData.
-        rootNode.leafGroup = this.usingTreeData ? false : groupedCols.length === 0;
+        rootNode.leafGroup = details.usingTreeData ? false : groupedCols.length === 0;
 
         // we are doing everything from scratch, so reset childrenAfterGroup and childrenMapped from the rootNode
         rootNode.childrenAfterGroup = [];
@@ -501,7 +492,7 @@ export class GroupStage extends BeanStub implements IRowNodeStage {
         if (afterColumnsChanged) {
             // we only need to redo grouping if doing normal grouping (ie not tree data)
             // and the group cols have changed.
-            noFurtherProcessingNeeded = this.usingTreeData || this.areGroupColsEqual(details, this.oldGroupingDetails);
+            noFurtherProcessingNeeded = details.usingTreeData || this.areGroupColsEqual(details, this.oldGroupingDetails);
 
             // if the group display cols have changed, then we need to update rowNode.groupData
             // (regardless of tree data or row grouping)
@@ -535,7 +526,7 @@ export class GroupStage extends BeanStub implements IRowNodeStage {
                 [parentGroup.data, childNode.data]);
         }
 
-        if (this.usingTreeData) {
+        if (details.usingTreeData) {
             this.swapGroupWithUserNode(parentGroup, childNode, isMove);
         } else {
             childNode.parent = parentGroup;
@@ -616,7 +607,7 @@ export class GroupStage extends BeanStub implements IRowNodeStage {
         groupNode.field = groupInfo.field;
         groupNode.rowGroupColumn = groupInfo.rowGroupColumn;
 
-        this.setGroupData(groupNode, groupInfo);
+        this.setGroupData(groupNode, groupInfo, details);
 
         // we put 'row-group-' before the group id, so it doesn't clash with standard row id's. we also use 't-' and 'b-'
         // for top pinned and bottom pinned rows.
@@ -624,7 +615,7 @@ export class GroupStage extends BeanStub implements IRowNodeStage {
         groupNode.key = groupInfo.key;
 
         groupNode.level = level;
-        groupNode.leafGroup = this.usingTreeData ? false : level === (details.groupedColCount - 1);
+        groupNode.leafGroup = details.usingTreeData ? false : level === (details.groupedColCount - 1);
 
         groupNode.allLeafChildren = [];
 
@@ -632,7 +623,7 @@ export class GroupStage extends BeanStub implements IRowNodeStage {
         // i suspect this is updated in the filter stage
         groupNode.setAllChildrenCount(0);
 
-        groupNode.rowGroupIndex = this.usingTreeData ? null : level;
+        groupNode.rowGroupIndex = details.usingTreeData ? null : level;
 
         groupNode.childrenAfterGroup = [];
         groupNode.childrenMapped = {};
@@ -645,20 +636,20 @@ export class GroupStage extends BeanStub implements IRowNodeStage {
         // if groupIncludeFooter is true or callback, we always create a group node footer
         // this is for export as otherwise if we create in the flatten stage then footers
         // aren't created for non-expanded group nodes.
-        if (this.createGroupFooter) {
+        if (details.createGroupFooter) {
             groupNode.createFooter();
         }
 
         return groupNode;
     }
 
-    private setGroupData(groupNode: RowNode, groupInfo: GroupInfo): void {
+    private setGroupData(groupNode: RowNode, groupInfo: GroupInfo, details: GroupingDetails): void {
         groupNode.groupData = {};
         const groupDisplayCols: Column[] = this.columnModel.getGroupDisplayColumns();
         groupDisplayCols.forEach(col => {
             // newGroup.rowGroupColumn=null when working off GroupInfo, and we always display the group in the group column
             // if rowGroupColumn is present, then it's grid row grouping and we only include if configuration says so
-            const displayGroupForCol = this.usingTreeData || (groupNode.rowGroupColumn ? col.isRowGroupDisplayed(groupNode.rowGroupColumn.getId()) : false);
+            const displayGroupForCol = details.usingTreeData || (groupNode.rowGroupColumn ? col.isRowGroupDisplayed(groupNode.rowGroupColumn.getId()) : false);
             if (displayGroupForCol) {
                 groupNode.groupData![col.getColId()] = groupInfo.key;
             }
@@ -682,7 +673,7 @@ export class GroupStage extends BeanStub implements IRowNodeStage {
         }
 
         // use callback if exists
-        const userCallback = this.gridOptionsService.getCallback('isGroupOpenByDefault');
+        const userCallback = details.isGroupOpenByDefault;
         if (userCallback) {
             const params: WithoutGridCommon<IsGroupOpenByDefaultParams> = {
                 rowNode: groupNode,
@@ -707,14 +698,14 @@ export class GroupStage extends BeanStub implements IRowNodeStage {
     }
 
     private getGroupInfo(rowNode: RowNode, details: GroupingDetails): GroupInfo[] {
-        if (this.usingTreeData) {
-            return this.getGroupInfoFromCallback(rowNode);
+        if (details.usingTreeData) {
+            return this.getGroupInfoFromCallback(rowNode, details);
         }
         return this.getGroupInfoFromGroupColumns(rowNode, details);
     }
 
-    private getGroupInfoFromCallback(rowNode: RowNode): GroupInfo[] {
-        const keys: string[] | null = this.getDataPath ? this.getDataPath(rowNode.data) : null;
+    private getGroupInfoFromCallback(rowNode: RowNode, details: GroupingDetails): GroupInfo[] {        
+        const keys: string[] | null = details.getDataPath ? details.getDataPath(rowNode.data) : null;
 
         if (keys === null || keys === undefined || keys.length === 0) {
             _.doOnce(
@@ -735,7 +726,7 @@ export class GroupStage extends BeanStub implements IRowNodeStage {
             // unbalanced tree and pivot mode don't work together - not because of the grid, it doesn't make
             // mathematical sense as you are building up a cube. so if pivot mode, we put in a blank key where missing.
             // this keeps the tree balanced and hence can be represented as a group.
-            const createGroupForEmpty = details.pivotMode || !this.gridOptionsService.is('groupAllowUnbalanced');
+            const createGroupForEmpty = details.pivotMode || !details.groupAllowUnbalanced;
             if (createGroupForEmpty && !keyExists) {
                 key = '';
                 keyExists = true;

--- a/grid-enterprise-modules/row-grouping/src/rowGrouping/groupStage.ts
+++ b/grid-enterprise-modules/row-grouping/src/rowGrouping/groupStage.ts
@@ -73,7 +73,7 @@ export class GroupStage extends BeanStub implements IRowNodeStage {
 
     @PostConstruct
     private postConstruct(): void {
-        this.usingTreeData = this.gridOptionsService.isTreeData();
+        this.usingTreeData = this.gridOptionsService.is('treeData');
         if (this.usingTreeData) {
             this.getDataPath = this.gridOptionsService.get('getDataPath');
         }

--- a/grid-enterprise-modules/server-side-row-model/src/serverSideRowModel/blocks/blockUtils.ts
+++ b/grid-enterprise-modules/server-side-row-model/src/serverSideRowModel/blocks/blockUtils.ts
@@ -34,8 +34,8 @@ export class BlockUtils extends BeanStub {
     @PostConstruct
     private postConstruct(): void {
         this.rowHeight = this.gridOptionsService.getRowHeightAsNumber();
-        this.usingTreeData = this.gridOptionsService.isTreeData();
-        this.usingMasterDetail = this.gridOptionsService.isMasterDetail();
+        this.usingTreeData = this.gridOptionsService.is('treeData');
+        this.usingMasterDetail = this.gridOptionsService.is('masterDetail');
     }
 
     public createRowNode(params: {
@@ -214,7 +214,7 @@ export class BlockUtils extends BeanStub {
     private setGroupDataIntoRowNode(rowNode: RowNode): void {
         const groupDisplayCols: Column[] = this.columnModel.getGroupDisplayColumns();
 
-        const usingTreeData = this.gridOptionsService.isTreeData();
+        const usingTreeData = this.gridOptionsService.is('treeData');
 
         groupDisplayCols.forEach(col => {
             if (rowNode.groupData == null) {

--- a/grid-enterprise-modules/server-side-row-model/src/serverSideRowModel/listeners/sortListener.ts
+++ b/grid-enterprise-modules/server-side-row-model/src/serverSideRowModel/listeners/sortListener.ts
@@ -36,7 +36,7 @@ export class SortListener extends BeanStub {
 
         // when using tree data we just return the sort model with the 'ag-Grid-AutoColumn' as is, i.e not broken out
         // into it's constitute group columns as they are not defined up front and can vary per node.
-        if (this.gridOptionsService.isTreeData()) {
+        if (this.gridOptionsService.is('treeData')) {
             return sortModel;
         }
 

--- a/grid-enterprise-modules/server-side-row-model/src/serverSideRowModel/stores/fullStore.ts
+++ b/grid-enterprise-modules/server-side-row-model/src/serverSideRowModel/stores/fullStore.ts
@@ -93,7 +93,7 @@ export class FullStore extends RowNodeBlock implements IServerSideStore {
 
     @PostConstruct
     private postConstruct(): void {
-        this.usingTreeData = this.gridOptionsService.isTreeData();
+        this.usingTreeData = this.gridOptionsService.is('treeData');
         this.nodeIdPrefix = this.blockUtils.createNodeIdPrefix(this.parentRowNode);
 
         if (!this.usingTreeData && this.groupLevel) {

--- a/grid-enterprise-modules/server-side-row-model/src/serverSideRowModel/stores/lazy/lazyCache.ts
+++ b/grid-enterprise-modules/server-side-row-model/src/serverSideRowModel/stores/lazy/lazyCache.ts
@@ -91,7 +91,7 @@ export class LazyCache extends BeanStub {
         this.defaultNodeIdPrefix = this.blockUtils.createNodeIdPrefix(this.store.getParentNode());
         this.rowLoader = this.createManagedBean(new LazyBlockLoader(this, this.store.getParentNode(), this.storeParams));
         this.getRowIdFunc = this.gridOptionsService.getCallback('getRowId');
-        this.isMasterDetail = this.gridOptionsService.isMasterDetail();
+        this.isMasterDetail = this.gridOptionsService.is('masterDetail');
     }
 
     @PreDestroy

--- a/grid-enterprise-modules/server-side-row-model/src/serverSideRowModel/stores/lazy/lazyStore.ts
+++ b/grid-enterprise-modules/server-side-row-model/src/serverSideRowModel/stores/lazy/lazyStore.ts
@@ -80,7 +80,7 @@ export class LazyStore extends BeanStub implements IServerSideStore {
         }
         this.cache = this.createManagedBean(new LazyCache(this, numberOfRows, this.storeParams));
 
-        const usingTreeData = this.gridOptionsService.isTreeData();
+        const usingTreeData = this.gridOptionsService.is('treeData');
 
         if (!usingTreeData && this.group) {
             const groupColVo = this.ssrmParams.rowGroupCols[this.level];


### PR DESCRIPTION
Update all props on the GridOptions before then looping through and firing property change events. Motivation to have consistent property state before any update listeners get run.