### PR TITLE
AG-11658 Deselection of indeterminate row with tree data

### DIFF
--- a/community-modules/core/src/entities/rowNode.ts
+++ b/community-modules/core/src/entities/rowNode.ts
@@ -956,8 +956,8 @@ export class RowNode<TData = any> implements IEventEmitter, IRowNode<TData> {
         return this.__hasChildren;
     }
 
-    public isEmptyRowGroupNode(): boolean | undefined {
-        return this.group && _missingOrEmpty(this.childrenAfterGroup);
+    public isEmptyRowGroupNode(): boolean {
+        return (this.group && _missingOrEmpty(this.childrenAfterGroup)) ?? false;
     }
 
     private dispatchCellChangedEvent(column: AgColumn, newValue: TData, oldValue: TData): void {

--- a/community-modules/core/src/selectionService.ts
+++ b/community-modules/core/src/selectionService.ts
@@ -111,7 +111,7 @@ export class SelectionService extends BeanStub implements NamedBean, ISelectionS
             // trying to set it to true / false. this group will be calculated further on
             // down when we call calculatedSelectedForAllGroupNodes(). we need to skip it
             // here, otherwise the updatedCount would include it.
-            const skipThisNode = groupSelectsFiltered && node.group;
+            const skipThisNode = groupSelectsFiltered && (node.group || node.hasChildren());
 
             if (!skipThisNode) {
                 const thisNodeWasSelected = node.selectThisNode(newValue, event, source);

--- a/community-modules/core/src/selectionService.ts
+++ b/community-modules/core/src/selectionService.ts
@@ -107,10 +107,12 @@ export class SelectionService extends BeanStub implements NamedBean, ISelectionS
         let updatedCount = 0;
         for (let i = 0; i < filteredNodes.length; i++) {
             const node = filteredNodes[i];
-            // when groupSelectsFiltered, then this node may end up intermediate despite
+            // when groupSelectsFiltered, then this node may end up indeterminate despite
             // trying to set it to true / false. this group will be calculated further on
-            // down when we call calculatedSelectedForAllGroupNodes(). we need to skip it
+            // down when we call updateGroupsFromChildrenSelections(). we need to skip it
             // here, otherwise the updatedCount would include it.
+            // (note: `hasChildren` is used in the tree data case as `RowNode.group` isn't
+            // set correctly on rows with user data)
             const skipThisNode = groupSelectsFiltered && (node.group || node.hasChildren());
 
             if (!skipThisNode) {

--- a/community-modules/core/src/selectionService.ts
+++ b/community-modules/core/src/selectionService.ts
@@ -113,7 +113,7 @@ export class SelectionService extends BeanStub implements NamedBean, ISelectionS
             // here, otherwise the updatedCount would include it.
             // (note: `hasChildren` is used in the tree data case as `RowNode.group` isn't
             // set correctly on rows with user data)
-            const skipThisNode = groupSelectsFiltered && (node.group || node.hasChildren());
+            const skipThisNode = groupSelectsFiltered && node.group;
 
             if (!skipThisNode) {
                 const thisNodeWasSelected = node.selectThisNode(newValue, event, source);

--- a/enterprise-modules/row-grouping/src/rowGrouping/groupStage.ts
+++ b/enterprise-modules/row-grouping/src/rowGrouping/groupStage.ts
@@ -387,10 +387,11 @@ export class GroupStage extends BeanStub implements NamedBean, IRowNodeStage {
                 this.forEachParentGroup(details, possibleEmptyGroup, (rowNode) => {
                     if (groupShouldBeRemoved(rowNode)) {
                         if (details.usingTreeData && details.getDataPath?.(rowNode.data)) {
-                            // This node has associated tree data so shouldn't be removed, but should no longer be marked as a group
-                            // since it has no children.
-                            rowNode.group =
-                                (rowNode.childrenAfterGroup && rowNode.childrenAfterGroup.length > 0) ?? false;
+                            // This node has associated tree data so shouldn't be removed, but should no longer be
+                            // marked as a group if it has no children.
+                            rowNode.setGroup(
+                                (rowNode.childrenAfterGroup && rowNode.childrenAfterGroup.length > 0) ?? false
+                            );
                         } else {
                             checkAgain = true;
 
@@ -445,8 +446,7 @@ export class GroupStage extends BeanStub implements NamedBean, IRowNodeStage {
             if (parent?.childrenMapped?.[mapKey] !== child) {
                 parent.childrenMapped[mapKey] = child;
                 parent.childrenAfterGroup!.push(child);
-                parent.group = true;
-                parent.updateHasChildren();
+                parent.setGroup(true); // calls `.updateHasChildren` internally
             }
         }
     }

--- a/enterprise-modules/row-grouping/src/rowGrouping/groupStage.ts
+++ b/enterprise-modules/row-grouping/src/rowGrouping/groupStage.ts
@@ -369,8 +369,7 @@ export class GroupStage extends BeanStub implements NamedBean, IRowNodeStage {
             // so double check before trying to remove again.
             const mapKey = this.getChildrenMappedKey(rowNode.key!, rowNode.rowGroupColumn);
             const parentRowNode = rowNode.parent;
-            const groupAlreadyRemoved =
-                parentRowNode && parentRowNode.childrenMapped ? !parentRowNode.childrenMapped[mapKey] : true;
+            const groupAlreadyRemoved = parentRowNode?.childrenMapped ? !parentRowNode.childrenMapped[mapKey] : true;
 
             if (groupAlreadyRemoved) {
                 // if not linked, then group was already removed
@@ -382,7 +381,7 @@ export class GroupStage extends BeanStub implements NamedBean, IRowNodeStage {
 
         while (checkAgain) {
             checkAgain = false;
-            const batchRemover: BatchRemover = new BatchRemover();
+            const batchRemover = new BatchRemover();
             possibleEmptyGroups.forEach((possibleEmptyGroup) => {
                 // remove empty groups
                 this.forEachParentGroup(details, possibleEmptyGroup, (rowNode) => {
@@ -414,8 +413,8 @@ export class GroupStage extends BeanStub implements NamedBean, IRowNodeStage {
             }
         }
         const mapKey = this.getChildrenMappedKey(child.key!, child.rowGroupColumn);
-        if (child.parent && child.parent.childrenMapped) {
-            child.parent.childrenMapped[mapKey] = undefined;
+        if (child.parent?.childrenMapped != undefined) {
+            delete child.parent.childrenMapped[mapKey];
         }
         // this is important for transition, see rowComp removeFirstPassFuncs. when doing animation and
         // remove, if rowTop is still present, the rowComp thinks it's just moved position.

--- a/enterprise-modules/row-grouping/src/rowGrouping/groupStage.ts
+++ b/enterprise-modules/row-grouping/src/rowGrouping/groupStage.ts
@@ -385,27 +385,20 @@ export class GroupStage extends BeanStub implements NamedBean, IRowNodeStage {
             possibleEmptyGroups.forEach((possibleEmptyGroup) => {
                 // remove empty groups
                 this.forEachParentGroup(details, possibleEmptyGroup, (rowNode) => {
-                    if (groupShouldBeRemoved(rowNode)) {
-                        if (details.usingTreeData && details.getDataPath?.(rowNode.data)) {
-                            // This node has associated tree data so shouldn't be removed, but should no longer be
-                            // marked as a group if it has no children.
-                            rowNode.setGroup(
-                                (rowNode.childrenAfterGroup && rowNode.childrenAfterGroup.length > 0) ?? false
-                            );
-                        } else {
-                            checkAgain = true;
+                    const shouldBeRemoved = groupShouldBeRemoved(rowNode);
+                    if (shouldBeRemoved && details.usingTreeData && details.getDataPath?.(rowNode.data)) {
+                        // This node has associated tree data so shouldn't be removed, but should no longer be
+                        // marked as a group if it has no children.
+                        rowNode.setGroup(
+                            (rowNode.childrenAfterGroup && rowNode.childrenAfterGroup.length > 0) ?? false
+                        );
+                    } else if (shouldBeRemoved) {
+                        checkAgain = true;
 
-                            this.removeFromParent(rowNode, batchRemover);
-                            // we remove selection on filler nodes here, as the selection would not be removed
-                            // from the RowNodeManager, as filler nodes don't exist on the RowNodeManager
-                            rowNode.setSelectedParams({ newValue: false, source: 'rowGroupChanged' });
-                            checkAgain = true;
-
-                            this.removeFromParent(rowNode, batchRemover);
-                            // we remove selection on filler nodes here, as the selection would not be removed
-                            // from the RowNodeManager, as filler nodes don't exist on the RowNodeManager
-                            rowNode.setSelectedParams({ newValue: false, source: 'rowGroupChanged' });
-                        }
+                        this.removeFromParent(rowNode, batchRemover);
+                        // we remove selection on filler nodes here, as the selection would not be removed
+                        // from the RowNodeManager, as filler nodes don't exist on the RowNodeManager
+                        rowNode.setSelectedParams({ newValue: false, source: 'rowGroupChanged' });
                     }
                 });
             });

--- a/enterprise-modules/row-grouping/src/rowGrouping/groupStage.ts
+++ b/enterprise-modules/row-grouping/src/rowGrouping/groupStage.ts
@@ -377,7 +377,7 @@ export class GroupStage extends BeanStub implements NamedBean, IRowNodeStage {
                 return false;
             }
             // if still not removed, then we remove if this group is empty
-            return !!rowNode.isEmptyRowGroupNode();
+            return rowNode.isEmptyRowGroupNode();
         };
 
         while (checkAgain) {

--- a/enterprise-modules/row-grouping/src/rowGrouping/groupStage.ts
+++ b/enterprise-modules/row-grouping/src/rowGrouping/groupStage.ts
@@ -432,7 +432,8 @@ export class GroupStage extends BeanStub implements NamedBean, IRowNodeStage {
             if (parent?.childrenMapped?.[mapKey] !== child) {
                 parent.childrenMapped[mapKey] = child;
                 parent.childrenAfterGroup!.push(child);
-                parent?.updateHasChildren();
+                parent.group = true;
+                parent.updateHasChildren();
             }
         }
     }

--- a/enterprise-modules/row-grouping/src/rowGrouping/groupStage.ts
+++ b/enterprise-modules/row-grouping/src/rowGrouping/groupStage.ts
@@ -387,6 +387,8 @@ export class GroupStage extends BeanStub implements NamedBean, IRowNodeStage {
                 this.forEachParentGroup(details, possibleEmptyGroup, (rowNode) => {
                     if (groupShouldBeRemoved(rowNode)) {
                         checkAgain = true;
+                        // This node no longer represents a group
+                        rowNode.group = false;
                         this.removeFromParent(rowNode, batchRemover);
                         // we remove selection on filler nodes here, as the selection would not be removed
                         // from the RowNodeManager, as filler nodes don't exist on the RowNodeManager

--- a/enterprise-modules/row-grouping/src/rowGrouping/pivotStage.ts
+++ b/enterprise-modules/row-grouping/src/rowGrouping/pivotStage.ts
@@ -215,8 +215,13 @@ export class PivotStage extends BeanStub implements NamedBean, IRowNodeStage {
         }
     }
 
-    private bucketChildren(children: RowNode[], pivotColumns: AgColumn[], pivotIndex: number, uniqueValues: any): any {
-        const mappedChildren: any = {};
+    private bucketChildren(
+        children: RowNode[],
+        pivotColumns: AgColumn[],
+        pivotIndex: number,
+        uniqueValues: any
+    ): Record<string, any> {
+        const mappedChildren: Record<string, any> = {};
         const pivotColumn = pivotColumns[pivotIndex];
 
         // map the children out based on the pivot column
@@ -249,7 +254,7 @@ export class PivotStage extends BeanStub implements NamedBean, IRowNodeStage {
         if (pivotIndex === pivotColumns.length - 1) {
             return mappedChildren;
         } else {
-            const result: any = {};
+            const result: Record<string, any> = {};
 
             _iterateObject(mappedChildren, (key: string, value: RowNode[]) => {
                 result[key] = this.bucketChildren(value, pivotColumns, pivotIndex + 1, uniqueValues[key]);


### PR DESCRIPTION
See https://ag-grid.atlassian.net/browse/AG-11658

TLDR: We couldn't rely on `RowNode.group` for tree data because it didn't get set for rows with user data. This flag was being relied on to determine the selection for group nodes.

### Changes
- Set the `node.group = true` in [GroupStage.addToParent](https://github.com/ag-grid/ag-grid/blob/86ca65867280595de7f21fb94d8c14dd618aa3c7/enterprise-modules/row-grouping/src/rowGrouping/groupStage.ts#L418) to make value of `group` consistent between tree data and normal row grouping.
- Don't remove an empty group node if using tree data and the node has associated tree data, simply mark the `.group` field `false`.
- Replace what I assume is an outdated reference to `calculatedSelectedForAllGroupNodes`
- A little bit of tidying

### Note
The original PR description is posted in a comment below for context on the initial solution (which you can see in [b49928a](https://github.com/ag-grid/ag-grid/pull/8002/commits/b49928a8b2d01008c62dfc242c5f9584cd32f567)).

The initial solution is a simple single line fix, but the current solution means that the semantics of `RowNode.group` are (more?) consistent between tree data and normal row grouping.