### PR TITLE
AG-9259 Log a warning when getRowId doesn't return a string

### DIFF
--- a/community-modules/client-side-row-model/src/clientSideRowModel/clientSideNodeManager.ts
+++ b/community-modules/client-side-row-model/src/clientSideRowModel/clientSideNodeManager.ts
@@ -291,12 +291,12 @@ export class ClientSideNodeManager {
     }
 
     private lookupRowNode(data: any): RowNode | null {
-        const getRowIdFunc = this.gos.getCallback('getRowId');
+        const getRowIdFunc = this.gos.getRowIdCallback();
 
         let rowNode: RowNode | undefined;
         if (getRowIdFunc) {
             // find rowNode using id
-            const id: string = getRowIdFunc({ data, level: 0 });
+            const id = getRowIdFunc({ data, level: 0 });
             rowNode = this.allNodesMap[id];
             if (!rowNode) {
                 console.error(`AG Grid: could not find row id=${id}, data item was not found for this id`);

--- a/community-modules/client-side-row-model/src/clientSideRowModel/immutableService.ts
+++ b/community-modules/client-side-row-model/src/clientSideRowModel/immutableService.ts
@@ -63,7 +63,7 @@ export class ImmutableService extends BeanStub implements NamedBean, IImmutableS
             return;
         }
 
-        const getRowIdFunc = this.gos.getCallback('getRowId');
+        const getRowIdFunc = this.gos.getRowIdCallback();
         if (getRowIdFunc == null) {
             console.error(
                 'AG Grid: ImmutableService requires getRowId() callback to be implemented, your row data needs IDs!'

--- a/community-modules/core/src/entities/rowNode.ts
+++ b/community-modules/core/src/entities/rowNode.ts
@@ -361,7 +361,7 @@ export class RowNode<TData = any> implements IEventEmitter<RowNodeEventType>, IR
 
     public setId(id?: string): void {
         // see if user is providing the id's
-        const getRowIdFunc = this.beans.gos.getCallback('getRowId');
+        const getRowIdFunc = this.beans.gos.getRowIdCallback();
 
         if (getRowIdFunc) {
             // if user is providing the id's, then we set the id only after the data has been set.

--- a/community-modules/core/src/entities/rowNode.ts
+++ b/community-modules/core/src/entities/rowNode.ts
@@ -378,13 +378,6 @@ export class RowNode<TData = any> implements IEventEmitter<RowNodeEventType>, IR
                     level: this.level,
                 });
 
-                if (typeof this.id !== 'string') {
-                    console.warn(
-                        `AG Grid: The getRowId callback must return a string. The ID ${this.id} is being cast to a string.`
-                    );
-                    this.id = String(this.id);
-                }
-
                 // make sure id provided doesn't start with 'row-group-' as this is reserved.
                 if (this.id.startsWith(RowNode.ID_PREFIX_ROW_GROUP)) {
                     console.error(

--- a/community-modules/core/src/entities/rowNode.ts
+++ b/community-modules/core/src/entities/rowNode.ts
@@ -377,20 +377,19 @@ export class RowNode<TData = any> implements IEventEmitter<RowNodeEventType>, IR
                     parentKeys: parentKeys.length > 0 ? parentKeys : undefined,
                     level: this.level,
                 });
-                // make sure id provided doesn't start with 'row-group-' as this is reserved. also check that
-                // it has 'startsWith' in case the user provided a number.
-                if (
-                    this.id !== null &&
-                    typeof this.id === 'string' &&
-                    this.id.startsWith(RowNode.ID_PREFIX_ROW_GROUP)
-                ) {
+
+                if (typeof this.id !== 'string') {
+                    console.warn(
+                        `AG Grid: The getRowId callback must return a string. The ID ${this.id} is being cast to a string.`
+                    );
+                    this.id = String(this.id);
+                }
+
+                // make sure id provided doesn't start with 'row-group-' as this is reserved.
+                if (this.id.startsWith(RowNode.ID_PREFIX_ROW_GROUP)) {
                     console.error(
                         `AG Grid: Row IDs cannot start with ${RowNode.ID_PREFIX_ROW_GROUP}, this is a reserved prefix for AG Grid's row grouping feature.`
                     );
-                }
-                // force id to be a string
-                if (this.id !== null && typeof this.id !== 'string') {
-                    this.id = '' + this.id;
                 }
             } else {
                 // this can happen if user has set blank into the rowNode after the row previously

--- a/community-modules/core/src/gridBodyComp/rowDragFeature.ts
+++ b/community-modules/core/src/gridBodyComp/rowDragFeature.ts
@@ -241,7 +241,7 @@ export class RowDragFeature extends BeanStub implements DropTarget {
             });
             this.moveRows(rowNodes!, pixel, increment);
         } else {
-            const getRowIdFunc = this.gos.getCallback('getRowId');
+            const getRowIdFunc = this.gos.getRowIdCallback();
 
             let addIndex = this.clientSideRowModel.getRowIndexAtPixel(pixel) + 1;
 
@@ -253,10 +253,7 @@ export class RowDragFeature extends BeanStub implements DropTarget {
                 add: rowNodes!
                     .map((node) => node.data)
                     .filter(
-                        (data) =>
-                            !this.clientSideRowModel.getRowNode(
-                                getRowIdFunc ? getRowIdFunc({ data, level: 0 }) : data.id
-                            )
+                        (data) => !this.clientSideRowModel.getRowNode(getRowIdFunc?.({ data, level: 0 }) ?? data.id)
                     ),
                 addIndex,
             });

--- a/community-modules/core/src/gridOptionsService.ts
+++ b/community-modules/core/src/gridOptionsService.ts
@@ -2,7 +2,7 @@ import { ComponentUtil } from './components/componentUtil';
 import type { NamedBean } from './context/bean';
 import { BeanStub } from './context/beanStub';
 import type { BeanCollection } from './context/context';
-import type { DomLayoutType, GridOptions } from './entities/gridOptions';
+import type { DomLayoutType, GetRowIdFunc, GridOptions } from './entities/gridOptions';
 import type { Environment } from './environment';
 import type { AgEvent, GridOptionsChangedEvent } from './events';
 import { ALWAYS_SYNC_GLOBAL_EVENTS } from './events';
@@ -589,5 +589,26 @@ export class GridOptionsService extends BeanStub implements NamedBean {
         updatedParams.api = this.api;
         updatedParams.context = this.gridOptionsContext;
         return updatedParams;
+    }
+
+    public getRowIdCallback<TData = any>(): WrappedCallback<'getRowId', GetRowIdFunc<TData> | undefined> {
+        const getRowId = this.getCallback('getRowId');
+
+        if (getRowId === undefined) {
+            return getRowId;
+        }
+
+        return (params) => {
+            let id = getRowId(params);
+
+            if (typeof id !== 'string') {
+                console.warn(
+                    `AG Grid: The getRowId callback must return a string. The ID ${id} is being cast to a string.`
+                );
+                id = String(id);
+            }
+
+            return id;
+        };
     }
 }

--- a/community-modules/core/src/pinnedRowModel/pinnedRowModel.ts
+++ b/community-modules/core/src/pinnedRowModel/pinnedRowModel.ts
@@ -109,7 +109,7 @@ export class PinnedRowModel extends BeanStub implements NamedBean {
     private createNodesFromData(allData: any[] | undefined, isTop: boolean): RowNode[] {
         const rowNodes: RowNode[] = [];
         if (allData) {
-            const getRowId = this.gos.getCallback('getRowId');
+            const getRowId = this.gos.getRowIdCallback();
             const idPrefix = isTop ? RowNode.ID_PREFIX_TOP_PINNED : RowNode.ID_PREFIX_BOTTOM_PINNED;
 
             let nextRowTop = 0;

--- a/community-modules/infinite-row-model/src/infiniteRowModel/infiniteRowModel.ts
+++ b/community-modules/infinite-row-model/src/infiniteRowModel/infiniteRowModel.ts
@@ -173,7 +173,7 @@ export class InfiniteRowModel extends BeanStub implements NamedBean, IInfiniteRo
         // if user is providing id's, then this means we can keep the selection between datasource hits,
         // as the rows will keep their unique id's even if, for example, server side sorting or filtering
         // is done.
-        const getRowIdFunc = this.gos.getCallback('getRowId');
+        const getRowIdFunc = this.gos.getRowIdCallback();
         const userGeneratingIds = getRowIdFunc != null;
 
         if (!userGeneratingIds) {

--- a/enterprise-modules/server-side-row-model/src/serverSideRowModel/stores/fullStore.ts
+++ b/enterprise-modules/server-side-row-model/src/serverSideRowModel/stores/fullStore.ts
@@ -294,7 +294,7 @@ export class FullStore extends RowNodeBlock implements IServerSideStore {
                 return undefined;
             }
 
-            const getRowIdFunc = this.gos.getCallback('getRowId');
+            const getRowIdFunc = this.gos.getRowIdCallback();
             if (!getRowIdFunc) {
                 return undefined;
             }
@@ -742,7 +742,7 @@ export class FullStore extends RowNodeBlock implements IServerSideStore {
     }
 
     private lookupRowNode(data: any): RowNode | null {
-        const getRowIdFunc = this.gos.getCallback('getRowId');
+        const getRowIdFunc = this.gos.getRowIdCallback();
 
         let rowNode: RowNode;
         if (getRowIdFunc != null) {

--- a/enterprise-modules/server-side-row-model/src/serverSideRowModel/stores/fullStore.ts
+++ b/enterprise-modules/server-side-row-model/src/serverSideRowModel/stores/fullStore.ts
@@ -744,31 +744,29 @@ export class FullStore extends RowNodeBlock implements IServerSideStore {
     private lookupRowNode(data: any): RowNode | null {
         const getRowIdFunc = this.gos.getRowIdCallback();
 
-        let rowNode: RowNode;
         if (getRowIdFunc != null) {
             // find rowNode using id
-            const level = this.level;
             const parentKeys = this.parentRowNode.getGroupKeys();
-            const id: string = getRowIdFunc({
+            const id = getRowIdFunc({
                 data,
                 parentKeys: parentKeys.length > 0 ? parentKeys : undefined,
-                level,
+                level: this.level,
             });
-            rowNode = this.allNodesMap[id];
+            const rowNode = this.allNodesMap[id];
             if (!rowNode) {
                 console.error(`AG Grid: could not find row id=${id}, data item was not found for this id`);
                 return null;
             }
+            return rowNode;
         } else {
             // find rowNode using object references
-            rowNode = this.allRowNodes.find((currentRowNode) => currentRowNode.data === data)!;
+            const rowNode = this.allRowNodes.find((currentRowNode) => currentRowNode.data === data)!;
             if (!rowNode) {
                 console.error(`AG Grid: could not find data item as object was not found`, data);
                 return null;
             }
+            return rowNode;
         }
-
-        return rowNode;
     }
 
     public addStoreStates(result: ServerSideGroupLevelState[]): void {

--- a/enterprise-modules/server-side-row-model/src/serverSideRowModel/stores/lazy/lazyCache.ts
+++ b/enterprise-modules/server-side-row-model/src/serverSideRowModel/stores/lazy/lazyCache.ts
@@ -615,12 +615,8 @@ export class LazyCache extends BeanStub {
         if (node.stub) {
             return false;
         }
-
-        if (this.getRowIdFunc != null) {
-            const id: string = this.getRowId(data)!;
-            return node.id === id;
-        }
-        return node.data === data;
+        const id = this.getRowId(data);
+        return id === null ? node.data === data : node.id === id;
     }
 
     /**

--- a/enterprise-modules/server-side-row-model/src/serverSideRowModel/stores/lazy/lazyCache.ts
+++ b/enterprise-modules/server-side-row-model/src/serverSideRowModel/stores/lazy/lazyCache.ts
@@ -117,7 +117,7 @@ export class LazyCache extends BeanStub {
         this.nodesToRefresh = new Set();
 
         this.defaultNodeIdPrefix = this.blockUtils.createNodeIdPrefix(this.store.getParentNode());
-        this.getRowIdFunc = this.gos.getCallback('getRowId');
+        this.getRowIdFunc = this.gos.getRowIdCallback();
         this.isMasterDetail = this.gos.get('masterDetail');
     }
 

--- a/enterprise-modules/server-side-row-model/src/serverSideRowModel/stores/lazy/lazyCache.ts
+++ b/enterprise-modules/server-side-row-model/src/serverSideRowModel/stores/lazy/lazyCache.ts
@@ -88,7 +88,7 @@ export class LazyCache extends BeanStub {
     /**
      * Grid options properties - stored locally for access speed.
      */
-    private getRowIdFunc?: (params: WithoutGridCommon<GetRowIdParams<any, any>>) => string;
+    private getRowIdFunc?: (params: WithoutGridCommon<GetRowIdParams>) => string;
     private isMasterDetail: boolean;
 
     /**
@@ -630,7 +630,7 @@ export class LazyCache extends BeanStub {
         const firstRow = this.rowRenderer.getFirstVirtualRenderedRow();
         const lastRow = this.rowRenderer.getLastVirtualRenderedRow();
         const firstRowBlockStart = this.getBlockStartIndex(firstRow);
-        const [_, lastRowBlockEnd] = this.getBlockBounds(lastRow);
+        const [, lastRowBlockEnd] = this.getBlockBounds(lastRow);
 
         this.nodeMap.forEach((lazyNode) => {
             // failed loads are still useful, so we don't purge them
@@ -969,7 +969,7 @@ export class LazyCache extends BeanStub {
         this.store.fireStoreUpdatedEvent();
     }
 
-    private getRowId(data: any) {
+    private getRowId(data: any): string | null {
         if (this.getRowIdFunc == null) {
             return null;
         }
@@ -977,7 +977,7 @@ export class LazyCache extends BeanStub {
         // find rowNode using id
         const { level } = this.store.getRowDetails();
         const parentKeys = this.store.getParentNode().getGroupKeys();
-        const id: string = this.getRowIdFunc({
+        return this.getRowIdFunc({
             data,
             parentKeys: parentKeys.length > 0 ? parentKeys : undefined,
             level,
@@ -1031,7 +1031,7 @@ export class LazyCache extends BeanStub {
 
         const updatedNodes: RowNode[] = [];
         updates.forEach((data) => {
-            const id: string = this.getRowId(data)!;
+            const id = this.getRowId(data);
             const lazyNode = this.nodeMap.getBy('id', id);
             if (lazyNode) {
                 this.blockUtils.updateDataIntoRowNode(lazyNode.node, data);

--- a/enterprise-modules/server-side-row-model/src/serverSideRowModel/stores/lazy/lazyCache.ts
+++ b/enterprise-modules/server-side-row-model/src/serverSideRowModel/stores/lazy/lazyCache.ts
@@ -978,7 +978,6 @@ export class LazyCache extends BeanStub {
             parentKeys: parentKeys.length > 0 ? parentKeys : undefined,
             level,
         });
-        return String(id);
     }
 
     public getOrderedNodeMap() {

--- a/enterprise-modules/server-side-row-model/src/serverSideRowModel/stores/lazy/lazyStore.ts
+++ b/enterprise-modules/server-side-row-model/src/serverSideRowModel/stores/lazy/lazyStore.ts
@@ -116,7 +116,7 @@ export class LazyStore extends BeanStub implements IServerSideStore {
      * @returns an object determining the status of this transaction and effected nodes
      */
     applyTransaction(transaction: ServerSideTransaction): ServerSideTransactionResult {
-        const idFunc = this.gos.getCallback('getRowId');
+        const idFunc = this.gos.getRowIdCallback();
         if (!idFunc) {
             console.warn(
                 'AG Grid: getRowId callback must be implemented for transactions to work. Transaction was ignored.'


### PR DESCRIPTION
See https://ag-grid.atlassian.net/browse/AG-9259

### Changes
- Introduce `GridOptionsService.getRowIdCallback` as a wrapper for `GridOptionsService.getCallback('getRowId')` which takes care of the logging and coercion of the ID to string
- Replace all calls to `.getCallback('getRowId')`
- **WARNING**: There's a behaviour change in this PR which IMO is a bugfix. Previously in [`RowNode.setId`](https://github.com/ag-grid/ag-grid/pull/8022/files#diff-d0c64a7a3232b7f4f9890f4a725b899809107fcb368720f1278839d5a6968f85L418-L421) we would only cast to string if the ID returned from the callback was non-`null`. We now cast to string whenever the return type is not "string". `RowNode.id` is typed as `string | undefined` anyway, so we shouldn't allow it to be `null`. The only thing this might break is if a user was relying on checking the `RowNode.id` in their application code and expecting to find a `null` value. I can revert to the existing behaviour if we don't want to risk this.
- Some light tidying