### PR TITLE
AG-11304 - Reduce HTML page size

### DIFF
--- a/documentation/ag-grid-docs/src/components/reference-documentation/ApiDocumentation.astro
+++ b/documentation/ag-grid-docs/src/components/reference-documentation/ApiDocumentation.astro
@@ -1,13 +1,11 @@
 ---
-import { ApiDocumentation } from './ReferenceDocumentation';
+import { ApiDocumentationWithQuery } from './ApiDocumentationWithQuery';
 import { getFrameworkFromPath } from '@features/docs/utils/urlPaths';
-import { getJsonFile } from '@utils/pages';
 import { getPropertiesFromSource } from './getPropertiesFromSource';
 
 const { names, config, source, sources: sourcesProp, section } = Astro.props;
 
 const framework = getFrameworkFromPath(Astro.url.pathname);
-const interfaceLookup = getJsonFile('reference/interfaces.AUTO.json');
 
 const { sources, propertiesFromFiles, propertyConfigs, codeConfigs } = await getPropertiesFromSource({
     source,
@@ -15,7 +13,7 @@ const { sources, propertiesFromFiles, propertyConfigs, codeConfigs } = await get
 });
 ---
 
-<ApiDocumentation
+<ApiDocumentationWithQuery
     client:load
     framework={framework}
     sources={sources}
@@ -23,7 +21,6 @@ const { sources, propertiesFromFiles, propertyConfigs, codeConfigs } = await get
     names={names}
     config={config}
     propertiesFromFiles={propertiesFromFiles}
-    interfaceLookup={interfaceLookup}
     propertyConfigs={propertyConfigs}
     codeConfigs={codeConfigs}
 />

--- a/documentation/ag-grid-docs/src/components/reference-documentation/ApiDocumentationWithQuery.tsx
+++ b/documentation/ag-grid-docs/src/components/reference-documentation/ApiDocumentationWithQuery.tsx
@@ -1,0 +1,39 @@
+import { fetchExtraFile } from '@utils/client/fetchExtraFile';
+import { QueryClient, QueryClientProvider, useQuery } from 'react-query';
+
+import { ApiDocumentation, type ApiDocumentationProps } from './ReferenceDocumentation';
+
+// NOTE: Not on the layout level, as that is generated at build time, and queryClient needs to be
+// loaded on the client side
+const queryClient = new QueryClient();
+
+const queryOptions = {
+    retry: false,
+    refetchOnMount: false,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+};
+
+type Props = Omit<ApiDocumentationProps, 'interfaceLookup'>;
+
+export function ApiDocumentationWithQuery(props: Props) {
+    return (
+        <QueryClientProvider client={queryClient}>
+            {' '}
+            <ApiDocumentationWithLookups {...props} />{' '}
+        </QueryClientProvider>
+    );
+}
+
+function ApiDocumentationWithLookups(props: Props) {
+    const { data: interfaceLookup } = useQuery(
+        ['resolved-interfaces'],
+        async () => {
+            const data = await fetchExtraFile('/reference/interfaces.AUTO.json');
+            return data;
+        },
+        queryOptions
+    );
+
+    return interfaceLookup && <ApiDocumentation {...props} interfaceLookup={interfaceLookup} />;
+}

--- a/documentation/ag-grid-docs/src/components/reference-documentation/InterfaceDocumentation.astro
+++ b/documentation/ag-grid-docs/src/components/reference-documentation/InterfaceDocumentation.astro
@@ -1,5 +1,5 @@
 ---
-import { InterfaceDocumentation } from './ReferenceDocumentation';
+import { InterfaceDocumentationWithQuery } from './InterfaceDocumentationWithQuery';
 import { getFrameworkFromPath } from '@features/docs/utils/urlPaths';
 import { getJsonFile } from '@utils/pages';
 import { getEntry } from 'astro:content';
@@ -26,13 +26,11 @@ if (overrideSrc) {
     }
 }
 
-const interfaceLookup = getJsonFile('reference/interfaces.AUTO.json');
-const codeLookup = getJsonFile('reference/doc-interfaces.AUTO.json');
 // TODO: Remove?
 const htmlLookup = getJsonFile('reference/doc-interfaces.HTML.json');
 ---
 
-<InterfaceDocumentation
+<InterfaceDocumentationWithQuery
     client:load
     interfaceName={interfaceName}
     framework={framework}
@@ -41,7 +39,5 @@ const htmlLookup = getJsonFile('reference/doc-interfaces.HTML.json');
     exclude={exclude}
     wrapNamesAt={wrapNamesAt}
     config={config}
-    interfaceLookup={interfaceLookup}
-    codeLookup={codeLookup}
     htmlLookup={htmlLookup}
 />

--- a/documentation/ag-grid-docs/src/components/reference-documentation/InterfaceDocumentationWithQuery.tsx
+++ b/documentation/ag-grid-docs/src/components/reference-documentation/InterfaceDocumentationWithQuery.tsx
@@ -1,0 +1,44 @@
+import { fetchExtraFile } from '@utils/client/fetchExtraFile';
+import { QueryClient, QueryClientProvider, useQuery } from 'react-query';
+
+import { InterfaceDocumentation } from './ReferenceDocumentation';
+
+// NOTE: Not on the layout level, as that is generated at build time, and queryClient needs to be
+// loaded on the client side
+const queryClient = new QueryClient();
+
+const queryOptions = {
+    retry: false,
+    refetchOnMount: false,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+};
+
+type Props = Omit<ApiDocumentationProps, 'interfaceLookup' | 'codeLookup'>;
+
+export function InterfaceDocumentationWithQuery(props: Props) {
+    return (
+        <QueryClientProvider client={queryClient}>
+            {' '}
+            <InterfaceDocumentationWithLookups {...props} />{' '}
+        </QueryClientProvider>
+    );
+}
+
+function InterfaceDocumentationWithLookups(props: Props) {
+    const { data: [interfaceLookup, codeLookup] = [] } = useQuery(
+        ['resolved-interfaces'],
+        async () => {
+            return Promise.all([
+                fetchExtraFile('/reference/interfaces.AUTO.json'),
+                fetchExtraFile('/reference/doc-interfaces.AUTO.json'),
+            ]);
+        },
+        queryOptions
+    );
+
+    return (
+        interfaceLookup &&
+        codeLookup && <InterfaceDocumentation {...props} interfaceLookup={interfaceLookup} codeLookup={codeLookup} />
+    );
+}

--- a/documentation/ag-grid-docs/src/components/reference-documentation/ReferenceDocumentation.tsx
+++ b/documentation/ag-grid-docs/src/components/reference-documentation/ReferenceDocumentation.tsx
@@ -44,7 +44,7 @@ import type {
     SectionProps,
 } from './types';
 
-interface InterfaceDocumentationProps {
+export interface InterfaceDocumentationProps {
     interfaceName: string;
     framework: Framework;
     overrides: Overrides;
@@ -57,8 +57,7 @@ interface InterfaceDocumentationProps {
     htmlLookup: Record<string, any>;
 }
 
-interface ApiDocumentationProps {
-    pageName: string;
+export interface ApiDocumentationProps {
     framework: Framework;
     sources: string[];
     section: string;

--- a/documentation/ag-grid-docs/src/utils/client/fetchExtraFile.ts
+++ b/documentation/ag-grid-docs/src/utils/client/fetchExtraFile.ts
@@ -1,0 +1,11 @@
+import { getExtraFileUrl } from '@utils/extraFileUrl';
+
+export async function fetchExtraFile(filePath: string) {
+    const contents = await fetch(
+        getExtraFileUrl({
+            filePath,
+        })
+    ).then((res) => res.json());
+
+    return contents;
+}


### PR DESCRIPTION
by fetching resolved interfaces instead of injecting onto page

Get interfaces and code interfaces on client side instead of injecting it from the astro file into the react component. This caused the html to be very large.

Also remove unused `pageName` prop.

On charts: https://github.com/ag-grid/ag-charts/pull/1564