### PR TITLE
RTI-2177 [regression] fix no-rows showing with infinite row model, fix tests 

### DIFF
--- a/community-modules/core/src/rendering/overlays/overlayService.ts
+++ b/community-modules/core/src/rendering/overlays/overlayService.ts
@@ -94,7 +94,11 @@ export class OverlayService extends BeanStub implements NamedBean {
             }
         } else {
             this.showInitialOverlay = false;
-            if (this.rowModel.isEmpty() && !this.gos.get('suppressNoRowsOverlay')) {
+            if (
+                this.rowModel.isEmpty() &&
+                !this.gos.get('suppressNoRowsOverlay') &&
+                this.gos.isRowModelType('clientSide')
+            ) {
                 if (this.state !== OverlayServiceState.NoRows) {
                     this.doShowNoRowsOverlay();
                 }

--- a/testing/behavioural/src/overlays/overlays-infinite-scrolling.test.tsx
+++ b/testing/behavioural/src/overlays/overlays-infinite-scrolling.test.tsx
@@ -1,0 +1,77 @@
+import type { GridOptions } from '@ag-grid-community/core';
+import { ModuleRegistry, createGrid } from '@ag-grid-community/core';
+import { InfiniteRowModelModule } from '@ag-grid-community/infinite-row-model';
+
+describe('ag-grid overlays infinite scrolling state', () => {
+    const columnDefs = [{ field: 'athlete' }, { field: 'sport' }, { field: 'age' }];
+    let consoleWarnSpy: jest.SpyInstance | undefined;
+
+    function createMyGrid(gridOptions: GridOptions) {
+        return createGrid(document.getElementById('myGrid')!, gridOptions);
+    }
+
+    function resetGrids() {
+        document.body.innerHTML = '<div id="myGrid"></div>';
+    }
+
+    function hasLoadingOverlay() {
+        return !!document.querySelector('.ag-overlay-loading-center');
+    }
+
+    function hasNoRowsOverlay() {
+        return !!document.querySelector('.ag-overlay-no-rows-center');
+    }
+
+    beforeAll(() => {
+        ModuleRegistry.register(InfiniteRowModelModule);
+    });
+
+    beforeEach(() => {
+        resetGrids();
+    });
+
+    afterEach(() => {
+        consoleWarnSpy?.mockRestore();
+    });
+
+    test('does not shows no-rows when using InfiniteRowModelModule', () => {
+        const pendingGetRows: (() => void)[] = [];
+
+        const api = createMyGrid({
+            columnDefs,
+            rowModelType: 'infinite',
+            datasource: { getRows: (params) => pendingGetRows.push(() => params.successCallback([], 0)) },
+        });
+
+        expect(hasLoadingOverlay()).toBe(false);
+        expect(hasNoRowsOverlay()).toBe(false);
+
+        for (const pending of pendingGetRows) {
+            pending();
+        }
+
+        expect(hasLoadingOverlay()).toBe(false);
+        expect(hasNoRowsOverlay()).toBe(false);
+
+        consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+        api.setGridOption('rowData', []);
+
+        expect(consoleWarnSpy).toHaveBeenCalledWith("AG Grid: rowData is not supported with the 'infinite' row model.");
+
+        expect(hasLoadingOverlay()).toBe(false);
+        expect(hasNoRowsOverlay()).toBe(false);
+    });
+
+    test('it does show loading if forced', () => {
+        createMyGrid({
+            columnDefs,
+            rowModelType: 'infinite',
+            datasource: { getRows: () => {} },
+            loading: true,
+        });
+
+        expect(hasLoadingOverlay()).toBe(true);
+        expect(hasNoRowsOverlay()).toBe(false);
+    });
+});


### PR DESCRIPTION
With infinite row models, no-rows should not show, but instead with the new changing on overlays state management it was appearing over the rows.

- Fix the no-rows logic in overlayService
- Add unit tests for infinite rows and loading and no-rows

Before the fix: 
![image](https://github.com/ag-grid/ag-grid/assets/6913178/0b99369f-f857-4d75-97a7-47a7b275dd82)


After the fix: ![image](https://github.com/ag-grid/ag-grid/assets/6913178/1ee0be1b-9847-4cf4-8b7f-b7f689405f5c)
