### PR TITLE
AG-9939 - Fix changelog versions dropdown

### DIFF
--- a/grid-packages/ag-grid-docs/documentation/src/components/release-notes/Collapsible.tsx
+++ b/grid-packages/ag-grid-docs/documentation/src/components/release-notes/Collapsible.tsx
@@ -25,9 +25,13 @@ const Collapsible: FunctionComponent<Props> = ({ title, versions, fixVersion, on
         event.stopPropagation();
     };
 
+    const buttonDisabledProps = isEmptyContent ? {
+        'aria-disabled': true
+    } : {};
+
     return (
         <div className={showNotes ? styles.isOpen : undefined}>
-            <button className={classNames(styles.showHideButton, isEmptyContent ? styles.noHyperlink : '')} onClick={!isEmptyContent ? collapsibleHandler : undefined} disabled={isEmptyContent}>
+            <button className={classNames(styles.showHideButton, isEmptyContent ? 'button-tertiary' : '')} onClick={!isEmptyContent ? collapsibleHandler : undefined} {...buttonDisabledProps}>
                 <div>
                     {title && !isEmptyContent && title}
                     {!hideExpander && (

--- a/grid-packages/ag-grid-docs/documentation/src/design-system/elements/_button.scss
+++ b/grid-packages/ag-grid-docs/documentation/src/design-system/elements/_button.scss
@@ -36,6 +36,10 @@ input[type='submit']#{$selector-exclude-grid},
     &:hover,
     &.hover {
         background-color: var(--color-button-primary-bg-hover);
+
+        &[aria-disabled] {
+            background-color: var(--color-button-primary-bg);
+        }
     }
 
     &:active {
@@ -52,12 +56,19 @@ input[type='submit']#{$selector-exclude-grid},
 
     &:disabled,
     &[disabled],
+    &[aria-disabled],
     &.disabled {
         background-color: var(--color-button-disabled-bg);
         color: var(--color-button-disabled-fg);
         border: 1px solid var(--color-button-disabled-border);
-        pointer-events: none;
         cursor: default;
+    }
+
+    /* Disable pointer events for `disabled` but not `aria-disabled` */
+    &:disabled,
+    &[disabled],
+    &.disabled {
+        pointer-events: none;
     }
 
     .icon {
@@ -112,8 +123,16 @@ input[type='submit']#{$selector-exclude-grid},
 .button-tertiary {
     &:disabled,
     &[disabled],
+    &[aria-disabled],
     &.disabled {
         color: var(--color-button-disabled-fg);
+    }
+
+    &:hover,
+    &.hover {
+        &[aria-disabled] {
+            background-color: var(--color-button-disabled-bg);
+        }
     }
 }
 
@@ -131,6 +150,7 @@ input[type='submit']#{$selector-exclude-grid},
     &.hover,
     &:disabled,
     &[disabled],
+    &[aria-disabled],
     &.disabled {
         background-color: transparent;
         border: none;
@@ -139,6 +159,14 @@ input[type='submit']#{$selector-exclude-grid},
     &:focus-visible,
     &.focus {
         box-shadow: none;
+    }
+
+    &:hover,
+    &.hover {
+        &[aria-disabled] {
+            background-color: transparent;
+            color: var(--color-button-disabled-fg);
+        }
     }
 }
 

--- a/grid-packages/ag-grid-docs/documentation/src/design-system/modules/Collapsible.module.scss
+++ b/grid-packages/ag-grid-docs/documentation/src/design-system/modules/Collapsible.module.scss
@@ -6,27 +6,12 @@
     justify-content: space-between;
     gap: $spacing-size-2;
     width: 100%;
-    padding: $spacing-size-2 $spacing-size-2 $spacing-size-2 $spacing-size-4;
-    text-align: left;
-    font-weight: var(--text-bold);
-    color: var(--color-link);
-    background-color: transparent;
-    transition: color $transition-default-timing;
 
-    &:hover {
-        color: var(--color-link-hover);
-    }
-
-    &:disabled {
-        cursor: default;
-        color: black;
-        background-color: var(--color-util-brand-100);
-    }
-
-    &:not(:disabled) {
+    .isOpen & {
         border-bottom-right-radius: 0;
         border-bottom-left-radius: 0;
     }
+
 
     svg {
         width: 20px;
@@ -82,7 +67,6 @@
 .showMoreLink {
     display: block;
     position: absolute;
-    font-size: var(--text-fs-lg);
     width: 100%;
     left: 0;
     bottom: 0;
@@ -111,5 +95,9 @@
 
 .versionLabel {
     font-weight: var(--text-regular);
-    color: var(--color-fg-secondary);
+    color: var(--color-button-primary-fg);
+
+    [aria-disabled] & {
+        color: var(--color-button-secondary-fg);
+    }
 }

--- a/grid-packages/ag-grid-docs/documentation/src/design-system/style-guide/Buttons.tsx
+++ b/grid-packages/ag-grid-docs/documentation/src/design-system/style-guide/Buttons.tsx
@@ -51,6 +51,23 @@ export const Buttons: FunctionComponent = () => {
                     Button style none
                 </button>
             </div>
+
+            <div className={styles.buttonExamples}>
+                <label>Aria Disabled: </label>
+                <button disabled>Primary</button>
+                <button className="button-secondary" aria-disabled>
+                    Secondary
+                </button>
+                <button className="button-tertiary" aria-disabled>
+                    Tertiary
+                </button>
+                <button className="button-as-link" aria-disabled>
+                    Button as link
+                </button>
+                <button className="button-style-none" aria-disabled>
+                    Button style none
+                </button>
+            </div>
         </>
     );
 };

--- a/grid-packages/ag-grid-docs/documentation/src/design-system/style-guide/StyleGuide.module.scss
+++ b/grid-packages/ag-grid-docs/documentation/src/design-system/style-guide/StyleGuide.module.scss
@@ -152,7 +152,7 @@
     margin-bottom: $spacing-size-8;
 
     label {
-        min-width: 80px;
+        min-width: 100px;
         text-align: right;
     }
 }


### PR DESCRIPTION
Fix changelog versions dropdown not being clickable

## Changes

* Add aria-disabled styles to design system 
  * `aria-disabled` is useful if you want the styles of a disabled button, but still want pointer events to continue working eg, if the button contains other interactive elements.
* Fix changelog versions drop down not being clickable 
  * Use `aria-disabled` instead of `disabled` so that pointer events are still passed through
  * Clean up Collapsible button `color` and `background-color` to use design system buttons more