### PR TITLE
Fix filter in ChangeLog page

### DIFF
--- a/grid-packages/ag-grid-docs/documentation/src/pages/changelog.jsx
+++ b/grid-packages/ag-grid-docs/documentation/src/pages/changelog.jsx
@@ -250,8 +250,8 @@ const Changelog = ({ location }) => {
                 filter: 'agSetColumnFilter',
                 filterParams: {
                     comparator: (a, b) => {
-                        const valA = parseInt(a);
-                        const valB = parseInt(b);
+                        const valA = parseInt(a.replace('AG-',''));
+                        const valB = parseInt(b.replace('AG-',''));
                         if (valA === valB) return 0;
                         return valA > valB ? -1 : 1;
                     }
@@ -272,8 +272,8 @@ const Changelog = ({ location }) => {
                 filter: 'agSetColumnFilter',
                 filterParams: {
                     comparator: (a, b) => {
-                        const valA = parseInt(a);
-                        const valB = parseInt(b);
+                        const valA = parseInt(a.replace(/\./g,''));
+                        const valB = parseInt(b.replace(/\./g,''));
                         if (valA === valB) return 0;
                         return valA > valB ? -1 : 1;
                     }


### PR DESCRIPTION
Hi AG Grid Team!
As I was taking a look at the [changelogs](https://www.ag-grid.com/changelog/?fixVersion=31.0.0), I noticed that the filter of the `Version` column seems broken, thus this PR to propose a fix.
![image](https://github.com/ag-grid/ag-grid/assets/73602526/56ae3fa8-3ea4-4a6b-a253-33850be4bf5c)

I'm also proposing a modification for the `Issue` column even if it seems fine I'm not sure the comparator works as is.