### PR TITLE
AG-7026 Allow getRowId to be called for pinned rows

### DIFF
--- a/community-modules/core/src/cellNavigationService.ts
+++ b/community-modules/core/src/cellNavigationService.ts
@@ -267,12 +267,12 @@ export class CellNavigationService extends BeanStub implements NamedBean {
         const index = rowPosition.rowIndex;
 
         if (pinned === 'top') {
-            const lastTopIndex = this.pinnedRowModel.getPinnedTopRowData().length - 1;
+            const lastTopIndex = this.pinnedRowModel.getPinnedTopRowNodes().length - 1;
             return lastTopIndex <= index;
         }
 
         if (pinned === 'bottom') {
-            const lastBottomIndex = this.pinnedRowModel.getPinnedBottomRowData().length - 1;
+            const lastBottomIndex = this.pinnedRowModel.getPinnedBottomRowNodes().length - 1;
             return lastBottomIndex <= index;
         }
 
@@ -346,7 +346,7 @@ export class CellNavigationService extends BeanStub implements NamedBean {
     }
 
     private getLastFloatingTopRow(): RowPosition {
-        const lastFloatingRow = this.pinnedRowModel.getPinnedTopRowData().length - 1;
+        const lastFloatingRow = this.pinnedRowModel.getPinnedTopRowNodes().length - 1;
 
         return { rowIndex: lastFloatingRow, rowPinned: 'top' } as RowPosition;
     }

--- a/community-modules/core/src/entities/rowPositionUtils.ts
+++ b/community-modules/core/src/entities/rowPositionUtils.ts
@@ -70,9 +70,9 @@ export class RowPositionUtils extends BeanStub implements NamedBean {
     public getRowNode(gridRow: RowPosition): RowNode | undefined {
         switch (gridRow.rowPinned) {
             case 'top':
-                return this.pinnedRowModel.getPinnedTopRowData()[gridRow.rowIndex];
+                return this.pinnedRowModel.getPinnedTopRowNodes()[gridRow.rowIndex];
             case 'bottom':
-                return this.pinnedRowModel.getPinnedBottomRowData()[gridRow.rowIndex];
+                return this.pinnedRowModel.getPinnedBottomRowNodes()[gridRow.rowIndex];
             default:
                 return this.rowModel.getRow(gridRow.rowIndex);
         }

--- a/community-modules/core/src/gridBodyComp/rowContainer/rowContainerEventsFeature.ts
+++ b/community-modules/core/src/gridBodyComp/rowContainer/rowContainerEventsFeature.ts
@@ -333,7 +333,7 @@ export class RowContainerEventsFeature extends BeanStub {
                 rowEnd = this.paginationProxy.getRowCount() - 1;
             } else {
                 floatingEnd = 'bottom';
-                rowEnd = pinnedRowModel.getPinnedBottomRowData().length - 1;
+                rowEnd = pinnedRowModel.getPinnedBottomRowNodes().length - 1;
             }
 
             const allDisplayedColumns = this.visibleColsService.getAllCols();

--- a/community-modules/core/src/pinnedRowModel/pinnedRowModel.ts
+++ b/community-modules/core/src/pinnedRowModel/pinnedRowModel.ts
@@ -114,13 +114,18 @@ export class PinnedRowModel extends BeanStub implements NamedBean {
     private createNodesFromData(allData: any[] | undefined, isTop: boolean): RowNode[] {
         const rowNodes: RowNode[] = [];
         if (allData) {
+            const getRowId = this.gos.get('getRowId');
+            const goContext = this.gos.get('context');
+            const idPrefix = isTop ? RowNode.ID_PREFIX_TOP_PINNED : RowNode.ID_PREFIX_BOTTOM_PINNED;
+
             let nextRowTop = 0;
             allData.forEach((dataItem: any, index: number) => {
                 const rowNode = new RowNode(this.beans);
                 rowNode.data = dataItem;
 
-                const idPrefix = isTop ? RowNode.ID_PREFIX_TOP_PINNED : RowNode.ID_PREFIX_BOTTOM_PINNED;
-                rowNode.id = idPrefix + index;
+                rowNode.id =
+                    getRowId?.({ data: dataItem, level: 0, api: this.beans.gridApi, context: goContext }) ??
+                    idPrefix + index;
 
                 rowNode.rowPinned = isTop ? 'top' : 'bottom';
                 rowNode.setRowTop(nextRowTop);

--- a/community-modules/core/src/pinnedRowModel/pinnedRowModel.ts
+++ b/community-modules/core/src/pinnedRowModel/pinnedRowModel.ts
@@ -114,8 +114,7 @@ export class PinnedRowModel extends BeanStub implements NamedBean {
     private createNodesFromData(allData: any[] | undefined, isTop: boolean): RowNode[] {
         const rowNodes: RowNode[] = [];
         if (allData) {
-            const getRowId = this.gos.get('getRowId');
-            const goContext = this.gos.get('context');
+            const getRowId = this.gos.getCallback('getRowId');
             const idPrefix = isTop ? RowNode.ID_PREFIX_TOP_PINNED : RowNode.ID_PREFIX_BOTTOM_PINNED;
 
             let nextRowTop = 0;
@@ -123,9 +122,7 @@ export class PinnedRowModel extends BeanStub implements NamedBean {
                 const rowNode = new RowNode(this.beans);
                 rowNode.data = dataItem;
 
-                rowNode.id =
-                    getRowId?.({ data: dataItem, level: 0, api: this.beans.gridApi, context: goContext }) ??
-                    idPrefix + index;
+                rowNode.id = getRowId?.({ data: dataItem, level: 0 }) ?? idPrefix + index;
 
                 rowNode.rowPinned = isTop ? 'top' : 'bottom';
                 rowNode.setRowTop(nextRowTop);

--- a/community-modules/core/src/pinnedRowModel/pinnedRowModel.ts
+++ b/community-modules/core/src/pinnedRowModel/pinnedRowModel.ts
@@ -138,11 +138,11 @@ export class PinnedRowModel extends BeanStub implements NamedBean {
         return rowNodes;
     }
 
-    public getPinnedTopRowData(): RowNode[] {
+    public getPinnedTopRowNodes(): RowNode[] {
         return this.pinnedTopRows;
     }
 
-    public getPinnedBottomRowData(): RowNode[] {
+    public getPinnedBottomRowNodes(): RowNode[] {
         return this.pinnedBottomRows;
     }
 

--- a/community-modules/core/src/rendering/rowRenderer.ts
+++ b/community-modules/core/src/rendering/rowRenderer.ts
@@ -449,9 +449,9 @@ export class RowRenderer extends BeanStub implements NamedBean {
     }
 
     public refreshFloatingRowComps(): void {
-        this.refreshFloatingRows(this.topRowCtrls, this.pinnedRowModel.getPinnedTopRowData());
+        this.refreshFloatingRows(this.topRowCtrls, this.pinnedRowModel.getPinnedTopRowNodes());
 
-        this.refreshFloatingRows(this.bottomRowCtrls, this.pinnedRowModel.getPinnedBottomRowData());
+        this.refreshFloatingRows(this.bottomRowCtrls, this.pinnedRowModel.getPinnedBottomRowNodes());
     }
 
     public getTopRowCtrls(): RowCtrl[] {

--- a/community-modules/core/src/rendering/rowRenderer.ts
+++ b/community-modules/core/src/rendering/rowRenderer.ts
@@ -526,7 +526,7 @@ export class RowRenderer extends BeanStub implements NamedBean {
             this.cachedRowCtrls.removeRow(rowNode);
             return;
         } else {
-            const destroyAndRecreateCtrl = (dataStruct: RowCtrl[] | { [idx: number]: RowCtrl }) => {
+            const destroyAndRecreateCtrl = (dataStruct: RowCtrl[] | RowCtrlByRowIndex) => {
                 const ctrl = dataStruct[rowNode.rowIndex!];
                 if (!ctrl) {
                     return;

--- a/community-modules/core/src/rendering/rowRenderer.ts
+++ b/community-modules/core/src/rendering/rowRenderer.ts
@@ -602,14 +602,14 @@ export class RowRenderer extends BeanStub implements NamedBean {
     private redrawAfterModelUpdate(params: RefreshViewParams = {}): void {
         this.getLockOnRefresh();
 
-        const focusedCell: CellPosition | null = this.getCellToRestoreFocusToAfterRefresh(params);
+        const focusedCell = this.getCellToRestoreFocusToAfterRefresh(params);
 
         this.updateContainerHeights();
         this.scrollToTopIfNewData(params);
 
         // never recycle rows on layout change as rows could change from normal DOM layout
         // back to the grid's row positioning.
-        const recycleRows: boolean = !params.domLayoutChanged && !!params.recycleRows;
+        const recycleRows = !params.domLayoutChanged && !!params.recycleRows;
         const animate = params.animate && this.gos.isAnimateRows();
 
         // after modelUpdate, row indexes can change, so we clear out the rowsByIndex map,
@@ -961,7 +961,7 @@ export class RowRenderer extends BeanStub implements NamedBean {
     private getRowsToRecycle(): RowCtrlByRowNodeIdMap {
         // remove all stub nodes, they can't be reused, as no rowNode id
         const stubNodeIndexes: string[] = [];
-        _iterateObject(this.rowCtrlsByRowIndex, (index: string, rowCtrl: RowCtrl) => {
+        _iterateObject(this.rowCtrlsByRowIndex, (index, rowCtrl) => {
             const stubNode = rowCtrl.getRowNode().id == null;
             if (stubNode) {
                 stubNodeIndexes.push(index);
@@ -971,7 +971,7 @@ export class RowRenderer extends BeanStub implements NamedBean {
 
         // then clear out rowCompsByIndex, but before that take a copy, but index by id, not rowIndex
         const ctrlsByIdMap: RowCtrlByRowNodeIdMap = {};
-        _iterateObject(this.rowCtrlsByRowIndex, (index: string, rowCtrl: RowCtrl) => {
+        _iterateObject(this.rowCtrlsByRowIndex, (_, rowCtrl) => {
             const rowNode = rowCtrl.getRowNode();
             ctrlsByIdMap[rowNode.id!] = rowCtrl;
         });


### PR DESCRIPTION
See https://ag-grid.atlassian.net/browse/AG-7026

### Changes
- Call `getRowId` if it's defined when setting the `RowNode.id` of pinned rows in the `pinnedRowModel`
  - I don't think we ever rely on pinned rows having a specific prefix, so I think this is a safe change.
- Add recycling logic to refresh checks in `RowRenderer` specifically for pinned rows. This addresses TC2 in the issue
- Tidying:
  - Renames `PinnedRowModel.getPinned[Top|Bottom]RowData` to `PinnedRowModel.getPinned[Top|Bottom]RowNodes` to better reflect the signature
  - Removes some type annotations that are inferred

This should probably be merged after #8022 and also then be updated to use the new `getRowIdCallback` method that it introduces.

### Question
- What is the reason for `RowCtrl.rowId` being an HTML escaped version of `RowNode.id`?