### PR TITLE
AG-5497 [Overlays] the priority of suppressLoadingOverlay should be lower than setting loading=true

### DIFF
--- a/community-modules/core/src/rendering/overlays/overlayService.ts
+++ b/community-modules/core/src/rendering/overlays/overlayService.ts
@@ -94,17 +94,14 @@ export class OverlayService extends BeanStub implements NamedBean {
     }
 
     private updateOverlayVisibility(): void {
-        const loading = this.gos.get('loading');
+        let loading = this.gos.get('loading');
 
-        let loadingVisible = false;
-        if (loading) {
-            loadingVisible = true;
-        } else if (loading === undefined && !this.gos.get('suppressLoadingOverlay')) {
-            loadingVisible =
+        if (loading === undefined && !this.gos.get('suppressLoadingOverlay')) {
+            loading =
                 !this.gos.get('columnDefs') || (this.gos.isRowModelType('clientSide') && !this.gos.get('rowData'));
         }
 
-        if (loadingVisible) {
+        if (loading) {
             this.showLoadingOverlay();
         } else if (this.rowModel.isEmpty() && !this.gos.get('suppressNoRowsOverlay')) {
             this.showNoRowsOverlay();

--- a/community-modules/core/src/rendering/overlays/overlayService.ts
+++ b/community-modules/core/src/rendering/overlays/overlayService.ts
@@ -48,30 +48,33 @@ export class OverlayService extends BeanStub implements NamedBean {
     }
 
     public showLoadingOverlay(): void {
+        this.showInitialOverlay = false;
+
         const loading = this.gos.get('loading');
         if (!loading && (loading !== undefined || this.gos.get('suppressLoadingOverlay'))) {
             return;
         }
 
-        this.showInitialOverlay = false;
         this.doShowLoadingOverlay();
     }
 
     public showNoRowsOverlay(): void {
+        this.showInitialOverlay = false;
+
         if (this.gos.get('loading') || this.gos.get('suppressNoRowsOverlay')) {
             return;
         }
 
-        this.showInitialOverlay = false;
         this.doShowNoRowsOverlay();
     }
 
     public hideOverlay(): void {
+        this.showInitialOverlay = false;
+
         if (this.gos.get('loading')) {
             return;
         }
 
-        this.showInitialOverlay = false;
         this.doHideOverlay();
     }
 

--- a/community-modules/core/src/rendering/overlays/overlayService.ts
+++ b/community-modules/core/src/rendering/overlays/overlayService.ts
@@ -6,7 +6,6 @@ import type { BeanCollection } from '../../context/context';
 import type { GridOptions } from '../../entities/gridOptions';
 import type { WithoutGridCommon } from '../../interfaces/iCommon';
 import type { IRowModel } from '../../interfaces/iRowModel';
-import { _warnOnce } from '../../utils/function';
 import type { ILoadingOverlayParams } from './loadingOverlayComponent';
 import type { INoRowsOverlayParams } from './noRowsOverlayComponent';
 import type { OverlayWrapperComponent } from './overlayWrapperComponent';
@@ -43,10 +42,8 @@ export class OverlayService extends BeanStub implements NamedBean {
     }
 
     public showLoadingOverlay(): void {
-        if (this.gos.get('suppressLoadingOverlay')) {
-            return;
-        }
-        if (this.gos.get('loading') === false) {
+        const loading = this.gos.get('loading');
+        if (!loading && (loading !== undefined || this.gos.get('suppressLoadingOverlay'))) {
             return;
         }
 
@@ -60,7 +57,7 @@ export class OverlayService extends BeanStub implements NamedBean {
         if (this.gos.get('suppressNoRowsOverlay')) {
             return;
         }
-        if (this.gos.get('loading') && !this.gos.get('suppressLoadingOverlay')) {
+        if (this.gos.get('loading')) {
             return; // loading property is true, we cannot show the no-rows overlay
         }
 
@@ -89,7 +86,7 @@ export class OverlayService extends BeanStub implements NamedBean {
     }
 
     public hideOverlay(): void {
-        if (this.gos.get('loading') && !this.gos.get('suppressLoadingOverlay')) {
+        if (this.gos.get('loading')) {
             return; // loading property is true, we cannot hide the overlay
         }
         this.manuallyDisplayed = false;
@@ -97,16 +94,14 @@ export class OverlayService extends BeanStub implements NamedBean {
     }
 
     private updateOverlayVisibility(): void {
-        let loadingVisible = false;
-
         const loading = this.gos.get('loading');
-        if (!this.gos.get('suppressLoadingOverlay')) {
-            if (loading) {
-                loadingVisible = true;
-            } else if (loading === undefined) {
-                loadingVisible =
-                    !this.gos.get('columnDefs') || (this.gos.isRowModelType('clientSide') && !this.gos.get('rowData'));
-            }
+
+        let loadingVisible = false;
+        if (loading) {
+            loadingVisible = true;
+        } else if (loading === undefined && !this.gos.get('suppressLoadingOverlay')) {
+            loadingVisible =
+                !this.gos.get('columnDefs') || (this.gos.isRowModelType('clientSide') && !this.gos.get('rowData'));
         }
 
         if (loadingVisible) {

--- a/community-modules/core/src/rendering/overlays/overlayWrapperComponent.ts
+++ b/community-modules/core/src/rendering/overlays/overlayWrapperComponent.ts
@@ -67,9 +67,8 @@ export class OverlayWrapperComponent extends Component implements LayoutView {
         this.setWrapperTypeClass(overlayWrapperCssClass);
         this.destroyActiveOverlay();
 
-        this.inProgress = true;
-
         if (overlayComp) {
+            this.inProgress = true;
             overlayComp.then((comp) => {
                 this.inProgress = false;
 

--- a/testing/behavioural/src/overlays/overlays-react-unmount.test.tsx
+++ b/testing/behavioural/src/overlays/overlays-react-unmount.test.tsx
@@ -1,0 +1,115 @@
+import { ClientSideRowModelModule } from '@ag-grid-community/client-side-row-model';
+import type { ColDef } from '@ag-grid-community/core';
+import { ModuleRegistry } from '@ag-grid-community/core';
+import { AgGridReact } from '@ag-grid-community/react';
+import type { AgGridReactProps } from '@ag-grid-community/react';
+import '@testing-library/jest-dom';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+
+describe('ag-grid custom overlay react unmount', () => {
+    const columnDefs: ColDef[] = [{ field: 'athlete' }, { field: 'sport' }, { field: 'age' }];
+
+    beforeAll(() => {
+        ModuleRegistry.register(ClientSideRowModelModule);
+    });
+
+    let mounts = 0;
+    let unmounts = 0;
+
+    beforeEach(() => {
+        cleanup();
+        mounts = 0;
+        unmounts = 0;
+    });
+
+    class CustomLoadingOverlay extends React.Component {
+        override render() {
+            return <div>Custom Overlay</div>;
+        }
+
+        override componentDidMount() {
+            ++mounts;
+        }
+
+        override componentWillUnmount() {
+            ++unmounts;
+        }
+    }
+
+    describe('loading transition', () => {
+        test('transition loading true -> false', async () => {
+            const defaultProps: AgGridReactProps<any> = {
+                columnDefs,
+                rowData: [],
+                loadingOverlayComponent: CustomLoadingOverlay,
+            };
+
+            const { rerender } = render(<AgGridReact {...defaultProps} loading={true} />);
+
+            await waitFor(() => expect(screen.queryByText('Custom Overlay')).toBeInTheDocument());
+
+            expect(mounts).toBe(1);
+
+            rerender(<AgGridReact {...defaultProps} loading={false} />);
+
+            await waitFor(() => expect(screen.queryByText('Custom Overlay')).not.toBeInTheDocument());
+
+            await new Promise((resolve) => setTimeout(resolve)); // unmount will be called on the next tick
+
+            expect(mounts).toBe(1);
+            expect(unmounts).toBe(1);
+        });
+
+        test('transition loading false -> true', async () => {
+            const defaultProps: AgGridReactProps<any> = {
+                columnDefs,
+                rowData: [],
+                loadingOverlayComponent: CustomLoadingOverlay,
+            };
+
+            const { rerender } = render(<AgGridReact {...defaultProps} loading={false} />);
+
+            await waitFor(() => expect(screen.queryByText('Custom Overlay')).not.toBeInTheDocument());
+
+            expect(mounts).toBe(0);
+
+            rerender(<AgGridReact {...defaultProps} loading={true} />);
+
+            await waitFor(() => expect(screen.queryByText('Custom Overlay')).toBeInTheDocument());
+
+            expect(mounts).toBe(1);
+
+            rerender(<AgGridReact {...defaultProps} loading={false} />);
+
+            await waitFor(() => expect(screen.queryByText('Custom Overlay')).not.toBeInTheDocument());
+
+            await new Promise((resolve) => setTimeout(resolve)); // unmount will be called on the next tick
+
+            expect(mounts).toBe(1);
+            expect(unmounts).toBe(1);
+        });
+
+        test('loading undefined', async () => {
+            const defaultProps: AgGridReactProps<any> = {
+                columnDefs,
+                loadingOverlayComponent: CustomLoadingOverlay,
+            };
+
+            const { rerender } = render(<AgGridReact {...defaultProps} />);
+
+            await waitFor(() => expect(screen.queryByText('Custom Overlay')).toBeInTheDocument());
+
+            expect(mounts).toBe(1);
+
+            rerender(<AgGridReact {...defaultProps} rowData={[{}]} />);
+
+            await waitFor(() => expect(screen.queryByText('Custom Overlay')).not.toBeInTheDocument());
+
+            await new Promise((resolve) => setTimeout(resolve)); // unmount will be called on the next tick
+
+            expect(mounts).toBe(1);
+            expect(unmounts).toBe(1);
+        });
+    });
+});

--- a/testing/behavioural/src/overlays/overlays-state.test.ts
+++ b/testing/behavioural/src/overlays/overlays-state.test.ts
@@ -158,11 +158,13 @@ describe('ag-grid overlays state', () => {
             expect(hasNoRowsOverlay()).toBeFalsy();
         });
 
-        test('if gridOptions.suppressLoadingOverlay = true, and loading=true, the loading property value is ignored', () => {
+        test('loading=true has higher priority than suppressLoadingOverlay', () => {
             const api = createMyGrid({ columnDefs, loading: true, suppressLoadingOverlay: true });
-            expect(hasLoadingOverlay()).toBeFalsy();
+            expect(hasLoadingOverlay()).toBeTruthy();
+            expect(hasNoRowsOverlay()).toBeFalsy();
             api.showNoRowsOverlay();
-            expect(hasNoRowsOverlay()).toBeTruthy();
+            expect(hasLoadingOverlay()).toBeTruthy();
+            expect(hasNoRowsOverlay()).toBeFalsy();
         });
 
         test('Calls to api.showLoadingOverlay() will have no effect', () => {
@@ -308,10 +310,10 @@ describe('ag-grid overlays state', () => {
             expect(hasLoadingOverlay()).toBeFalsy();
         });
 
-        test('suppressLoadingOverlay has priority', () => {
+        test('suppressLoadingOverlay has less priority', () => {
             const api = createMyGrid({ columnDefs, loading: true, suppressLoadingOverlay: true });
-            expect(hasLoadingOverlay()).toBeFalsy();
-            expect(hasNoRowsOverlay()).toBeTruthy();
+            expect(hasLoadingOverlay()).toBeTruthy();
+            expect(hasNoRowsOverlay()).toBeFalsy();
 
             api.setGridOption('loading', undefined); // undefined is coerced to false
             expect(hasLoadingOverlay()).toBeFalsy();
@@ -319,11 +321,11 @@ describe('ag-grid overlays state', () => {
 
             api.setGridOption('loading', true);
             api.setGridOption('rowData', []);
-            expect(hasLoadingOverlay()).toBeFalsy();
-            expect(hasNoRowsOverlay()).toBeTruthy();
+            expect(hasLoadingOverlay()).toBeTruthy();
+            expect(hasNoRowsOverlay()).toBeFalsy();
 
             api.setGridOption('rowData', [{}]);
-            expect(hasLoadingOverlay()).toBeFalsy();
+            expect(hasLoadingOverlay()).toBeTruthy();
             expect(hasNoRowsOverlay()).toBeFalsy();
 
             api.setGridOption('loading', false);
@@ -375,14 +377,14 @@ describe('ag-grid overlays state', () => {
             expect(hasNoRowsOverlay()).toBeFalsy();
         });
 
-        test('suppressLoadingOverlay has priority', () => {
+        test('suppressLoadingOverlay has no effect', () => {
             const api = createMyGrid({ columnDefs, loading: false, suppressLoadingOverlay: true });
             expect(hasLoadingOverlay()).toBeFalsy();
             expect(hasNoRowsOverlay()).toBeTruthy();
 
             api.setGridOption('loading', true);
-            expect(hasLoadingOverlay()).toBeFalsy();
-            expect(hasNoRowsOverlay()).toBeTruthy();
+            expect(hasLoadingOverlay()).toBeTruthy();
+            expect(hasNoRowsOverlay()).toBeFalsy();
 
             api.setGridOption('loading', false);
             expect(hasLoadingOverlay()).toBeFalsy();

--- a/testing/behavioural/src/overlays/overlays-state.test.ts
+++ b/testing/behavioural/src/overlays/overlays-state.test.ts
@@ -124,6 +124,31 @@ describe('ag-grid overlays state', () => {
                 expect(hasLoadingOverlay()).toBeFalsy();
             });
         });
+
+        test('setting the rowdata and coldefs to undefined does not cause loading to reappear', () => {
+            const api = createMyGrid({ columnDefs });
+            expect(hasLoadingOverlay()).toBeTruthy();
+
+            api.setGridOption('rowData', [{ athlete: 'Michael Phelps', country: 'US' }]);
+            expect(hasLoadingOverlay()).toBeFalsy();
+
+            api.setGridOption('columnDefs', undefined);
+            expect(hasLoadingOverlay()).toBeFalsy();
+
+            api.setGridOption('rowData', undefined);
+            expect(hasLoadingOverlay()).toBeFalsy();
+
+            api.setGridOption('columnDefs', columnDefs);
+            expect(hasLoadingOverlay()).toBeFalsy();
+
+            api.setGridOption('rowData', []);
+            expect(hasLoadingOverlay()).toBeFalsy();
+            expect(hasNoRowsOverlay()).toBeTruthy();
+
+            api.setGridOption('rowData', [{ athlete: 'Michael Phelps', country: 'US' }]);
+            expect(hasLoadingOverlay()).toBeFalsy();
+            expect(hasNoRowsOverlay()).toBeFalsy();
+        });
     });
 
     describe('When loading=true:', () => {

--- a/testing/behavioural/src/overlays/overlays-state.test.ts
+++ b/testing/behavioural/src/overlays/overlays-state.test.ts
@@ -149,6 +149,17 @@ describe('ag-grid overlays state', () => {
             expect(hasLoadingOverlay()).toBeFalsy();
             expect(hasNoRowsOverlay()).toBeFalsy();
         });
+
+        test('it behaves correctly also when columns are set after rows', () => {
+            const api = createMyGrid({ rowData: [{ athlete: 'Michael Phelps', country: 'US' }] });
+            expect(hasLoadingOverlay()).toBeTruthy();
+
+            api.setGridOption('columnDefs', columnDefs);
+            expect(hasLoadingOverlay()).toBeFalsy();
+
+            api.setGridOption('columnDefs', undefined);
+            expect(hasLoadingOverlay()).toBeFalsy();
+        });
     });
 
     describe('When loading=true:', () => {


### PR DESCRIPTION
- change the logic of suppressLoadingOverlay and loading=true so that loading=true overrides it
- change the behavioural unit tests, as the behaviour changed
- handle the colDef being set after rowData better, centralising the logic
- handle better the initial loading better so it is not possible for the loading screen to show twice if loading=undefined
- avoid double rendering if the state didn't change - maintain the old behaviour instead if "legacy" show and hide is called
- removed unused warnOnce import
- simplify logic