### PR TITLE
Reduce use of innerHTML

### DIFF
--- a/grid-community-modules/core/src/ts/rendering/cell/cellComp.ts
+++ b/grid-community-modules/core/src/ts/rendering/cell/cellComp.ts
@@ -11,6 +11,7 @@ import { PopupEditorWrapper } from "./../cellEditors/popupEditorWrapper";
 import { DndSourceComp } from "./../dndSourceComp";
 import { TooltipParentComp } from "../../widgets/customTooltipFeature";
 import { setAriaRole } from "../../utils/aria";
+import { escapeString } from "../../utils/string";
 import { missing } from "../../utils/generic";
 import { addStylesToElement, clearElement, loadTemplate, removeFromParent } from "../../utils/dom";
 import { CellCtrl, ICellComp } from "./cellCtrl";
@@ -267,8 +268,9 @@ export class CellComp extends Component implements TooltipParentComp {
         const eParent = this.getParentOfValue();
         clearElement(eParent);
 
-        if (valueToDisplay != null) {
-            eParent.innerText = valueToDisplay;
+        const escapedValue = valueToDisplay != null ? escapeString(valueToDisplay, true) : null;
+        if (escapedValue != null) {
+            eParent.textContent = escapedValue;
         }
     }
 

--- a/grid-community-modules/core/src/ts/rendering/cell/cellComp.ts
+++ b/grid-community-modules/core/src/ts/rendering/cell/cellComp.ts
@@ -11,7 +11,6 @@ import { PopupEditorWrapper } from "./../cellEditors/popupEditorWrapper";
 import { DndSourceComp } from "./../dndSourceComp";
 import { TooltipParentComp } from "../../widgets/customTooltipFeature";
 import { setAriaRole } from "../../utils/aria";
-import { escapeString } from "../../utils/string";
 import { missing } from "../../utils/generic";
 import { addStylesToElement, clearElement, loadTemplate, removeFromParent } from "../../utils/dom";
 import { CellCtrl, ICellComp } from "./cellCtrl";
@@ -73,7 +72,9 @@ export class CellComp extends Component implements TooltipParentComp {
         this.eRow = eRow;
         this.cellCtrl = cellCtrl;
 
-        this.setTemplate(/* html */`<div comp-id="${this.getCompId()}"/>`);
+        const cellDiv = document.createElement('div');
+        cellDiv.setAttribute('comp-id', this.getCompId().toString());
+        this.setTemplateFromElement(cellDiv);
 
         const eGui = this.getGui();
 
@@ -266,9 +267,8 @@ export class CellComp extends Component implements TooltipParentComp {
         const eParent = this.getParentOfValue();
         clearElement(eParent);
 
-        const escapedValue = valueToDisplay != null ? escapeString(valueToDisplay) : null;
-        if (escapedValue != null) {
-            eParent.innerHTML = escapedValue;
+        if (valueToDisplay != null) {
+            eParent.innerText = valueToDisplay;
         }
     }
 

--- a/grid-community-modules/core/src/ts/rendering/row/rowComp.ts
+++ b/grid-community-modules/core/src/ts/rendering/row/rowComp.ts
@@ -28,7 +28,10 @@ export class RowComp extends Component {
         this.beans = beans;
         this.rowCtrl = ctrl;
 
-        this.setTemplate(/* html */`<div comp-id="${this.getCompId()}" style="${this.getInitialStyle(containerType)}"/>`);
+        const rowDiv = document.createElement('div');
+        rowDiv.setAttribute('comp-id', this.getCompId().toString());
+        rowDiv.setAttribute('style', this.getInitialStyle(containerType));
+        this.setTemplateFromElement(rowDiv);
 
         const eGui = this.getGui();
         const style = eGui.style;


### PR DESCRIPTION
There are some significant performance gains with these changes.

Manually creating the cell and row divs are safe changes so they should definitely land. Done in https://github.com/ag-grid/ag-grid/commit/f7165844ba97d253f7819b75f442d717005c0c37

The second change on how we render standard cells will need more validation and checks but can give a big performance gain.