### PR TITLE
AG-9259 Fix usage of getRowId in examples

### DIFF
--- a/documentation/ag-grid-docs/src/components/automated-examples/examples/row-grouping/index.ts
+++ b/documentation/ag-grid-docs/src/components/automated-examples/examples/row-grouping/index.ts
@@ -105,9 +105,7 @@ const gridOptions: GridOptions = {
     enableCharts: true,
     enableRangeSelection: true,
     suppressAggFuncInHeader: true,
-    getRowId: (params) => {
-        return params.data.id;
-    },
+    getRowId: (params) => String(params.data.id),
     rowGroupPanelShow: 'always',
 };
 

--- a/documentation/ag-grid-docs/src/components/hero-grid/heroGrid.ts
+++ b/documentation/ag-grid-docs/src/components/hero-grid/heroGrid.ts
@@ -37,9 +37,7 @@ const gridOptions: GridOptions = {
     headerHeight: 30,
     domLayout: 'autoHeight',
     animateRows: false,
-    getRowId: ({ data }: GetRowIdParams) => {
-        return data.stock;
-    },
+    getRowId: ({ data }: GetRowIdParams) => String(data.stock),
     onGridSizeChanged(params: GridSizeChangedEvent) {
         const columnsToShow: string[] = [];
         const columnsToHide: string[] = [];

--- a/documentation/ag-grid-docs/src/content/docs/change-detection/_examples/change-detection-delta-aggregation/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/change-detection/_examples/change-detection-delta-aggregation/main.ts
@@ -69,9 +69,7 @@ const gridOptions: GridOptions = {
     },
     groupDefaultExpanded: 1,
     suppressAggFuncInHeader: true,
-    getRowId: (params: GetRowIdParams) => {
-        return params.data.id;
-    },
+    getRowId: (params: GetRowIdParams) => String(params.data.id),
     onGridReady: (params) => {
         params.api.setGridOption('rowData', createRowData());
     },

--- a/documentation/ag-grid-docs/src/content/docs/change-detection/_examples/change-detection-pivot/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/change-detection/_examples/change-detection-pivot/main.ts
@@ -44,9 +44,7 @@ const gridOptions: GridOptions = {
     rowData: getRowData(),
     pivotMode: true,
     groupDefaultExpanded: 1,
-    getRowId: (params: GetRowIdParams) => {
-        return params.data.student;
-    },
+    getRowId: (params: GetRowIdParams) => String(params.data.student),
     onGridReady: (params: GridReadyEvent) => {
         (document.getElementById('pivot-mode') as HTMLInputElement).checked = true;
     },

--- a/documentation/ag-grid-docs/src/content/docs/clipboard/_examples/read-only-edit/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/clipboard/_examples/read-only-edit/main.ts
@@ -26,7 +26,7 @@ const gridOptions: GridOptions<IOlympicDataWithId> = {
         minWidth: 100,
         editable: true,
     },
-    getRowId: (params: GetRowIdParams) => params.data.id,
+    getRowId: (params: GetRowIdParams) => String(params.data.id),
 
     enableRangeSelection: true,
     readOnlyEdit: true,

--- a/documentation/ag-grid-docs/src/content/docs/data-update-high-frequency/_examples/async-transaction/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/data-update-high-frequency/_examples/async-transaction/main.ts
@@ -157,9 +157,7 @@ const gridOptions: GridOptions = {
     suppressAggFuncInHeader: true,
     rowGroupPanelShow: 'always',
     pivotPanelShow: 'always',
-    getRowId: (params: GetRowIdParams) => {
-        return params.data.trade;
-    },
+    getRowId: (params: GetRowIdParams) => String(params.data.trade),
     defaultColDef: {
         width: 120,
     },

--- a/documentation/ag-grid-docs/src/content/docs/data-update-high-frequency/_examples/flush-transactions/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/data-update-high-frequency/_examples/flush-transactions/main.ts
@@ -165,9 +165,7 @@ const gridOptions: GridOptions = {
     rowGroupPanelShow: 'always',
     pivotPanelShow: 'always',
     asyncTransactionWaitMillis: 4000,
-    getRowId: (params: GetRowIdParams) => {
-        return params.data.trade;
-    },
+    getRowId: (params: GetRowIdParams) => String(params.data.trade),
     defaultColDef: {
         width: 120,
     },

--- a/documentation/ag-grid-docs/src/content/docs/data-update-row-data/_examples/complex-immutable-store/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/data-update-row-data/_examples/complex-immutable-store/main.ts
@@ -312,9 +312,7 @@ const gridOptions: GridOptions = {
     rowData: globalRowData,
     suppressAggFuncInHeader: true,
     suppressRowClickSelection: true,
-    getRowId: (params: GetRowIdParams) => {
-        return params.data.trade;
-    },
+    getRowId: (params: GetRowIdParams) => String(params.data.trade),
     onGridReady: (params) => {
         createRowData();
         params.api.setGridOption('rowData', globalRowData);

--- a/documentation/ag-grid-docs/src/content/docs/data-update-row-data/_examples/complex-immutable-store/provided/modules/reactFunctional/index.jsx
+++ b/documentation/ag-grid-docs/src/content/docs/data-update-row-data/_examples/complex-immutable-store/provided/modules/reactFunctional/index.jsx
@@ -365,7 +365,7 @@ const GridExample = () => {
         };
     }, []);
     const getRowId = useCallback(function (params) {
-        return params.data.trade;
+        return String(params.data.trade);
     }, []);
 
     const updateData = useCallback(() => {

--- a/documentation/ag-grid-docs/src/content/docs/data-update-row-data/_examples/complex-immutable-store/provided/modules/reactFunctionalTs/index.tsx
+++ b/documentation/ag-grid-docs/src/content/docs/data-update-row-data/_examples/complex-immutable-store/provided/modules/reactFunctionalTs/index.tsx
@@ -371,7 +371,7 @@ const GridExample = () => {
         };
     }, []);
     const getRowId = useCallback(function (params: GetRowIdParams) {
-        return params.data.trade;
+        return String(params.data.trade);
     }, []);
 
     const updateData = useCallback(() => {

--- a/documentation/ag-grid-docs/src/content/docs/data-update-transactions/_examples/delta-sorting/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/data-update-transactions/_examples/delta-sorting/main.ts
@@ -32,7 +32,7 @@ const gridOptions: GridOptions = {
     },
     rowData: getRowData(100000),
     deltaSort: true,
-    getRowId: ({ data }: GetRowIdParams) => data.id,
+    getRowId: ({ data }: GetRowIdParams) => String(data.id),
 };
 
 function addDelta() {

--- a/documentation/ag-grid-docs/src/content/docs/data-update-transactions/_examples/small-changes-big-data/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/data-update-transactions/_examples/small-changes-big-data/main.ts
@@ -98,7 +98,7 @@ function getMyFilter(): IFilterType {
 var myFilter = getMyFilter();
 
 function getRowId(params: GetRowIdParams) {
-    return params.data.id;
+    return String(params.data.id);
 }
 
 function onBtDuplicate() {

--- a/documentation/ag-grid-docs/src/content/docs/data-update-transactions/_examples/suppress-update-model/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/data-update-transactions/_examples/suppress-update-model/main.ts
@@ -20,7 +20,7 @@ import { createDataItem, getData } from './data';
 ModuleRegistry.registerModules([ClientSideRowModelModule, RowGroupingModule]);
 
 function getRowId(params) {
-    return params.data.id;
+    return String(params.data.id);
 }
 
 let gridApi: GridApi;

--- a/documentation/ag-grid-docs/src/content/docs/filter-set-tree-list/_examples/sorting-tree-lists/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/filter-set-tree-list/_examples/sorting-tree-lists/main.ts
@@ -61,9 +61,7 @@ const gridOptions: GridOptions = {
     getDataPath: (data) => {
         return data.dataPath;
     },
-    getRowId: (params) => {
-        return params.data.employeeId;
-    },
+    getRowId: (params) => String(params.data.employeeId),
 };
 
 function arrayComparator(a: string[] | null, b: string[] | null): number {

--- a/documentation/ag-grid-docs/src/content/docs/integrated-charts-application-created/_examples/application-created-charts/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/integrated-charts-application-created/_examples/application-created-charts/main.ts
@@ -69,7 +69,7 @@ const gridOptions: GridOptions = {
     },
     enableCharts: true,
     suppressAggFuncInHeader: true,
-    getRowId: (params: GetRowIdParams) => params.data.trade,
+    getRowId: (params: GetRowIdParams) => String(params.data.trade),
     getChartToolbarItems: (): ChartToolbarMenuItemOptions[] => [],
     onFirstDataRendered,
 };

--- a/documentation/ag-grid-docs/src/content/docs/master-detail-grids/_examples/detail-grid-api/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/master-detail-grids/_examples/detail-grid-api/main.ts
@@ -46,7 +46,7 @@ const gridOptions: GridOptions<IAccount> = {
     } as IDetailCellRendererParams<IAccount, ICallRecord>,
     getRowId: (params: GetRowIdParams) => {
         // use 'account' as the row ID
-        return params.data.account;
+        return String(params.data.account);
     },
     defaultColDef: {
         flex: 1,

--- a/documentation/ag-grid-docs/src/content/docs/master-detail-master-rows/_examples/changing-dynamic-1/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/master-detail-master-rows/_examples/changing-dynamic-1/main.ts
@@ -31,9 +31,7 @@ const gridOptions: GridOptions = {
     defaultColDef: {
         flex: 1,
     },
-    getRowId: (params: GetRowIdParams) => {
-        return params.data.account;
-    },
+    getRowId: (params: GetRowIdParams) => String(params.data.account),
     detailCellRendererParams: {
         detailGridOptions: {
             columnDefs: [

--- a/documentation/ag-grid-docs/src/content/docs/master-detail-master-rows/_examples/changing-dynamic-2/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/master-detail-master-rows/_examples/changing-dynamic-2/main.ts
@@ -33,9 +33,7 @@ const gridOptions: GridOptions = {
     defaultColDef: {
         flex: 1,
     },
-    getRowId: (params: GetRowIdParams) => {
-        return params.data.account;
-    },
+    getRowId: (params: GetRowIdParams) => String(params.data.account),
     detailCellRendererParams: {
         detailGridOptions: {
             columnDefs: [

--- a/documentation/ag-grid-docs/src/content/docs/master-detail-refresh/_examples/refresh-everything/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/master-detail-refresh/_examples/refresh-everything/main.ts
@@ -28,9 +28,7 @@ const gridOptions: GridOptions<IAccount> = {
         flex: 1,
         enableCellChangeFlash: true,
     },
-    getRowId: (params: GetRowIdParams) => {
-        return params.data.account;
-    },
+    getRowId: (params: GetRowIdParams) => String(params.data.account),
     masterDetail: true,
     detailCellRendererParams: {
         refreshStrategy: 'everything',

--- a/documentation/ag-grid-docs/src/content/docs/master-detail-refresh/_examples/refresh-everything/provided/modules/reactFunctional/index.jsx
+++ b/documentation/ag-grid-docs/src/content/docs/master-detail-refresh/_examples/refresh-everything/provided/modules/reactFunctional/index.jsx
@@ -34,16 +34,14 @@ const GridExample = () => {
         };
     }, []);
     const getRowId = useMemo(() => {
-        return (params) => params.data.account;
+        return (params) => String(params.data.account);
     }, []);
     const detailCellRendererParams = useMemo(() => {
         return {
             refreshStrategy: 'everything',
             detailGridOptions: {
                 rowSelection: 'multiple',
-                getRowId: (params) => {
-                    return params.data.callId;
-                },
+                getRowId: (params) => String(params.data.callId),
                 columnDefs: [
                     { field: 'callId', checkboxSelection: true },
                     { field: 'direction' },

--- a/documentation/ag-grid-docs/src/content/docs/master-detail-refresh/_examples/refresh-everything/provided/modules/reactFunctionalTs/index.tsx
+++ b/documentation/ag-grid-docs/src/content/docs/master-detail-refresh/_examples/refresh-everything/provided/modules/reactFunctionalTs/index.tsx
@@ -43,9 +43,7 @@ const GridExample = () => {
         };
     }, []);
     const getRowId = useMemo<GetRowIdFunc>(() => {
-        return (params: GetRowIdParams) => {
-            return params.data.account;
-        };
+        return (params: GetRowIdParams) => String(params.data.account);
     }, []);
     const detailCellRendererParams = useMemo(() => {
         return {

--- a/documentation/ag-grid-docs/src/content/docs/master-detail-refresh/_examples/refresh-nothing/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/master-detail-refresh/_examples/refresh-nothing/main.ts
@@ -28,9 +28,7 @@ const gridOptions: GridOptions<IAccount> = {
         flex: 1,
         enableCellChangeFlash: true,
     },
-    getRowId: (params: GetRowIdParams) => {
-        return params.data.account;
-    },
+    getRowId: (params: GetRowIdParams) => String(params.data.account),
     masterDetail: true,
     detailCellRendererParams: {
         refreshStrategy: 'nothing',
@@ -50,9 +48,7 @@ const gridOptions: GridOptions<IAccount> = {
 
         detailGridOptions: {
             rowSelection: 'multiple',
-            getRowId: (params: GetRowIdParams) => {
-                return params.data.callId;
-            },
+            getRowId: (params: GetRowIdParams) => String(params.data.callId),
             columnDefs: [
                 { field: 'callId', checkboxSelection: true },
                 { field: 'direction' },

--- a/documentation/ag-grid-docs/src/content/docs/master-detail-refresh/_examples/refresh-nothing/provided/modules/reactFunctional/index.jsx
+++ b/documentation/ag-grid-docs/src/content/docs/master-detail-refresh/_examples/refresh-nothing/provided/modules/reactFunctional/index.jsx
@@ -34,18 +34,14 @@ const GridExample = () => {
         };
     }, []);
     const getRowId = useMemo(() => {
-        return (params) => {
-            return params.data.account;
-        };
+        return (params) => String(params.data.account);
     }, []);
     const detailCellRendererParams = useMemo(() => {
         return {
             refreshStrategy: 'nothing',
             detailGridOptions: {
                 rowSelection: 'multiple',
-                getRowId: (params) => {
-                    return params.data.callId;
-                },
+                getRowId: (params) => String(params.data.callId),
                 columnDefs: [
                     { field: 'callId', checkboxSelection: true },
                     { field: 'direction' },

--- a/documentation/ag-grid-docs/src/content/docs/master-detail-refresh/_examples/refresh-nothing/provided/modules/reactFunctionalTs/index.tsx
+++ b/documentation/ag-grid-docs/src/content/docs/master-detail-refresh/_examples/refresh-nothing/provided/modules/reactFunctionalTs/index.tsx
@@ -42,19 +42,15 @@ const GridExample = () => {
             enableCellChangeFlash: true,
         };
     }, []);
-    const getRowId = useMemo<GetRowIdFunc>(() => {
-        return (params: GetRowIdParams) => {
-            return params.data.account;
-        };
+    const getRowId = useMemo(() => {
+        return (params: GetRowIdParams) => String(params.data.account);
     }, []);
     const detailCellRendererParams = useMemo(() => {
         return {
             refreshStrategy: 'nothing',
             detailGridOptions: {
                 rowSelection: 'multiple',
-                getRowId: (params: GetRowIdParams) => {
-                    return params.data.callId;
-                },
+                getRowId: (params) => String(params.data.callId),
                 columnDefs: [
                     { field: 'callId', checkboxSelection: true },
                     { field: 'direction' },

--- a/documentation/ag-grid-docs/src/content/docs/master-detail-refresh/_examples/refresh-nothing/provided/modules/reactFunctionalTs/index.tsx
+++ b/documentation/ag-grid-docs/src/content/docs/master-detail-refresh/_examples/refresh-nothing/provided/modules/reactFunctionalTs/index.tsx
@@ -50,7 +50,7 @@ const GridExample = () => {
             refreshStrategy: 'nothing',
             detailGridOptions: {
                 rowSelection: 'multiple',
-                getRowId: (params) => String(params.data.callId),
+                getRowId: (params: GetRowIdParams) => String(params.data.callId),
                 columnDefs: [
                     { field: 'callId', checkboxSelection: true },
                     { field: 'direction' },

--- a/documentation/ag-grid-docs/src/content/docs/master-detail-refresh/_examples/refresh-rows/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/master-detail-refresh/_examples/refresh-rows/main.ts
@@ -29,7 +29,7 @@ const gridOptions: GridOptions<IAccount> = {
         enableCellChangeFlash: true,
     },
     getRowId: (params: GetRowIdParams) => {
-        return params.data.account;
+        return String(params.data.account);
     },
     masterDetail: true,
     detailCellRendererParams: {
@@ -44,7 +44,7 @@ const gridOptions: GridOptions<IAccount> = {
         detailGridOptions: {
             rowSelection: 'multiple',
             getRowId: (params: GetRowIdParams) => {
-                return params.data.callId;
+                return String(params.data.callId);
             },
             columnDefs: [
                 { field: 'callId', checkboxSelection: true },

--- a/documentation/ag-grid-docs/src/content/docs/master-detail-refresh/_examples/refresh-rows/provided/modules/reactFunctional/index.jsx
+++ b/documentation/ag-grid-docs/src/content/docs/master-detail-refresh/_examples/refresh-rows/provided/modules/reactFunctional/index.jsx
@@ -34,7 +34,7 @@ const GridExample = () => {
         };
     }, []);
     const getRowId = useCallback(function (params) {
-        return params.data.account;
+        return String(params.data.account);
     }, []);
     const detailCellRendererParams = useMemo(() => {
         return {
@@ -42,7 +42,7 @@ const GridExample = () => {
             detailGridOptions: {
                 rowSelection: 'multiple',
                 getRowId: (params) => {
-                    return params.data.callId;
+                    return String(params.data.callId);
                 },
                 columnDefs: [
                     { field: 'callId', checkboxSelection: true },

--- a/documentation/ag-grid-docs/src/content/docs/master-detail-refresh/_examples/refresh-rows/provided/modules/reactFunctionalTs/index.tsx
+++ b/documentation/ag-grid-docs/src/content/docs/master-detail-refresh/_examples/refresh-rows/provided/modules/reactFunctionalTs/index.tsx
@@ -41,7 +41,7 @@ const GridExample = () => {
         };
     }, []);
     const getRowId = useCallback(function (params: GetRowIdParams) {
-        return params.data.account;
+        return String(params.data.account);
     }, []);
     const detailCellRendererParams = useMemo(() => {
         return {
@@ -49,7 +49,7 @@ const GridExample = () => {
             detailGridOptions: {
                 rowSelection: 'multiple',
                 getRowId: (params: GetRowIdParams) => {
-                    return params.data.callId;
+                    return String(params.data.callId);
                 },
                 columnDefs: [
                     { field: 'callId', checkboxSelection: true },

--- a/documentation/ag-grid-docs/src/content/docs/range-selection-fill-handle/_examples/read-only-edit/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/range-selection-fill-handle/_examples/read-only-edit/main.ts
@@ -26,7 +26,7 @@ const gridOptions: GridOptions<IOlympicDataWithId> = {
         editable: true,
         cellDataType: false,
     },
-    getRowId: (params: GetRowIdParams) => params.data.id,
+    getRowId: (params: GetRowIdParams) => String(params.data.id),
     enableRangeSelection: true,
     enableFillHandle: true,
     readOnlyEdit: true,

--- a/documentation/ag-grid-docs/src/content/docs/row-dragging-to-external-dropzone/_examples/two-grids/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/row-dragging-to-external-dropzone/_examples/two-grids/main.ts
@@ -40,7 +40,7 @@ var leftGridOptions: GridOptions = {
         'blue-row': 'data.color == "Blue"',
     },
     getRowId: (params: GetRowIdParams) => {
-        return params.data.id;
+        return String(params.data.id);
     },
     rowData: createLeftRowData(),
     rowDragManaged: true,
@@ -64,7 +64,7 @@ var rightGridOptions: GridOptions = {
         'blue-row': 'data.color == "Blue"',
     },
     getRowId: (params: GetRowIdParams) => {
-        return params.data.id;
+        return String(params.data.id);
     },
     rowData: [],
     rowDragManaged: true,

--- a/documentation/ag-grid-docs/src/content/docs/row-dragging-to-external-dropzone/_examples/two-grids/provided/modules/reactFunctional/index.jsx
+++ b/documentation/ag-grid-docs/src/content/docs/row-dragging-to-external-dropzone/_examples/two-grids/provided/modules/reactFunctional/index.jsx
@@ -56,7 +56,7 @@ const GridExample = () => {
         setLeftRowData(createLeftRowData());
     }, [createDataItem]);
 
-    const getRowId = (params) => params.data.id;
+    const getRowId = (params) => String(params.data.id);
 
     const addRecordToGrid = (side, data) => {
         // if data missing or data has no it, do nothing

--- a/documentation/ag-grid-docs/src/content/docs/row-dragging-to-external-dropzone/_examples/two-grids/provided/modules/reactFunctionalTs/index.tsx
+++ b/documentation/ag-grid-docs/src/content/docs/row-dragging-to-external-dropzone/_examples/two-grids/provided/modules/reactFunctionalTs/index.tsx
@@ -68,7 +68,7 @@ const GridExample = () => {
         setLeftRowData(createLeftRowData());
     }, [createDataItem]);
 
-    const getRowId = (params: GetRowIdParams) => params.data.id;
+    const getRowId = (params: GetRowIdParams) => String(params.data.id);
 
     const addRecordToGrid = (side: string, data: any) => {
         // if data missing or data has no it, do nothing

--- a/documentation/ag-grid-docs/src/content/docs/row-dragging-to-grid/_examples/two-grids-with-drop-position/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/row-dragging-to-grid/_examples/two-grids-with-drop-position/main.ts
@@ -41,7 +41,7 @@ var leftGridOptions: GridOptions = {
         'blue-row': 'data.color == "Blue"',
     },
     getRowId: (params: GetRowIdParams) => {
-        return params.data.id;
+        return String(params.data.id);
     },
     rowData: createRowBlock(2),
     rowDragManaged: true,
@@ -65,7 +65,7 @@ var rightGridOptions: GridOptions = {
         'blue-row': 'data.color == "Blue"',
     },
     getRowId: (params: GetRowIdParams) => {
-        return params.data.id;
+        return String(params.data.id);
     },
     rowData: createRowBlock(2),
     rowDragManaged: true,

--- a/documentation/ag-grid-docs/src/content/docs/row-dragging-to-grid/_examples/two-grids-with-drop-position/provided/modules/reactFunctional/index.jsx
+++ b/documentation/ag-grid-docs/src/content/docs/row-dragging-to-grid/_examples/two-grids-with-drop-position/provided/modules/reactFunctional/index.jsx
@@ -61,7 +61,7 @@ const GridExample = () => {
         setRightRowData(createRowBlock(2));
     }, [createDataItem]);
 
-    const getRowId = (params) => params.data.id;
+    const getRowId = (params) => String(params.data.id);
 
     const addRecordToGrid = (side, data) => {
         // if data missing or data has no it, do nothing

--- a/documentation/ag-grid-docs/src/content/docs/row-dragging-to-grid/_examples/two-grids-with-drop-position/provided/modules/reactFunctionalTs/index.tsx
+++ b/documentation/ag-grid-docs/src/content/docs/row-dragging-to-grid/_examples/two-grids-with-drop-position/provided/modules/reactFunctionalTs/index.tsx
@@ -75,7 +75,7 @@ const GridExample = () => {
         setRightRowData(createRowBlock(2));
     }, [createDataItem]);
 
-    const getRowId = (params: GetRowIdParams) => params.data.id;
+    const getRowId = (params: GetRowIdParams) => String(params.data.id);
 
     const addRecordToGrid = (side: string, data: any) => {
         // if data missing or data has no it, do nothing

--- a/documentation/ag-grid-docs/src/content/docs/row-dragging/_examples/dragging-with-tree-data/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/row-dragging/_examples/dragging-with-tree-data/main.ts
@@ -67,7 +67,7 @@ const gridOptions: GridOptions = {
         return data.filePath;
     },
     getRowId: (params: GetRowIdParams) => {
-        return params.data.id;
+        return String(params.data.id);
     },
     autoGroupColumnDef: {
         rowDrag: true,

--- a/documentation/ag-grid-docs/src/content/docs/row-dragging/_examples/highlighting-drag-tree-data/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/row-dragging/_examples/highlighting-drag-tree-data/main.ts
@@ -81,7 +81,7 @@ const gridOptions: GridOptions = {
         return data.filePath;
     },
     getRowId: (params: GetRowIdParams) => {
-        return params.data.id;
+        return String(params.data.id);
     },
     autoGroupColumnDef: {
         rowDrag: true,

--- a/documentation/ag-grid-docs/src/content/docs/row-dragging/_examples/simple-unmanaged/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/row-dragging/_examples/simple-unmanaged/main.ts
@@ -67,7 +67,7 @@ function onFilterChanged() {
 }
 
 function getRowId(params: GetRowIdParams) {
-    return params.data.id;
+    return String(params.data.id);
 }
 
 function onRowDragMove(event: RowDragMoveEvent) {

--- a/documentation/ag-grid-docs/src/content/docs/row-ids/_examples/get-row-id/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/row-ids/_examples/get-row-id/main.ts
@@ -29,7 +29,7 @@ const gridOptions: GridOptions = {
         flex: 1,
     },
     rowData: rowData,
-    getRowId: (params: GetRowIdParams) => params.data.id,
+    getRowId: (params: GetRowIdParams) => String(params.data.id),
 };
 
 // setup the grid after the page has finished loading

--- a/documentation/ag-grid-docs/src/content/docs/row-ids/_examples/row-node/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/row-ids/_examples/row-node/main.ts
@@ -52,7 +52,7 @@ const gridOptions: GridOptions = {
     },
     rowData: rowData,
     rowSelection: 'multiple',
-    getRowId: (params: GetRowIdParams) => params.data.id,
+    getRowId: (params: GetRowIdParams) => String(params.data.id),
 };
 
 // setup the grid after the page has finished loading

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-selection/_examples/group-selects-children-transactions/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-selection/_examples/group-selects-children-transactions/main.ts
@@ -50,7 +50,7 @@ const gridOptions: GridOptions = {
         if (params.level === 0) {
             return params.data.portfolio;
         }
-        return params.data.tradeId;
+        return String(params.data.tradeId);
     },
     onGridReady: (params: GridReadyEvent) => {
         // setup the fake server

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-updating-transactions/_examples/transactions-grouping/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-updating-transactions/_examples/transactions-grouping/main.ts
@@ -46,7 +46,7 @@ const gridOptions: GridOptions = {
         if (params.level === 0) {
             return params.data.portfolio;
         }
-        return params.data.tradeId;
+        return String(params.data.tradeId);
     },
     onGridReady: (params: GridReadyEvent) => {
         // setup the fake server

--- a/documentation/ag-grid-docs/src/content/docs/tree-data/_examples/file-browser/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/tree-data/_examples/file-browser/main.ts
@@ -56,7 +56,7 @@ const gridOptions: GridOptions = {
         return data.filePath;
     },
     getRowId: (params: GetRowIdParams) => {
-        return params.data.id;
+        return String(params.data.id);
     },
 };
 

--- a/documentation/ag-grid-docs/src/content/docs/tree-data/_examples/group-agg-filtering/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/tree-data/_examples/group-agg-filtering/main.ts
@@ -58,7 +58,7 @@ const gridOptions: GridOptions = {
         return data.filePath;
     },
     getRowId: (params: GetRowIdParams) => {
-        return params.data.id;
+        return String(params.data.id);
     },
     groupAggFiltering: true,
 };

--- a/documentation/ag-grid-docs/src/content/docs/tree-data/_examples/tree-list-filtering/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/tree-data/_examples/tree-list-filtering/main.ts
@@ -60,7 +60,7 @@ const gridOptions: GridOptions = {
     treeData: true,
     groupDefaultExpanded: -1,
     getDataPath: (data: any) => data.dataPath,
-    getRowId: (params: GetRowIdParams<any>) => params.data.employeeId,
+    getRowId: (params: GetRowIdParams<any>) => String(params.data.employeeId),
 };
 
 function processData(data: any[]) {

--- a/documentation/ag-grid-docs/src/content/docs/value-cache/_examples/expiring-through-editing/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/value-cache/_examples/expiring-through-editing/main.ts
@@ -85,7 +85,7 @@ const gridOptions: GridOptions = {
     groupDefaultExpanded: 1,
     valueCache: true,
     getRowId: (params: GetRowIdParams) => {
-        return params.data.id;
+        return String(params.data.id);
     },
     onCellValueChanged: () => {
         console.log('onCellValueChanged');

--- a/documentation/ag-grid-docs/src/content/docs/value-cache/_examples/never-expire/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/value-cache/_examples/never-expire/main.ts
@@ -92,7 +92,7 @@ const gridOptions: GridOptions = {
     suppressAggFuncInHeader: true,
     groupDefaultExpanded: 1,
     getRowId: (params: GetRowIdParams) => {
-        return params.data.id;
+        return String(params.data.id);
     },
     onCellValueChanged: () => {
         console.log('onCellValueChanged');

--- a/documentation/ag-grid-docs/src/content/docs/value-cache/_examples/value-cache/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/value-cache/_examples/value-cache/main.ts
@@ -71,7 +71,7 @@ const gridOptions: GridOptions = {
     suppressAggFuncInHeader: true,
     groupDefaultExpanded: 1,
     getRowId: (params: GetRowIdParams) => {
-        return params.data.id;
+        return String(params.data.id);
     },
     onCellValueChanged: () => {
         console.log('onCellValueChanged');

--- a/documentation/ag-grid-docs/src/content/docs/value-setters/_examples/read-only-row-data/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/value-setters/_examples/read-only-row-data/main.ts
@@ -24,7 +24,7 @@ const gridOptions: GridOptions<IOlympicDataWithId> = {
         minWidth: 100,
         editable: true,
     },
-    getRowId: (params: GetRowIdParams) => params.data.id,
+    getRowId: (params: GetRowIdParams) => String(params.data.id),
     readOnlyEdit: true,
     onCellEditRequest: onCellEditRequest,
 };


### PR DESCRIPTION
The examples were triggering lots of warnings. My original PR #8022 should also have used `_warnOnce` but this was fixed by https://github.com/ag-grid/ag-grid/pull/8074