### PR TITLE
Fix regex to avoid matching multiple script tags

### DIFF
--- a/external/ag-website-shared/src/utils/cleanIndexHtml.ts
+++ b/external/ag-website-shared/src/utils/cleanIndexHtml.ts
@@ -6,5 +6,5 @@ function replaceUrlPrefixWithWindowLocation(text: string) {
 }
 
 export const cleanIndexHtml = (htmlFile: string) => {
-    return replaceUrlPrefixWithWindowLocation(htmlFile).replace(/<script.*\/@vite\/client"><\/script>/g, '');
+    return replaceUrlPrefixWithWindowLocation(htmlFile).replace(/<script([^<]*)\/@vite\/client"><\/script>/g, '');
 };


### PR DESCRIPTION
The existing regex was matching any script tags immediately before the vite script tag so would also remove anything included under "extras", for example, `alasql`, which in turn breaks the SSRM plunkr examples.

This code path is only active is dev mode.