### PR TITLE
AG-11843 Prevent tracking non-selectable nodes in selected state

### DIFF
--- a/enterprise-modules/server-side-row-model/src/serverSideRowModel/services/selection/strategies/defaultStrategy.ts
+++ b/enterprise-modules/server-side-row-model/src/serverSideRowModel/services/selection/strategies/defaultStrategy.ts
@@ -121,7 +121,7 @@ export class DefaultStrategy extends BeanStub implements ISelectionStrategy {
                 throw new Error("AG Grid: cannot select multiple rows when rowSelection is set to 'single'");
             }
             const node = nodes[0];
-            if (newValue) {
+            if (newValue && node.selectable) {
                 this.selectedNodes = { [node.id!]: node };
                 this.selectedState = {
                     selectAll: false,

--- a/enterprise-modules/server-side-row-model/src/serverSideRowModel/services/selection/strategies/defaultStrategy.ts
+++ b/enterprise-modules/server-side-row-model/src/serverSideRowModel/services/selection/strategies/defaultStrategy.ts
@@ -147,13 +147,12 @@ export class DefaultStrategy extends BeanStub implements ISelectionStrategy {
                 delete this.selectedNodes[node.id!];
             }
 
-            const isNodeSelectable = node.selectable;
             const doesNodeConform = value === this.selectedState.selectAll;
-            if (doesNodeConform || !isNodeSelectable) {
+            if (doesNodeConform || !node.selectable) {
                 this.selectedState.toggledNodes.delete(node.id!);
-                return;
+            } else {
+                this.selectedState.toggledNodes.add(node.id!);
             }
-            this.selectedState.toggledNodes.add(node.id!);
         };
 
         if (rangeSelect) {

--- a/enterprise-modules/server-side-row-model/src/serverSideRowModel/services/selection/strategies/defaultStrategy.ts
+++ b/enterprise-modules/server-side-row-model/src/serverSideRowModel/services/selection/strategies/defaultStrategy.ts
@@ -139,7 +139,7 @@ export class DefaultStrategy extends BeanStub implements ISelectionStrategy {
         }
 
         const updateNodeState = (node: RowNode, value = newValue) => {
-            if (value) {
+            if (value && node.selectable) {
                 this.selectedNodes[node.id!] = node;
             } else {
                 delete this.selectedNodes[node.id!];

--- a/enterprise-modules/server-side-row-model/src/serverSideRowModel/services/selection/strategies/defaultStrategy.ts
+++ b/enterprise-modules/server-side-row-model/src/serverSideRowModel/services/selection/strategies/defaultStrategy.ts
@@ -134,7 +134,9 @@ export class DefaultStrategy extends BeanStub implements ISelectionStrategy {
                     toggledNodes: new Set(),
                 };
             }
-            this.selectionCtx.reset(node.id!);
+            if (node.selectable) {
+                this.selectionCtx.reset(node.id!);
+            }
             return 1;
         }
 


### PR DESCRIPTION
As far as I can tell this is was only happening when using the default selection strategy in SSRM since the group-selects-children strategy uses the `RowNode` state as its source of truth.

I've also added a guard against the same bug in the case of selecting a single node, although this shouldn't be possible to do via the UI (it might be possible via API calls).

Also the selection context probably should be reset when trying to select a non-selectable node (or in any other case where a selection is rejected).