### PR TITLE
AG-10140 Render Performance

### DIFF
--- a/grid-community-modules/core/src/ts/rendering/cell/cellComp.ts
+++ b/grid-community-modules/core/src/ts/rendering/cell/cellComp.ts
@@ -270,7 +270,7 @@ export class CellComp extends Component implements TooltipParentComp {
 
         const escapedValue = valueToDisplay != null ? escapeString(valueToDisplay, true) : null;
         if (escapedValue != null) {
-            eParent.textContent = escapedValue;
+            eParent.innerHTML = escapedValue;
         }
     }
 

--- a/grid-community-modules/core/src/ts/rendering/cell/cellComp.ts
+++ b/grid-community-modules/core/src/ts/rendering/cell/cellComp.ts
@@ -11,6 +11,7 @@ import { PopupEditorWrapper } from "./../cellEditors/popupEditorWrapper";
 import { DndSourceComp } from "./../dndSourceComp";
 import { TooltipParentComp } from "../../widgets/customTooltipFeature";
 import { setAriaRole } from "../../utils/aria";
+import { escapeString } from "../../utils/string";
 import { missing } from "../../utils/generic";
 import { addStylesToElement, clearElement, loadTemplate, removeFromParent } from "../../utils/dom";
 import { CellCtrl, ICellComp } from "./cellCtrl";
@@ -267,8 +268,9 @@ export class CellComp extends Component implements TooltipParentComp {
         const eParent = this.getParentOfValue();
         clearElement(eParent);
 
-        if (valueToDisplay != null) {
-            eParent.innerText = valueToDisplay;
+        const escapedValue = valueToDisplay != null ? escapeString(valueToDisplay, true) : null;
+        if (escapedValue != null) {
+            eParent.textContent = escapedValue;
         }
     }
 

--- a/grid-community-modules/core/src/ts/rendering/cell/cellComp.ts
+++ b/grid-community-modules/core/src/ts/rendering/cell/cellComp.ts
@@ -268,7 +268,7 @@ export class CellComp extends Component implements TooltipParentComp {
         const eParent = this.getParentOfValue();
         clearElement(eParent);
 
-        const escapedValue = valueToDisplay != null ? escapeString(valueToDisplay, true) : null;
+        const escapedValue = valueToDisplay != null ? escapeString(valueToDisplay) : null;
         if (escapedValue != null) {
             eParent.innerHTML = escapedValue;
         }

--- a/grid-community-modules/core/src/ts/rendering/cell/cellComp.ts
+++ b/grid-community-modules/core/src/ts/rendering/cell/cellComp.ts
@@ -74,7 +74,7 @@ export class CellComp extends Component implements TooltipParentComp {
         this.cellCtrl = cellCtrl;
 
         const cellDiv = document.createElement('div');
-        cellDiv.setAttribute('comp-id', this.getCompId().toString());
+        cellDiv.setAttribute('comp-id', `${this.getCompId()}`);
         this.setTemplateFromElement(cellDiv);
 
         const eGui = this.getGui();

--- a/grid-community-modules/core/src/ts/rendering/cell/cellComp.ts
+++ b/grid-community-modules/core/src/ts/rendering/cell/cellComp.ts
@@ -11,7 +11,6 @@ import { PopupEditorWrapper } from "./../cellEditors/popupEditorWrapper";
 import { DndSourceComp } from "./../dndSourceComp";
 import { TooltipParentComp } from "../../widgets/customTooltipFeature";
 import { setAriaRole } from "../../utils/aria";
-import { escapeString } from "../../utils/string";
 import { missing } from "../../utils/generic";
 import { addStylesToElement, clearElement, loadTemplate, removeFromParent } from "../../utils/dom";
 import { CellCtrl, ICellComp } from "./cellCtrl";
@@ -73,7 +72,9 @@ export class CellComp extends Component implements TooltipParentComp {
         this.eRow = eRow;
         this.cellCtrl = cellCtrl;
 
-        this.setTemplate(/* html */`<div comp-id="${this.getCompId()}"/>`);
+        const cellDiv = document.createElement('div');
+        cellDiv.setAttribute('comp-id', this.getCompId().toString());
+        this.setTemplateFromElement(cellDiv);
 
         const eGui = this.getGui();
 
@@ -266,9 +267,8 @@ export class CellComp extends Component implements TooltipParentComp {
         const eParent = this.getParentOfValue();
         clearElement(eParent);
 
-        const escapedValue = valueToDisplay != null ? escapeString(valueToDisplay) : null;
-        if (escapedValue != null) {
-            eParent.innerHTML = escapedValue;
+        if (valueToDisplay != null) {
+            eParent.innerText = valueToDisplay;
         }
     }
 

--- a/grid-community-modules/core/src/ts/rendering/row/rowComp.ts
+++ b/grid-community-modules/core/src/ts/rendering/row/rowComp.ts
@@ -29,7 +29,7 @@ export class RowComp extends Component {
         this.rowCtrl = ctrl;
 
         const rowDiv = document.createElement('div');
-        rowDiv.setAttribute('comp-id', this.getCompId().toString());
+        rowDiv.setAttribute('comp-id', `${this.getCompId()}`);
         rowDiv.setAttribute('style', this.getInitialStyle(containerType));
         this.setTemplateFromElement(rowDiv);
 

--- a/grid-community-modules/core/src/ts/rendering/row/rowComp.ts
+++ b/grid-community-modules/core/src/ts/rendering/row/rowComp.ts
@@ -28,7 +28,10 @@ export class RowComp extends Component {
         this.beans = beans;
         this.rowCtrl = ctrl;
 
-        this.setTemplate(/* html */`<div comp-id="${this.getCompId()}" style="${this.getInitialStyle(containerType)}"/>`);
+        const rowDiv = document.createElement('div');
+        rowDiv.setAttribute('comp-id', this.getCompId().toString());
+        rowDiv.setAttribute('style', this.getInitialStyle(containerType));
+        this.setTemplateFromElement(rowDiv);
 
         const eGui = this.getGui();
         const style = eGui.style;

--- a/grid-community-modules/core/src/ts/rendering/row/rowCtrl.ts
+++ b/grid-community-modules/core/src/ts/rendering/row/rowCtrl.ts
@@ -121,6 +121,7 @@ export class RowCtrl extends BeanStub {
     private rowStyles: RowStyle | undefined;
     private readonly emptyStyle: RowStyle = {};
     private readonly printLayout: boolean;
+    private readonly suppressRowTransform: boolean;
 
     private updateColumnListsPending = false;
 
@@ -143,6 +144,7 @@ export class RowCtrl extends BeanStub {
         this.paginationPage = beans.paginationProxy.getCurrentPage();
         this.useAnimationFrameForCreate = useAnimationFrameForCreate;
         this.printLayout = printLayout;
+        this.suppressRowTransform = this.gridOptionsService.get('suppressRowTransform');
 
         this.instanceId = rowNode.id + '-' + instanceIdSequence++;
         this.rowId = escapeString(rowNode.id);
@@ -1580,12 +1582,10 @@ export class RowCtrl extends BeanStub {
     // to below the viewport, so the row will appear to animate up. if we didn't set the initial position at creation
     // time, the row would animate down (ie from position zero).
     public getInitialRowTop(rowContainerType: RowContainerType): string | undefined {
-        const suppressRowTransform = this.gridOptionsService.get('suppressRowTransform');
-        return suppressRowTransform ? this.getInitialRowTopShared(rowContainerType) : undefined;
+        return this.suppressRowTransform ? this.getInitialRowTopShared(rowContainerType) : undefined;
     }
     public getInitialTransform(rowContainerType: RowContainerType): string | undefined {
-        const suppressRowTransform = this.gridOptionsService.get('suppressRowTransform');
-        return suppressRowTransform ? undefined : `translateY(${this.getInitialRowTopShared(rowContainerType)})`;
+        return this.suppressRowTransform ? undefined : `translateY(${this.getInitialRowTopShared(rowContainerType)})`;
     }
     private getInitialRowTopShared(rowContainerType: RowContainerType): string {
         // print layout uses normal flow layout for row positioning
@@ -1606,9 +1606,8 @@ export class RowCtrl extends BeanStub {
     }
 
     private setRowTopStyle(topPx: string): void {
-        const suppressRowTransform = this.gridOptionsService.get('suppressRowTransform');
         this.allRowGuis.forEach(
-            gui => suppressRowTransform ?
+            gui => this.suppressRowTransform ?
                 gui.rowComp.setTop(topPx) :
                 gui.rowComp.setTransform(`translateY(${topPx})`)
         );


### PR DESCRIPTION
For Cells and Rows it is quicker for us to build the simple dom elements as opposed to re-using the general approach of providing the string value and setting this to innerHTML. As these are done a lot it is worth switching to manual creation for the speed boost.

Before the change rendering a grid with a rowBuffer of 400 to force more rendering:
<img width="373" alt="Screenshot 2023-12-19 at 09 13 03" src="https://github.com/ag-grid/ag-grid/assets/20125490/58fab6a0-98a8-4c69-9a1c-e3aa27a35c96">

After this change
<img width="372" alt="Screenshot 2023-12-19 at 09 10 35" src="https://github.com/ag-grid/ag-grid/assets/20125490/51447aa5-183f-4b5d-a585-bddaa5c7ca6d">

