### PR TITLE
AG-11941 Set selection root on first selection when in range selection

### DIFF
--- a/community-modules/core/src/selection/rowRangeSelectionContext.ts
+++ b/community-modules/core/src/selection/rowRangeSelectionContext.ts
@@ -131,10 +131,17 @@ export class RowRangeSelectionContext implements ISelectionContext<RowNode> {
     public extend(node: RowNode): { keep: RowNode[]; discard: RowNode[] } {
         const root = this.getRoot();
 
-        // If the root node is no longer retrievable, we cannot iterate from the root
-        // to the given `node`. So we keep the existing selection, plus the given `node`
+        // If the root node is null, we cannot iterate from the root to the given `node`.
+        // So we keep the existing selection, plus the given `node`, plus any leaf children.
         if (root == null) {
-            return { keep: this.getRange().concat(node), discard: [] };
+            const keep = this.getRange().slice();
+            node.depthFirstSearch((node) => !node.group && keep.push(node));
+            keep.push(node);
+
+            // We now have a node we can use as the root of the selection
+            this.setRoot(node);
+
+            return { keep, discard: [] };
         }
 
         const newRange = this.rowModel.getNodesInRangeForSelection(root, node);

--- a/community-modules/core/src/selection/rowRangeSelectionContext.ts
+++ b/community-modules/core/src/selection/rowRangeSelectionContext.ts
@@ -10,7 +10,7 @@ export interface ISelectionContext<TNode> {
     getRoot(): TNode | null;
     isInRange(node: TNode): boolean;
     truncate(node: TNode): { keep: RowNode[]; discard: RowNode[] };
-    extend(node: TNode): { keep: RowNode[]; discard: RowNode[] };
+    extend(node: TNode, groupSelectsChildren?: boolean): { keep: RowNode[]; discard: RowNode[] };
 }
 
 /**
@@ -128,14 +128,16 @@ export class RowRangeSelectionContext implements ISelectionContext<RowNode> {
      * @param node - Node marking the new end of the range
      * @returns Object of nodes to either keep or discard (i.e. deselect) from the range
      */
-    public extend(node: RowNode): { keep: RowNode[]; discard: RowNode[] } {
+    public extend(node: RowNode, groupSelectsChildren = false): { keep: RowNode[]; discard: RowNode[] } {
         const root = this.getRoot();
 
         // If the root node is null, we cannot iterate from the root to the given `node`.
         // So we keep the existing selection, plus the given `node`, plus any leaf children.
         if (root == null) {
             const keep = this.getRange().slice();
-            node.depthFirstSearch((node) => !node.group && keep.push(node));
+            if (groupSelectsChildren) {
+                node.depthFirstSearch((node) => !node.group && keep.push(node));
+            }
             keep.push(node);
 
             // We now have a node we can use as the root of the selection

--- a/community-modules/core/src/selection/selectionService.ts
+++ b/community-modules/core/src/selection/selectionService.ts
@@ -113,7 +113,7 @@ export class SelectionService extends BeanStub implements NamedBean, ISelectionS
                 const fromNode = this.selectionCtx.getRoot();
                 const toNode = node;
                 if (fromNode !== toNode) {
-                    const partition = this.selectionCtx.extend(node);
+                    const partition = this.selectionCtx.extend(node, this.groupSelectsChildren);
                     if (newSelectionValue) {
                         this.selectRange(partition.discard, false, source);
                     }

--- a/enterprise-modules/server-side-row-model/src/serverSideRowModel/services/selection/serverSideRowRangeSelectionContext.ts
+++ b/enterprise-modules/server-side-row-model/src/serverSideRowModel/services/selection/serverSideRowRangeSelectionContext.ts
@@ -100,8 +100,24 @@ export class ServerSideRowRangeSelectionContext implements ISelectionContext<str
      * @returns Object of nodes to either keep or discard (i.e. deselect) from the range
      */
     public extend(node: string): { keep: RowNode[]; discard: RowNode[] } {
+        // If the root ID is null, this is the first selection.
+        // That means we add the given `node` plus any leaf children to the selection
+        if (this.root == null) {
+            const keep = this.getRange().slice(); // current range should be empty but include it anyway
+            const rowNode = this.rowModel.getRowNode(node);
+            if (rowNode) {
+                rowNode?.depthFirstSearch((node) => !node.group && keep.push(node));
+                keep.push(rowNode);
+            }
+
+            // We now have a node we can use as the root of the selection
+            this.setRoot(node);
+
+            return { keep, discard: [] };
+        }
+
         const rowNode = this.rowModel.getRowNode(node);
-        const rootNode = this.rowModel.getRowNode(this.root!);
+        const rootNode = this.rowModel.getRowNode(this.root);
 
         if (rowNode == null) {
             return { keep: this.getRange(), discard: [] };

--- a/enterprise-modules/server-side-row-model/src/serverSideRowModel/services/selection/serverSideRowRangeSelectionContext.ts
+++ b/enterprise-modules/server-side-row-model/src/serverSideRowModel/services/selection/serverSideRowRangeSelectionContext.ts
@@ -99,14 +99,16 @@ export class ServerSideRowRangeSelectionContext implements ISelectionContext<str
      * @param node - Node marking the new end of the range
      * @returns Object of nodes to either keep or discard (i.e. deselect) from the range
      */
-    public extend(node: string): { keep: RowNode[]; discard: RowNode[] } {
+    public extend(node: string, groupSelectsChildren = false): { keep: RowNode[]; discard: RowNode[] } {
         // If the root ID is null, this is the first selection.
         // That means we add the given `node` plus any leaf children to the selection
         if (this.root == null) {
             const keep = this.getRange().slice(); // current range should be empty but include it anyway
             const rowNode = this.rowModel.getRowNode(node);
             if (rowNode) {
-                rowNode?.depthFirstSearch((node) => !node.group && keep.push(node));
+                if (groupSelectsChildren) {
+                    rowNode.depthFirstSearch((node) => !node.group && keep.push(node));
+                }
                 keep.push(rowNode);
             }
 

--- a/enterprise-modules/server-side-row-model/src/serverSideRowModel/services/selection/strategies/groupSelectsChildrenStrategy.ts
+++ b/enterprise-modules/server-side-row-model/src/serverSideRowModel/services/selection/strategies/groupSelectsChildrenStrategy.ts
@@ -188,7 +188,7 @@ export class GroupSelectsChildrenStrategy extends BeanStub implements ISelection
                 const fromNode = this.selectionCtx.getRoot();
                 const toNode = node;
                 if (fromNode !== toNode.id) {
-                    const partition = this.selectionCtx.extend(node.id!);
+                    const partition = this.selectionCtx.extend(node.id!, true);
                     if (newSelectionValue) {
                         this.selectRange(partition.discard, false);
                     }


### PR DESCRIPTION
See https://ag-grid.atlassian.net/browse/AG-11941

The issue is that the root of the selection context (i.e. the call to `.setRoot(...)`) was only being set during single selection mode. So if a user held SHIFT for the first selection, it was never initialised. This PR explicitly handles the initial case inside the `RowRangeSelectionContext` and `ServerSideRowRangeSelectionContext`.

We also need some additional code to handle the row-grouping case where an initial SHIFT-click on a row group node should properly select its children.