### PR TITLE
AG-11863 Make example description consistent with example

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-selection/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-selection/index.mdoc
@@ -106,7 +106,7 @@ In the example below, note the following;
 
 ### Group Selection API
 
-The below snippet demonstrates how to set all nodes as selected, except for the row which has the ID `group-country-year-United States`, and its child row with the ID `group-country-year-United States2004`.
+The below snippet demonstrates how to set all nodes as selected, except in the case of the "United States" group, whose only selected child is the row with the ID `group-country-year-United States2004`.
 
 ```{% frameworkTransform=true spaceBetweenProperties=true %}
 params.api.setServerSideSelectionState({


### PR DESCRIPTION
It's been pointed out that the description of the snippet was actually inconsistent with the example.