### PR TITLE
AG-10689 Quick start style tweaks

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/getting-started/_examples/custom-quartz-theme/index.html
+++ b/documentation/ag-grid-docs/src/content/docs/getting-started/_examples/custom-quartz-theme/index.html
@@ -1,0 +1,1 @@
+<div id="myGrid" style="height: 100%;" class="ag-theme-quartz"></div>

--- a/documentation/ag-grid-docs/src/content/docs/getting-started/_examples/custom-quartz-theme/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/getting-started/_examples/custom-quartz-theme/main.ts
@@ -1,0 +1,40 @@
+import { GridApi, createGrid, ColDef, GridOptions } from '@ag-grid-community/core';
+
+import { ClientSideRowModelModule } from '@ag-grid-community/client-side-row-model';
+import { ModuleRegistry } from "@ag-grid-community/core";
+
+ModuleRegistry.registerModules([ClientSideRowModelModule]);
+
+const columnDefs: ColDef[] = [
+  { field: 'athlete', minWidth: 170 },
+  { field: 'age' },
+  { field: 'country' },
+  { field: 'year' },
+  { field: 'date' },
+  { field: 'sport' },
+  { field: 'gold' },
+  { field: 'silver' },
+  { field: 'bronze' },
+  { field: 'total' },
+]
+
+let gridApi: GridApi<IOlympicData>;
+
+const gridOptions: GridOptions<IOlympicData> = {
+  rowData: null,
+  columnDefs: columnDefs,
+  defaultColDef: {
+    editable: true,
+    filter: true,
+  }
+}
+
+// setup the grid after the page has finished loading
+document.addEventListener('DOMContentLoaded', function () {
+  var gridDiv = document.querySelector<HTMLElement>('#myGrid')!
+  gridApi = createGrid(gridDiv, gridOptions);
+
+  fetch('https://www.ag-grid.com/example-assets/olympic-winners.json')
+    .then(response => response.json())
+    .then((data: IOlympicData[]) => gridApi!.setGridOption('rowData', data))
+})

--- a/documentation/ag-grid-docs/src/content/docs/getting-started/_examples/custom-quartz-theme/styles.css
+++ b/documentation/ag-grid-docs/src/content/docs/getting-started/_examples/custom-quartz-theme/styles.css
@@ -1,0 +1,11 @@
+.ag-theme-quartz, .ag-theme-quartz-dark {
+    --ag-foreground-color: rgb(126, 46, 132);
+    --ag-background-color: rgb(249, 245, 227);
+    --ag-header-foreground-color: rgb(204, 245, 172);
+    --ag-header-background-color: rgb(209, 64, 129);
+    --ag-odd-row-background-color: rgb(0, 0, 0, 0.03);
+    --ag-header-column-resize-handle-color: rgb(126, 46, 132);
+
+    --ag-font-size: 17px;
+    --ag-font-family: monospace;
+}

--- a/documentation/ag-grid-docs/src/content/docs/getting-started/_examples/custom-quartz-theme/styles.css
+++ b/documentation/ag-grid-docs/src/content/docs/getting-started/_examples/custom-quartz-theme/styles.css
@@ -1,11 +1,8 @@
 .ag-theme-quartz, .ag-theme-quartz-dark {
-    --ag-foreground-color: rgb(126, 46, 132);
-    --ag-background-color: rgb(249, 245, 227);
-    --ag-header-foreground-color: rgb(204, 245, 172);
-    --ag-header-background-color: rgb(209, 64, 129);
-    --ag-odd-row-background-color: rgb(0, 0, 0, 0.03);
-    --ag-header-column-resize-handle-color: rgb(126, 46, 132);
-
-    --ag-font-size: 17px;
-    --ag-font-family: monospace;
+      /* Changes the color of the grid text */
+      --ag-foreground-color: rgb(163, 64, 64);
+      /* Changes the color of the grid background */
+      --ag-background-color: rgba(215, 245, 231, 0.212);
+      /* Changes the background color of selected rows */
+      --ag-selected-row-background-color: rgba(0, 38, 255, 0.1);
 }

--- a/documentation/ag-grid-docs/src/content/docs/getting-started/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/getting-started/index.mdoc
@@ -1,8 +1,9 @@
 ---
-title: "Quick Start" 
+title: "Quick Start"
 ---
 
-Welcome to the AG Grid documentation. After reading this page you will have an overview of the key concepts of AG Grid that you will use on a daily basis.
+Welcome to the AG Grid documentation. After reading this page you will have an overview of the key concepts of AG Grid
+that you will use on a daily basis.
 
 ## Your First Grid
 
@@ -45,14 +46,17 @@ Load the AG Grid library and create a blank container div:
 
 ```html
 <html lang="en">
- <head>
-   <!-- Includes all JS & CSS for AG Grid -->
-   <script src="https://cdn.jsdelivr.net/npm/ag-grid-community/dist/ag-grid-community.min.js"></script>
- </head>
- <body>
-   <!-- Your grid container -->
-   <div id="myGrid"></div>
- </body>
+
+<head>
+  <!-- Includes all JS & CSS for AG Grid -->
+  <script src="https://cdn.jsdelivr.net/npm/ag-grid-community/dist/ag-grid-community.min.js"></script>
+</head>
+
+<body>
+  <!-- Your grid container -->
+  <div id="myGrid"></div>
+</body>
+
 </html>
 ```
 
@@ -74,19 +78,19 @@ agGrid.createGrid(myGridElement, gridOptions);
 ```js
 // Grid Options: Contains all of the grid configurations
 const gridOptions = {
- // Row Data: The data to be displayed.
- rowData: [
-   { make: "Tesla", model: "Model Y", price: 64950, electric: true },
-   { make: "Ford", model: "F-Series", price: 33850, electric: false },
-   { make: "Toyota", model: "Corolla", price: 29600, electric: false },
- ],
- // Column Definitions: Defines the columns to be displayed.
- columnDefs: [
-   { field: "make" },
-   { field: "model" },
-   { field: "price" },
-   { field: "electric" }
- ]
+// Row Data: The data to be displayed.
+rowData: [
+{ make: "Tesla", model: "Model Y", price: 64950, electric: true },
+{ make: "Ford", model: "F-Series", price: 33850, electric: false },
+{ make: "Toyota", model: "Corolla", price: 29600, electric: false },
+],
+// Column Definitions: Defines the columns to be displayed.
+columnDefs: [
+{ field: "make" },
+{ field: "model" },
+{ field: "price" },
+{ field: "electric" }
+]
 };
 ```
 
@@ -115,22 +119,22 @@ import "ag-grid-community/styles/ag-theme-quartz.css"; // Optional Theme applied
 
 ```js
 const GridExample = () => {
- // Row Data: The data to be displayed.
- const [rowData, setRowData] = useState([
-   { make: "Tesla", model: "Model Y", price: 64950, electric: true },
-   { make: "Ford", model: "F-Series", price: 33850, electric: false },
-   { make: "Toyota", model: "Corolla", price: 29600, electric: false },
- ]);
- 
- // Column Definitions: Defines the columns to be displayed.
- const [colDefs, setColDefs] = useState([
-   { field: "make" },
-   { field: "model" },
-   { field: "price" },
-   { field: "electric" }
- ]);
+// Row Data: The data to be displayed.
+const [rowData, setRowData] = useState([
+{ make: "Tesla", model: "Model Y", price: 64950, electric: true },
+{ make: "Ford", model: "F-Series", price: 33850, electric: false },
+{ make: "Toyota", model: "Corolla", price: 29600, electric: false },
+]);
 
- // ...
+// Column Definitions: Defines the columns to be displayed.
+const [colDefs, setColDefs] = useState([
+{ field: "make" },
+{ field: "model" },
+{ field: "price" },
+{ field: "electric" }
+]);
+
+// ...
 
 }
 ```
@@ -142,16 +146,11 @@ Rows and Columns are set as `AgGridReact` component attributes.
 
 ```jsx
 return (
- // wrapping container with theme & size
- <div
-  className="ag-theme-quartz" // applying the grid theme
-  style={{ height: 500 }} // the grid will fill the size of the parent container
- >
-   <AgGridReact
-       rowData={rowData}
-       columnDefs={colDefs}
-   />
- </div>
+// wrapping container with theme & size
+<div className="ag-theme-quartz" // applying the grid theme style={{ height: 500 }} // the grid will fill the size of
+  the parent container>
+  <AgGridReact rowData={rowData} columnDefs={colDefs} />
+</div>
 )
 ```
 {% /if %}
@@ -170,28 +169,28 @@ import { ColDef } from 'ag-grid-community'; // Column Definition Type Interface
 
 ```jsx
 @Component({
- selector: 'app-root',
- standalone: true,
- imports: [AgGridAngular], // Add AG Grid component
- styleUrls: ['./app.component.css'],
- template: ``
+selector: 'app-root',
+standalone: true,
+imports: [AgGridAngular], // Add AG Grid component
+styleUrls: ['./app.component.css'],
+template: ``
 })
 
 export class AppComponent {
- // Row Data: The data to be displayed.
- rowData = [
-   { make: "Tesla", model: "Model Y", price: 64950, electric: true },
-   { make: "Ford", model: "F-Series", price: 33850, electric: false },
-   { make: "Toyota", model: "Corolla", price: 29600, electric: false },
- ];
+// Row Data: The data to be displayed.
+rowData = [
+{ make: "Tesla", model: "Model Y", price: 64950, electric: true },
+{ make: "Ford", model: "F-Series", price: 33850, electric: false },
+{ make: "Toyota", model: "Corolla", price: 29600, electric: false },
+];
 
- // Column Definitions: Defines the columns to be displayed.
- colDefs: ColDef[] = [
-   { field: "make" },
-   { field: "model" },
-   { field: "price" },
-   { field: "electric" }
- ];
+// Column Definitions: Defines the columns to be displayed.
+colDefs: ColDef[] = [
+{ field: "make" },
+{ field: "model" },
+{ field: "price" },
+{ field: "electric" }
+];
 }
 ```
 
@@ -202,11 +201,9 @@ Rows and Columns are set as `ag-grid-angular` component attributes.
 ```js
 template:
 `
- <!-- The AG Grid component -->
- <ag-grid-angular
-   [rowData]="rowData"
-   [columnDefs]="colDefs">
- </ag-grid-angular>
+<!-- The AG Grid component -->
+<ag-grid-angular [rowData]="rowData" [columnDefs]="colDefs">
+</ag-grid-angular>
 `
 ```
 
@@ -224,11 +221,7 @@ Import the required dependencies into your `styles.css` file.
 Add the `class` and `style` props to the `ag-grid-angular` component.
 
 ```html
-<ag-grid-angular
- class="ag-theme-quartz"
- style="height: 500px;"
- ...
->
+<ag-grid-angular class="ag-theme-quartz" style="height: 500px;" ...>
 </ag-grid-angular>
 ```
 {% /if %}
@@ -241,18 +234,18 @@ Add the `class` and `style` props to the `ag-grid-angular` component.
 <template></template>
 
 <script>
-import { ref } from 'vue';
-import "ag-grid-community/styles/ag-grid.css"; // Mandatory CSS required by the grid
-import "ag-grid-community/styles/ag-theme-quartz.css"; // Optional Theme applied to the grid
-import { AgGridVue } from "ag-grid-vue3"; // AG Grid Component
+  import { ref } from 'vue';
+  import "ag-grid-community/styles/ag-grid.css"; // Mandatory CSS required by the grid
+  import "ag-grid-community/styles/ag-theme-quartz.css"; // Optional Theme applied to the grid
+  import { AgGridVue } from "ag-grid-vue3"; // AG Grid Component
 
-export default {
- name: "App",
- components: {
-   AgGridVue, // Add AG Grid Vue3 component
- },
- setup() {},
-};
+  export default {
+    name: "App",
+    components: {
+      AgGridVue, // Add AG Grid Vue3 component
+    },
+    setup() { },
+  };
 </script>
 ```
 
@@ -260,42 +253,38 @@ export default {
 
 ```js
 setup() {
- // Row Data: The data to be displayed.
- const rowData = ref([
-   { make: "Tesla", model: "Model Y", price: 64950, electric: true },
-   { make: "Ford", model: "F-Series", price: 33850, electric: false },
-   { make: "Toyota", model: "Corolla", price: 29600, electric: false },
- ]);
+// Row Data: The data to be displayed.
+const rowData = ref([
+{ make: "Tesla", model: "Model Y", price: 64950, electric: true },
+{ make: "Ford", model: "F-Series", price: 33850, electric: false },
+{ make: "Toyota", model: "Corolla", price: 29600, electric: false },
+]);
 
- // Column Definitions: Defines the columns to be displayed.
- const colDefs = ref([
-   { field: "make" },
-   { field: "model" },
-   { field: "price" },
-   { field: "electric" }
- ]);
+// Column Definitions: Defines the columns to be displayed.
+const colDefs = ref([
+{ field: "make" },
+{ field: "model" },
+{ field: "price" },
+{ field: "electric" }
+]);
 
- return {
-   rowData,
-   colDefs,
- };
+return {
+rowData,
+colDefs,
+};
 },
 ```
 
 **4. Grid Component**
 
-Rows and Columns are set as `ag-grid-vue` component attributes. Styling is applied through the class and style attributes.
+Rows and Columns are set as `ag-grid-vue` component attributes. Styling is applied through the class and style
+attributes.
 
 ```html
 <template>
- <!-- The AG Grid component -->
- <ag-grid-vue
-   :rowData="rowData"
-   :columnDefs="colDefs"
-   style="height: 500px"
-   class="ag-theme-quartz"
- >
- </ag-grid-vue>
+  <!-- The AG Grid component -->
+  <ag-grid-vue :rowData="rowData" :columnDefs="colDefs" style="height: 500px" class="ag-theme-quartz">
+  </ag-grid-vue>
 </template>
 ```
 {% /if %}
@@ -310,7 +299,7 @@ Rows and Columns are set as `ag-grid-vue` component attributes. Styling is appli
 
 Below is a live example of the application running. Click `</> Code` to see the code.
 
-{% gridExampleRunner title="Quick Start Example" name="quick-start-example"  exampleHeight=302 /%}
+{% gridExampleRunner title="Quick Start Example" name="quick-start-example" exampleHeight=302 /%}
 
 {% note %}
 To live-edit the code, open the example in CodeSandbox or Plunker using the buttons to the lower-right.
@@ -322,16 +311,17 @@ Now that you have a basic grid running, the remainder of this page explores some
 
 ### Mapping Values
 
-The `field` or `valueGetter` attributes map data to columns. A field maps to a field in the data. A [Value Getter](./value-getters/) is a function callback that returns the cell value.
+The `field` or `valueGetter` attributes map data to columns. A field maps to a field in the data. A [Value
+Getter](./value-getters/) is a function callback that returns the cell value.
 
 The `headerName` provides the title for the header. If missing the title is derived from `field`.
 
 ```js {% frameworkTransform=true %}
 const gridOptions = {
-    columnDefs: [
-        { headerName: "Make & Model", valueGetter: p => p.make + ' ' + p.model},
-        { field: "price" },
-    ],
+columnDefs: [
+{ headerName: "Make & Model", valueGetter: p => p.make + ' ' + p.model},
+{ field: "price" },
+],
 };
 ```
 
@@ -341,9 +331,9 @@ Format text for cell content using a [Value Formatter](./value-formatters/).
 
 ```js {% frameworkTransform=true %}
 const gridOptions = {
-    columnDefs: [
-        { field: "price", valueFormatter: p => '£' + Math.floor(p.value).toLocaleString() },
-    ],
+columnDefs: [
+{ field: "price", valueFormatter: p => '£' + Math.floor(p.value).toLocaleString() },
+],
 };
 ```
 
@@ -354,52 +344,52 @@ Add buttons, checkboxes or images to cells with a [Cell Component](./component-c
 {% if isFramework("react") %}
 ```jsx
 const CustomButtonComponent = (props) => {
-   return <button onClick={() => window.alert('clicked') }>Push Me!</button>;
- };
+return <button onClick={()=> window.alert('clicked') }>Push Me!</button>;
+};
 
 const [colDefs, setColDefs] = useState([
-   { field: "button", cellRenderer: CustomButtonComponent },
-   // ...
- ]);
+{ field: "button", cellRenderer: CustomButtonComponent },
+// ...
+]);
 ```
 {% /if %}
 
 {% if isFramework("javascript") %}
 ```js
 class CustomButtonComponent {
- eGui;
- eButton;
- eventListener;
+eGui;
+eButton;
+eventListener;
 
- init(params) {
-   this.eGui = document.createElement("div");
-   let button = document.createElement("button");
-   button.className = "btn-simple";
-   button.innerText = "Push Me!";
-   this.eventListener = () => alert("clicked");
-   button.addEventListener("click", this.eventListener);
-   this.eGui.appendChild(button);
- }
+init(params) {
+this.eGui = document.createElement("div");
+let button = document.createElement("button");
+button.className = "btn-simple";
+button.innerText = "Push Me!";
+this.eventListener = () => alert("clicked");
+button.addEventListener("click", this.eventListener);
+this.eGui.appendChild(button);
+}
 
- getGui() {
-   return this.eGui;
- }
+getGui() {
+return this.eGui;
+}
 
- refresh(params) {
-   return true;
- }
+refresh(params) {
+return true;
+}
 
- destroy() {
-   if (button) {
-     button.removeEventListener("click", this.eventListener);
-   }
- }
+destroy() {
+if (button) {
+button.removeEventListener("click", this.eventListener);
+}
+}
 }
 
 
 const columnDefs = [
-   { field: "button", cellRenderer: CustomButtonComponent },
-   // ...
+{ field: "button", cellRenderer: CustomButtonComponent },
+// ...
 ];
 ```
 {% /if %}
@@ -407,22 +397,22 @@ const columnDefs = [
 {% if isFramework("angular") %}
 ```js
 @Component({
- standalone: true,
- template: `<button (click)="buttonClicked()">Push Me!</button>`,
+standalone: true,
+template: `<button (click)="buttonClicked()">Push Me!</button>`,
 })
 export class CustomButtonComponent implements ICellRendererAngularComp {
- agInit(params: ICellRendererParams): void {}
- refresh(params: ICellRendererParams) {
-   return true;
- }
- buttonClicked() {
-   alert("clicked");
- }
+agInit(params: ICellRendererParams): void {}
+refresh(params: ICellRendererParams) {
+return true;
+}
+buttonClicked() {
+alert("clicked");
+}
 }
 
 columnDefs: ColDef[] = [
-   { field: "button", cellRenderer: CustomButtonComponent },
-   // ...
+{ field: "button", cellRenderer: CustomButtonComponent },
+// ...
 ];
 ```
 {% /if %}
@@ -430,26 +420,26 @@ columnDefs: ColDef[] = [
 {% if isFramework("vue") %}
 ```js
 // ...
- components: {
-   "ag-grid-vue": AgGridVue,
-   CustomButtonComponent: {
-     template: `
-        <button @click="buttonClicked()">Push Me!</button>
-       `,
-     methods: {
-       buttonClicked() {
-         alert("clicked");
-       },
-     },
-   },
- },
- data: function () {
-   return {
-   columnDefs: [
-       { field: "button", cellRenderer: CustomButtonComponent },
-       // ...
-   ],
- };
+components: {
+"ag-grid-vue": AgGridVue,
+CustomButtonComponent: {
+template: `
+<button @click="buttonClicked()">Push Me!</button>
+`,
+methods: {
+buttonClicked() {
+alert("clicked");
+},
+},
+},
+},
+data: function () {
+return {
+columnDefs: [
+{ field: "button", cellRenderer: CustomButtonComponent },
+// ...
+],
+};
 },
 // ...
 ```
@@ -462,12 +452,12 @@ allow columns to flex to the grid width.
 
 ```js {% frameworkTransform=true %}
 const gridOptions = {
-    columnDefs: [
-        { field: "make", flex: 2 }, //This column will be twice as wide as the others
-        { field: "model", flex: 1 },
-        { field: "price", flex: 1 },
-        { field: "electric", flex: 1 }
-    ],
+columnDefs: [
+{ field: "make", flex: 2 }, //This column will be twice as wide as the others
+{ field: "model", flex: 1 },
+{ field: "price", flex: 1 },
+{ field: "electric", flex: 1 }
+],
 };
 ```
 
@@ -479,17 +469,19 @@ This example demonstrates mapping and formatting values, cell components, and re
 
 ## Working with Data
 
-By default, the row data is used to infer the [Cell Data Type](./cell-data-types/). The cell data type allows grid features, such as filtering and editing, to work without additional configuration.
+By default, the row data is used to infer the [Cell Data Type](./cell-data-types/). The cell data type allows grid
+features, such as filtering and editing, to work without additional configuration.
 
 ### Filtering
 
-[Column Filters](./filtering/) are embedded into each column menu. These are enabled using the `filter` attribute. The filter type is inferred from the cell data type.
+[Column Filters](./filtering/) are embedded into each column menu. These are enabled using the `filter` attribute. The
+filter type is inferred from the cell data type.
 
 ```js {% frameworkTransform=true %}
 const gridOptions = {
-    columnDefs: [
-        { field: "make", filter: true },
-    ],
+columnDefs: [
+{ field: "make", filter: true },
+],
 };
 ```
 
@@ -500,39 +492,41 @@ You can also create your own [Custom Filter](./filter-custom/).
 
 ```js {% frameworkTransform=true %}
 const gridOptions = {
-    columnDefs: [
-        { field: "make", filter: true, floatingFilter: true },
-    ],
+columnDefs: [
+{ field: "make", filter: true, floatingFilter: true },
+],
 };
 ```
 
 ### Editing
 
-Enable [Editing](./cell-editing/) by setting the `editable` attribute to `true`. The cell editor is inferred from the cell data type.
+Enable [Editing](./cell-editing/) by setting the `editable` attribute to `true`. The cell editor is inferred from the
+cell data type.
 
 ```js {% frameworkTransform=true %}
 const gridOptions = {
-    columnDefs: [
-        { field: "make", editable: true },
-    ],
+columnDefs: [
+{ field: "make", editable: true },
+],
 };
 ```
 
-Set the cell editor type using the `cellEditor` attribute. There are 7 [Provided Cell Editors](./provided-cell-editors/) which can be set through this attribute.
+Set the cell editor type using the `cellEditor` attribute. There are 7 [Provided Cell Editors](./provided-cell-editors/)
+which can be set through this attribute.
 You can also create your own [Custom Editors](./cell-editors/).
 
 ```js {% frameworkTransform=true %}
 const gridOptions = {
-    columnDefs: [
-        {
-            field: "make",
-            editable: true,
-            cellEditor: 'agSelectCellEditor',
-            cellEditorParams: {
-                values: ['Tesla', 'Ford', 'Toyota'],
-            },
-        },
-    ],
+columnDefs: [
+{
+field: "make",
+editable: true,
+cellEditor: 'agSelectCellEditor',
+cellEditorParams: {
+values: ['Tesla', 'Ford', 'Toyota'],
+},
+},
+],
 };
 ```
 
@@ -542,15 +536,16 @@ Data is [Sorted](./row-sorting/) by clicking the column headers. Sorting is enab
 
 ### Row Selection
 
-[Row Selection](./row-selection/) is enabled using the `rowSelection` attribute. Use the `checkboxSelection` column definition attribute to render checkboxes for selection.
+[Row Selection](./row-selection/) is enabled using the `rowSelection` attribute. Use the `checkboxSelection` column
+definition attribute to render checkboxes for selection.
 
 ```js {% frameworkTransform=true %}
 const gridOptions = {
-    // Column Definitions: Defines the columns to be displayed.
-    columnDefs: [
-        { field: "make", checkboxSelection: true },
-    ],
-    rowSelection: 'multiple',
+// Column Definitions: Defines the columns to be displayed.
+columnDefs: [
+{ field: "make", checkboxSelection: true },
+],
+rowSelection: 'multiple',
 };
 ```
 
@@ -560,9 +555,9 @@ Enable [Pagination](./row-pagination/) by setting `pagination` to be true.
 
 ```js {% frameworkTransform=true %}
 const gridOptions = {
-    pagination: true,
-    paginationPageSize: 500,
-    paginationPageSizeSelector: [200, 500, 1000],
+pagination: true,
+paginationPageSize: 500,
+paginationPageSizeSelector: [200, 500, 1000],
 };
 ```
 
@@ -587,9 +582,9 @@ import "ag-grid-community/styles/ag-theme-quartz.css"; // import Quartz theme
 // import "ag-grid-community/styles/ag-theme-alpine.css"; // import Alpine theme, not used here
 ...
 return (
- <div class="ag-theme-quartz"> // set Quartz Theme on parent div
-   <AgGridReact rowData={...} columnDefs={...} />
- </div>
+<div class="ag-theme-quartz"> // set Quartz Theme on parent div
+  <AgGridReact rowData={...} columnDefs={...} />
+</div>
 )
 ```
 {% /if %}
@@ -611,12 +606,9 @@ import "ag-grid-community/styles/ag-theme-quartz.css"; // import Quartz theme
 import "ag-grid-community/styles/ag-theme-quartz.css"; // import Quartz theme
 // import "ag-grid-community/styles/ag-theme-alpine.css"; // import Alpine theme, not used here
 // ...
- template: `<div style="height: 100%; box-sizing: border-box;">
-   <ag-grid-angular
-     // ...
-     [class]="themeClass"
-   ></ag-grid-angular>
- </div>`,
+template: `<div style="height: 100%; box-sizing: border-box;">
+  <ag-grid-angular // ... [class]="themeClass"></ag-grid-angular>
+</div>`,
 // ...
 public themeClass: string = "ag-theme-quartz";
 ```
@@ -628,22 +620,20 @@ import "ag-grid-community/styles/ag-theme-quartz.css"; // import Quartz theme
 // import "ag-grid-community/styles/ag-theme-alpine.css"; // import Alpine theme, not used here
 
 const VueExample = {
- template: `
-       <div style="height: 100%">
-           <div style="height: 100%; box-sizing: border-box;">
-               <ag-grid-vue
-               // ...
-               :class="themeClass"></ag-grid-vue>
-           </div>
-       </div>
-   `,
+template: `
+<div style="height: 100%">
+  <div style="height: 100%; box-sizing: border-box;">
+    <ag-grid-vue // ... :class="themeClass"></ag-grid-vue>
+  </div>
+</div>
+`,
 // ...
- data: function () {
-   return {
-     // ...
-     themeClass: "ag-theme-quartz",
-   };
- },
+data: function () {
+return {
+// ...
+themeClass: "ag-theme-quartz",
+};
+},
 // ...
 ```
 {% /if %}
@@ -679,61 +669,66 @@ Customise themes using CSS variables.
 
 ```css
 .ag-theme-quartz {
-    /* Changes the color of the grid text */
-    --ag-foreground-color: rgb(163, 64, 64);
-    /* Changes the color of the grid background */
-    --ag-background-color: rgba(215, 245, 231, 0.212);
-    /* Changes the background color of selected rows */
-    --ag-selected-row-background-color: rgba(0, 38, 255, 0.1);
+/* Changes the color of the grid text */
+--ag-foreground-color: rgb(163, 64, 64);
+/* Changes the color of the grid background */
+--ag-background-color: rgba(215, 245, 231, 0.212);
+/* Changes the background color of selected rows */
+--ag-selected-row-background-color: rgba(0, 38, 255, 0.1);
 }
 ```
 
-{% imageCaption imagePath="resources/customisingThemeExample.png" alt="Customising a Theme with CSS Variables" centered=true constrained=true /%}
+{% gridExampleRunner title="Theming Example" name="theming-example" /%}
 
 ### Figma
 
-If you are designing within Figma, you can use the [AG Grid Design System](./ag-grid-design-system/) to replicate the  Quartz and Alpine AG Grid themes within Figma. These default themes can be extended with Figma variables to match any existing visual design or create entirely new AG Grid themes. These can then be exported and generated into new AG Grid themes.
+If you are designing within Figma, you can use the [AG Grid Design System](./ag-grid-design-system/) to replicate the
+Quartz and Alpine AG Grid themes within Figma. These default themes can be extended with Figma variables to match any
+existing visual design or create entirely new AG Grid themes. These can then be exported and generated into new AG Grid
+themes.
 
-{% imageCaption imagePath="resources/FDS-Example.png" alt="Figma Design System with AG Grid" centered=true constrained=true /%}
+{% downloadDSButton /%}
 
 ### Cell Style
 
-Define rules to apply styling to cells using `cellClassRules`. This can be used, for example, to set cell background colour based on its value.
+Define rules to apply styling to cells using `cellClassRules`. This can be used, for example, to set cell background
+colour based on its value.
 
 ```css
 .rag-green {
-  background-color: #33cc3344;
+background-color: #33cc3344;
 }
 ```
 
 ```js {% frameworkTransform=true %}
 const gridOptions = {
-    columnDefs: [{
-        field: 'electric',
-        cellClassRules: {
-            // apply green to electric cars
-            'rag-green': params => params.value === true,
-        }
-    }],
+columnDefs: [{
+field: 'electric',
+cellClassRules: {
+// apply green to electric cars
+'rag-green': params => params.value === true,
+}
+}],
 };
 ```
 
 ### Row Style
 
-Define rules to apply styling to rows using  and `rowClassRules`. This allows changing style (e.g. row colour) based on row values.
+Define rules to apply styling to rows using and `rowClassRules`. This allows changing style (e.g. row colour) based on
+row values.
 
 ```css
 .rag-red {
-  background-color: #cc222244;
+background-color: #cc222244;
 }
 ```
 
 ```js {% frameworkTransform=true %}
 const gridOptions = {
-    rowClassRules: {
-        // apply red to Ford cars
-        'rag-red': params => params.data.make === 'Ford',
-    },
+rowClassRules: {
+// apply red to Ford cars
+'rag-red': params => params.data.make === 'Ford',
+},
 };
 ```
 
@@ -741,7 +736,7 @@ const gridOptions = {
 
 This example demonstrates cell style and row style.
 
-{% gridExampleRunner title="Theming Example" name="theming-example" /%}
+{% gridExampleRunner title="Theming Example" name="custom-quartz-theme" /%}
 
 ## Next Steps
 

--- a/documentation/ag-grid-docs/src/content/docs/getting-started/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/getting-started/index.mdoc
@@ -1,9 +1,8 @@
 ---
-title: "Quick Start"
+title: 'Quick Start'
 ---
 
-Welcome to the AG Grid documentation. After reading this page you will have an overview of the key concepts of AG Grid
-that you will use on a daily basis.
+Welcome to the AG Grid documentation. After reading this page you will have an overview of the key concepts of AG Grid that you will use on a daily basis.
 
 ## Your First Grid
 
@@ -14,27 +13,33 @@ Add AG Grid to your application in these steps:
 {% /if %}
 
 {% if isFramework("react") %}
+
 <!-- Install React -->
 
 ```bash
 npm install ag-grid-react
 ```
+
 {% /if %}
 
 {% if isFramework("angular") %}
+
 <!-- Install Angular -->
 
 ```bash
 npm install ag-grid-angular
 ```
+
 {% /if %}
 
 {% if isFramework("vue") %}
+
 <!-- Install Vue3 -->
 
 ```bash
 npm install ag-grid-vue3
 ```
+
 {% /if %}
 
 {% if isFramework("javascript") %}
@@ -46,17 +51,14 @@ Load the AG Grid library and create a blank container div:
 
 ```html
 <html lang="en">
-
-<head>
-  <!-- Includes all JS & CSS for AG Grid -->
-  <script src="https://cdn.jsdelivr.net/npm/ag-grid-community/dist/ag-grid-community.min.js"></script>
-</head>
-
-<body>
-  <!-- Your grid container -->
-  <div id="myGrid"></div>
-</body>
-
+    <head>
+        <!-- Includes all JS & CSS for AG Grid -->
+        <script src="https://cdn.jsdelivr.net/npm/ag-grid-community/dist/ag-grid-community.min.js"></script>
+    </head>
+    <body>
+        <!-- Your grid container -->
+        <div id="myGrid"></div>
+    </body>
 </html>
 ```
 
@@ -78,19 +80,14 @@ agGrid.createGrid(myGridElement, gridOptions);
 ```js
 // Grid Options: Contains all of the grid configurations
 const gridOptions = {
-// Row Data: The data to be displayed.
-rowData: [
-{ make: "Tesla", model: "Model Y", price: 64950, electric: true },
-{ make: "Ford", model: "F-Series", price: 33850, electric: false },
-{ make: "Toyota", model: "Corolla", price: 29600, electric: false },
-],
-// Column Definitions: Defines the columns to be displayed.
-columnDefs: [
-{ field: "make" },
-{ field: "model" },
-{ field: "price" },
-{ field: "electric" }
-]
+    // Row Data: The data to be displayed.
+    rowData: [
+        { make: 'Tesla', model: 'Model Y', price: 64950, electric: true },
+        { make: 'Ford', model: 'F-Series', price: 33850, electric: false },
+        { make: 'Toyota', model: 'Corolla', price: 29600, electric: false },
+    ],
+    // Column Definitions: Defines the columns to be displayed.
+    columnDefs: [{ field: 'make' }, { field: 'model' }, { field: 'price' }, { field: 'electric' }],
 };
 ```
 
@@ -102,41 +99,46 @@ Add the `ag-theme-quartz` CSS class to your grid container div to apply the grid
 <!-- Your grid container -->
 <div id="myGrid" class="ag-theme-quartz" style="height: 500px"></div>
 ```
+
 {% /if %}
 
 {% if isFramework("react") %}
+
 <!-- Create React -->
 
 **2. Import the Grid**
 
 ```js
-import { AgGridReact } from 'ag-grid-react'; // AG Grid Component
-import "ag-grid-community/styles/ag-grid.css"; // Mandatory CSS required by the grid
-import "ag-grid-community/styles/ag-theme-quartz.css"; // Optional Theme applied to the grid
+// AG Grid Component
+import 'ag-grid-community/styles/ag-grid.css';
+// Mandatory CSS required by the grid
+import 'ag-grid-community/styles/ag-theme-quartz.css';
+import { AgGridReact } from 'ag-grid-react';
+
+// Optional Theme applied to the grid
 ```
 
 **3. Define Rows and Columns**
 
 ```js
 const GridExample = () => {
-// Row Data: The data to be displayed.
-const [rowData, setRowData] = useState([
-{ make: "Tesla", model: "Model Y", price: 64950, electric: true },
-{ make: "Ford", model: "F-Series", price: 33850, electric: false },
-{ make: "Toyota", model: "Corolla", price: 29600, electric: false },
-]);
+    // Row Data: The data to be displayed.
+    const [rowData, setRowData] = useState([
+        { make: 'Tesla', model: 'Model Y', price: 64950, electric: true },
+        { make: 'Ford', model: 'F-Series', price: 33850, electric: false },
+        { make: 'Toyota', model: 'Corolla', price: 29600, electric: false },
+    ]);
 
-// Column Definitions: Defines the columns to be displayed.
-const [colDefs, setColDefs] = useState([
-{ field: "make" },
-{ field: "model" },
-{ field: "price" },
-{ field: "electric" }
-]);
+    // Column Definitions: Defines the columns to be displayed.
+    const [colDefs, setColDefs] = useState([
+        { field: 'make' },
+        { field: 'model' },
+        { field: 'price' },
+        { field: 'electric' },
+    ]);
 
-// ...
-
-}
+    // ...
+};
 ```
 
 **4. Grid Component**
@@ -146,13 +148,19 @@ Rows and Columns are set as `AgGridReact` component attributes.
 
 ```jsx
 return (
-// wrapping container with theme & size
-<div className="ag-theme-quartz" // applying the grid theme style={{ height: 500 }} // the grid will fill the size of
-  the parent container>
-  <AgGridReact rowData={rowData} columnDefs={colDefs} />
-</div>
+ // wrapping container with theme & size
+ <div
+  className="ag-theme-quartz" // applying the grid theme
+  style={{ height: 500 }} // the grid will fill the size of the parent container
+ >
+   <AgGridReact
+       rowData={rowData}
+       columnDefs={colDefs}
+   />
+ </div>
 )
 ```
+
 {% /if %}
 
 {% if isFramework("angular") %}
@@ -161,36 +169,40 @@ return (
 
 ```js
 import { Component } from '@angular/core';
-import { AgGridAngular } from 'ag-grid-angular'; // AG Grid Component
-import { ColDef } from 'ag-grid-community'; // Column Definition Type Interface
+
+import { AgGridAngular } from 'ag-grid-angular';
+// AG Grid Component
+import { ColDef } from 'ag-grid-community';
+
+// Column Definition Type Interface
 ```
 
 **3. Define Rows and Columns**
 
 ```jsx
 @Component({
-selector: 'app-root',
-standalone: true,
-imports: [AgGridAngular], // Add AG Grid component
-styleUrls: ['./app.component.css'],
-template: ``
+ selector: 'app-root',
+ standalone: true,
+ imports: [AgGridAngular], // Add AG Grid component
+ styleUrls: ['./app.component.css'],
+ template: ``
 })
 
 export class AppComponent {
-// Row Data: The data to be displayed.
-rowData = [
-{ make: "Tesla", model: "Model Y", price: 64950, electric: true },
-{ make: "Ford", model: "F-Series", price: 33850, electric: false },
-{ make: "Toyota", model: "Corolla", price: 29600, electric: false },
-];
+ // Row Data: The data to be displayed.
+ rowData = [
+   { make: "Tesla", model: "Model Y", price: 64950, electric: true },
+   { make: "Ford", model: "F-Series", price: 33850, electric: false },
+   { make: "Toyota", model: "Corolla", price: 29600, electric: false },
+ ];
 
-// Column Definitions: Defines the columns to be displayed.
-colDefs: ColDef[] = [
-{ field: "make" },
-{ field: "model" },
-{ field: "price" },
-{ field: "electric" }
-];
+ // Column Definitions: Defines the columns to be displayed.
+ colDefs: ColDef[] = [
+   { field: "make" },
+   { field: "model" },
+   { field: "price" },
+   { field: "electric" }
+ ];
 }
 ```
 
@@ -199,12 +211,13 @@ colDefs: ColDef[] = [
 Rows and Columns are set as `ag-grid-angular` component attributes.
 
 ```js
-template:
-`
-<!-- The AG Grid component -->
-<ag-grid-angular [rowData]="rowData" [columnDefs]="colDefs">
-</ag-grid-angular>
-`
+template: `
+ <!-- The AG Grid component -->
+ <ag-grid-angular
+   [rowData]="rowData"
+   [columnDefs]="colDefs">
+ </ag-grid-angular>
+`;
 ```
 
 **5. Styling the Grid**
@@ -221,9 +234,9 @@ Import the required dependencies into your `styles.css` file.
 Add the `class` and `style` props to the `ag-grid-angular` component.
 
 ```html
-<ag-grid-angular class="ag-theme-quartz" style="height: 500px;" ...>
-</ag-grid-angular>
+<ag-grid-angular class="ag-theme-quartz" style="height: 500px;" ...> </ag-grid-angular>
 ```
+
 {% /if %}
 
 {% if isFramework("vue") %}
@@ -234,18 +247,23 @@ Add the `class` and `style` props to the `ag-grid-angular` component.
 <template></template>
 
 <script>
-  import { ref } from 'vue';
-  import "ag-grid-community/styles/ag-grid.css"; // Mandatory CSS required by the grid
-  import "ag-grid-community/styles/ag-theme-quartz.css"; // Optional Theme applied to the grid
-  import { AgGridVue } from "ag-grid-vue3"; // AG Grid Component
+    import { ref } from 'vue';
 
-  export default {
-    name: "App",
-    components: {
-      AgGridVue, // Add AG Grid Vue3 component
-    },
-    setup() { },
-  };
+    import 'ag-grid-community/styles/ag-grid.css';
+    // Mandatory CSS required by the grid
+    import 'ag-grid-community/styles/ag-theme-quartz.css';
+    // Optional Theme applied to the grid
+    import { AgGridVue } from 'ag-grid-vue3';
+
+    // AG Grid Component
+
+    export default {
+        name: 'App',
+        components: {
+            AgGridVue, // Add AG Grid Vue3 component
+        },
+        setup() {},
+    };
 </script>
 ```
 
@@ -253,40 +271,39 @@ Add the `class` and `style` props to the `ag-grid-angular` component.
 
 ```js
 setup() {
-// Row Data: The data to be displayed.
-const rowData = ref([
-{ make: "Tesla", model: "Model Y", price: 64950, electric: true },
-{ make: "Ford", model: "F-Series", price: 33850, electric: false },
-{ make: "Toyota", model: "Corolla", price: 29600, electric: false },
-]);
+ // Row Data: The data to be displayed.
+ const rowData = ref([
+   { make: "Tesla", model: "Model Y", price: 64950, electric: true },
+   { make: "Ford", model: "F-Series", price: 33850, electric: false },
+   { make: "Toyota", model: "Corolla", price: 29600, electric: false },
+ ]);
 
-// Column Definitions: Defines the columns to be displayed.
-const colDefs = ref([
-{ field: "make" },
-{ field: "model" },
-{ field: "price" },
-{ field: "electric" }
-]);
+ // Column Definitions: Defines the columns to be displayed.
+ const colDefs = ref([
+   { field: "make" },
+   { field: "model" },
+   { field: "price" },
+   { field: "electric" }
+ ]);
 
-return {
-rowData,
-colDefs,
-};
+ return {
+   rowData,
+   colDefs,
+ };
 },
 ```
 
 **4. Grid Component**
 
-Rows and Columns are set as `ag-grid-vue` component attributes. Styling is applied through the class and style
-attributes.
+Rows and Columns are set as `ag-grid-vue` component attributes. Styling is applied through the class and style attributes.
 
 ```html
 <template>
-  <!-- The AG Grid component -->
-  <ag-grid-vue :rowData="rowData" :columnDefs="colDefs" style="height: 500px" class="ag-theme-quartz">
-  </ag-grid-vue>
+    <!-- The AG Grid component -->
+    <ag-grid-vue :rowData="rowData" :columnDefs="colDefs" style="height: 500px" class="ag-theme-quartz"> </ag-grid-vue>
 </template>
 ```
+
 {% /if %}
 
 {% if isFramework("angular") %}
@@ -299,7 +316,7 @@ attributes.
 
 Below is a live example of the application running. Click `</> Code` to see the code.
 
-{% gridExampleRunner title="Quick Start Example" name="quick-start-example" exampleHeight=302 /%}
+{% gridExampleRunner title="Quick Start Example" name="quick-start-example"  exampleHeight=302 /%}
 
 {% note %}
 To live-edit the code, open the example in CodeSandbox or Plunker using the buttons to the lower-right.
@@ -311,17 +328,13 @@ Now that you have a basic grid running, the remainder of this page explores some
 
 ### Mapping Values
 
-The `field` or `valueGetter` attributes map data to columns. A field maps to a field in the data. A [Value
-Getter](./value-getters/) is a function callback that returns the cell value.
+The `field` or `valueGetter` attributes map data to columns. A field maps to a field in the data. A [Value Getter](./value-getters/) is a function callback that returns the cell value.
 
 The `headerName` provides the title for the header. If missing the title is derived from `field`.
 
 ```js {% frameworkTransform=true %}
 const gridOptions = {
-columnDefs: [
-{ headerName: "Make & Model", valueGetter: p => p.make + ' ' + p.model},
-{ field: "price" },
-],
+    columnDefs: [{ headerName: 'Make & Model', valueGetter: (p) => p.make + ' ' + p.model }, { field: 'price' }],
 };
 ```
 
@@ -331,9 +344,7 @@ Format text for cell content using a [Value Formatter](./value-formatters/).
 
 ```js {% frameworkTransform=true %}
 const gridOptions = {
-columnDefs: [
-{ field: "price", valueFormatter: p => '£' + Math.floor(p.value).toLocaleString() },
-],
+    columnDefs: [{ field: 'price', valueFormatter: (p) => '£' + Math.floor(p.value).toLocaleString() }],
 };
 ```
 
@@ -342,6 +353,7 @@ columnDefs: [
 Add buttons, checkboxes or images to cells with a [Cell Component](./component-cell-renderer/).
 
 {% if isFramework("react") %}
+
 ```jsx
 const CustomButtonComponent = (props) => {
 return <button onClick={()=> window.alert('clicked') }>Push Me!</button>;
@@ -352,49 +364,52 @@ const [colDefs, setColDefs] = useState([
 // ...
 ]);
 ```
+
 {% /if %}
 
 {% if isFramework("javascript") %}
+
 ```js
 class CustomButtonComponent {
-eGui;
-eButton;
-eventListener;
+    eGui;
+    eButton;
+    eventListener;
 
-init(params) {
-this.eGui = document.createElement("div");
-let button = document.createElement("button");
-button.className = "btn-simple";
-button.innerText = "Push Me!";
-this.eventListener = () => alert("clicked");
-button.addEventListener("click", this.eventListener);
-this.eGui.appendChild(button);
-}
+    init(params) {
+        this.eGui = document.createElement('div');
+        let button = document.createElement('button');
+        button.className = 'btn-simple';
+        button.innerText = 'Push Me!';
+        this.eventListener = () => alert('clicked');
+        button.addEventListener('click', this.eventListener);
+        this.eGui.appendChild(button);
+    }
 
-getGui() {
-return this.eGui;
-}
+    getGui() {
+        return this.eGui;
+    }
 
-refresh(params) {
-return true;
-}
+    refresh(params) {
+        return true;
+    }
 
-destroy() {
-if (button) {
-button.removeEventListener("click", this.eventListener);
+    destroy() {
+        if (button) {
+            button.removeEventListener('click', this.eventListener);
+        }
+    }
 }
-}
-}
-
 
 const columnDefs = [
-{ field: "button", cellRenderer: CustomButtonComponent },
-// ...
+    { field: 'button', cellRenderer: CustomButtonComponent },
+    // ...
 ];
 ```
+
 {% /if %}
 
 {% if isFramework("angular") %}
+
 ```js
 @Component({
 standalone: true,
@@ -415,9 +430,11 @@ columnDefs: ColDef[] = [
 // ...
 ];
 ```
+
 {% /if %}
 
 {% if isFramework("vue") %}
+
 ```js
 // ...
 components: {
@@ -443,6 +460,7 @@ columnDefs: [
 },
 // ...
 ```
+
 {% /if %}
 
 ### Resizing Columns
@@ -452,12 +470,12 @@ allow columns to flex to the grid width.
 
 ```js {% frameworkTransform=true %}
 const gridOptions = {
-columnDefs: [
-{ field: "make", flex: 2 }, //This column will be twice as wide as the others
-{ field: "model", flex: 1 },
-{ field: "price", flex: 1 },
-{ field: "electric", flex: 1 }
-],
+    columnDefs: [
+        { field: 'make', flex: 2 }, //This column will be twice as wide as the others
+        { field: 'model', flex: 1 },
+        { field: 'price', flex: 1 },
+        { field: 'electric', flex: 1 },
+    ],
 };
 ```
 
@@ -479,9 +497,7 @@ filter type is inferred from the cell data type.
 
 ```js {% frameworkTransform=true %}
 const gridOptions = {
-columnDefs: [
-{ field: "make", filter: true },
-],
+    columnDefs: [{ field: 'make', filter: true }],
 };
 ```
 
@@ -492,9 +508,7 @@ You can also create your own [Custom Filter](./filter-custom/).
 
 ```js {% frameworkTransform=true %}
 const gridOptions = {
-columnDefs: [
-{ field: "make", filter: true, floatingFilter: true },
-],
+    columnDefs: [{ field: 'make', filter: true, floatingFilter: true }],
 };
 ```
 
@@ -505,9 +519,7 @@ cell data type.
 
 ```js {% frameworkTransform=true %}
 const gridOptions = {
-columnDefs: [
-{ field: "make", editable: true },
-],
+    columnDefs: [{ field: 'make', editable: true }],
 };
 ```
 
@@ -517,16 +529,16 @@ You can also create your own [Custom Editors](./cell-editors/).
 
 ```js {% frameworkTransform=true %}
 const gridOptions = {
-columnDefs: [
-{
-field: "make",
-editable: true,
-cellEditor: 'agSelectCellEditor',
-cellEditorParams: {
-values: ['Tesla', 'Ford', 'Toyota'],
-},
-},
-],
+    columnDefs: [
+        {
+            field: 'make',
+            editable: true,
+            cellEditor: 'agSelectCellEditor',
+            cellEditorParams: {
+                values: ['Tesla', 'Ford', 'Toyota'],
+            },
+        },
+    ],
 };
 ```
 
@@ -541,11 +553,9 @@ definition attribute to render checkboxes for selection.
 
 ```js {% frameworkTransform=true %}
 const gridOptions = {
-// Column Definitions: Defines the columns to be displayed.
-columnDefs: [
-{ field: "make", checkboxSelection: true },
-],
-rowSelection: 'multiple',
+    // Column Definitions: Defines the columns to be displayed.
+    columnDefs: [{ field: 'make', checkboxSelection: true }],
+    rowSelection: 'multiple',
 };
 ```
 
@@ -555,9 +565,9 @@ Enable [Pagination](./row-pagination/) by setting `pagination` to be true.
 
 ```js {% frameworkTransform=true %}
 const gridOptions = {
-pagination: true,
-paginationPageSize: 500,
-paginationPageSizeSelector: [200, 500, 1000],
+    pagination: true,
+    paginationPageSize: 500,
+    paginationPageSizeSelector: [200, 500, 1000],
 };
 ```
 
@@ -577,6 +587,7 @@ To use a theme you need to 1) import the themes CSS and 2) apply the theme to th
 HTML element of the grid.
 
 {% if isFramework("react") %}
+
 ```jsx
 import "ag-grid-community/styles/ag-theme-quartz.css"; // import Quartz theme
 // import "ag-grid-community/styles/ag-theme-alpine.css"; // import Alpine theme, not used here
@@ -587,11 +598,15 @@ return (
 </div>
 )
 ```
+
 {% /if %}
 
 {% if isFramework("javascript") %}
+
 ```js
-import "ag-grid-community/styles/ag-theme-quartz.css"; // import Quartz theme
+import 'ag-grid-community/styles/ag-theme-quartz.css';
+
+// import Quartz theme
 // import "ag-grid-community/styles/ag-theme-alpine.css"; // import Alpine theme, not used here
 ```
 
@@ -599,9 +614,11 @@ import "ag-grid-community/styles/ag-theme-quartz.css"; // import Quartz theme
 <!-- Your grid container -->
 <div id="myGrid" class="ag-theme-quartz" style="height: 500px"></div>
 ```
+
 {% /if %}
 
 {% if isFramework("angular") %}
+
 ```js
 import "ag-grid-community/styles/ag-theme-quartz.css"; // import Quartz theme
 // import "ag-grid-community/styles/ag-theme-alpine.css"; // import Alpine theme, not used here
@@ -612,9 +629,11 @@ template: `<div style="height: 100%; box-sizing: border-box;">
 // ...
 public themeClass: string = "ag-theme-quartz";
 ```
+
 {% /if %}
 
 {% if isFramework("vue") %}
+
 ```js
 import "ag-grid-community/styles/ag-theme-quartz.css"; // import Quartz theme
 // import "ag-grid-community/styles/ag-theme-alpine.css"; // import Alpine theme, not used here
@@ -636,6 +655,7 @@ themeClass: "ag-theme-quartz",
 },
 // ...
 ```
+
 {% /if %}
 
 {% tabs %}
@@ -669,12 +689,12 @@ Customise themes using CSS variables.
 
 ```css
 .ag-theme-quartz {
-/* Changes the color of the grid text */
---ag-foreground-color: rgb(163, 64, 64);
-/* Changes the color of the grid background */
---ag-background-color: rgba(215, 245, 231, 0.212);
-/* Changes the background color of selected rows */
---ag-selected-row-background-color: rgba(0, 38, 255, 0.1);
+    /* Changes the color of the grid text */
+    --ag-foreground-color: rgb(163, 64, 64);
+    /* Changes the color of the grid background */
+    --ag-background-color: rgba(215, 245, 231, 0.212);
+    /* Changes the background color of selected rows */
+    --ag-selected-row-background-color: rgba(0, 38, 255, 0.1);
 }
 ```
 
@@ -696,19 +716,21 @@ colour based on its value.
 
 ```css
 .rag-green {
-background-color: #33cc3344;
+    background-color: #33cc3344;
 }
 ```
 
 ```js {% frameworkTransform=true %}
 const gridOptions = {
-columnDefs: [{
-field: 'electric',
-cellClassRules: {
-// apply green to electric cars
-'rag-green': params => params.value === true,
-}
-}],
+    columnDefs: [
+        {
+            field: 'electric',
+            cellClassRules: {
+                // apply green to electric cars
+                'rag-green': (params) => params.value === true,
+            },
+        },
+    ],
 };
 ```
 
@@ -719,16 +741,16 @@ row values.
 
 ```css
 .rag-red {
-background-color: #cc222244;
+    background-color: #cc222244;
 }
 ```
 
 ```js {% frameworkTransform=true %}
 const gridOptions = {
-rowClassRules: {
-// apply red to Ford cars
-'rag-red': params => params.data.make === 'Ford',
-},
+    rowClassRules: {
+        // apply red to Ford cars
+        'rag-red': (params) => params.data.make === 'Ford',
+    },
 };
 ```
 
@@ -740,5 +762,5 @@ This example demonstrates cell style and row style.
 
 ## Next Steps
 
-* Read our [Introductory Tutorial](./deep-dive/).
-* Watch our [Video Tutorials](./videos/).
+-   Read our [Introductory Tutorial](./deep-dive/).
+-   Watch our [Video Tutorials](./videos/).

--- a/documentation/ag-grid-docs/src/content/docs/getting-started/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/getting-started/index.mdoc
@@ -1,5 +1,5 @@
 ---
-title: 'Quick Start'
+title: "Quick Start" 
 ---
 
 Welcome to the AG Grid documentation. After reading this page you will have an overview of the key concepts of AG Grid that you will use on a daily basis.
@@ -13,33 +13,27 @@ Add AG Grid to your application in these steps:
 {% /if %}
 
 {% if isFramework("react") %}
-
 <!-- Install React -->
 
 ```bash
 npm install ag-grid-react
 ```
-
 {% /if %}
 
 {% if isFramework("angular") %}
-
 <!-- Install Angular -->
 
 ```bash
 npm install ag-grid-angular
 ```
-
 {% /if %}
 
 {% if isFramework("vue") %}
-
 <!-- Install Vue3 -->
 
 ```bash
 npm install ag-grid-vue3
 ```
-
 {% /if %}
 
 {% if isFramework("javascript") %}
@@ -51,14 +45,14 @@ Load the AG Grid library and create a blank container div:
 
 ```html
 <html lang="en">
-    <head>
-        <!-- Includes all JS & CSS for AG Grid -->
-        <script src="https://cdn.jsdelivr.net/npm/ag-grid-community/dist/ag-grid-community.min.js"></script>
-    </head>
-    <body>
-        <!-- Your grid container -->
-        <div id="myGrid"></div>
-    </body>
+ <head>
+   <!-- Includes all JS & CSS for AG Grid -->
+   <script src="https://cdn.jsdelivr.net/npm/ag-grid-community/dist/ag-grid-community.min.js"></script>
+ </head>
+ <body>
+   <!-- Your grid container -->
+   <div id="myGrid"></div>
+ </body>
 </html>
 ```
 
@@ -80,14 +74,19 @@ agGrid.createGrid(myGridElement, gridOptions);
 ```js
 // Grid Options: Contains all of the grid configurations
 const gridOptions = {
-    // Row Data: The data to be displayed.
-    rowData: [
-        { make: 'Tesla', model: 'Model Y', price: 64950, electric: true },
-        { make: 'Ford', model: 'F-Series', price: 33850, electric: false },
-        { make: 'Toyota', model: 'Corolla', price: 29600, electric: false },
-    ],
-    // Column Definitions: Defines the columns to be displayed.
-    columnDefs: [{ field: 'make' }, { field: 'model' }, { field: 'price' }, { field: 'electric' }],
+ // Row Data: The data to be displayed.
+ rowData: [
+   { make: "Tesla", model: "Model Y", price: 64950, electric: true },
+   { make: "Ford", model: "F-Series", price: 33850, electric: false },
+   { make: "Toyota", model: "Corolla", price: 29600, electric: false },
+ ],
+ // Column Definitions: Defines the columns to be displayed.
+ columnDefs: [
+   { field: "make" },
+   { field: "model" },
+   { field: "price" },
+   { field: "electric" }
+ ]
 };
 ```
 
@@ -99,46 +98,41 @@ Add the `ag-theme-quartz` CSS class to your grid container div to apply the grid
 <!-- Your grid container -->
 <div id="myGrid" class="ag-theme-quartz" style="height: 500px"></div>
 ```
-
 {% /if %}
 
 {% if isFramework("react") %}
-
 <!-- Create React -->
 
 **2. Import the Grid**
 
 ```js
-// AG Grid Component
-import 'ag-grid-community/styles/ag-grid.css';
-// Mandatory CSS required by the grid
-import 'ag-grid-community/styles/ag-theme-quartz.css';
-import { AgGridReact } from 'ag-grid-react';
-
-// Optional Theme applied to the grid
+import { AgGridReact } from 'ag-grid-react'; // AG Grid Component
+import "ag-grid-community/styles/ag-grid.css"; // Mandatory CSS required by the grid
+import "ag-grid-community/styles/ag-theme-quartz.css"; // Optional Theme applied to the grid
 ```
 
 **3. Define Rows and Columns**
 
 ```js
 const GridExample = () => {
-    // Row Data: The data to be displayed.
-    const [rowData, setRowData] = useState([
-        { make: 'Tesla', model: 'Model Y', price: 64950, electric: true },
-        { make: 'Ford', model: 'F-Series', price: 33850, electric: false },
-        { make: 'Toyota', model: 'Corolla', price: 29600, electric: false },
-    ]);
+ // Row Data: The data to be displayed.
+ const [rowData, setRowData] = useState([
+   { make: "Tesla", model: "Model Y", price: 64950, electric: true },
+   { make: "Ford", model: "F-Series", price: 33850, electric: false },
+   { make: "Toyota", model: "Corolla", price: 29600, electric: false },
+ ]);
+ 
+ // Column Definitions: Defines the columns to be displayed.
+ const [colDefs, setColDefs] = useState([
+   { field: "make" },
+   { field: "model" },
+   { field: "price" },
+   { field: "electric" }
+ ]);
 
-    // Column Definitions: Defines the columns to be displayed.
-    const [colDefs, setColDefs] = useState([
-        { field: 'make' },
-        { field: 'model' },
-        { field: 'price' },
-        { field: 'electric' },
-    ]);
+ // ...
 
-    // ...
-};
+}
 ```
 
 **4. Grid Component**
@@ -160,7 +154,6 @@ return (
  </div>
 )
 ```
-
 {% /if %}
 
 {% if isFramework("angular") %}
@@ -169,12 +162,8 @@ return (
 
 ```js
 import { Component } from '@angular/core';
-
-import { AgGridAngular } from 'ag-grid-angular';
-// AG Grid Component
-import { ColDef } from 'ag-grid-community';
-
-// Column Definition Type Interface
+import { AgGridAngular } from 'ag-grid-angular'; // AG Grid Component
+import { ColDef } from 'ag-grid-community'; // Column Definition Type Interface
 ```
 
 **3. Define Rows and Columns**
@@ -211,13 +200,14 @@ export class AppComponent {
 Rows and Columns are set as `ag-grid-angular` component attributes.
 
 ```js
-template: `
+template:
+`
  <!-- The AG Grid component -->
  <ag-grid-angular
    [rowData]="rowData"
    [columnDefs]="colDefs">
  </ag-grid-angular>
-`;
+`
 ```
 
 **5. Styling the Grid**
@@ -234,9 +224,13 @@ Import the required dependencies into your `styles.css` file.
 Add the `class` and `style` props to the `ag-grid-angular` component.
 
 ```html
-<ag-grid-angular class="ag-theme-quartz" style="height: 500px;" ...> </ag-grid-angular>
+<ag-grid-angular
+ class="ag-theme-quartz"
+ style="height: 500px;"
+ ...
+>
+</ag-grid-angular>
 ```
-
 {% /if %}
 
 {% if isFramework("vue") %}
@@ -247,23 +241,18 @@ Add the `class` and `style` props to the `ag-grid-angular` component.
 <template></template>
 
 <script>
-    import { ref } from 'vue';
+import { ref } from 'vue';
+import "ag-grid-community/styles/ag-grid.css"; // Mandatory CSS required by the grid
+import "ag-grid-community/styles/ag-theme-quartz.css"; // Optional Theme applied to the grid
+import { AgGridVue } from "ag-grid-vue3"; // AG Grid Component
 
-    import 'ag-grid-community/styles/ag-grid.css';
-    // Mandatory CSS required by the grid
-    import 'ag-grid-community/styles/ag-theme-quartz.css';
-    // Optional Theme applied to the grid
-    import { AgGridVue } from 'ag-grid-vue3';
-
-    // AG Grid Component
-
-    export default {
-        name: 'App',
-        components: {
-            AgGridVue, // Add AG Grid Vue3 component
-        },
-        setup() {},
-    };
+export default {
+ name: "App",
+ components: {
+   AgGridVue, // Add AG Grid Vue3 component
+ },
+ setup() {},
+};
 </script>
 ```
 
@@ -299,11 +288,16 @@ Rows and Columns are set as `ag-grid-vue` component attributes. Styling is appli
 
 ```html
 <template>
-    <!-- The AG Grid component -->
-    <ag-grid-vue :rowData="rowData" :columnDefs="colDefs" style="height: 500px" class="ag-theme-quartz"> </ag-grid-vue>
+ <!-- The AG Grid component -->
+ <ag-grid-vue
+   :rowData="rowData"
+   :columnDefs="colDefs"
+   style="height: 500px"
+   class="ag-theme-quartz"
+ >
+ </ag-grid-vue>
 </template>
 ```
-
 {% /if %}
 
 {% if isFramework("angular") %}
@@ -334,7 +328,10 @@ The `headerName` provides the title for the header. If missing the title is deri
 
 ```js {% frameworkTransform=true %}
 const gridOptions = {
-    columnDefs: [{ headerName: 'Make & Model', valueGetter: (p) => p.make + ' ' + p.model }, { field: 'price' }],
+    columnDefs: [
+        { headerName: "Make & Model", valueGetter: p => p.make + ' ' + p.model},
+        { field: "price" },
+    ],
 };
 ```
 
@@ -344,7 +341,9 @@ Format text for cell content using a [Value Formatter](./value-formatters/).
 
 ```js {% frameworkTransform=true %}
 const gridOptions = {
-    columnDefs: [{ field: 'price', valueFormatter: (p) => '£' + Math.floor(p.value).toLocaleString() }],
+    columnDefs: [
+        { field: "price", valueFormatter: p => '£' + Math.floor(p.value).toLocaleString() },
+    ],
 };
 ```
 
@@ -353,114 +352,107 @@ const gridOptions = {
 Add buttons, checkboxes or images to cells with a [Cell Component](./component-cell-renderer/).
 
 {% if isFramework("react") %}
-
 ```jsx
 const CustomButtonComponent = (props) => {
-return <button onClick={()=> window.alert('clicked') }>Push Me!</button>;
-};
+   return <button onClick={() => window.alert('clicked') }>Push Me!</button>;
+ };
 
 const [colDefs, setColDefs] = useState([
-{ field: "button", cellRenderer: CustomButtonComponent },
-// ...
-]);
+   { field: "button", cellRenderer: CustomButtonComponent },
+   // ...
+ ]);
 ```
-
 {% /if %}
 
 {% if isFramework("javascript") %}
-
 ```js
 class CustomButtonComponent {
-    eGui;
-    eButton;
-    eventListener;
+ eGui;
+ eButton;
+ eventListener;
 
-    init(params) {
-        this.eGui = document.createElement('div');
-        let button = document.createElement('button');
-        button.className = 'btn-simple';
-        button.innerText = 'Push Me!';
-        this.eventListener = () => alert('clicked');
-        button.addEventListener('click', this.eventListener);
-        this.eGui.appendChild(button);
-    }
+ init(params) {
+   this.eGui = document.createElement("div");
+   let button = document.createElement("button");
+   button.className = "btn-simple";
+   button.innerText = "Push Me!";
+   this.eventListener = () => alert("clicked");
+   button.addEventListener("click", this.eventListener);
+   this.eGui.appendChild(button);
+ }
 
-    getGui() {
-        return this.eGui;
-    }
+ getGui() {
+   return this.eGui;
+ }
 
-    refresh(params) {
-        return true;
-    }
+ refresh(params) {
+   return true;
+ }
 
-    destroy() {
-        if (button) {
-            button.removeEventListener('click', this.eventListener);
-        }
-    }
+ destroy() {
+   if (button) {
+     button.removeEventListener("click", this.eventListener);
+   }
+ }
 }
 
+
 const columnDefs = [
-    { field: 'button', cellRenderer: CustomButtonComponent },
-    // ...
+   { field: "button", cellRenderer: CustomButtonComponent },
+   // ...
 ];
 ```
-
 {% /if %}
 
 {% if isFramework("angular") %}
-
 ```js
 @Component({
-standalone: true,
-template: `<button (click)="buttonClicked()">Push Me!</button>`,
+ standalone: true,
+ template: `<button (click)="buttonClicked()">Push Me!</button>`,
 })
 export class CustomButtonComponent implements ICellRendererAngularComp {
-agInit(params: ICellRendererParams): void {}
-refresh(params: ICellRendererParams) {
-return true;
-}
-buttonClicked() {
-alert("clicked");
-}
+ agInit(params: ICellRendererParams): void {}
+ refresh(params: ICellRendererParams) {
+   return true;
+ }
+ buttonClicked() {
+   alert("clicked");
+ }
 }
 
 columnDefs: ColDef[] = [
-{ field: "button", cellRenderer: CustomButtonComponent },
-// ...
+   { field: "button", cellRenderer: CustomButtonComponent },
+   // ...
 ];
 ```
-
 {% /if %}
 
 {% if isFramework("vue") %}
-
 ```js
 // ...
-components: {
-"ag-grid-vue": AgGridVue,
-CustomButtonComponent: {
-template: `
-<button @click="buttonClicked()">Push Me!</button>
-`,
-methods: {
-buttonClicked() {
-alert("clicked");
-},
-},
-},
-},
-data: function () {
-return {
-columnDefs: [
-{ field: "button", cellRenderer: CustomButtonComponent },
-// ...
-],
-};
+ components: {
+   "ag-grid-vue": AgGridVue,
+   CustomButtonComponent: {
+     template: `
+        <button @click="buttonClicked()">Push Me!</button>
+       `,
+     methods: {
+       buttonClicked() {
+         alert("clicked");
+       },
+     },
+   },
+ },
+ data: function () {
+   return {
+   columnDefs: [
+       { field: "button", cellRenderer: CustomButtonComponent },
+       // ...
+   ],
+ };
 },
 // ...
 ```
-
 {% /if %}
 
 ### Resizing Columns
@@ -471,10 +463,10 @@ allow columns to flex to the grid width.
 ```js {% frameworkTransform=true %}
 const gridOptions = {
     columnDefs: [
-        { field: 'make', flex: 2 }, //This column will be twice as wide as the others
-        { field: 'model', flex: 1 },
-        { field: 'price', flex: 1 },
-        { field: 'electric', flex: 1 },
+        { field: "make", flex: 2 }, //This column will be twice as wide as the others
+        { field: "model", flex: 1 },
+        { field: "price", flex: 1 },
+        { field: "electric", flex: 1 }
     ],
 };
 ```
@@ -487,17 +479,17 @@ This example demonstrates mapping and formatting values, cell components, and re
 
 ## Working with Data
 
-By default, the row data is used to infer the [Cell Data Type](./cell-data-types/). The cell data type allows grid
-features, such as filtering and editing, to work without additional configuration.
+By default, the row data is used to infer the [Cell Data Type](./cell-data-types/). The cell data type allows grid features, such as filtering and editing, to work without additional configuration.
 
 ### Filtering
 
-[Column Filters](./filtering/) are embedded into each column menu. These are enabled using the `filter` attribute. The
-filter type is inferred from the cell data type.
+[Column Filters](./filtering/) are embedded into each column menu. These are enabled using the `filter` attribute. The filter type is inferred from the cell data type.
 
 ```js {% frameworkTransform=true %}
 const gridOptions = {
-    columnDefs: [{ field: 'make', filter: true }],
+    columnDefs: [
+        { field: "make", filter: true },
+    ],
 };
 ```
 
@@ -508,30 +500,32 @@ You can also create your own [Custom Filter](./filter-custom/).
 
 ```js {% frameworkTransform=true %}
 const gridOptions = {
-    columnDefs: [{ field: 'make', filter: true, floatingFilter: true }],
+    columnDefs: [
+        { field: "make", filter: true, floatingFilter: true },
+    ],
 };
 ```
 
 ### Editing
 
-Enable [Editing](./cell-editing/) by setting the `editable` attribute to `true`. The cell editor is inferred from the
-cell data type.
+Enable [Editing](./cell-editing/) by setting the `editable` attribute to `true`. The cell editor is inferred from the cell data type.
 
 ```js {% frameworkTransform=true %}
 const gridOptions = {
-    columnDefs: [{ field: 'make', editable: true }],
+    columnDefs: [
+        { field: "make", editable: true },
+    ],
 };
 ```
 
-Set the cell editor type using the `cellEditor` attribute. There are 7 [Provided Cell Editors](./provided-cell-editors/)
-which can be set through this attribute.
+Set the cell editor type using the `cellEditor` attribute. There are 7 [Provided Cell Editors](./provided-cell-editors/) which can be set through this attribute.
 You can also create your own [Custom Editors](./cell-editors/).
 
 ```js {% frameworkTransform=true %}
 const gridOptions = {
     columnDefs: [
         {
-            field: 'make',
+            field: "make",
             editable: true,
             cellEditor: 'agSelectCellEditor',
             cellEditorParams: {
@@ -548,13 +542,14 @@ Data is [Sorted](./row-sorting/) by clicking the column headers. Sorting is enab
 
 ### Row Selection
 
-[Row Selection](./row-selection/) is enabled using the `rowSelection` attribute. Use the `checkboxSelection` column
-definition attribute to render checkboxes for selection.
+[Row Selection](./row-selection/) is enabled using the `rowSelection` attribute. Use the `checkboxSelection` column definition attribute to render checkboxes for selection.
 
 ```js {% frameworkTransform=true %}
 const gridOptions = {
     // Column Definitions: Defines the columns to be displayed.
-    columnDefs: [{ field: 'make', checkboxSelection: true }],
+    columnDefs: [
+        { field: "make", checkboxSelection: true },
+    ],
     rowSelection: 'multiple',
 };
 ```
@@ -587,26 +582,21 @@ To use a theme you need to 1) import the themes CSS and 2) apply the theme to th
 HTML element of the grid.
 
 {% if isFramework("react") %}
-
 ```jsx
 import "ag-grid-community/styles/ag-theme-quartz.css"; // import Quartz theme
 // import "ag-grid-community/styles/ag-theme-alpine.css"; // import Alpine theme, not used here
 ...
 return (
-<div class="ag-theme-quartz"> // set Quartz Theme on parent div
-  <AgGridReact rowData={...} columnDefs={...} />
-</div>
+ <div class="ag-theme-quartz"> // set Quartz Theme on parent div
+   <AgGridReact rowData={...} columnDefs={...} />
+ </div>
 )
 ```
-
 {% /if %}
 
 {% if isFramework("javascript") %}
-
 ```js
-import 'ag-grid-community/styles/ag-theme-quartz.css';
-
-// import Quartz theme
+import "ag-grid-community/styles/ag-theme-quartz.css"; // import Quartz theme
 // import "ag-grid-community/styles/ag-theme-alpine.css"; // import Alpine theme, not used here
 ```
 
@@ -614,45 +604,46 @@ import 'ag-grid-community/styles/ag-theme-quartz.css';
 <!-- Your grid container -->
 <div id="myGrid" class="ag-theme-quartz" style="height: 500px"></div>
 ```
-
 {% /if %}
 
 {% if isFramework("angular") %}
-
 ```js
 import "ag-grid-community/styles/ag-theme-quartz.css"; // import Quartz theme
 // import "ag-grid-community/styles/ag-theme-alpine.css"; // import Alpine theme, not used here
 // ...
-template: `<div style="height: 100%; box-sizing: border-box;">
-  <ag-grid-angular // ... [class]="themeClass"></ag-grid-angular>
-</div>`,
+ template: `<div style="height: 100%; box-sizing: border-box;">
+   <ag-grid-angular
+     // ...
+     [class]="themeClass"
+   ></ag-grid-angular>
+ </div>`,
 // ...
 public themeClass: string = "ag-theme-quartz";
 ```
-
 {% /if %}
 
 {% if isFramework("vue") %}
-
 ```js
 import "ag-grid-community/styles/ag-theme-quartz.css"; // import Quartz theme
 // import "ag-grid-community/styles/ag-theme-alpine.css"; // import Alpine theme, not used here
 
 const VueExample = {
-template: `
-<div style="height: 100%">
-  <div style="height: 100%; box-sizing: border-box;">
-    <ag-grid-vue // ... :class="themeClass"></ag-grid-vue>
-  </div>
-</div>
-`,
+ template: `
+       <div style="height: 100%">
+           <div style="height: 100%; box-sizing: border-box;">
+               <ag-grid-vue
+               // ...
+               :class="themeClass"></ag-grid-vue>
+           </div>
+       </div>
+   `,
 // ...
-data: function () {
-return {
-// ...
-themeClass: "ag-theme-quartz",
-};
-},
+ data: function () {
+   return {
+     // ...
+     themeClass: "ag-theme-quartz",
+   };
+ },
 // ...
 ```
 
@@ -711,37 +702,33 @@ themes.
 
 ### Cell Style
 
-Define rules to apply styling to cells using `cellClassRules`. This can be used, for example, to set cell background
-colour based on its value.
+Define rules to apply styling to cells using `cellClassRules`. This can be used, for example, to set cell background colour based on its value.
 
 ```css
 .rag-green {
-    background-color: #33cc3344;
+  background-color: #33cc3344;
 }
 ```
 
 ```js {% frameworkTransform=true %}
 const gridOptions = {
-    columnDefs: [
-        {
-            field: 'electric',
-            cellClassRules: {
-                // apply green to electric cars
-                'rag-green': (params) => params.value === true,
-            },
-        },
-    ],
+    columnDefs: [{
+        field: 'electric',
+        cellClassRules: {
+            // apply green to electric cars
+            'rag-green': params => params.value === true,
+        }
+    }],
 };
 ```
 
 ### Row Style
 
-Define rules to apply styling to rows using and `rowClassRules`. This allows changing style (e.g. row colour) based on
-row values.
+Define rules to apply styling to rows using  and `rowClassRules`. This allows changing style (e.g. row colour) based on row values.
 
 ```css
 .rag-red {
-    background-color: #cc222244;
+  background-color: #cc222244;
 }
 ```
 
@@ -749,7 +736,7 @@ row values.
 const gridOptions = {
     rowClassRules: {
         // apply red to Ford cars
-        'rag-red': (params) => params.data.make === 'Ford',
+        'rag-red': params => params.data.make === 'Ford',
     },
 };
 ```
@@ -762,5 +749,5 @@ This example demonstrates cell style and row style.
 
 ## Next Steps
 
--   Read our [Introductory Tutorial](./deep-dive/).
--   Watch our [Video Tutorials](./videos/).
+* Read our [Introductory Tutorial](./deep-dive/).
+* Watch our [Video Tutorials](./videos/).

--- a/documentation/ag-grid-docs/src/content/docs/getting-started/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/getting-started/index.mdoc
@@ -669,12 +669,14 @@ Customise themes using CSS variables.
 
 ```css
 .ag-theme-quartz {
-/* Changes the color of the grid text */
---ag-foreground-color: rgb(163, 64, 64);
-/* Changes the color of the grid background */
---ag-background-color: rgba(215, 245, 231, 0.212);
-/* Changes the background color of selected rows */
---ag-selected-row-background-color: rgba(0, 38, 255, 0.1);
+--ag-foreground-color: rgb(126, 46, 132);
+--ag-background-color: rgb(249, 245, 227);
+--ag-header-foreground-color: rgb(204, 245, 172);
+--ag-header-background-color: rgb(209, 64, 129);
+--ag-odd-row-background-color: rgb(0, 0, 0, 0.03);
+--ag-header-column-resize-handle-color: rgb(126, 46, 132);
+--ag-font-size: 17px;
+--ag-font-family: monospace;
 }
 ```
 

--- a/documentation/ag-grid-docs/src/content/docs/getting-started/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/getting-started/index.mdoc
@@ -678,7 +678,7 @@ Customise themes using CSS variables.
 }
 ```
 
-{% gridExampleRunner title="Theming Example" name="theming-example" /%}
+{% gridExampleRunner title="Theming Example" name="custom-quartz-theme" /%}
 
 ### Figma
 
@@ -736,7 +736,7 @@ rowClassRules: {
 
 This example demonstrates cell style and row style.
 
-{% gridExampleRunner title="Theming Example" name="custom-quartz-theme" /%}
+{% gridExampleRunner title="Theming Example" name="theming-example" /%}
 
 ## Next Steps
 

--- a/documentation/ag-grid-docs/src/content/docs/getting-started/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/getting-started/index.mdoc
@@ -638,7 +638,10 @@ themeClass: "ag-theme-quartz",
 ```
 {% /if %}
 
-{% flex justifyContent="center" %}
+{% tabs %}
+
+
+{% tabItem id="quartz" label="Quartz" %}
 
 {% imageCaption imagePath="resources/themeQuartz.png" alt="AG Theme Quartz" descriptionTop=true %}
 {% flex justifyContent="center" %}**Quartz**{% /flex %}
@@ -648,10 +651,11 @@ themeClass: "ag-theme-quartz",
 {% flex justifyContent="center" %}**Quartz Dark**{% /flex %}
 {% /imageCaption %}
 
-{% /flex %}
+
+{% /tabItem %}
 
 
-{% flex justifyContent="center" %}
+{% tabItem id="alpine" label="Alpine" %}
 
 {% imageCaption imagePath="resources/themeAlpine.png" alt="AG Theme Alpine" descriptionTop=true %}
 {% flex justifyContent="center" %}**Alpine**{% /flex %}
@@ -661,7 +665,13 @@ themeClass: "ag-theme-quartz",
 {% flex justifyContent="center" %}**Alpine Dark**{% /flex %}
 {% /imageCaption %}
 
-{% /flex %}
+
+{% /tabItem %}
+
+
+
+{% /tabs %}
+
 
 ### Customising a Theme
 

--- a/documentation/ag-grid-docs/src/content/docs/getting-started/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/getting-started/index.mdoc
@@ -639,8 +639,6 @@ themeClass: "ag-theme-quartz",
 {% /if %}
 
 {% tabs %}
-
-
 {% tabItem id="quartz" label="Quartz" %}
 
 {% imageCaption imagePath="resources/themeQuartz.png" alt="AG Theme Quartz" descriptionTop=true %}
@@ -651,10 +649,7 @@ themeClass: "ag-theme-quartz",
 {% flex justifyContent="center" %}**Quartz Dark**{% /flex %}
 {% /imageCaption %}
 
-
 {% /tabItem %}
-
-
 {% tabItem id="alpine" label="Alpine" %}
 
 {% imageCaption imagePath="resources/themeAlpine.png" alt="AG Theme Alpine" descriptionTop=true %}
@@ -664,14 +659,9 @@ themeClass: "ag-theme-quartz",
 {% imageCaption imagePath="resources/themeAlpineDark.png" alt="AG Theme Alpine Dark" descriptionTop=true %}
 {% flex justifyContent="center" %}**Alpine Dark**{% /flex %}
 {% /imageCaption %}
-
-
 {% /tabItem %}
 
-
-
 {% /tabs %}
-
 
 ### Customising a Theme
 

--- a/documentation/ag-grid-docs/src/content/docs/getting-started/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/getting-started/index.mdoc
@@ -679,14 +679,12 @@ Customise themes using CSS variables.
 
 ```css
 .ag-theme-quartz {
---ag-foreground-color: rgb(126, 46, 132);
---ag-background-color: rgb(249, 245, 227);
---ag-header-foreground-color: rgb(204, 245, 172);
---ag-header-background-color: rgb(209, 64, 129);
---ag-odd-row-background-color: rgb(0, 0, 0, 0.03);
---ag-header-column-resize-handle-color: rgb(126, 46, 132);
---ag-font-size: 17px;
---ag-font-family: monospace;
+/* Changes the color of the grid text */
+--ag-foreground-color: rgb(163, 64, 64);
+/* Changes the color of the grid background */
+--ag-background-color: rgba(215, 245, 231, 0.212);
+/* Changes the background color of selected rows */
+--ag-selected-row-background-color: rgba(0, 38, 255, 0.1);
 }
 ```
 


### PR DESCRIPTION
**Changes**

- Removed Figma image (now uses DS button)

<img width="1013" alt="Screenshot 2024-03-11 at 12 14 11" src="https://github.com/ag-grid/ag-grid/assets/9768489/db36e5fb-b3a0-4a30-a175-62f1f823826c">

- Moved theme grid into tab switcher

<img width="957" alt="Screenshot 2024-03-11 at 12 14 25" src="https://github.com/ag-grid/ag-grid/assets/9768489/1b02a30f-5495-4e13-9dbf-99699647fc68">


- Uses real example for theme customisation

<img width="644" alt="Screenshot 2024-03-11 at 12 14 43" src="https://github.com/ag-grid/ag-grid/assets/9768489/ccad0ba2-9f95-4ddd-a457-d51a96e8db11">
