### PR TITLE
Revert "RTI-2018 Enable JS output for Application Created Charts example (#7765)"

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/integrated-charts-application-created/_examples/application-created-charts/exampleConfig.json
+++ b/documentation/ag-grid-docs/src/content/docs/integrated-charts-application-created/_examples/application-created-charts/exampleConfig.json
@@ -1,3 +1,3 @@
 {
-    "supportedFrameworks": ["typescript", "vanilla"]
+    "supportedFrameworks": ["typescript"]
 }

--- a/documentation/ag-grid-docs/src/content/docs/integrated-charts-application-created/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/integrated-charts-application-created/index.mdoc
@@ -5,7 +5,7 @@ enterprise: true
 
 This section introduces Integrated Charts that are created programmatically within an application.
 
-{% gridExampleRunner title="Application Created Charts" name="application-created-charts"  exampleHeight=825 /%}
+{% gridExampleRunner title="Application Created Charts" name="application-created-charts"  exampleHeight=825 typescriptOnly=true /%}
 
 The dummy financial application above shows some of the grid's integrated charting capabilities. Note the following:
 


### PR DESCRIPTION
This reverts commit 9ab87ddb78912c2e4948dee276838becc3a77f0a.

While the JS output was generated correctly, the example does not work when other frameworks are selected.