### PR TITLE
[AG-11710] Add a context property to column definitions to support custom meta-data on the column-level

### DIFF
--- a/community-modules/core/src/entities/colDef.ts
+++ b/community-modules/core/src/entities/colDef.ts
@@ -57,7 +57,7 @@ export interface AbstractColDef<TData = any, TValue = any> {
     cellAriaRole?: string;
 
     /**
-     * Provides a context object that is provided to different callbacks the column uses. Used for passing additional information to the callbacks by your application.
+     * Context property can be used to associate arbitrary application data with this column definition.
      */
     context?: any;
 }

--- a/community-modules/core/src/entities/colDef.ts
+++ b/community-modules/core/src/entities/colDef.ts
@@ -59,7 +59,7 @@ export interface AbstractColDef<TData = any, TValue = any> {
     /**
      * Provides a context object that is provided to different callbacks the column uses. Used for passing additional information to the callbacks by your application.
      */
-    colContext?: any;
+    context?: any;
 }
 
 /** Configuration options for column groups in AG Grid.  */

--- a/community-modules/core/src/entities/colDef.ts
+++ b/community-modules/core/src/entities/colDef.ts
@@ -55,6 +55,11 @@ export interface AbstractColDef<TData = any, TValue = any> {
      * @default 'gridcell'
      */
     cellAriaRole?: string;
+
+    /**
+     * Provides a context object that is provided to different callbacks the column uses. Used for passing additional information to the callbacks by your application.
+     */
+    colContext?: any;
 }
 
 /** Configuration options for column groups in AG Grid.  */

--- a/community-modules/core/src/entities/colDef.ts
+++ b/community-modules/core/src/entities/colDef.ts
@@ -57,7 +57,7 @@ export interface AbstractColDef<TData = any, TValue = any> {
     cellAriaRole?: string;
 
     /**
-     * Context property can be used to associate arbitrary application data with this column definition.
+     * Context property that can be used to associate arbitrary application data with this column definition.
      */
     context?: any;
 }

--- a/community-modules/core/src/gridOptionsService.ts
+++ b/community-modules/core/src/gridOptionsService.ts
@@ -6,7 +6,7 @@ import type { BeanCollection } from './context/context';
 import type { DomLayoutType, GetRowIdFunc, GridOptions } from './entities/gridOptions';
 import type { Environment } from './environment';
 import type { AgEventType } from './eventTypes';
-import type { AgEvent, GridOptionsChangedEvent } from './events';
+import type { AgEvent } from './events';
 import { ALWAYS_SYNC_GLOBAL_EVENTS } from './events';
 import type {
     GetGroupAggFilteringParams,

--- a/community-modules/core/src/interfaces/iCommon.ts
+++ b/community-modules/core/src/interfaces/iCommon.ts
@@ -4,7 +4,7 @@ import type { GridApi } from '../api/gridApi';
  * Enables types safe create of the given type without the need to set the common grid properties
  * that will be merged with the object in a centralised location.
  */
-export type WithoutGridCommon<T extends AgGridCommon<any, any>> = Omit<T, keyof AgGridCommon<any, any>>;
+export type WithoutGridCommon<T> = Omit<T, keyof AgGridCommon<any, any>>;
 
 export interface AgGridCommon<TData, TContext> {
     /** The grid api. */

--- a/community-modules/core/src/propertyKeys.ts
+++ b/community-modules/core/src/propertyKeys.ts
@@ -391,8 +391,7 @@ export class PropertyKeys {
     // If property does not fit above, i.e union that should not be coerced.
     public static OTHER_PROPERTIES: GridOptionKey[] = ['suppressStickyTotalRow'];
 
-    /** You do not need to include event callbacks in this list, as they are generated automatically. */
-    public static FUNCTIONAL_PROPERTIES: FunctionKeys[] = [
+    public static FUNCTION_PROPERTIES: (CallbackKeys | FunctionKeys)[] = [
         'doesExternalFilterPass',
         'processPivotResultColDef',
         'processPivotResultColGroupDef',
@@ -407,10 +406,6 @@ export class PropertyKeys {
         'detailCellRenderer',
         'quickFilterParser',
         'quickFilterMatcher',
-    ];
-
-    /** These callbacks extend AgGridCommon interface */
-    public static CALLBACK_PROPERTIES: CallbackKeys[] = [
         'getLocaleText',
         'isExternalFilterPresent',
         'getRowHeight',
@@ -455,11 +450,6 @@ export class PropertyKeys {
         'groupAggFiltering',
         'chartMenuItems',
         'groupTotalRow',
-    ];
-
-    public static FUNCTION_PROPERTIES: GridOptionKey[] = [
-        ...PropertyKeys.FUNCTIONAL_PROPERTIES,
-        ...PropertyKeys.CALLBACK_PROPERTIES,
     ];
 
     public static ALL_PROPERTIES: GridOptionKey[] = [

--- a/community-modules/core/src/validation/rules/colDefValidations.ts
+++ b/community-modules/core/src/validation/rules/colDefValidations.ts
@@ -217,6 +217,7 @@ const colDefPropertyMap: Record<ColKey, undefined> = {
     loadingCellRenderer: undefined,
     loadingCellRendererParams: undefined,
     loadingCellRendererSelector: undefined,
+    colContext: undefined,
 };
 const ALL_PROPERTIES: ColKey[] = Object.keys(colDefPropertyMap) as ColKey[];
 

--- a/community-modules/core/src/validation/rules/colDefValidations.ts
+++ b/community-modules/core/src/validation/rules/colDefValidations.ts
@@ -217,7 +217,7 @@ const colDefPropertyMap: Record<ColKey, undefined> = {
     loadingCellRenderer: undefined,
     loadingCellRendererParams: undefined,
     loadingCellRendererSelector: undefined,
-    colContext: undefined,
+    context: undefined,
 };
 const ALL_PROPERTIES: ColKey[] = Object.keys(colDefPropertyMap) as ColKey[];
 

--- a/community-modules/core/src/validation/validationService.ts
+++ b/community-modules/core/src/validation/validationService.ts
@@ -196,9 +196,11 @@ export class ValidationService extends BeanStub implements NamedBean {
         );
 
         _iterateObject(invalidProperties, (key, value) => {
-            _warnOnce(
-                `invalid ${containerName} property '${key}' did you mean any of these: ${value.slice(0, 8).join(', ')}`
-            );
+            let message = `invalid ${containerName} property '${key}' did you mean any of these: ${value.slice(0, 8).join(', ')}.`;
+            if (validProperties.includes('context')) {
+                message += `\nIf you are trying to annotate ${containerName} with application data, use the '${containerName}.context' property instead.`;
+            }
+            _warnOnce(message);
         });
 
         if (Object.keys(invalidProperties).length > 0 && docsUrl) {

--- a/documentation/ag-grid-docs/src/content/api-documentation/column-properties/properties.json
+++ b/documentation/ag-grid-docs/src/content/api-documentation/column-properties/properties.json
@@ -115,7 +115,8 @@
                 "url": "./tooltips"
             }
         },
-        "tooltipComponentParams": {}
+        "tooltipComponentParams": {},
+        "colContext": {}
     },
     "header": {
         "meta": {
@@ -541,7 +542,8 @@
                 "url": "./tooltips"
             }
         },
-        "tooltipComponentParams": {}
+        "tooltipComponentParams": {},
+        "colContext": {}
     },
     "groupsHeader": {
         "meta": {

--- a/documentation/ag-grid-docs/src/content/api-documentation/column-properties/properties.json
+++ b/documentation/ag-grid-docs/src/content/api-documentation/column-properties/properties.json
@@ -84,7 +84,8 @@
                 "name": "Configuring the Context Menu",
                 "url": "./context-menu/#configuring-the-context-menu"
             }
-        }
+        },
+        "colContext": {}
     },
     "charts": {
         "meta": {
@@ -115,8 +116,7 @@
                 "url": "./tooltips"
             }
         },
-        "tooltipComponentParams": {},
-        "colContext": {}
+        "tooltipComponentParams": {}
     },
     "header": {
         "meta": {

--- a/documentation/ag-grid-docs/src/content/api-documentation/column-properties/properties.json
+++ b/documentation/ag-grid-docs/src/content/api-documentation/column-properties/properties.json
@@ -85,7 +85,7 @@
                 "url": "./context-menu/#configuring-the-context-menu"
             }
         },
-        "colContext": {}
+        "context": {}
     },
     "charts": {
         "meta": {
@@ -543,7 +543,7 @@
             }
         },
         "tooltipComponentParams": {},
-        "colContext": {}
+        "context": {}
     },
     "groupsHeader": {
         "meta": {

--- a/documentation/ag-grid-docs/src/content/docs/context/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/context/index.mdoc
@@ -12,12 +12,6 @@ The context object is passed to all callbacks and events used in the grid. The p
 
 To update the context call `api.setGridOption` with the new context. Alternatively, if you maintain a reference to the context object it's values can be mutated directly.
 
-## Per column context
-
-Column groups and columns can have a context, the property is named `colContext` that can be set in the column definition.
-
-{% apiDocumentation source="column-properties/properties.json" section="columns" names=["colContext"] /%}
-
 ## Context Object Example
 
 The example below demonstrates how the context object can be used. Note the following:

--- a/documentation/ag-grid-docs/src/content/docs/context/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/context/index.mdoc
@@ -12,6 +12,12 @@ The context object is passed to all callbacks and events used in the grid. The p
 
 To update the context call `api.setGridOption` with the new context. Alternatively, if you maintain a reference to the context object it's values can be mutated directly.
 
+## Per column context
+
+Column groups and columns can have a context, the property is named `colContext` that can be set in the column definition.
+
+{% apiDocumentation source="column-properties/properties.json" section="columns" names=["colContext"] /%}
+
 ## Context Object Example
 
 The example below demonstrates how the context object can be used. Note the following:

--- a/plugins/ag-grid-generate-example-files/gridOptionsTypes/_gridOptions_Types.json
+++ b/plugins/ag-grid-generate-example-files/gridOptionsTypes/_gridOptions_Types.json
@@ -473,12 +473,6 @@
       "IRowNode"
     ]
   },
-  "processPivotResultColDef": {
-    "typeName": "(colDef: ColDef<TData>) => void",
-    "typesToInclude": [
-      "ColDef"
-    ]
-  },
   "processPivotResultColGroupDef": {
     "typeName": "(colGroupDef: ColGroupDef<TData>) => void",
     "typesToInclude": [
@@ -534,6 +528,12 @@
   "quickFilterMatcher": {
     "typeName": "(quickFilterParts: string[], rowQuickFilterAggregateText: string) => boolean",
     "typesToInclude": []
+  },
+  "processPivotResultColDef": {
+    "typeName": "(colDef: ColDef<TData>) => void",
+    "typesToInclude": [
+      "ColDef"
+    ]
   },
   "getLocaleText": {
     "typeName": "(params: GetLocaleTextParams<TData>) => string",

--- a/plugins/ag-grid-generate-example-files/src/executors/generate/generator/transformation-scripts/react-utils.ts
+++ b/plugins/ag-grid-generate-example-files/src/executors/generate/generator/transformation-scripts/react-utils.ts
@@ -105,8 +105,4 @@ export const convertFunctionToConstCallbackTs = (code: string, callbackDependenc
     return `${code.replace(/function\s+([^(\s]+)\s*\(([^)]*)\)(:?\s+[^{]*)/, 'const $1 = useCallback(($2) $3 =>')}, [${callbackDependencies[functionName] || ''}])`;
 };
 
-export const EventAndCallbackNames = new Set([
-    ...PropertyKeys.CALLBACK_PROPERTIES,
-    ...PropertyKeys.FUNCTIONAL_PROPERTIES,
-    ...ALL_EVENTS,
-]);
+export const EventAndCallbackNames = new Set([...PropertyKeys.FUNCTION_PROPERTIES, ...ALL_EVENTS]);


### PR DESCRIPTION
Background:

There is already a `context` property of type any, see https://localhost:4610/react-data-grid/context
Users have requested a context property also per column.

Changes:

- Adds an additional property `context` to AbstractColDef (and consequently to ColDef and ColGroupDef) of type any that allows to assign and passing custom data to to callbacks.
- Augment the error message in such a way it includes a reference to the "context" property to the valid properties validator so users know what is the proper way to pass custom data to the grid definition or columns and column groups definitions.
- Fix the documentation by adding the context property to colDef and colGroupDef
- Merge FUNCTIONAL_PROPERTIES and CALLBACK_PROPERTIES in FUNCTION_PROPERTIES for the column definitions, this is required to fix typescript confusing coldef and grid def "context" properties.
- Fix the constraint for the type WithoutGridCommon, this is required to fix typescript confusing coldef and grid def "context" properties.

<img width="674" alt="image" src="https://github.com/ag-grid/ag-grid/assets/6913178/76935a73-a6d8-4ca8-83fd-3c3cc0ad1778">
