### PR TITLE
AG-10010 Angular CD avoidance

### DIFF
--- a/grid-community-modules/angular/package.json
+++ b/grid-community-modules/angular/package.json
@@ -29,6 +29,7 @@
   },
   "devDependencies": {
     "@ag-grid-community/core": "~31.0.1",
+    "@ag-grid-community/client-side-row-model": "~31.0.1",
     "@angular-devkit/build-angular": "^14.2.12",
     "@angular/cli": "^14.2.12",
     "@angular/compiler-cli": "^14.3.0",

--- a/grid-community-modules/angular/projects/ag-grid-angular/src/lib/ag-grid-angular.component.spec.ts
+++ b/grid-community-modules/angular/projects/ag-grid-angular/src/lib/ag-grid-angular.component.spec.ts
@@ -1,25 +1,199 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { Component, NgZone, ViewChild } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { AgGridAngular } from './ag-grid-angular.component';
+import { ClientSideRowModelModule } from '@ag-grid-community/client-side-row-model';
+import { GetRowIdParams, GridOptions, GridReadyEvent, Module } from '@ag-grid-community/core';
 
-describe('MyLibComponent', () => {
-  let component: AgGridAngular;
-  let fixture: ComponentFixture<AgGridAngular>;
+function updateCount(counts: Record<string, Record<string, number>>, key: string, isInAngularZone: boolean) {
+    if (!counts[key]) {
+        counts[key] = {};
+    }
+    if(!counts[key][isInAngularZone.toString()]){
+        counts[key][isInAngularZone.toString()] = 0;
+    }else{
+        counts[key][isInAngularZone.toString()]++;
+    }
+}
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      imports: [ AgGridAngular ]
-    })
-    .compileComponents();
-  }));
+@Component({
+    selector: 'app-grid-wrapper',
+    standalone: true,
+    imports: [AgGridAngular],
+    template:
+        '<ag-grid-angular [gridOptions]="gridOptions" [getRowId]="getRowId" [rowData]="rowData" [columnDefs]="columnDefs" [modules]="modules" (gridReady)="onGridReady($event)" ></ag-grid-angular>',
+})
+export class GridWrapperComponent {
+    modules: Module[] = [ClientSideRowModelModule];
+    rowData: any[] = [{ make: 'Toyota', model: 'Celica', price: 35000 }];
+    columnDefs = [{ field: 'make' }, { field: 'model' }, { field: 'price' }];
 
-  beforeEach(() => {
-    fixture = TestBed.createComponent(AgGridAngular);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
+    gridOptions: GridOptions = {
+        getRowClass: (params) => {
+            updateCount(this.zoneStatus,'gridOptions -> callback',NgZone.isInAngularZone());
+            return 'my-class';
+        },
+        onStateUpdated: () => {
+            updateCount(this.zoneStatus,'gridOptions -> event',NgZone.isInAngularZone());
+        },
+    };
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
-  });
+    zoneStatus: any = {};
+ 
+    @ViewChild(AgGridAngular) agGrid: AgGridAngular;
+
+    constructor(private zone: NgZone) {}
+
+    onGridReady(params: GridReadyEvent) {
+        updateCount(this.zoneStatus,'component -> event', NgZone.isInAngularZone());
+
+        // For testing purposes, we are going to add listeners to the grid outside of angular to mimic
+        // these events being fired from the grid itself which is running outside of angular.
+        //this.zone.runOutsideAngular(() => {
+            const globalListener = (event: any) => {
+                updateCount(this.zoneStatus,'api -> globalListener', NgZone.isInAngularZone());
+            };
+
+            const eventListener = (event: any) => {
+                updateCount(this.zoneStatus,'api -> eventListener', NgZone.isInAngularZone());
+            };
+
+            params.api.addGlobalListener(globalListener);
+            params.api.addEventListener('newColumnsLoaded', eventListener);
+
+             params.api.getRowNode('Toyota')?.addEventListener('dataChanged', (event: any) => {
+                 updateCount(this.zoneStatus,'RowNode -> eventListener', NgZone.isInAngularZone());
+             });
+
+            params.api.getColumn('make')?.addEventListener('visibleChanged', (event: any) => {
+                updateCount(this.zoneStatus,'Column -> eventListener', NgZone.isInAngularZone());
+            });
+
+            params.api.getRowNode('Toyota')?.setData({ make: 'Toyota', model: 'Celica', price: 40000 });
+
+            params.api.applyColumnState({
+                state: [
+                    {
+                        colId: 'make',
+                        hide: true,
+                    },
+                ],
+            });
+      //  });
+    }
+
+    getRowId = (params: GetRowIdParams) => {
+        updateCount(this.zoneStatus,'component -> callback', NgZone.isInAngularZone());
+        return params.data.make;
+    };
+}
+
+describe('GridWrapperComponent', () => {
+    let component: GridWrapperComponent;
+    let fixture: ComponentFixture<GridWrapperComponent>;
+
+    beforeEach(async () => {
+        await TestBed.configureTestingModule({
+            imports: [GridWrapperComponent, AgGridAngular],
+        }).compileComponents();
+    });
+
+    beforeEach(async () => {
+        fixture = TestBed.createComponent(GridWrapperComponent);
+        component = fixture.componentInstance;
+        component.zoneStatus = {};
+        fixture.detectChanges();
+    });
+
+    it('should run in / out Angular Zone', (done) => {
+        // Access AG Grid API and check if the row data is updated
+        const api = fixture.componentInstance.agGrid.api;
+        expect(api).toBeDefined();
+        expect(api.getDisplayedRowCount()).toEqual(1);
+
+        setTimeout(() => {
+            api.updateGridOptions({ columnDefs: [{ field: 'make' }, { field: 'model' }] });
+            fixture.detectChanges();
+
+            setTimeout(() => {
+                const results = Object.entries(component.zoneStatus).map(
+                  ([key, value]) => {
+                    const valueString = JSON.stringify(value);
+                    return `${key}: ${valueString}`;
+                  }
+                );
+                results.sort();
+                console.log('\n', results.join('\n'));
+                const expected: Record<string, boolean> = {
+                    'Column -> eventListener': true,
+                    'RowNode -> eventListener': true,
+                    'api -> eventListener': true,
+                    'api -> globalListener': true,
+                    'component -> callback': false,
+                    'component -> event': true,
+                    'gridOptions -> callback': false,
+                };
+
+                Object.keys(expected).forEach((key) => {
+                   // expect(`${key}: ${component.zoneStatus[key]}`).toBe(`${key}: ${expected[key]}`);
+                });
+
+                done();
+            }, 1000);
+        }, 1000);
+    });
+
+    xit('should remove event listeners', (done) => {
+        // Access AG Grid API and check if the row data is updated
+        const api = fixture.componentInstance.agGrid.api;
+        expect(api).toBeDefined();
+
+        const listeners = {
+            eventListener: (event: any) => {},
+            globalEventListener: (event: any) => {},
+            rowEventListener: (event: any) => {},
+            columnEventListener: (event: any) => {},
+        };
+
+        const eventListenerSpy = spyOn(listeners, 'eventListener');
+        const globalEventListenerSpy = spyOn(listeners, 'globalEventListener');
+        const rowEventListenerSpy = spyOn(listeners, 'rowEventListener');
+        const columnEventListenerSpy = spyOn(listeners, 'columnEventListener');
+
+        // Test add and remove works
+        api.addEventListener('newColumnsLoaded', listeners.eventListener);
+        api.removeEventListener('newColumnsLoaded', listeners.eventListener);
+
+        api.addGlobalListener(listeners.globalEventListener);
+        api.removeGlobalListener(listeners.globalEventListener);
+
+        api.getRowNode('Toyota')?.addEventListener('dataChanged', listeners.rowEventListener);
+        api.getRowNode('Toyota')?.removeEventListener('dataChanged', listeners.rowEventListener);
+
+        api.getColumn('make')?.addEventListener('visibleChanged', listeners.columnEventListener);
+        api.getColumn('make')?.removeEventListener('visibleChanged', listeners.columnEventListener);
+
+        api.getRowNode('Toyota')?.setData({ make: 'Toyota', model: 'Celica', price: 40000 });
+
+        api.applyColumnState({
+            state: [
+                {
+                    colId: 'make',
+                    hide: true,
+                },
+            ],
+        });
+
+        setTimeout(() => {
+            api.updateGridOptions({ columnDefs: [{ field: 'make' }, { field: 'model' }] });
+            fixture.detectChanges();
+
+            expect(eventListenerSpy).toHaveBeenCalledTimes(0);
+            expect(globalEventListenerSpy).toHaveBeenCalledTimes(0);
+            expect(rowEventListenerSpy).toHaveBeenCalledTimes(0);
+            expect(columnEventListenerSpy).toHaveBeenCalledTimes(0);
+
+            done();
+        }, 100);
+    });
 });

--- a/grid-community-modules/angular/projects/ag-grid-angular/src/lib/ag-grid-angular.component.spec.ts
+++ b/grid-community-modules/angular/projects/ag-grid-angular/src/lib/ag-grid-angular.component.spec.ts
@@ -5,15 +5,8 @@ import { AgGridAngular } from './ag-grid-angular.component';
 import { ClientSideRowModelModule } from '@ag-grid-community/client-side-row-model';
 import { GetRowIdParams, GridApi, GridOptions, GridReadyEvent, Module } from '@ag-grid-community/core';
 
-function updateCount(counts: Record<string, Record<string, number>>, key: string, isInAngularZone: boolean) {
-    if (!counts[key]) {
-        counts[key] = {};
-    }
-    if (!counts[key][isInAngularZone.toString()]) {
-        counts[key][isInAngularZone.toString()] = 1;
-    } else {
-        counts[key][isInAngularZone.toString()]++;
-    }
+function updateCount(counts: Record<string, boolean>, key: string, isInAngularZone: boolean) {
+    counts[key] = isInAngularZone;
 }
 
 @Component({
@@ -127,15 +120,15 @@ describe('GridWrapperComponent', () => {
                 );
                 // results.sort();
                 // console.log('\n', results.join('\n'));
-                const expected: Record<string, string> = {
-                    'Column -> eventListener': '{"true":1}',
-                    'RowNode -> eventListener': '{"true":1}',
-                    'api -> eventListener': '{"true":1}',
-                    'api -> globalListener': '{"true":15}',
-                    'component -> callback': '{"false":1}',
-                    'component -> event': '{"true":1}',
-                    'gridOptions -> callback': '{"false":2}',
-                    'gridOptions -> event': '{"true":2}',
+                const expected: Record<string, boolean> = {
+                    'Column -> eventListener': true,
+                    'RowNode -> eventListener': true,
+                    'api -> eventListener': true,
+                    'api -> globalListener': true,
+                    'component -> callback': false,
+                    'component -> event': true,
+                    'gridOptions -> callback': false,
+                    'gridOptions -> event': true,
                 };
 
                 Object.keys(expected).forEach((key) => {
@@ -143,8 +136,8 @@ describe('GridWrapperComponent', () => {
                 });
 
                 done();
-            }, 500);
-        }, 500);
+            }, 1500);
+        }, 1500);
     });
 
     it('should remove event listeners', (done) => {
@@ -256,15 +249,15 @@ describe('GridWrapperComponent', () => {
                 );
                 // results.sort();
                 // console.log('\n', results.join('\n'));
-                const expected: Record<string, string> = {
-                    'Column -> eventListener': '{"false":1}', // Will stay outside
-                    'RowNode -> eventListener': '{"false":1}', // Will stay outside
-                    'api -> eventListener': '{"false":1}', // Will stay outside
-                    'api -> globalListener': '{"false":15}', // Will stay outside
-                    'component -> callback': '{"false":1}',
-                    'component -> event': '{"true":1}',
-                    'gridOptions -> callback': '{"false":2}',
-                    'gridOptions -> event': '{"true":2}',
+                const expected: Record<string, boolean> = {
+                    'Column -> eventListener': false, // Will stay outside
+                    'RowNode -> eventListener': false, // Will stay outside
+                    'api -> eventListener': false, // Will stay outside
+                    'api -> globalListener': false, // Will stay outside
+                    'component -> callback': false,
+                    'component -> event': true,
+                    'gridOptions -> callback': false,
+                    'gridOptions -> event': true
                 };
 
                 Object.keys(expected).forEach((key) => {
@@ -272,7 +265,7 @@ describe('GridWrapperComponent', () => {
                 });
 
                 done();
-            }, 500);
-        }, 500);
+            }, 1500);
+        }, 1500);
     });
 });

--- a/grid-community-modules/angular/projects/ag-grid-angular/src/lib/angularFrameworkComponentWrapper.ts
+++ b/grid-community-modules/angular/projects/ag-grid-angular/src/lib/angularFrameworkComponentWrapper.ts
@@ -1,34 +1,29 @@
 import {ComponentRef, Injectable, NgZone, ViewContainerRef} from "@angular/core";
 import {BaseComponentWrapper, FrameworkComponentWrapper, GridApi, WrappableInterface} from '@ag-grid-community/core';
 import {AgFrameworkComponent} from "./interfaces";
+import { AngularFrameworkOverrides } from "./angularFrameworkOverrides";
 
 @Injectable()
 export class AngularFrameworkComponentWrapper extends BaseComponentWrapper<WrappableInterface> implements FrameworkComponentWrapper {
     private viewContainerRef: ViewContainerRef;
-    private zone: NgZone;
+    private angularFrameworkOverrides: AngularFrameworkOverrides;
 
-    public setViewContainerRef(viewContainerRef: ViewContainerRef, zone: NgZone) {
+    public setViewContainerRef(viewContainerRef: ViewContainerRef, angularFrameworkOverrides: AngularFrameworkOverrides) {
         this.viewContainerRef = viewContainerRef;
-        this.zone = zone;
+        this.angularFrameworkOverrides = angularFrameworkOverrides;
     }
 
     createWrapper(OriginalConstructor: { new(): any }, compType: any): WrappableInterface {
-        let zone = this.zone;
+        let angularFrameworkOverrides = this.angularFrameworkOverrides;
         let that = this;
-
-        // Ensure methods within custom components are running inside the angular zone, so that
-        // change detection works properly with components.
-        function runInZone<T>(callback: () => T): T {
-            return zone ? zone.run(callback) : callback();
-        }
         class DynamicAgNg2Component extends BaseGuiComponent<any, AgFrameworkComponent<any>> implements WrappableInterface {
             init(params: any): void {
-                runInZone(() => super.init(params));
+                angularFrameworkOverrides.runInsideAngular(() => super.init(params));
                 this._componentRef.changeDetectorRef.detectChanges();
             }
 
             protected createComponent(): ComponentRef<AgFrameworkComponent<any>> {
-                return runInZone(() => that.createComponent(OriginalConstructor));
+                return angularFrameworkOverrides.runInsideAngular(() => that.createComponent(OriginalConstructor));
             }
 
             hasMethod(name: string): boolean {
@@ -37,7 +32,7 @@ export class AngularFrameworkComponentWrapper extends BaseComponentWrapper<Wrapp
 
             callMethod(name: string, args: IArguments): void {
                 const componentRef = this.getFrameworkComponentInstance();
-                return runInZone(() => wrapper.getFrameworkComponentInstance()[name].apply(componentRef, args));
+                return angularFrameworkOverrides.runInsideAngular(() => wrapper.getFrameworkComponentInstance()[name].apply(componentRef, args));
             }
 
             addMethod(name: string, callback: Function): void {

--- a/grid-community-modules/angular/projects/ag-grid-angular/src/lib/angularFrameworkOverrides.ts
+++ b/grid-community-modules/angular/projects/ag-grid-angular/src/lib/angularFrameworkOverrides.ts
@@ -10,12 +10,16 @@ export class AngularFrameworkOverrides extends VanillaFrameworkOverrides {
     dispatchEvent(listener: () => void): void {
         // Make all events run outside Angular as they often trigger the setup of event listeners
         // By having the event listeners outside Angular we can avoid triggering change detection
-        // Check for _ngZone existence as it is not present when Zoneless
-        if (this._ngZone) {
-            this._ngZone.runOutsideAngular(listener);
-        } else {
-            listener();
-        }
+        // This also means that if a user calls an AG Grid API method from within their component
+        // the internal side effects will not trigger change detection. Without this the events would
+        // run inside Angular and trigger change detection as the source of the event was within the angular zone.
+        this.runOutsideAngular(listener);
+    }
+
+    // Only setup wrapping when the call is coming from within Angular zone, i.e from a users application code.
+    // Used to distinguish between user code and AG Grid code setting up events against RowNodes and Columns
+    get shouldWrap() {
+        return this._ngZone && NgZone.isInAngularZone(); 
     }
 
     /**
@@ -23,7 +27,7 @@ export class AngularFrameworkOverrides extends VanillaFrameworkOverrides {
      * This means users can update templates and use binding without having to do anything extra.
      */
     wrapOutgoing<T>( callback: () => T): T {
-        return this._ngZone ? this._ngZone.run(callback) : callback();
+        return this.runInsideAngular(callback);
     }
 
     isFrameworkComponent(comp: any): boolean {
@@ -31,5 +35,13 @@ export class AngularFrameworkOverrides extends VanillaFrameworkOverrides {
         const prototype = comp.prototype;
         const isAngularComp = prototype && 'agInit' in prototype;
         return isAngularComp;
+    }
+
+    runInsideAngular<T>( callback: () => T): T {
+        // Check for _ngZone existence as it is not present when Zoneless
+        return this._ngZone ? this._ngZone.run(callback) : callback();
+    }
+    runOutsideAngular<T>( callback: () => T): T {
+        return this._ngZone ? this._ngZone.runOutsideAngular(callback) : callback();
     }
 }

--- a/grid-community-modules/core/src/ts/eventService.ts
+++ b/grid-community-modules/core/src/ts/eventService.ts
@@ -50,6 +50,10 @@ export class EventService implements IEventEmitter {
         }
     }
 
+    public setFrameworkOverrides(frameworkOverrides: IFrameworkOverrides): void {
+        this.frameworkOverrides = frameworkOverrides;
+    }
+
     private getListeners(eventType: string, async: boolean, autoCreateListenerCollection: boolean): Set<AgEventListener> | undefined {
         const listenerMap = async ? this.allAsyncListeners : this.allSyncListeners;
         let listeners = listenerMap.get(eventType);
@@ -132,9 +136,12 @@ export class EventService implements IEventEmitter {
                 // A listener could have been removed by a previously processed listener. In this case we don't want to call 
                 return;
             }
-            const callback = this.frameworkOverrides ? () => this.frameworkOverrides.dispatchEvent(() => listener(event)) : () => listener(event);
+            const callback = this.frameworkOverrides?.dispatchEvent
+                ? () => this.frameworkOverrides.dispatchEvent!(() => listener(event))
+                : () => listener(event);
+
             if (async) {
-                this.dispatchAsync(callback);
+                this.dispatchAsync(callback)
             } else {
                 callback();
             }
@@ -150,11 +157,14 @@ export class EventService implements IEventEmitter {
         const globalListeners = new Set(async ? this.globalAsyncListeners : this.globalSyncListeners);
 
         globalListeners.forEach((listener) => {
-            const callback = () => this.frameworkOverrides ? this.frameworkOverrides.dispatchEvent(() => listener(eventType, event)) : listener(eventType, event);
+            const callback = this.frameworkOverrides?.dispatchEvent
+                ? () => this.frameworkOverrides.dispatchEvent!(() => listener(eventType, event))
+                : () => listener(eventType, event);
+           
             if (async) {
                 this.dispatchAsync(callback);
             } else {
-                callback();
+                callback()
             }
         });
     }

--- a/grid-community-modules/core/src/ts/gridOptionsService.ts
+++ b/grid-community-modules/core/src/ts/gridOptionsService.ts
@@ -100,6 +100,8 @@ export class GridOptionsService {
         this.eventService.addGlobalListener(this.globalEventHandlerFactory().bind(this), async);
         this.eventService.addGlobalListener(this.globalEventHandlerFactory(true).bind(this), false);
 
+        // Ensure the propertyEventService has framework overrides set so that it can fire events outside of angular
+        this.propertyEventService.setFrameworkOverrides(this.frameworkOverrides);
         // sets an initial calculation for the scrollbar width
         this.getScrollbarWidth();
 
@@ -148,7 +150,8 @@ export class GridOptionsService {
                 mergedParams.columnApi = this.columnApi;
                 mergedParams.context = this.context;
 
-                return this.frameworkOverrides.wrapOutgoing(() => callback(mergedParams));
+                return  callback(mergedParams);
+               //return (this.frameworkOverrides as any).runOutsideAngular(() => callback(mergedParams));
             };
             return wrapped;
         }
@@ -294,11 +297,16 @@ export class GridOptionsService {
                 return;
             }
 
-            const callbackMethodName = ComponentUtil.getCallbackForEvent(eventName);
-            if (typeof (this.gridOptions as any)[callbackMethodName] === 'function') {
-                this.frameworkOverrides.wrapOutgoing(() => {
-                    (this.gridOptions as any)[callbackMethodName](event);
-                })
+            const eventHandlerName = ComponentUtil.getCallbackForEvent(eventName);
+            const eventHandler = (this.gridOptions as any)[eventHandlerName];
+            if (typeof eventHandler === 'function') {
+                if(this.frameworkOverrides.wrapOutgoing) {
+                    this.frameworkOverrides.wrapOutgoing(() => {
+                        eventHandler(event);
+                    })
+                }else{
+                    eventHandler(event);
+                }
             }
         }
     };

--- a/grid-community-modules/core/src/ts/gridOptionsService.ts
+++ b/grid-community-modules/core/src/ts/gridOptionsService.ts
@@ -150,8 +150,7 @@ export class GridOptionsService {
                 mergedParams.columnApi = this.columnApi;
                 mergedParams.context = this.context;
 
-                return  callback(mergedParams);
-               //return (this.frameworkOverrides as any).runOutsideAngular(() => callback(mergedParams));
+                return callback(mergedParams);
             };
             return wrapped;
         }

--- a/grid-community-modules/core/src/ts/interfaces/iFrameworkOverrides.ts
+++ b/grid-community-modules/core/src/ts/interfaces/iFrameworkOverrides.ts
@@ -6,21 +6,31 @@ export interface IFrameworkOverrides {
 
     addEventListener(element: HTMLElement, type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     
-    /** Angular uses Zones, we run ALL events outside of Zone JS so that we do not kick off
+    /** 
+     * This method is to cater for Angular's change detection. 
+     * Angular uses Zones, we run ALL events outside of Zone JS so that we do not kick off
      * the Angular change detection. Any event listener or setTimeout() or setInterval() run by our code 
      * would trigger change detection in Angular. 
      * 
      * Before events are returned to the user / callbacks called, those functions are wrapping in Angular's zone
      * again so that the user's code triggers change detection as normal. See wrapOutgoing() below.
      */
-    dispatchEvent(listener: () => void): void;
+    dispatchEvent?: (listener: () => void) => void;
 
     /**
-     * Any code that is executed outside of AG Grid should be wrapped in this method. This is to cater for Angular's
-     * change detection. This is currently used for events, callbacks that the user provides either via the component
-     * or via registration with the grid api.     
+     * This method is to cater for Angular's change detection. 
+     * This is currently used for events that the user provides either via the component or via registration with the grid api.
+     * This method should not be implemented for the other frameworks to avoid unnecessary overhead.
      */
-    wrapOutgoing<T>(listener: () => T): T;
+    wrapOutgoing?: <T>(listener: () => T) => T;
+
+    /**
+     * The shouldWrap property is used to determine if events should be run outside of Angular or not.
+     * If an event handler is registered outside of Angular then we should not wrap the event handler
+     * with runInsideAngular() as the user may not have wanted this.
+     * This is also used to not wrap internal event listeners that are registered with RowNodes and Columns.
+     */
+    shouldWrap?: boolean;
 
     /*
     * vue components are specified in the "components" part of the vue component - as such we need a way to deteremine if a given component is

--- a/grid-community-modules/core/src/ts/misc/frameworkEventListenerService.ts
+++ b/grid-community-modules/core/src/ts/misc/frameworkEventListenerService.ts
@@ -1,0 +1,41 @@
+import { IFrameworkOverrides } from "../interfaces/iFrameworkOverrides";
+import { AgEventListener, AgGlobalEventListener } from "../events";
+
+
+export class FrameworkEventListenerService {
+    // Map from user listener to wrapped listener so we can remove listener provided by user
+    private wrappedListeners: Map<AgEventListener, AgEventListener> = new Map();
+    private wrappedGlobalListeners: Map<AgGlobalEventListener, AgGlobalEventListener> = new Map();
+
+    constructor(private frameworkOverrides: IFrameworkOverrides) {}
+
+    public wrap(userListener: AgEventListener): AgEventListener {
+        let listener = userListener;
+        if (this.frameworkOverrides.shouldWrap) {
+            listener = (event: any) => {
+                this.frameworkOverrides.wrapOutgoing!(() => userListener(event));
+            };
+            this.wrappedListeners.set(userListener, listener);
+        }
+        return listener;
+    }
+
+    public wrapGlobal(userListener: AgGlobalEventListener): AgGlobalEventListener {
+        let listener = userListener;
+
+        if (this.frameworkOverrides.shouldWrap) {
+            listener = (eventType: string, event: any) => {
+                this.frameworkOverrides.wrapOutgoing!(() => userListener(eventType, event));
+            };
+            this.wrappedGlobalListeners.set(userListener, listener);
+        }
+        return listener;
+    }
+
+    public unwrap(userListener: AgEventListener): AgEventListener {
+        return this.wrappedListeners.get(userListener) ?? userListener;
+    }
+    public unwrapGlobal(userListener: AgGlobalEventListener): AgGlobalEventListener {
+        return this.wrappedGlobalListeners.get(userListener) ?? userListener;
+    }
+}

--- a/grid-community-modules/core/src/ts/vanillaFrameworkOverrides.ts
+++ b/grid-community-modules/core/src/ts/vanillaFrameworkOverrides.ts
@@ -11,10 +11,6 @@ export class VanillaFrameworkOverrides implements IFrameworkOverrides {
 
     constructor(private frameworkName: 'javascript' | 'angular' | 'react' | 'vue' | 'solid' = 'javascript') {}
 
-    // for Vanilla JS, we use simple timeout
-    public setTimeout(action: any, timeout?: any): void {
-        window.setTimeout(action, timeout);
-    }
     public setInterval(action: any, timeout?: any): AgPromise<number> {
         return new AgPromise(resolve => {
             resolve(window.setInterval(action, timeout));
@@ -32,13 +28,6 @@ export class VanillaFrameworkOverrides implements IFrameworkOverrides {
         element.addEventListener(type, listener, { capture: !!useCapture, passive: isPassive });
     }
 
-    dispatchEvent(listener: () => void): void {
-        listener();
-    }
-
-    wrapOutgoing<T>( callback: () => T): T {
-        return callback();
-    }
 
     frameworkComponent(name: string): any {
         return null;

--- a/grid-packages/ag-grid-angular/projects/ag-grid-angular/src/lib/ag-grid-angular.component.spec.ts
+++ b/grid-packages/ag-grid-angular/projects/ag-grid-angular/src/lib/ag-grid-angular.component.spec.ts
@@ -1,25 +1,185 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { Component, NgZone, ViewChild } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { AgGridAngular } from './ag-grid-angular.component';
+import { ClientSideRowModelModule } from '@ag-grid-community/client-side-row-model';
+import { GetRowIdParams, GridOptions, GridReadyEvent, Module } from 'ag-grid-community';
+import * as exp from 'constants';
 
-describe('MyLibComponent', () => {
-  let component: AgGridAngular;
-  let fixture: ComponentFixture<AgGridAngular>;
+@Component({
+    selector: 'app-grid-wrapper',
+    standalone: true,
+    imports: [AgGridAngular],
+    template:
+        '<ag-grid-angular [gridOptions]="gridOptions" [getRowId]="getRowId" [rowData]="rowData" [columnDefs]="columnDefs" [modules]="modules" (gridReady)="onGridReady($event)" ></ag-grid-angular>',
+})
+export class GridWrapperComponent {
+    modules: Module[] = [ClientSideRowModelModule];
+    rowData: any[] = [{ make: 'Toyota', model: 'Celica', price: 35000 }];
+    columnDefs = [{ field: 'make' }, { field: 'model' }, { field: 'price' }];
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      imports: [ AgGridAngular ]
-    })
-    .compileComponents();
-  }));
+    gridOptions: GridOptions = {
+        getRowClass: (params) => {
+            this.zoneStatus['gridOptions -> callback'] = NgZone.isInAngularZone();
+            return 'my-class';
+        },
+        onStateUpdated: () => {
+            this.zoneStatus['gridOptions -> event'] = NgZone.isInAngularZone();
+        },
+    };
 
-  beforeEach(() => {
-    fixture = TestBed.createComponent(AgGridAngular);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
+    zoneStatus: { [key: string]: boolean } = {};
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
-  });
+    @ViewChild(AgGridAngular) agGrid: AgGridAngular;
+
+    constructor(private zone: NgZone) {}
+
+    onGridReady(params: GridReadyEvent) {
+        this.zoneStatus['component -> event'] = NgZone.isInAngularZone();
+
+        // For testing purposes, we are going to add listeners to the grid outside of angular to mimic
+        // these events being fired from the grid itself which is running outside of angular.
+        this.zone.runOutsideAngular(() => {
+            const globalListener = (event: any) => {
+                this.zoneStatus['api -> globalListener'] = NgZone.isInAngularZone();
+            };
+
+            const eventListener = (event: any) => {
+                this.zoneStatus['api -> eventListener'] = NgZone.isInAngularZone();
+            };
+
+            params.api.addGlobalListener(globalListener);
+            params.api.addEventListener('newColumnsLoaded', eventListener);
+
+            params.api.getRowNode('Toyota')?.addEventListener('dataChanged', (event: any) => {
+                this.zoneStatus['RowNode -> eventListener'] = NgZone.isInAngularZone();
+            });
+
+            params.api.getColumn('make')?.addEventListener('visibleChanged', (event: any) => {
+                this.zoneStatus['Column -> eventListener'] = NgZone.isInAngularZone();
+            });
+
+            params.api.getRowNode('Toyota')?.setData({ make: 'Toyota', model: 'Celica', price: 40000 });
+
+            params.api.applyColumnState({
+                state: [
+                    {
+                        colId: 'make',
+                        hide: true,
+                    },
+                ],
+            });
+        });
+    }
+
+    getRowId = (params: GetRowIdParams) => {
+        this.zoneStatus['component -> callback'] = NgZone.isInAngularZone();
+        return params.data.make;
+    };
+}
+
+describe('GridWrapperComponent', () => {
+    let component: GridWrapperComponent;
+    let fixture: ComponentFixture<GridWrapperComponent>;
+
+    beforeEach(async () => {
+        await TestBed.configureTestingModule({
+            imports: [GridWrapperComponent, AgGridAngular],
+        }).compileComponents();
+    });
+
+    beforeEach(async () => {
+        fixture = TestBed.createComponent(GridWrapperComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+    });
+
+    it('should run in / out Angular Zone', (done) => {
+        // Access AG Grid API and check if the row data is updated
+        const api = fixture.componentInstance.agGrid.api;
+        expect(api).toBeDefined();
+        expect(api.getDisplayedRowCount()).toEqual(1);
+
+        setTimeout(() => {
+            api.updateGridOptions({ columnDefs: [{ field: 'make' }, { field: 'model' }] });
+            fixture.detectChanges();
+
+            setTimeout(() => {
+                // const results = Object.keys(component.zoneStatus).map(
+                //     (key: any) => `${key} ${component.zoneStatus[key]}`
+                // );
+                // results.sort();
+                // console.log('\n', results.join('\n'));
+                const expected: Record<string, boolean> = {
+                    'Column -> eventListener': false,
+                    'RowNode -> eventListener': false,
+                    'api -> eventListener': true,
+                    'api -> globalListener': true,
+                    'component -> callback': false,
+                    'component -> event': true,
+                    'gridOptions -> callback': false,
+                };
+
+                Object.keys(expected).forEach((key) => {
+                    expect(component.zoneStatus[key]).toBe(expected[key]);
+                });
+
+                done();
+            }, 1000);
+        }, 1000);
+    });
+
+    it('should remove event listeners', (done) => {
+        // Access AG Grid API and check if the row data is updated
+        const api = fixture.componentInstance.agGrid.api;
+        expect(api).toBeDefined();
+
+        const listeners = {
+            eventListener: (event: any) => {},
+            globalEventListener: (event: any) => {},
+            rowEventListener: (event: any) => {},
+            columnEventListener: (event: any) => {},
+        };
+
+        const eventListenerSpy = spyOn(listeners, 'eventListener');
+        const globalEventListenerSpy = spyOn(listeners, 'globalEventListener');
+        const rowEventListenerSpy = spyOn(listeners, 'rowEventListener');
+        const columnEventListenerSpy = spyOn(listeners, 'columnEventListener');
+
+        // Test add and remove works
+        api.addEventListener('newColumnsLoaded', listeners.eventListener);
+        api.removeEventListener('newColumnsLoaded', listeners.eventListener);
+
+        api.addGlobalListener(listeners.globalEventListener);
+        api.removeGlobalListener(listeners.globalEventListener);
+
+        api.getRowNode('Toyota')?.addEventListener('dataChanged', listeners.rowEventListener);
+        api.getRowNode('Toyota')?.removeEventListener('dataChanged', listeners.rowEventListener);
+
+        api.getColumn('make')?.addEventListener('visibleChanged', listeners.columnEventListener);
+        api.getColumn('make')?.removeEventListener('visibleChanged', listeners.columnEventListener);
+
+        api.getRowNode('Toyota')?.setData({ make: 'Toyota', model: 'Celica', price: 40000 });
+
+        api.applyColumnState({
+            state: [
+                {
+                    colId: 'make',
+                    hide: true,
+                },
+            ],
+        });
+
+        setTimeout(() => {
+            api.updateGridOptions({ columnDefs: [{ field: 'make' }, { field: 'model' }] });
+            fixture.detectChanges();
+
+            expect(eventListenerSpy).toHaveBeenCalledTimes(0);
+            expect(globalEventListenerSpy).toHaveBeenCalledTimes(0);
+            expect(rowEventListenerSpy).toHaveBeenCalledTimes(0);
+            expect(columnEventListenerSpy).toHaveBeenCalledTimes(0);
+
+            done();
+        }, 100);
+    });
 });

--- a/grid-packages/ag-grid-angular/projects/ag-grid-angular/src/lib/angularFrameworkComponentWrapper.ts
+++ b/grid-packages/ag-grid-angular/projects/ag-grid-angular/src/lib/angularFrameworkComponentWrapper.ts
@@ -1,34 +1,29 @@
 import {ComponentRef, Injectable, NgZone, ViewContainerRef} from "@angular/core";
 import {BaseComponentWrapper, FrameworkComponentWrapper, GridApi, WrappableInterface} from 'ag-grid-community';
 import {AgFrameworkComponent} from "./interfaces";
+import { AngularFrameworkOverrides } from "./angularFrameworkOverrides";
 
 @Injectable()
 export class AngularFrameworkComponentWrapper extends BaseComponentWrapper<WrappableInterface> implements FrameworkComponentWrapper {
     private viewContainerRef: ViewContainerRef;
-    private zone: NgZone;
+    private angularFrameworkOverrides: AngularFrameworkOverrides;
 
-    public setViewContainerRef(viewContainerRef: ViewContainerRef, zone: NgZone) {
+    public setViewContainerRef(viewContainerRef: ViewContainerRef, angularFrameworkOverrides: AngularFrameworkOverrides) {
         this.viewContainerRef = viewContainerRef;
-        this.zone = zone;
+        this.angularFrameworkOverrides = angularFrameworkOverrides;
     }
 
     createWrapper(OriginalConstructor: { new(): any }, compType: any): WrappableInterface {
-        let zone = this.zone;
+        let angularFrameworkOverrides = this.angularFrameworkOverrides;
         let that = this;
-
-        // Ensure methods within custom components are running inside the angular zone, so that
-        // change detection works properly with components.
-        function runInZone<T>(callback: () => T): T {
-            return zone ? zone.run(callback) : callback();
-        }
         class DynamicAgNg2Component extends BaseGuiComponent<any, AgFrameworkComponent<any>> implements WrappableInterface {
             init(params: any): void {
-                runInZone(() => super.init(params));
+                angularFrameworkOverrides.runInsideAngular(() => super.init(params));
                 this._componentRef.changeDetectorRef.detectChanges();
             }
 
             protected createComponent(): ComponentRef<AgFrameworkComponent<any>> {
-                return runInZone(() => that.createComponent(OriginalConstructor));
+                return angularFrameworkOverrides.runInsideAngular(() => that.createComponent(OriginalConstructor));
             }
 
             hasMethod(name: string): boolean {
@@ -37,7 +32,7 @@ export class AngularFrameworkComponentWrapper extends BaseComponentWrapper<Wrapp
 
             callMethod(name: string, args: IArguments): void {
                 const componentRef = this.getFrameworkComponentInstance();
-                return runInZone(() => wrapper.getFrameworkComponentInstance()[name].apply(componentRef, args));
+                return angularFrameworkOverrides.runInsideAngular(() => wrapper.getFrameworkComponentInstance()[name].apply(componentRef, args));
             }
 
             addMethod(name: string, callback: Function): void {

--- a/grid-packages/ag-grid-angular/projects/ag-grid-angular/src/lib/angularFrameworkOverrides.ts
+++ b/grid-packages/ag-grid-angular/projects/ag-grid-angular/src/lib/angularFrameworkOverrides.ts
@@ -16,6 +16,12 @@ export class AngularFrameworkOverrides extends VanillaFrameworkOverrides {
         this.runOutsideAngular(listener);
     }
 
+    // Only setup wrapping when the call is coming from within Angular zone, i.e from a users application code.
+    // Used to distinguish between user code and AG Grid code setting up events against RowNodes and Columns
+    get shouldWrap() {
+        return this._ngZone && NgZone.isInAngularZone(); 
+    }
+
     /**
      * Make sure that any code that is executed outside of AG Grid is running within the Angular zone.
      * This means users can update templates and use binding without having to do anything extra.

--- a/grid-packages/ag-grid-angular/projects/ag-grid-angular/src/lib/angularFrameworkOverrides.ts
+++ b/grid-packages/ag-grid-angular/projects/ag-grid-angular/src/lib/angularFrameworkOverrides.ts
@@ -10,12 +10,10 @@ export class AngularFrameworkOverrides extends VanillaFrameworkOverrides {
     dispatchEvent(listener: () => void): void {
         // Make all events run outside Angular as they often trigger the setup of event listeners
         // By having the event listeners outside Angular we can avoid triggering change detection
-        // Check for _ngZone existence as it is not present when Zoneless
-        if (this._ngZone) {
-            this._ngZone.runOutsideAngular(listener);
-        } else {
-            listener();
-        }
+        // This also means that if a user calls an AG Grid API method from within their component
+        // the internal side effects will not trigger change detection. Without this the events would
+        // run inside Angular and trigger change detection as the source of the event was within the angular zone.
+        this.runOutsideAngular(listener);
     }
 
     /**
@@ -23,7 +21,7 @@ export class AngularFrameworkOverrides extends VanillaFrameworkOverrides {
      * This means users can update templates and use binding without having to do anything extra.
      */
     wrapOutgoing<T>( callback: () => T): T {
-        return this._ngZone ? this._ngZone.run(callback) : callback();
+        return this.runInsideAngular(callback);
     }
 
     isFrameworkComponent(comp: any): boolean {
@@ -31,5 +29,13 @@ export class AngularFrameworkOverrides extends VanillaFrameworkOverrides {
         const prototype = comp.prototype;
         const isAngularComp = prototype && 'agInit' in prototype;
         return isAngularComp;
+    }
+
+    runInsideAngular<T>( callback: () => T): T {
+        // Check for _ngZone existence as it is not present when Zoneless
+        return this._ngZone ? this._ngZone.run(callback) : callback();
+    }
+    runOutsideAngular<T>( callback: () => T): T {
+        return this._ngZone ? this._ngZone.runOutsideAngular(callback) : callback();
     }
 }


### PR DESCRIPTION
Main concept is to run AG Grid internals outside of Angular Zone to prevent the grid from triggering application Change Detection cycles.

We need to ensure that user provide event handlers are run inside Angular Zone to enable users to update their templates from with event callbacks.

However, grid configuration callbacks, although running code defined in users applications should run outside of Zone as these should only be used to configure the grid and not update templates.

For event listeners registered via, gridApi, row node or column these will maintain the Zone status at registration. So if an event handler is registered within the Zone then the event handler itself will run within the Zone. However, if the event handler is registered outside the Zone then the event handler itself will also run outside the zone.

This gives fine grained control to the users while maintaining the expected default behaviour for users who are not suffering from performance issues due to excessive CD.