### PR TITLE
AG-11941 Fix regression in row range selection

### DIFF
--- a/community-modules/client-side-row-model/src/clientSideRowModel/clientSideRowModel.ts
+++ b/community-modules/client-side-row-model/src/clientSideRowModel/clientSideRowModel.ts
@@ -743,9 +743,8 @@ export class ClientSideRowModel extends BeanStub implements IClientSideRowModel,
         return _exists(this.rowsToDisplay) && this.rowsToDisplay.length > 0;
     }
 
-    public getNodesInRangeForSelection(firstInRange: RowNode | null, lastInRange: RowNode): RowNode[] {
-        // if firstInRange is null, we start at the first row
-        let started = !firstInRange;
+    public getNodesInRangeForSelection(firstInRange: RowNode, lastInRange: RowNode): RowNode[] {
+        let started = false;
         let finished = false;
 
         const result: RowNode[] = [];

--- a/community-modules/core/src/interfaces/iRowModel.ts
+++ b/community-modules/core/src/interfaces/iRowModel.ts
@@ -38,7 +38,7 @@ export interface IRowModel {
 
     /** Returns all rows in range that should be selected. If there is a gap in range (non ClientSideRowModel) then
      *  then no rows should be returned  */
-    getNodesInRangeForSelection(first: RowNode | null, last: RowNode): RowNode[];
+    getNodesInRangeForSelection(first: RowNode, last: RowNode): RowNode[];
 
     /** Iterate through each node. What this does depends on the model type. For clientSide, goes through
      * all nodes. For serverSide, goes through what's loaded in memory. */

--- a/community-modules/core/src/selection/rowRangeSelectionContext.ts
+++ b/community-modules/core/src/selection/rowRangeSelectionContext.ts
@@ -4,7 +4,7 @@ import type { IRowModel } from '../interfaces/iRowModel';
 export interface ISelectionContext<TNode> {
     init(rowModel: IRowModel): void;
     destroy(): void;
-    reset(node: TNode): void;
+    reset(node: TNode | null): void;
     setEndRange(node: TNode): void;
     getRange(): RowNode[];
     getRoot(): TNode | null;
@@ -42,7 +42,7 @@ export class RowRangeSelectionContext implements ISelectionContext<RowNode> {
         this.cachedRange.length = 0;
     }
 
-    public reset(node: RowNode): void {
+    public reset(node: RowNode | null): void {
         this.root = node;
         this.end = null;
         this.cachedRange.length = 0;

--- a/community-modules/core/src/selection/rowRangeSelectionContext.ts
+++ b/community-modules/core/src/selection/rowRangeSelectionContext.ts
@@ -3,8 +3,8 @@ import type { IRowModel } from '../interfaces/iRowModel';
 
 export interface ISelectionContext<TNode> {
     init(rowModel: IRowModel): void;
-    destroy(): void;
-    reset(node: TNode | null): void;
+    reset(): void;
+    setRoot(node: TNode): void;
     setEndRange(node: TNode): void;
     getRange(): RowNode[];
     getRoot(): TNode | null;
@@ -36,13 +36,13 @@ export class RowRangeSelectionContext implements ISelectionContext<RowNode> {
         this.rowModel = rowModel;
     }
 
-    public destroy(): void {
+    public reset(): void {
         this.root = null;
         this.end = null;
         this.cachedRange.length = 0;
     }
 
-    public reset(node: RowNode | null): void {
+    public setRoot(node: RowNode): void {
         this.root = node;
         this.end = null;
         this.cachedRange.length = 0;

--- a/community-modules/core/src/selection/rowRangeSelectionContext.ts
+++ b/community-modules/core/src/selection/rowRangeSelectionContext.ts
@@ -58,7 +58,7 @@ export class RowRangeSelectionContext implements ISelectionContext<RowNode> {
             const root = this.getRoot();
             const end = this.getEnd();
 
-            if (end == null) {
+            if (root == null || end == null) {
                 return this.cachedRange;
             }
 
@@ -129,7 +129,15 @@ export class RowRangeSelectionContext implements ISelectionContext<RowNode> {
      * @returns Object of nodes to either keep or discard (i.e. deselect) from the range
      */
     public extend(node: RowNode): { keep: RowNode[]; discard: RowNode[] } {
-        const newRange = this.rowModel.getNodesInRangeForSelection(this.getRoot(), node);
+        const root = this.getRoot();
+
+        // If the root node is no longer retrievable, we cannot iterate from the root
+        // to the given `node`. So we keep the existing selection, plus the given `node`
+        if (root == null) {
+            return { keep: this.getRange().concat(node), discard: [] };
+        }
+
+        const newRange = this.rowModel.getNodesInRangeForSelection(root, node);
 
         if (newRange.find((newRangeNode) => newRangeNode.id === this.end?.id)) {
             // Range between root and given node contains the current "end"

--- a/community-modules/core/src/selection/selectionService.ts
+++ b/community-modules/core/src/selection/selectionService.ts
@@ -48,7 +48,7 @@ export class SelectionService extends BeanStub implements NamedBean, ISelectionS
     public override destroy(): void {
         super.destroy();
         this.resetNodes();
-        this.selectionCtx.destroy();
+        this.selectionCtx.reset();
     }
 
     private isMultiselect() {
@@ -125,7 +125,7 @@ export class SelectionService extends BeanStub implements NamedBean, ISelectionS
         // call is not a result of a user action, but rather a follow-on call (e.g
         // in this.clearOtherNodes).
         if (!suppressFinishActions) {
-            this.selectionCtx.reset(filteredNodes[0]);
+            this.selectionCtx.setRoot(filteredNodes[0]);
         }
 
         let updatedCount = 0;
@@ -457,7 +457,7 @@ export class SelectionService extends BeanStub implements NamedBean, ISelectionS
             this.reset(source);
         }
 
-        this.selectionCtx.reset(null);
+        this.selectionCtx.reset();
 
         // the above does not clean up the parent rows if they are selected
         if (rowModelClientSide && this.groupSelectsChildren) {
@@ -600,7 +600,7 @@ export class SelectionService extends BeanStub implements NamedBean, ISelectionS
         this.getNodesToSelect(justFiltered, justCurrentPage).forEach((rowNode) =>
             rowNode.selectThisNode(true, undefined, source)
         );
-        this.selectionCtx.reset(null);
+        this.selectionCtx.reset();
 
         // the above does not clean up the parent rows if they are selected
         if (this.rowModel.getType() === 'clientSide' && this.groupSelectsChildren) {

--- a/community-modules/core/src/selection/selectionService.ts
+++ b/community-modules/core/src/selection/selectionService.ts
@@ -10,6 +10,7 @@ import type { IRowModel } from '../interfaces/iRowModel';
 import type { ISelectionService, ISetNodesSelectedParams } from '../interfaces/iSelectionService';
 import type { ServerSideRowGroupSelectionState, ServerSideRowSelectionState } from '../interfaces/selectionState';
 import type { PageBoundsService } from '../pagination/pageBoundsService';
+import { _last } from '../utils/array';
 import { ChangedPath } from '../utils/changedPath';
 import { _errorOnce, _warnOnce } from '../utils/function';
 import { _exists, _missing } from '../utils/generic';
@@ -597,10 +598,11 @@ export class SelectionService extends BeanStub implements NamedBean, ISelectionS
 
         const { source, justFiltered, justCurrentPage } = params;
 
-        this.getNodesToSelect(justFiltered, justCurrentPage).forEach((rowNode) =>
-            rowNode.selectThisNode(true, undefined, source)
-        );
+        const nodes = this.getNodesToSelect(justFiltered, justCurrentPage);
+        nodes.forEach((rowNode) => rowNode.selectThisNode(true, undefined, source));
+
         this.selectionCtx.reset();
+        this.selectionCtx.setEndRange(_last(nodes) ?? null);
 
         // the above does not clean up the parent rows if they are selected
         if (this.rowModel.getType() === 'clientSide' && this.groupSelectsChildren) {

--- a/community-modules/core/src/selection/selectionService.ts
+++ b/community-modules/core/src/selection/selectionService.ts
@@ -601,7 +601,7 @@ export class SelectionService extends BeanStub implements NamedBean, ISelectionS
         const nodes = this.getNodesToSelect(justFiltered, justCurrentPage);
         nodes.forEach((rowNode) => rowNode.selectThisNode(true, undefined, source));
 
-        this.selectionCtx.reset();
+        this.selectionCtx.setRoot(nodes[0] ?? null);
         this.selectionCtx.setEndRange(_last(nodes) ?? null);
 
         // the above does not clean up the parent rows if they are selected

--- a/community-modules/core/src/selection/selectionService.ts
+++ b/community-modules/core/src/selection/selectionService.ts
@@ -55,6 +55,12 @@ export class SelectionService extends BeanStub implements NamedBean, ISelectionS
         return this.rowSelection === 'multiple';
     }
 
+    /**
+     * We override the selection value for UI-triggered events because it's the
+     * current selection state that should determine the next selection state. This
+     * is a stepping stone towards removing selection logic from event listeners and
+     * other code external to the selection service(s).
+     */
     private overrideSelectionValue(newValue: boolean, source: SelectionEventSourceType): boolean {
         if (!isSelectionUIEvent(source)) {
             return newValue;

--- a/community-modules/core/src/selection/selectionService.ts
+++ b/community-modules/core/src/selection/selectionService.ts
@@ -451,6 +451,8 @@ export class SelectionService extends BeanStub implements NamedBean, ISelectionS
             this.reset(source);
         }
 
+        this.selectionCtx.reset(null);
+
         // the above does not clean up the parent rows if they are selected
         if (rowModelClientSide && this.groupSelectsChildren) {
             this.updateGroupsFromChildrenSelections(source);
@@ -589,9 +591,10 @@ export class SelectionService extends BeanStub implements NamedBean, ISelectionS
 
         const { source, justFiltered, justCurrentPage } = params;
 
-        const callback = (rowNode: RowNode) => rowNode.selectThisNode(true, undefined, source);
-
-        this.getNodesToSelect(justFiltered, justCurrentPage).forEach(callback);
+        this.getNodesToSelect(justFiltered, justCurrentPage).forEach((rowNode) =>
+            rowNode.selectThisNode(true, undefined, source)
+        );
+        this.selectionCtx.reset(null);
 
         // the above does not clean up the parent rows if they are selected
         if (this.rowModel.getType() === 'clientSide' && this.groupSelectsChildren) {

--- a/community-modules/infinite-row-model/src/infiniteRowModel/infiniteCache.ts
+++ b/community-modules/infinite-row-model/src/infiniteRowModel/infiniteCache.ts
@@ -307,17 +307,12 @@ export class InfiniteCache extends BeanStub {
         this.onCacheUpdated();
     }
 
-    public getRowNodesInRange(firstInRange: RowNode | null, lastInRange: RowNode): RowNode[] {
+    public getRowNodesInRange(firstInRange: RowNode, lastInRange: RowNode): RowNode[] {
         const result: RowNode[] = [];
 
         let lastBlockId = -1;
         let inActiveRange = false;
         const numberSequence: NumberSequence = new NumberSequence();
-
-        // if only one node passed, we start the selection at the top
-        if (_missing(firstInRange)) {
-            inActiveRange = true;
-        }
 
         let foundGapInSelection = false;
 

--- a/community-modules/infinite-row-model/src/infiniteRowModel/infiniteRowModel.ts
+++ b/community-modules/infinite-row-model/src/infiniteRowModel/infiniteRowModel.ts
@@ -159,7 +159,7 @@ export class InfiniteRowModel extends BeanStub implements NamedBean, IInfiniteRo
         return !!this.infiniteCache;
     }
 
-    public getNodesInRangeForSelection(firstInRange: RowNode | null, lastInRange: RowNode): RowNode[] {
+    public getNodesInRangeForSelection(firstInRange: RowNode, lastInRange: RowNode): RowNode[] {
         return this.infiniteCache ? this.infiniteCache.getRowNodesInRange(firstInRange, lastInRange) : [];
     }
 

--- a/enterprise-modules/server-side-row-model/src/serverSideRowModel/serverSideRowModel.ts
+++ b/enterprise-modules/server-side-row-model/src/serverSideRowModel/serverSideRowModel.ts
@@ -657,9 +657,8 @@ export class ServerSideRowModel extends BeanStub implements NamedBean, IServerSi
         return res;
     }
 
-    public getNodesInRangeForSelection(firstInRange: RowNode | null, lastInRange: RowNode): RowNode[] {
-        // if firstInRange is null, we begin from the first row
-        const startIndex = firstInRange ? firstInRange.rowIndex : 0;
+    public getNodesInRangeForSelection(firstInRange: RowNode, lastInRange: RowNode): RowNode[] {
+        const startIndex = firstInRange.rowIndex;
         const endIndex = lastInRange.rowIndex;
 
         if (startIndex === null && endIndex === null) {

--- a/enterprise-modules/server-side-row-model/src/serverSideRowModel/services/selection/serverSideRowRangeSelectionContext.ts
+++ b/enterprise-modules/server-side-row-model/src/serverSideRowModel/services/selection/serverSideRowRangeSelectionContext.ts
@@ -19,13 +19,13 @@ export class ServerSideRowRangeSelectionContext implements ISelectionContext<str
         this.rowModel = rowModel;
     }
 
-    public destroy(): void {
+    public reset(): void {
         this.root = null;
         this.end = null;
         this.cachedRange.length = 0;
     }
 
-    public reset(node: string): void {
+    public setRoot(node: string): void {
         this.root = node;
         this.end = null;
         this.cachedRange.length = 0;

--- a/enterprise-modules/server-side-row-model/src/serverSideRowModel/services/selection/serverSideRowRangeSelectionContext.ts
+++ b/enterprise-modules/server-side-row-model/src/serverSideRowModel/services/selection/serverSideRowRangeSelectionContext.ts
@@ -45,11 +45,11 @@ export class ServerSideRowRangeSelectionContext implements ISelectionContext<str
             const root = this.root ? this.rowModel.getRowNode(this.root) : undefined;
             const end = this.end ? this.rowModel.getRowNode(this.end) : undefined;
 
-            if (end == null) {
+            if (root == null || end == null) {
                 return this.cachedRange;
             }
 
-            this.cachedRange = this.rowModel.getNodesInRangeForSelection(root ?? null, end);
+            this.cachedRange = this.rowModel.getNodesInRangeForSelection(root, end);
         }
 
         return this.cachedRange;

--- a/enterprise-modules/server-side-row-model/src/serverSideRowModel/services/selection/strategies/defaultStrategy.ts
+++ b/enterprise-modules/server-side-row-model/src/serverSideRowModel/services/selection/strategies/defaultStrategy.ts
@@ -35,11 +35,11 @@ export class DefaultStrategy extends BeanStub implements ISelectionStrategy {
     private rowSelection?: 'single' | 'multiple';
 
     public postConstruct(): void {
+        this.selectionCtx.init(this.rowModel);
         this.rowSelection = this.gos.get('rowSelection');
         this.addManagedPropertyListener('rowSelection', (propChange) => {
             this.rowSelection = propChange.currentValue;
         });
-        this.selectionCtx.init(this.rowModel);
     }
 
     public getSelectedState(): IServerSideSelectionState {
@@ -254,11 +254,13 @@ export class DefaultStrategy extends BeanStub implements ISelectionStrategy {
         this.selectedState = { selectAll: true, toggledNodes: new Set() };
         this.selectedNodes = {};
         this.selectAllUsed = true;
+        this.selectionCtx.reset();
     }
 
     public deselectAllRowNodes(): void {
         this.selectedState = { selectAll: false, toggledNodes: new Set() };
         this.selectedNodes = {};
+        this.selectionCtx.reset();
     }
 
     public getSelectAllState(): boolean | null {

--- a/enterprise-modules/server-side-row-model/src/serverSideRowModel/services/selection/strategies/defaultStrategy.ts
+++ b/enterprise-modules/server-side-row-model/src/serverSideRowModel/services/selection/strategies/defaultStrategy.ts
@@ -135,7 +135,7 @@ export class DefaultStrategy extends BeanStub implements ISelectionStrategy {
                 };
             }
             if (node.selectable) {
-                this.selectionCtx.reset(node.id!);
+                this.selectionCtx.setRoot(node.id!);
             }
             return 1;
         }
@@ -188,7 +188,7 @@ export class DefaultStrategy extends BeanStub implements ISelectionStrategy {
         }
 
         nodes.forEach((node) => updateNodeState(node));
-        this.selectionCtx.reset(_last(nodes).id!);
+        this.selectionCtx.setRoot(_last(nodes).id!);
         return 1;
     }
 

--- a/enterprise-modules/server-side-row-model/src/serverSideRowModel/services/selection/strategies/groupSelectsChildrenStrategy.ts
+++ b/enterprise-modules/server-side-row-model/src/serverSideRowModel/services/selection/strategies/groupSelectsChildrenStrategy.ts
@@ -212,7 +212,7 @@ export class GroupSelectsChildrenStrategy extends BeanStub implements ISelection
             this.recursivelySelectNode(idPathToNode, this.selectedState, newValue);
         });
         this.removeRedundantState();
-        this.selectionCtx.reset(_last(nodes).id!);
+        this.selectionCtx.setRoot(_last(nodes).id!);
         return 1;
     }
 

--- a/enterprise-modules/server-side-row-model/src/serverSideRowModel/services/selection/strategies/groupSelectsChildrenStrategy.ts
+++ b/enterprise-modules/server-side-row-model/src/serverSideRowModel/services/selection/strategies/groupSelectsChildrenStrategy.ts
@@ -406,10 +406,12 @@ export class GroupSelectsChildrenStrategy extends BeanStub implements ISelection
 
     public selectAllRowNodes(): void {
         this.selectedState = { selectAllChildren: true, toggledNodes: new Map() };
+        this.selectionCtx.reset();
     }
 
     public deselectAllRowNodes(): void {
         this.selectedState = { selectAllChildren: false, toggledNodes: new Map() };
+        this.selectionCtx.reset();
     }
 
     public getSelectAllState(): boolean | null {

--- a/enterprise-modules/viewport-row-model/src/viewportRowModel/viewportRowModel.ts
+++ b/enterprise-modules/viewport-row-model/src/viewportRowModel/viewportRowModel.ts
@@ -254,8 +254,8 @@ export class ViewportRowModel extends BeanStub implements NamedBean, IRowModel {
         return this.rowCount > 0;
     }
 
-    public getNodesInRangeForSelection(firstInRange: RowNode | null, lastInRange: RowNode): RowNode[] {
-        const firstIndex = _missing(firstInRange) ? 0 : firstInRange.rowIndex!;
+    public getNodesInRangeForSelection(firstInRange: RowNode, lastInRange: RowNode): RowNode[] {
+        const firstIndex = firstInRange.rowIndex!;
         const lastIndex = lastInRange.rowIndex!;
 
         const firstNodeOutOfRange = firstIndex < this.firstRow || firstIndex > this.lastRow;


### PR DESCRIPTION
See https://ag-grid.atlassian.net/browse/AG-11941

- The issue was that the selection context was allowing `null` arguments to be passed to `getNodesInRangeForSelection`, which then began the range from the first row.
  - `getNodesInRangeForSelection` no longer accepts `null` arguments for either of its parameters. 
  - Code dealing with not knowing the limits of a range now lives in `RowRangeSelectionContext` and `ServerSideRowRangeSelectionContext`
- Implementations of `ISelectionService.selectAllRowNodes` and `ISelectionService.deselectAllRowNodes` should set the appropriate selection context.
   - For `selectAllRowNodes`:
     - In CSRM we set the start and end of the selection context to the first and last nodes of the selection
     - In SSRM, this isn't really possible, since we don't store selected nodes when using select all behaviour. Instead we reset the context so it behaves like a fresh/untouched grid
   - For `deselectAllRowNodes`:
     - For all row models we just reset the context
- Minor: Use better method names on `ISelectionContext`
  - `reset` -> `setRoot`
  - `destroy` -> `reset`