### PR TITLE
Fix import error in Readme usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ $ npm install --save ag-grid-community
 ### Import the grid and styles
 
 ```js
-import { Grid } from 'ag-grid-community';
+import { createGrid } from 'ag-grid-community';
 
 import 'ag-grid-community/styles/ag-grid.css';
 import 'ag-grid-community/styles/ag-theme-quartz.css';


### PR DESCRIPTION
The example inside readme shows the old method of importing a grid. This PR updates to the current approach of importing createGrid, which is already used in the rest of the example code.