### PR TITLE
RTI-2030 Fix specialized chart example (#7757)

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/integrated-charts-chart-types/_examples/specialized/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/integrated-charts-chart-types/_examples/specialized/main.ts
@@ -78,11 +78,10 @@ function onFirstDataRendered(params: FirstDataRenderedEvent) {
 
 function updateChart(chartType: 'heatmap' | 'waterfall') {
   getData(chartType).then((rowData) => {
-    gridApi.setGridOption('rowData', rowData);
-    gridApi.setGridOption(
-        'columnDefs',
-        chartType === 'heatmap' ? heatmapColDefs : waterfallColDefs
-    );
+    gridApi.updateGridOptions({
+      columnDefs: chartType === 'heatmap' ? heatmapColDefs : waterfallColDefs,
+      rowData,
+    });
     gridApi.updateChart({
       type: 'rangeChartUpdate',
       chartId: chartRef.chartId,

--- a/enterprise-modules/charts/src/charts/chartComp/model/chartDataModel.ts
+++ b/enterprise-modules/charts/src/charts/chartComp/model/chartDataModel.ts
@@ -136,7 +136,7 @@ export class ChartDataModel extends BeanStub {
         this.crossFiltering = !!crossFiltering;
 
         this.updateSelectedDimensions(cellRange?.columns);
-        this.updateCellRanges();
+        this.updateCellRanges({ setColsFromRange: true });
 
         const shouldUpdateComboModel = this.isComboChart() || seriesChartTypes;
         if (shouldUpdateComboModel) {


### PR DESCRIPTION
This ensures that the selected chart model cell range is reset when the chart cell range is updated when switching between chart types