### PR TITLE
If there were no comments available in meta. The entire page was crashing.

### DIFF
--- a/grid-packages/ag-grid-docs/documentation/src/components/ApiDocumentation.tsx
+++ b/grid-packages/ag-grid-docs/documentation/src/components/ApiDocumentation.tsx
@@ -454,7 +454,7 @@ const Property: React.FC<PropertyCall> = ({ framework, id, name, definition, con
         );
     }
 
-    let propDescription = definition.description || (gridParams && gridParams.meta.comment) || undefined;
+    let propDescription = definition.description || (gridParams && gridParams.meta?.comment) || undefined;
     if (propDescription) {
         propDescription = formatJsDocString(propDescription);
         // process property object


### PR DESCRIPTION
If there were no comments in the meta. It is crashing the entire page of App. Faced this bug and hence raising PR