### PR TITLE
AG-11444 Add "randomisation" to skeleton widths

### DIFF
--- a/community-modules/core/src/rendering/cellRenderers/skeletonCellRenderer.ts
+++ b/community-modules/core/src/rendering/cellRenderers/skeletonCellRenderer.ts
@@ -13,7 +13,7 @@ export class SkeletonCellRenderer extends Component implements ILoadingCellRende
         this.addDestroyFunc(() => _setAriaLabelledBy(params.eParentOfValue));
         _setAriaLabelledBy(params.eParentOfValue, id);
 
-        params.node.failedLoad ? this.setupFailed() : this.setupLoading();
+        params.node.failedLoad ? this.setupFailed() : this.setupLoading(params);
     }
 
     private setupFailed(): void {
@@ -24,10 +24,22 @@ export class SkeletonCellRenderer extends Component implements ILoadingCellRende
         _setAriaLabel(this.getGui(), ariaFailed);
     }
 
-    private setupLoading(): void {
+    private setupLoading(params: ILoadingCellRendererParams): void {
         const eDocument = this.gos.getDocument();
         const skeletonEffect = eDocument.createElement('div');
         skeletonEffect.classList.add('ag-skeleton-effect');
+
+        // AG-11444 Use the row index to derive a width value for the skeleton cell
+        // to avoid them having uniform width when rendering
+        const rowIndex = params.node.rowIndex;
+        if (rowIndex != null) {
+            // Base value of 75% with variation between [-25%, 25%]. We alternate between sin and
+            // cos to achieve a semi-random appearance without actually needing a random number.
+            // We avoid using random numbers because then skeletons have consistent widths after
+            // being scrolled on and off screen.
+            const width = 75 + 25 * (rowIndex % 2 === 0 ? Math.sin(rowIndex) : Math.cos(rowIndex));
+            skeletonEffect.style.width = `${width}%`;
+        }
 
         this.getGui().appendChild(skeletonEffect);
 


### PR DESCRIPTION
Adds variation to the skeleton cell widths to avoid them all looking uniform.

![Screenshot 2024-06-18 at 15 20 18](https://github.com/ag-grid/ag-grid/assets/12719553/92fd205f-e7ba-4dd1-90f9-2e2d86df6e7f)
