### PR TITLE
Export ColDefField from 'entities/colDef'

### DIFF
--- a/grid-community-modules/core/src/ts/main.ts
+++ b/grid-community-modules/core/src/ts/main.ts
@@ -394,6 +394,7 @@ export {
     IAggFuncParams,
     ColGroupDef,
     ColDef,
+    ColDefField,
     AbstractColDef,
     ColTypeDef,
     ValueSetterParams,


### PR DESCRIPTION
This enables developers to import and use the `ColDefField` when using AG Grid Modules.

Example: We currently have the following code in an Angular project:
```
localizeHeader(params: HeaderValueGetterParams<T>): string {
  const colDef: ColDef<T> = (params.colDef as ColDef<T>);
  const field: ColDefField<T> | undefined = colDef.field; // <- 'ColDefField' can not be imported
  ...
}
```
The following import does not work:
```
import {
  ColDefField
} from "@ag-grid-community/core";
```

This looks like an oversight to me. 
Related classes like `NestedFieldPaths` are exported as well, just `ColDefField` is not.