### PR TITLE
[AG-5497] [Overlay] Allow showing the loading overlay using a loading property

### DIFF
--- a/community-modules/core/src/entities/gridOptions.ts
+++ b/community-modules/core/src/entities/gridOptions.ts
@@ -770,11 +770,11 @@ export interface GridOptions<TData = any> {
      *
      * - When set to true, the grid will show the 'loading' overlay, regardless of the status of the grid.
      * - When set to false, the grid will never show any overlay, regardless of the status of the grid.
-     * - When not set, or set to undefined, the grid will show the the grid will show the loading overlay if rows are not set, and will show 'no rows' overlay if rows are set to empty (classic behavior).
+     * - When not set, or set to undefined, the grid will show the loading overlay if rows are not set, and will show 'no rows' overlay if rows are set to empty (classic behavior).
      *
      * When set, this property has priority over overlay APIs (showLoadingOverlay, showNoRowsOverlay, hideOverlay).
      */
-    loading?: boolean;
+    loading?: boolean | undefined;
     /**
      * Provide a template for 'loading' overlay.
      */

--- a/community-modules/core/src/entities/gridOptions.ts
+++ b/community-modules/core/src/entities/gridOptions.ts
@@ -766,6 +766,16 @@ export interface GridOptions<TData = any> {
 
     // *** Overlays *** //
     /**
+     * Forces the grid to show or hide the loading overlay.
+     *
+     * - When set to true, the grid will show the 'loading' overlay, regardless of the status of the grid.
+     * - When set to false, the grid will never show any overlay, regardless of the status of the grid.
+     * - When not set, or set to undefined, the grid will show the the grid will show the loading overlay if rows are not set, and will show 'no rows' overlay if rows are set to empty (classic behavior).
+     *
+     * When set, this property has priority over overlay APIs (showLoadingOverlay, showNoRowsOverlay, hideOverlay).
+     */
+    loading?: boolean;
+    /**
      * Provide a template for 'loading' overlay.
      */
     overlayLoadingTemplate?: string;

--- a/community-modules/core/src/gridOptionsService.ts
+++ b/community-modules/core/src/gridOptionsService.ts
@@ -21,7 +21,7 @@ import type { AnyGridOptions } from './propertyKeys';
 import { INITIAL_GRID_OPTION_KEYS, PropertyKeys } from './propertyKeys';
 import { _getScrollbarWidth } from './utils/browser';
 import { _log, _warnOnce } from './utils/function';
-import { _exists, _missing, toBoolean } from './utils/generic';
+import { _exists, _missing, toBoolean, toBooleanOrUndefined } from './utils/generic';
 import { toConstrainedNum, toNumber } from './utils/number';
 import { GRID_OPTION_DEFAULTS } from './validation/rules/gridOptionsValidations';
 import type { ValidationService } from './validation/validationService';
@@ -86,6 +86,7 @@ export type PropertyValueChangedListener<K extends keyof GridOptions> = (event: 
  */
 const PROPERTY_COERCIONS: Map<keyof GridOptions, (value: any) => GridOptions[keyof GridOptions]> = new Map([
     ...PropertyKeys.BOOLEAN_PROPERTIES.map((key) => [key as keyof GridOptions, toBoolean]),
+    ...PropertyKeys.BOOLEAN_OR_UNDEFINED_PROPERTIES.map((key) => [key as keyof GridOptions, toBooleanOrUndefined]),
     ...PropertyKeys.NUMBER_PROPERTIES.map((key) => [key as keyof GridOptions, toNumber]),
     ['groupAggFiltering', (val: any) => (typeof val === 'function' ? val : toBoolean(val))],
     ['pageSize', toConstrainedNum(1)],

--- a/community-modules/core/src/propertyKeys.ts
+++ b/community-modules/core/src/propertyKeys.ts
@@ -388,6 +388,8 @@ export class PropertyKeys {
         'suppressAdvancedFilterEval',
     ];
 
+    public static BOOLEAN_OR_UNDEFINED_PROPERTIES: KeysOfType<boolean | undefined>[] = ['loading'];
+
     // If property does not fit above, i.e union that should not be coerced.
     public static OTHER_PROPERTIES: GridOptionKey[] = ['suppressStickyTotalRow'];
 
@@ -469,6 +471,7 @@ export class PropertyKeys {
         ...PropertyKeys.NUMBER_PROPERTIES,
         ...PropertyKeys.FUNCTION_PROPERTIES,
         ...PropertyKeys.BOOLEAN_PROPERTIES,
+        ...PropertyKeys.BOOLEAN_OR_UNDEFINED_PROPERTIES,
         ...PropertyKeys.OTHER_PROPERTIES,
     ];
 }

--- a/community-modules/core/src/rendering/overlays/overlayService.ts
+++ b/community-modules/core/src/rendering/overlays/overlayService.ts
@@ -57,10 +57,6 @@ export class OverlayService extends BeanStub implements NamedBean {
     }
 
     public showNoRowsOverlay(): void {
-        console.log('showNoRowsOverlay', {
-            suppressNoRowsOverlay: this.gos.get('suppressNoRowsOverlay'),
-            loading: this.gos.get('loading'),
-        });
         if (this.gos.get('suppressNoRowsOverlay')) {
             return;
         }
@@ -75,7 +71,6 @@ export class OverlayService extends BeanStub implements NamedBean {
     }
 
     private showOverlay(compDetails: UserCompDetails, wrapperCssClass: string, gridOption: keyof GridOptions): void {
-        console.log('showOverlay', { wrapperCssClass });
         const promise = compDetails.newAgStackInstance();
         const listenerDestroyFunc = this.addManagedPropertyListener(gridOption, ({ currentValue }) => {
             promise.then((comp) => {
@@ -94,7 +89,6 @@ export class OverlayService extends BeanStub implements NamedBean {
     }
 
     public hideOverlay(): void {
-        console.log('hideOverlay', { loading: this.gos.get('loading') });
         if (this.gos.get('loading')) {
             return; // loading property is true, we cannot hide the overlay
         }
@@ -105,7 +99,6 @@ export class OverlayService extends BeanStub implements NamedBean {
     private showOrHideOverlay(): void {
         const isEmpty = this.rowModel.isEmpty();
         const isSuppressNoRowsOverlay = this.gos.get('suppressNoRowsOverlay');
-        console.log('showOrHideOverlay', { isEmpty, isSuppressNoRowsOverlay });
         if (isEmpty && !isSuppressNoRowsOverlay) {
             this.showNoRowsOverlay();
         } else {
@@ -115,7 +108,6 @@ export class OverlayService extends BeanStub implements NamedBean {
 
     private onLoadingChanged(): void {
         const loading = this.gos.get('loading');
-        console.log('onLoadingChanged', loading);
         if (loading === undefined) {
             if (!this.gos.get('columnDefs') || (this.gos.isRowModelType('clientSide') && !this.gos.get('rowData'))) {
                 if (this.gos.get('suppressLoadingOverlay')) {
@@ -137,12 +129,10 @@ export class OverlayService extends BeanStub implements NamedBean {
     }
 
     private onRowDataUpdated(): void {
-        console.log('onRowDataUpdated');
         this.showOrHideOverlay();
     }
 
     private onNewColumnsLoaded(): void {
-        console.log('onNewColumnsLoaded');
         // hide overlay if columns and rows exist, this can happen if columns are loaded after data.
         // this problem exists before of the race condition between the services (column controller in this case)
         // and the view (grid panel). if the model beans were all initialised first, and then the view beans second,

--- a/community-modules/core/src/rendering/overlays/overlayService.ts
+++ b/community-modules/core/src/rendering/overlays/overlayService.ts
@@ -6,6 +6,7 @@ import type { BeanCollection } from '../../context/context';
 import type { GridOptions } from '../../entities/gridOptions';
 import type { WithoutGridCommon } from '../../interfaces/iCommon';
 import type { IRowModel } from '../../interfaces/iRowModel';
+import { _warnOnce } from '../../utils/function';
 import type { ILoadingOverlayParams } from './loadingOverlayComponent';
 import type { INoRowsOverlayParams } from './noRowsOverlayComponent';
 import type { OverlayWrapperComponent } from './overlayWrapperComponent';
@@ -45,7 +46,8 @@ export class OverlayService extends BeanStub implements NamedBean {
         }
         const loading = this.gos.get('loading');
         if (loading !== undefined && !loading) {
-            return; // loading property is false, we cannot show the loading overlay
+            _warnOnce('AG Grid: showLoadingOverlay has no effect when loading=false');
+            return;
         }
 
         const params: WithoutGridCommon<ILoadingOverlayParams> = {};
@@ -62,8 +64,8 @@ export class OverlayService extends BeanStub implements NamedBean {
         if (this.gos.get('suppressNoRowsOverlay')) {
             return;
         }
-        if (this.gos.get('loading') !== undefined) {
-            return; // loading property is true or false, we cannot show the no-rows overlay
+        if (this.gos.get('loading')) {
+            return; // loading property is true, we cannot show the no-rows overlay
         }
 
         const params: WithoutGridCommon<INoRowsOverlayParams> = {};
@@ -125,9 +127,12 @@ export class OverlayService extends BeanStub implements NamedBean {
                 this.showOrHideOverlay();
             }
         } else if (loading) {
+            if (this.gos.get('suppressLoadingOverlay')) {
+                _warnOnce('AG Grid: setting loading to true has no effect when suppressLoadingOverlay is true');
+            }
             this.showLoadingOverlay();
         } else {
-            this.hideOverlay();
+            this.showOrHideOverlay();
         }
     }
 

--- a/community-modules/core/src/test/overlays.test.ts
+++ b/community-modules/core/src/test/overlays.test.ts
@@ -150,7 +150,7 @@ describe('ag-grid overlays', () => {
         });
 
         test('if gridOptions.suppressLoadingOverlay = true, and loading=true, the loading property value is ignored and a console warning is shown', () => {
-            const consoleWarnSpy = jest.spyOn(console, 'warn');
+            const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
             createMyGrid({ columnDefs, loading: true, suppressLoadingOverlay: true });
             expect(document.querySelector(OVERLAY)).toBeFalsy();
             expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
@@ -208,7 +208,7 @@ describe('ag-grid overlays', () => {
         });
 
         test('Calls to api.showLoadingOverlay() will have no effect and produce a console warn', () => {
-            const consoleWarnSpy = jest.spyOn(console, 'warn');
+            const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
             const api = createMyGrid({ columnDefs, loading: false });
             expect(document.querySelector(NO_ROWS)).toBeTruthy();
             api.showLoadingOverlay();

--- a/community-modules/core/src/test/overlays.test.ts
+++ b/community-modules/core/src/test/overlays.test.ts
@@ -1,0 +1,401 @@
+import { ClientSideRowModelModule } from '@ag-grid-community/client-side-row-model';
+
+import type { GridOptions } from '../entities/gridOptions';
+import { createGrid } from '../grid';
+import { ModuleRegistry } from '../modules/moduleRegistry';
+
+const OVERLAY = '.ag-overlay-loading-center';
+const NO_ROWS = '.ag-overlay-no-rows-center';
+
+describe('ag-grid overlays', () => {
+    const columnDefs = [{ field: 'athlete' }, { field: 'sport' }, { field: 'age' }];
+
+    function createMyGrid(gridOptions: GridOptions) {
+        return createGrid(document.getElementById('myGrid')!, gridOptions);
+    }
+
+    function resetGrids() {
+        document.body.innerHTML = '<div id="myGrid"></div>';
+    }
+
+    beforeAll(() => {
+        ModuleRegistry.register(ClientSideRowModelModule);
+    });
+
+    beforeEach(() => {
+        resetGrids();
+    });
+
+    describe('with loading unset, classic behaviour', () => {
+        test('without rows should show the loading overlay', () => {
+            createMyGrid({ columnDefs });
+            expect(document.querySelector(OVERLAY)).toBeTruthy();
+            expect(document.querySelector(NO_ROWS)).toBeFalsy();
+        });
+
+        test('with empty rows should show the no rows overlay', () => {
+            createMyGrid({ columnDefs, rowData: [] });
+            expect(document.querySelector(NO_ROWS)).toBeTruthy();
+        });
+
+        test('should not show any overlay if rows are present', () => {
+            createMyGrid({ columnDefs, rowData: [{ athlete: 'foo', sport: 'bar', age: 20 }] });
+            expect(document.querySelector(OVERLAY)).toBeFalsy();
+            expect(document.querySelector(NO_ROWS)).toBeFalsy();
+        });
+
+        test('should hide the overlay when rows are added', () => {
+            const api = createMyGrid({ columnDefs });
+            expect(document.querySelector(OVERLAY)).toBeTruthy();
+
+            api.setGridOption('rowData', [{}, {}]);
+            expect(document.querySelector(OVERLAY)).toBeFalsy();
+        });
+
+        test('should show no-rows overlay when empty rows are loaded', () => {
+            const api = createMyGrid({ columnDefs });
+            expect(document.querySelector(NO_ROWS)).toBeFalsy();
+
+            api.setGridOption('rowData', []);
+            expect(document.querySelector(NO_ROWS)).toBeTruthy();
+        });
+
+        describe('with suppressNoRowsOverlay', () => {
+            test('should not show no-rows overlay with initial empty rows', () => {
+                createMyGrid({ columnDefs, suppressNoRowsOverlay: true, rowData: [] });
+                expect(document.querySelector(NO_ROWS)).toBeFalsy();
+            });
+
+            test('should not show no-rows overlay when empty rows are loaded', () => {
+                const api = createMyGrid({ columnDefs, suppressNoRowsOverlay: true });
+                expect(document.querySelector(NO_ROWS)).toBeFalsy();
+                expect(document.querySelector(OVERLAY)).toBeTruthy();
+
+                api.setGridOption('rowData', []);
+                expect(document.querySelector(NO_ROWS)).toBeFalsy();
+                expect(document.querySelector(OVERLAY)).toBeFalsy();
+
+                api.setGridOption('rowData', [{}]);
+                expect(document.querySelector(NO_ROWS)).toBeFalsy();
+                expect(document.querySelector(OVERLAY)).toBeFalsy();
+            });
+        });
+
+        describe('with suppressLoadingOverlay', () => {
+            test('should not show loading overlay with initial empty rows', () => {
+                createMyGrid({ columnDefs, suppressLoadingOverlay: true, rowData: [] });
+                expect(document.querySelector(OVERLAY)).toBeFalsy();
+            });
+
+            test('should not show no-rows overlay', () => {
+                const api = createMyGrid({ columnDefs, suppressLoadingOverlay: true });
+                expect(document.querySelector(NO_ROWS)).toBeFalsy();
+                expect(document.querySelector(OVERLAY)).toBeFalsy();
+
+                api.setGridOption('rowData', []);
+                expect(document.querySelector(OVERLAY)).toBeFalsy();
+                expect(document.querySelector(NO_ROWS)).toBeTruthy();
+
+                api.setGridOption('rowData', [{}]);
+                expect(document.querySelector(NO_ROWS)).toBeFalsy();
+                expect(document.querySelector(OVERLAY)).toBeFalsy();
+            });
+
+            test('should not show loading overlay when empty rows are loaded', () => {
+                const api = createMyGrid({ columnDefs, suppressLoadingOverlay: true });
+                expect(document.querySelector(OVERLAY)).toBeFalsy();
+                expect(document.querySelector(NO_ROWS)).toBeFalsy();
+
+                api.setGridOption('rowData', []);
+                expect(document.querySelector(OVERLAY)).toBeFalsy();
+                expect(document.querySelector(NO_ROWS)).toBeTruthy();
+
+                api.setGridOption('rowData', [{}]);
+                expect(document.querySelector(OVERLAY)).toBeFalsy();
+                expect(document.querySelector(NO_ROWS)).toBeFalsy();
+            });
+        });
+    });
+
+    describe('When loading=true:', () => {
+        test('Loading overlay is displayed even if rowData=undefined', () => {
+            createMyGrid({ columnDefs, loading: true });
+            expect(document.querySelector(OVERLAY)).toBeTruthy();
+            expect(document.querySelector(NO_ROWS)).toBeFalsy();
+        });
+
+        test('When rowData=null/undefined or empty array, no rows overlay is not displayed', () => {
+            const api = createMyGrid({ columnDefs, loading: true });
+            expect(document.querySelector(OVERLAY)).toBeTruthy();
+            expect(document.querySelector(NO_ROWS)).toBeFalsy();
+
+            api.setGridOption('rowData', []);
+            expect(document.querySelector(OVERLAY)).toBeTruthy();
+            expect(document.querySelector(NO_ROWS)).toBeFalsy();
+
+            api.setGridOption('rowData', undefined);
+            expect(document.querySelector(OVERLAY)).toBeTruthy();
+            expect(document.querySelector(NO_ROWS)).toBeFalsy();
+        });
+
+        test('When rowData is an array, rows are shown in the grid and the loading overlay on top of them', () => {
+            createMyGrid({ columnDefs, loading: true, rowData: [{}] });
+            expect(document.querySelector(OVERLAY)).toBeTruthy();
+            expect(document.querySelector(NO_ROWS)).toBeFalsy();
+
+            resetGrids();
+            createMyGrid({ columnDefs, loading: true }).setGridOption('rowData', [{}]);
+            expect(document.querySelector(OVERLAY)).toBeTruthy();
+            expect(document.querySelector(NO_ROWS)).toBeFalsy();
+        });
+
+        test('if gridOptions.suppressLoadingOverlay = true, and loading=true, the loading property value is ignored and a console warning is shown', () => {
+            const consoleWarnSpy = jest.spyOn(console, 'warn');
+            createMyGrid({ columnDefs, loading: true, suppressLoadingOverlay: true });
+            expect(document.querySelector(OVERLAY)).toBeFalsy();
+            expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
+            consoleWarnSpy.mockRestore();
+        });
+
+        test('Calls to api.showLoadingOverlay() will have no effect', () => {
+            const api = createMyGrid({ columnDefs, loading: true });
+            expect(document.querySelector(OVERLAY)).toBeTruthy();
+            api.showLoadingOverlay();
+            expect(document.querySelector(OVERLAY)).toBeTruthy();
+            api.hideOverlay();
+            expect(document.querySelector(OVERLAY)).toBeTruthy();
+        });
+
+        test('Calls to api.showNoRowsOverlay() will have no effect', () => {
+            const api = createMyGrid({ columnDefs, loading: true });
+            expect(document.querySelector(OVERLAY)).toBeTruthy();
+            api.showNoRowsOverlay();
+            expect(document.querySelector(OVERLAY)).toBeTruthy();
+            api.hideOverlay();
+            expect(document.querySelector(OVERLAY)).toBeTruthy();
+        });
+
+        test('Calls to api.hideOverlay() will have no effect', () => {
+            const api = createMyGrid({ columnDefs, loading: true });
+            expect(document.querySelector(OVERLAY)).toBeTruthy();
+            api.hideOverlay();
+            expect(document.querySelector(OVERLAY)).toBeTruthy();
+        });
+    });
+
+    describe('When loading=false:', () => {
+        test('Before rowData is set, grid is not showing the loading overlay and shows the no rows overlay', () => {
+            createMyGrid({ columnDefs, loading: false });
+            expect(document.querySelector(OVERLAY)).toBeFalsy();
+            expect(document.querySelector(NO_ROWS)).toBeTruthy();
+        });
+
+        test('When rowData=null/undefined or empty array shows no rows overlay', () => {
+            const api = createMyGrid({ columnDefs, loading: false });
+            expect(document.querySelector(NO_ROWS)).toBeTruthy();
+
+            api.setGridOption('rowData', []);
+            expect(document.querySelector(NO_ROWS)).toBeTruthy();
+
+            api.setGridOption('rowData', undefined);
+            expect(document.querySelector(NO_ROWS)).toBeTruthy();
+        });
+
+        test('When rowData is an array, grid shows rows normally', () => {
+            createMyGrid({ columnDefs, loading: false, rowData: [{}] });
+            expect(document.querySelector(OVERLAY)).toBeFalsy();
+            expect(document.querySelector(NO_ROWS)).toBeFalsy();
+        });
+
+        test('Calls to api.showLoadingOverlay() will have no effect and produce a console warn', () => {
+            const consoleWarnSpy = jest.spyOn(console, 'warn');
+            const api = createMyGrid({ columnDefs, loading: false });
+            expect(document.querySelector(NO_ROWS)).toBeTruthy();
+            api.showLoadingOverlay();
+            expect(document.querySelector(NO_ROWS)).toBeTruthy();
+            expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
+            consoleWarnSpy.mockRestore();
+        });
+
+        test('Calls to api.showNoRowsOverlay() will work normally and the no rows overlay shown', () => {
+            const api = createMyGrid({ columnDefs, loading: false });
+            expect(document.querySelector(NO_ROWS)).toBeTruthy();
+            api.showNoRowsOverlay();
+            expect(document.querySelector(NO_ROWS)).toBeTruthy();
+        });
+
+        test('Calls to api.hideOverlay() will work normally to hide the no rows overlay if shown', () => {
+            const api = createMyGrid({ columnDefs, loading: false });
+            expect(document.querySelector(NO_ROWS)).toBeTruthy();
+            api.hideOverlay();
+            expect(document.querySelector(NO_ROWS)).toBeFalsy();
+        });
+    });
+
+    describe('update, with loading initially set to true', () => {
+        test('initial no rows, loading true has priority', () => {
+            const api = createMyGrid({ columnDefs, loading: true });
+            expect(document.querySelector(OVERLAY)).toBeTruthy();
+            expect(document.querySelector(NO_ROWS)).toBeFalsy();
+
+            api.setGridOption('loading', undefined);
+            expect(document.querySelector(OVERLAY)).toBeTruthy();
+            expect(document.querySelector(NO_ROWS)).toBeFalsy();
+
+            api.setGridOption('rowData', [{}, {}]);
+            expect(document.querySelector(OVERLAY)).toBeFalsy();
+
+            api.setGridOption('loading', true);
+            expect(document.querySelector(OVERLAY)).toBeTruthy();
+            expect(document.querySelector(NO_ROWS)).toBeFalsy();
+
+            api.setGridOption('loading', undefined);
+            expect(document.querySelector(OVERLAY)).toBeFalsy();
+
+            api.setGridOption('loading', false);
+            expect(document.querySelector(OVERLAY)).toBeFalsy();
+        });
+
+        test('initial empty rows, loading true has priority', () => {
+            const api = createMyGrid({ columnDefs, loading: true, rowData: [] });
+            expect(document.querySelector(OVERLAY)).toBeTruthy();
+            expect(document.querySelector(NO_ROWS)).toBeFalsy();
+
+            api.setGridOption('loading', undefined);
+            expect(document.querySelector(NO_ROWS)).toBeTruthy();
+
+            api.setGridOption('rowData', [{}, {}]);
+            expect(document.querySelector(OVERLAY)).toBeFalsy();
+
+            api.setGridOption('loading', true);
+            expect(document.querySelector(OVERLAY)).toBeTruthy();
+            expect(document.querySelector(NO_ROWS)).toBeFalsy();
+
+            api.setGridOption('loading', undefined);
+            expect(document.querySelector(OVERLAY)).toBeFalsy();
+            expect(document.querySelector(NO_ROWS)).toBeFalsy();
+
+            api.setGridOption('loading', false);
+            expect(document.querySelector(OVERLAY)).toBeFalsy();
+        });
+
+        test('initial rows, loading true has priority', () => {
+            const api = createMyGrid({ columnDefs, loading: true, rowData: [{}, {}] });
+            expect(document.querySelector(OVERLAY)).toBeTruthy();
+            expect(document.querySelector(NO_ROWS)).toBeFalsy();
+
+            api.setGridOption('loading', undefined);
+            expect(document.querySelector(OVERLAY)).toBeFalsy();
+            expect(document.querySelector(NO_ROWS)).toBeFalsy();
+
+            api.setGridOption('rowData', []);
+            expect(document.querySelector(OVERLAY)).toBeFalsy();
+            expect(document.querySelector(NO_ROWS)).toBeTruthy();
+
+            api.setGridOption('loading', true);
+            expect(document.querySelector(OVERLAY)).toBeTruthy();
+            expect(document.querySelector(NO_ROWS)).toBeFalsy();
+
+            api.setGridOption('loading', undefined);
+            expect(document.querySelector(OVERLAY)).toBeFalsy();
+
+            api.setGridOption('loading', false);
+            expect(document.querySelector(OVERLAY)).toBeFalsy();
+        });
+
+        test('suppressLoadingOverlay has priority', () => {
+            const api = createMyGrid({ columnDefs, loading: true, suppressLoadingOverlay: true });
+            expect(document.querySelector(OVERLAY)).toBeFalsy();
+            expect(document.querySelector(NO_ROWS)).toBeFalsy();
+
+            api.setGridOption('loading', undefined);
+            expect(document.querySelector(OVERLAY)).toBeFalsy();
+            expect(document.querySelector(NO_ROWS)).toBeFalsy();
+
+            api.setGridOption('loading', true);
+            api.setGridOption('rowData', []);
+            expect(document.querySelector(OVERLAY)).toBeFalsy();
+            expect(document.querySelector(NO_ROWS)).toBeFalsy();
+
+            api.setGridOption('rowData', [{}]);
+            expect(document.querySelector(OVERLAY)).toBeFalsy();
+            expect(document.querySelector(NO_ROWS)).toBeFalsy();
+
+            api.setGridOption('loading', false);
+            expect(document.querySelector(OVERLAY)).toBeFalsy();
+            expect(document.querySelector(NO_ROWS)).toBeFalsy();
+        });
+    });
+
+    describe('update, with loading initially set to false', () => {
+        test('initial no rows, loading false', () => {
+            const api = createMyGrid({ columnDefs, loading: false });
+            expect(document.querySelector(OVERLAY)).toBeFalsy();
+            expect(document.querySelector(NO_ROWS)).toBeTruthy();
+
+            api.setGridOption('loading', true);
+            expect(document.querySelector(OVERLAY)).toBeTruthy();
+            expect(document.querySelector(NO_ROWS)).toBeFalsy();
+
+            api.setGridOption('loading', undefined);
+            expect(document.querySelector(OVERLAY)).toBeTruthy();
+            expect(document.querySelector(NO_ROWS)).toBeFalsy();
+        });
+
+        test('initial empty rows, loading false', () => {
+            const api = createMyGrid({ columnDefs, loading: false, rowData: [] });
+            expect(document.querySelector(OVERLAY)).toBeFalsy();
+            expect(document.querySelector(NO_ROWS)).toBeTruthy();
+
+            api.setGridOption('loading', true);
+            expect(document.querySelector(OVERLAY)).toBeTruthy();
+            expect(document.querySelector(NO_ROWS)).toBeFalsy();
+
+            api.setGridOption('loading', undefined);
+            expect(document.querySelector(OVERLAY)).toBeFalsy();
+            expect(document.querySelector(NO_ROWS)).toBeTruthy();
+        });
+
+        test('initial rows, loading false', () => {
+            const api = createMyGrid({ columnDefs, loading: false, rowData: [{}, {}] });
+            expect(document.querySelector(OVERLAY)).toBeFalsy();
+            expect(document.querySelector(NO_ROWS)).toBeFalsy();
+
+            api.setGridOption('loading', true);
+            expect(document.querySelector(OVERLAY)).toBeTruthy();
+            expect(document.querySelector(NO_ROWS)).toBeFalsy();
+
+            api.setGridOption('loading', undefined);
+            expect(document.querySelector(OVERLAY)).toBeFalsy();
+            expect(document.querySelector(NO_ROWS)).toBeFalsy();
+        });
+
+        test('suppressLoadingOverlay has priority', () => {
+            const api = createMyGrid({ columnDefs, loading: false, suppressLoadingOverlay: true });
+            expect(document.querySelector(OVERLAY)).toBeFalsy();
+            expect(document.querySelector(NO_ROWS)).toBeTruthy();
+
+            api.setGridOption('loading', true);
+            expect(document.querySelector(OVERLAY)).toBeFalsy();
+            expect(document.querySelector(NO_ROWS)).toBeTruthy();
+
+            api.setGridOption('loading', false);
+            expect(document.querySelector(OVERLAY)).toBeFalsy();
+            expect(document.querySelector(NO_ROWS)).toBeTruthy();
+        });
+
+        test('suppressNoRowsOverlay has priority', () => {
+            const api = createMyGrid({ columnDefs, loading: false, suppressNoRowsOverlay: true });
+            expect(document.querySelector(OVERLAY)).toBeFalsy();
+            expect(document.querySelector(NO_ROWS)).toBeFalsy();
+
+            api.setGridOption('rowData', []);
+            expect(document.querySelector(OVERLAY)).toBeFalsy();
+            expect(document.querySelector(NO_ROWS)).toBeFalsy();
+
+            api.setGridOption('rowData', [{}]);
+            expect(document.querySelector(OVERLAY)).toBeFalsy();
+            expect(document.querySelector(NO_ROWS)).toBeFalsy();
+        });
+    });
+});

--- a/community-modules/core/src/utils/generic.test.ts
+++ b/community-modules/core/src/utils/generic.test.ts
@@ -1,4 +1,4 @@
-import { _exists, _makeNull } from './generic';
+import { _exists, _makeNull, toBooleanOrUndefined } from './generic';
 
 describe('_makeNull', () => {
     it.each([4, 'string', new Date()])('returns value if not null: %s', (value) => {
@@ -33,5 +33,23 @@ describe('exists', () => {
 
     it.each(['string', 123, true])('returns true if value is present: %s', (value) => {
         expect(_exists(value)).toBe(true);
+    });
+});
+
+describe('toBooleanOrUndefined', () => {
+    it('returns undefined for undefined', () => {
+        expect(toBooleanOrUndefined(undefined)).toBeUndefined();
+    });
+
+    it('returns false for falsy', () => {
+        expect(toBooleanOrUndefined(false)).toBe(false);
+        expect(toBooleanOrUndefined(0)).toBe(false);
+    });
+
+    it('returns true for truthy', () => {
+        expect(toBooleanOrUndefined(true)).toBe(true);
+        expect(toBooleanOrUndefined('')).toBe(true);
+        expect(toBooleanOrUndefined('true')).toBe(true);
+        expect(toBooleanOrUndefined('True')).toBe(true);
     });
 });

--- a/community-modules/core/src/utils/generic.ts
+++ b/community-modules/core/src/utils/generic.ts
@@ -79,6 +79,10 @@ export function toBoolean(value: any): boolean {
     return false;
 }
 
+export function toBooleanOrUndefined(value: any): boolean | undefined {
+    return value === undefined ? undefined : toBoolean(value);
+}
+
 // for parsing html attributes, where we want empty strings and missing attributes to be undefined
 export function _attrToString(value?: string): string | undefined {
     if (value == null || value === '') {


### PR DESCRIPTION
1/ Add a new grid loading property - boolean to override built-in logic showing loading overlay depending on rowData value.

Changes:

- Add in grid options a boolean property "loading" that can also be set to undefined
- Fix type coercion to support undefined boolean values
- Modify the overlayService to support the new logic based on loading property
- Exhaustive behavioural unit test that covers the behaviour described in the ticket and edge cases

DO NOT MERGE - work in progress