### PR TITLE
AG-11087 Fix(QA) shift selecting on a collapsed group node

### DIFF
--- a/community-modules/core/src/selection/selectionService.ts
+++ b/community-modules/core/src/selection/selectionService.ts
@@ -129,8 +129,6 @@ export class SelectionService extends BeanStub implements NamedBean, ISelectionS
             // trying to set it to true / false. this group will be calculated further on
             // down when we call updateGroupsFromChildrenSelections(). we need to skip it
             // here, otherwise the updatedCount would include it.
-            // (note: `hasChildren` is used in the tree data case as `RowNode.group` isn't
-            // set correctly on rows with user data)
             const skipThisNode = groupSelectsFiltered && node.group;
 
             if (!skipThisNode) {

--- a/enterprise-modules/server-side-row-model/src/serverSideRowModel/services/selection/strategies/groupSelectsChildrenStrategy.ts
+++ b/enterprise-modules/server-side-row-model/src/serverSideRowModel/services/selection/strategies/groupSelectsChildrenStrategy.ts
@@ -218,7 +218,12 @@ export class GroupSelectsChildrenStrategy extends BeanStub implements ISelection
 
     private selectRange(nodes: RowNode[], newValue: boolean) {
         // sort routes longest to shortest, meaning we can do the lowest level children first
-        const routes = nodes.map(this.getRouteToNode).sort((a, b) => a.length - b.length);
+        const routes = nodes
+            // we ignore nodes that represent expanded groups, since their selection state
+            // should be based on the state of their children
+            .filter((node) => (node.group ? !node.expanded : true))
+            .map(this.getRouteToNode)
+            .sort((a, b) => a.length - b.length);
 
         // keep track of nodes we've seen so we can skip branches we've visited already
         const seen = new Set<RowNode>();

--- a/enterprise-modules/server-side-row-model/src/serverSideRowModel/services/selection/strategies/groupSelectsChildrenStrategy.ts
+++ b/enterprise-modules/server-side-row-model/src/serverSideRowModel/services/selection/strategies/groupSelectsChildrenStrategy.ts
@@ -218,12 +218,7 @@ export class GroupSelectsChildrenStrategy extends BeanStub implements ISelection
 
     private selectRange(nodes: RowNode[], newValue: boolean) {
         // sort routes longest to shortest, meaning we can do the lowest level children first
-        const routes = nodes
-            // we ignore nodes that represent expanded groups, since their selection state
-            // should be based on the state of their children
-            .filter((node) => (node.group ? !node.expanded : true))
-            .map(this.getRouteToNode)
-            .sort((a, b) => a.length - b.length);
+        const routes = nodes.map(this.getRouteToNode).sort((a, b) => b.length - a.length);
 
         // keep track of nodes we've seen so we can skip branches we've visited already
         const seen = new Set<RowNode>();


### PR DESCRIPTION
My initial PR (https://github.com/ag-grid/ag-grid/pull/8055) incorrectly preserved the `.sort` call (see [L163](https://github.com/ag-grid/ag-grid/pull/8055/files#diff-f227c6434da8ec06ad2747ca7b44c53b072b5f3fa36218829f68fde0756b52e1L163) vs [L221](https://github.com/ag-grid/ag-grid/pull/8055/files#diff-f227c6434da8ec06ad2747ca7b44c53b072b5f3fa36218829f68fde0756b52e1R221))