### PR TITLE
Ag 11158 documentation archive

### DIFF
--- a/documentation/ag-grid-docs/src/components/quotes/Quotes.tsx
+++ b/documentation/ag-grid-docs/src/components/quotes/Quotes.tsx
@@ -41,7 +41,7 @@ const QuoteItems = ({ quotes }: { quotes: QuotesDataItem[] }) => {
                                     src={urlWithBaseUrl(avatarUrl)}
                                     alt={name}
                                 />
-                                <span className={classNames(styles.name, 'text-xl', 'bold-text')}>{name}</span>
+                                <span className={classNames(styles.name, 'text-xl', 'text-bold')}>{name}</span>
                                 <div className={styles.orgContainer}>
                                     <span className="text-xs text-secondary">{orgRole}</span>
                                     <img

--- a/documentation/ag-grid-docs/src/content/footer/data.json
+++ b/documentation/ag-grid-docs/src/content/footer/data.json
@@ -16,7 +16,7 @@
             },
             {
                 "name": "Documentation Archive",
-                "url": "/archive"
+                "url": "/documentation-archive"
             }
         ]
     },

--- a/documentation/ag-grid-docs/src/content/versions/ag-grid-versions.json
+++ b/documentation/ag-grid-docs/src/content/versions/ag-grid-versions.json
@@ -202,5 +202,165 @@
                 "text": "Displaying stacked and unstacked column series together in the chart"
             }
         ]
+    },
+    {
+        "version": "29.1.0",
+        "date": "March 2023"
+    },
+    {
+        "version": "29.0.0",
+        "date": "January 2023"
+    },
+    {
+        "version": "28.2.1",
+        "date": "November 2022"
+    },
+    {
+        "version": "28.1.1",
+        "date": "August 2022"
+    },
+    {
+        "version": "28.1.0",
+        "date": "August 2022"
+    },
+    {
+        "version": "28.0.0",
+        "date": "July 2022"
+    },
+    {
+        "version": "27.3.0",
+        "date": "May 2022"
+    },
+    {
+        "version": "27.2.0",
+        "date": "April 2022"
+    },
+    {
+        "version": "27.1.0",
+        "date": "March 2022"
+    },
+    {
+        "version": "27.0.1",
+        "date": "February 2022"
+    },
+    {
+        "version": "27.0.0",
+        "date": "February 2022"
+    },
+    {
+        "version": "26.2.0",
+        "date": "November 2021"
+    },
+    {
+        "version": "26.1.0",
+        "date": "November 2021"
+    },
+    {
+        "version": "26.0.0",
+        "date": "August 2021"
+    },
+    {
+        "version": "25.3.0",
+        "date": "July 2021"
+    },
+    {
+        "version": "25.2.0",
+        "date": "May 2021"
+    },
+    {
+        "version": "25.1.0",
+        "date": "March 2021"
+    },
+    {
+        "version": "25.0.0",
+        "date": "January 2021"
+    },
+    {
+        "version": "24.1.0",
+        "date": "October 2020"
+    },
+    {
+        "version": "24.0.0",
+        "date": "September 2020"
+    },
+    {
+        "version": "23.2.0",
+        "date": "June 2020"
+    },
+    {
+        "version": "23.1.1",
+        "date": "May 2020"
+    },
+    {
+        "version": "23.1.0",
+        "date": "May 2020"
+    },
+    {
+        "version": "23.0.2",
+        "date": "March 2020"
+    },
+    {
+        "version": "23.0.0",
+        "date": "March 2020"
+    },
+    {
+        "version": "22.1.1",
+        "date": "December 2019"
+    },
+    {
+        "version": "22.1.0",
+        "date": "December 2019"
+    },
+    {
+        "version": "22.0.0",
+        "date": "November 2019"
+    },
+    {
+        "version": "21.2.2",
+        "date": "September 2019"
+    },
+    {
+        "version": "21.2.1",
+        "date": "September 2019"
+    },
+    {
+        "version": "21.2.0",
+        "date": "August 2019"
+    },
+    {
+        "version": "21.1.0",
+        "date": "July 2019"
+    },
+    {
+        "version": "21.0.1",
+        "date": "June 2019"
+    },
+    {
+        "version": "21.0.0",
+        "date": "June 2019"
+    },
+    {
+        "version": "20.2.0",
+        "date": "March 2019"
+    },
+    {
+        "version": "20.1.0",
+        "date": "February 2019"
+    },
+    {
+        "version": "20.0.0",
+        "date": "January 2019"
+    },
+    {
+        "version": "19.1.4",
+        "date": "November 2018"
+    },
+    {
+        "version": "19.0.0",
+        "date": "September 2018"
+    },
+    {
+        "version": "18.1.0",
+        "date": "June 2018"
     }
 ]

--- a/documentation/ag-grid-docs/src/content/versions/ag-grid-versions.json
+++ b/documentation/ag-grid-docs/src/content/versions/ag-grid-versions.json
@@ -362,5 +362,29 @@
     {
         "version": "18.1.0",
         "date": "June 2018"
+    },
+    {
+        "version": "17.1.1",
+        "date": "April 2018"
+    },
+    {
+        "version": "17.0.0",
+        "date": "March 2018"
+    },
+    {
+        "version": "16.0.0",
+        "date": "January 2018"
+    },
+    {
+        "version": "15.0.0",
+        "date": "December 2017"
+    },
+    {
+        "version": "14.1.0",
+        "date": "November 2017"
+    },
+    {
+        "version": "14.0.0",
+        "date": "October 2017"
     }
 ]

--- a/documentation/ag-grid-docs/src/design-system/_typography.scss
+++ b/documentation/ag-grid-docs/src/design-system/_typography.scss
@@ -63,11 +63,35 @@ h5#{$selector-exclude-grid},
 h6#{$selector-exclude-grid},
 b#{$selector-exclude-grid},
 strong#{$selector-exclude-grid},
-.bold-text {
+.text-regular {
+    font-weight: var(--text-regular);
+}
+
+h1#{$selector-exclude-grid},
+h2#{$selector-exclude-grid},
+h3#{$selector-exclude-grid},
+h4#{$selector-exclude-grid},
+h5#{$selector-exclude-grid},
+h6#{$selector-exclude-grid},
+b#{$selector-exclude-grid},
+strong#{$selector-exclude-grid},
+.text-semibold {
     font-weight: var(--text-semibold);
 }
 
-.monospace-text {
+h1#{$selector-exclude-grid},
+h2#{$selector-exclude-grid},
+h3#{$selector-exclude-grid},
+h4#{$selector-exclude-grid},
+h5#{$selector-exclude-grid},
+h6#{$selector-exclude-grid},
+b#{$selector-exclude-grid},
+strong#{$selector-exclude-grid},
+.text-bold {
+    font-weight: var(--text-bold);
+}
+
+.text-monospace {
     font-family: var(--text-monospace-font-family);
 }
 

--- a/documentation/ag-grid-docs/src/design-system/modules/DocsArchive.module.scss
+++ b/documentation/ag-grid-docs/src/design-system/modules/DocsArchive.module.scss
@@ -70,3 +70,24 @@
     border: 1px solid var(--color-logo-orange);
     color: var(--color-logo-orange);
 }
+.archiveList {
+    display: flex;
+    flex-direction: column;
+    gap: $spacing-size-4;
+    margin-top: $spacing-size-8;
+    margin-bottom: $spacing-size-8;
+}
+
+.archiveItem {
+    display: flex;
+    flex-direction: column;
+    gap: $spacing-size-2;
+    width: 100%;
+    padding: $spacing-size-4;
+    border-radius: 8px;
+    border: 1px solid var(--color-border-primary);
+
+    a {
+        font-weight: var(--text-regular);
+    }
+}

--- a/documentation/ag-grid-docs/src/design-system/modules/DocsArchive.module.scss
+++ b/documentation/ag-grid-docs/src/design-system/modules/DocsArchive.module.scss
@@ -1,0 +1,40 @@
+@use '../core' as *;
+
+.docsArchiveContainer {
+    width: 100%;
+
+    @media screen and (min-width: $breakpoint-docs-nav-medium) {
+        width: calc(var(--layout-width-9-12));
+        padding-top: $spacing-size-10;
+    }
+
+    @media screen and (min-width: $breakpoint-docs-nav-large) {
+        width: calc(var(--layout-width-9-12) + $spacing-size-16);
+    }
+}
+
+.description {
+    font-size: 18px;
+}
+
+.archiveList {
+    display: flex;
+    flex-direction: column;
+    gap: $spacing-size-4;
+    margin-top: $spacing-size-8;
+    margin-bottom: $spacing-size-8;
+}
+
+.archiveItem {
+    display: flex;
+    flex-direction: column;
+    gap: $spacing-size-2;
+    width: 100%;
+    padding: $spacing-size-4;
+    border-radius: 8px;
+    border: 1px solid var(--color-border-primary);
+
+    a {
+        font-weight: var(--text-regular);
+    }
+}

--- a/documentation/ag-grid-docs/src/design-system/modules/DocsArchive.module.scss
+++ b/documentation/ag-grid-docs/src/design-system/modules/DocsArchive.module.scss
@@ -70,24 +70,11 @@
     border: 1px solid var(--color-logo-orange);
     color: var(--color-logo-orange);
 }
+
 .archiveList {
     display: flex;
     flex-direction: column;
     gap: $spacing-size-4;
     margin-top: $spacing-size-8;
     margin-bottom: $spacing-size-8;
-}
-
-.archiveItem {
-    display: flex;
-    flex-direction: column;
-    gap: $spacing-size-2;
-    width: 100%;
-    padding: $spacing-size-4;
-    border-radius: 8px;
-    border: 1px solid var(--color-border-primary);
-
-    a {
-        font-weight: var(--text-regular);
-    }
 }

--- a/documentation/ag-grid-docs/src/design-system/modules/DocsArchive.module.scss
+++ b/documentation/ag-grid-docs/src/design-system/modules/DocsArchive.module.scss
@@ -17,24 +17,56 @@
     font-size: 18px;
 }
 
-.archiveList {
-    display: flex;
-    flex-direction: column;
-    gap: $spacing-size-4;
-    margin-top: $spacing-size-8;
-    margin-bottom: $spacing-size-8;
-}
+.archiveTable {
+    max-width: 980px;
+    margin: $spacing-size-10 0 $spacing-size-56;
 
-.archiveItem {
-    display: flex;
-    flex-direction: column;
-    gap: $spacing-size-2;
-    width: 100%;
-    padding: $spacing-size-4;
-    border-radius: 8px;
-    border: 1px solid var(--color-border-primary);
+    tr {
+        transition: background-color $transition-default-timing;
+
+        &:hover {
+            background-color: var(--color-util-brand-50);
+
+            #{$selector-darkmode} & {
+                background-color: var(--color-util-gray-200);
+            }
+        }
+    }
+
+    td {
+        padding-top: $spacing-size-4;
+        padding-bottom: $spacing-size-4;
+        vertical-align: middle;
+
+        &:nth-child(n + 3) {
+            text-align: right;
+        }
+
+        @media screen and (max-width: 720px) {
+            &:not(:first-child):not(:last-child) {
+                display: none;
+            }
+        }
+    }
 
     a {
-        font-weight: var(--text-regular);
+        svg {
+            --icon-size: 20px;
+
+            margin-top: -2px;
+            transition: transform $transition-default-timing;
+        }
+
+        &:hover svg {
+            transform: translateX(3px);
+        }
     }
+}
+
+.major {
+    margin-right: -8px;
+    padding: 2px 8px;
+    border-radius: var(--radius-4xl);
+    border: 1px solid var(--color-logo-orange);
+    color: var(--color-logo-orange);
 }

--- a/documentation/ag-grid-docs/src/pages/documentation-archive.astro
+++ b/documentation/ag-grid-docs/src/pages/documentation-archive.astro
@@ -51,10 +51,8 @@ const isMajor = (version) => {
                         versionsData.slice(1).map((versionInfo) => {
                             return (
                                 <tr>
-                                    <td class="text-lg monospace-text">
-                                        <a href={`https://www.ag-grid.com/archive/${versionInfo.version}/`}>
+                                    <td class="text-base text-monospace text-semibold">
                                             {versionInfo.version}
-                                        </a>
                                     </td>
 
                                     <td>{versionInfo.date}</td>

--- a/documentation/ag-grid-docs/src/pages/documentation-archive.astro
+++ b/documentation/ag-grid-docs/src/pages/documentation-archive.astro
@@ -4,6 +4,7 @@ import Layout from '../layouts/Layout.astro';
 import { PagesNavigationFromLocalStorage } from '@features/pages-navigation/components/PagesNavigationFromLocalStorage';
 import { getDocsPages } from '../features/docs/utils/pageData';
 import type { Framework, MenuSection } from '@ag-grid-types';
+import { Icon } from '@components/icon/Icon';
 import styles from '@design-system/modules/DocsArchive.module.scss';
 
 export async function getStaticPaths() {
@@ -18,6 +19,22 @@ const allMenuSections = menu.main.sections as MenuSection[];
 
 const versionsContent = await getEntry('versions', 'ag-grid-versions');
 const versionsData: any[] = versionsContent ? versionsContent.data : [];
+
+const getVersionType = (version) => {
+    const [_, minor, patch] = version.split('.');
+
+    if (patch !== '0') {
+        return 'Patch';
+    } else if (minor !== '0') {
+        return 'Minor';
+    } else {
+        return 'Major';
+    }
+};
+
+const isMajor = (version) => {
+    return getVersionType(version) === 'Major';
+};
 ---
 
 <Layout title={'Documentation Archive'} showDocsNav={true} showSearchBar={true}>
@@ -29,28 +46,39 @@ const versionsData: any[] = versionsContent ? versionsContent.data : [];
                 <h1>Documentation Archive</h1>
                 <p class={styles.description}>Review documentation for previous AG Grid versions.</p>
 
-                <div class={styles.archiveList}>
+                <table class={styles.archiveTable}>
                     {
-                        versionsData.slice(1).map((versionInfo, index) => {
+                        versionsData.slice(1).map((versionInfo) => {
                             return (
-                                <div class={styles.archiveItem}>
-                                    <span class="text-tertiary">{versionInfo.date}</span>
+                                <tr>
+                                    <td class="text-lg monospace-text">
+                                        <a href={`https://www.ag-grid.com/archive/${versionInfo.version}/`}>
+                                            {versionInfo.version}
+                                        </a>
+                                    </td>
 
-                                    <a
-                                        class:list={[styles.docsLink, 'text-2xl']}
-                                        href={`https://www.ag-grid.com/archive/${versionInfo.version}/`}
-                                    >
-                                        <b>{versionInfo.version}</b> documentation
-                                    </a>
+                                    <td>{versionInfo.date}</td>
 
-                                    <a href={`https://ag-grid.com/changelog/?fixVersion=${versionInfo.version}`}>
-                                        View changelog
-                                    </a>
-                                </div>
+                                    <td>
+                                        <span class={ isMajor(versionInfo.version) ? styles.major : undefined } >{getVersionType(versionInfo.version)}</span>
+                                    </td>
+
+                                    <td>
+                                        <a href={`https://ag-grid.com/changelog/?fixVersion=${versionInfo.version}`}>
+                                            Changelog <Icon name="arrowRight" />
+                                        </a>
+                                    </td>
+
+                                    <td>
+                                        <a href={`https://www.ag-grid.com/archive/${versionInfo.version}/`}>
+                                            View Documentation <Icon name="arrowRight" />
+                                        </a>
+                                    </td>
+                                </tr>
                             );
                         })
                     }
-                </div>
+                </table>
             </div>
         </main>
     </div>

--- a/documentation/ag-grid-docs/src/pages/documentation-archive.astro
+++ b/documentation/ag-grid-docs/src/pages/documentation-archive.astro
@@ -1,0 +1,57 @@
+---
+import { getCollection, getEntry } from 'astro:content';
+import Layout from '../layouts/Layout.astro';
+import { PagesNavigationFromLocalStorage } from '@features/pages-navigation/components/PagesNavigationFromLocalStorage';
+import { getDocsPages } from '../features/docs/utils/pageData';
+import type { Framework, MenuSection } from '@ag-grid-types';
+import styles from '@design-system/modules/DocsArchive.module.scss';
+
+export async function getStaticPaths() {
+    const pages = await getCollection('docs');
+    return getDocsPages(pages);
+}
+
+const pageName = Astro.params.pageName as Framework;
+
+const { data: menu } = await getEntry('menu', 'data');
+const allMenuSections = menu.main.sections as MenuSection[];
+
+const versionsContent = await getEntry('versions', 'ag-grid-versions');
+const versionsData: any[] = versionsContent ? versionsContent.data : [];
+---
+
+<Layout title={'Documentation Archive'} showDocsNav={true} showSearchBar={true}>
+    <div class:list={['contentViewport layout-grid']}>
+        <PagesNavigationFromLocalStorage client:load allMenuSections={allMenuSections} pageName={pageName} />
+
+        <main is="div">
+            <div class={styles.docsArchiveContainer}>
+                <h1>Documentation Archive</h1>
+                <p class={styles.description}>Review documentation for previous AG Grid versions.</p>
+
+                <div class={styles.archiveList}>
+                    {
+                        versionsData.slice(1).map((versionInfo, index) => {
+                            return (
+                                <div class={styles.archiveItem}>
+                                    <span class="text-tertiary">{versionInfo.date}</span>
+
+                                    <a
+                                        class:list={[styles.docsLink, 'text-2xl']}
+                                        href={`https://www.ag-grid.com/archive/${versionInfo.version}/`}
+                                    >
+                                        <b>{versionInfo.version}</b> documentation
+                                    </a>
+
+                                    <a href={`https://ag-grid.com/changelog/?fixVersion=${versionInfo.version}`}>
+                                        View changelog
+                                    </a>
+                                </div>
+                            );
+                        })
+                    }
+                </div>
+            </div>
+        </main>
+    </div>
+</Layout>

--- a/documentation/ag-grid-docs/src/pages/whats-new.astro
+++ b/documentation/ag-grid-docs/src/pages/whats-new.astro
@@ -32,16 +32,18 @@ const versionsData: any[] = versionsContent ? versionsContent.data : [];
                 <div class={styles.versions}>
                     {
                         versionsData.map((versionInfo, index) => {
-                            return (
-                                <Version
-                                    client:load
-                                    isLatest={index === 0}
-                                    version={versionInfo.version}
-                                    date={versionInfo.date}
-                                    highlights={versionInfo.highlights}
-                                    notesPath={versionInfo.notesPath}
-                                />
-                            );
+                            if (versionInfo.highlights) {
+                                return (
+                                    <Version
+                                        client:load
+                                        isLatest={index === 0}
+                                        version={versionInfo.version}
+                                        date={versionInfo.date}
+                                        highlights={versionInfo.highlights}
+                                        notesPath={versionInfo.notesPath}
+                                    />
+                                );
+                            }
                         })
                     }
                 </div>


### PR DESCRIPTION
Create a new "Documentation Archive" page. Replaces `ag-grid.com/archive/` in the footer however `ag-grid.com/archive/` will still be accessible. 

Also includes a small refactor of typographic CSS classes. 