### PR TITLE
RTI-2176 Support multiple Vue grids

### DIFF
--- a/community-modules/vue3/src/AgGridVue.ts
+++ b/community-modules/vue3/src/AgGridVue.ts
@@ -53,6 +53,8 @@ export const AgGridVue = defineComponent({
         isDestroyed: boolean;
         gridReadyFired: boolean;
         emitRowModel?: () => void | null;
+        batchTimeout: number | null;
+        batchChanges: { [key: string]: any };
     } {
         return {
             api: undefined,
@@ -60,6 +62,8 @@ export const AgGridVue = defineComponent({
             isDestroyed: false,
             gridReadyFired: false,
             emitRowModel: undefined,
+            batchTimeout: null,
+            batchChanges: {},
         };
     },
     computed,

--- a/community-modules/vue3/src/Utils.ts
+++ b/community-modules/vue3/src/Utils.ts
@@ -52,8 +52,7 @@ export const getAgGridProperties = (): [Properties, Properties, Properties] => {
             deep: true,
         },
     };
-    let timeout: number | null = null;
-    let changes: { [key: string]: any } = {};
+
     ComponentUtil.ALL_PROPERTIES.filter((propertyName: string) => propertyName != 'gridOptions') // dealt with in AgGridVue itself
         .forEach((propertyName: string) => {
             props[propertyName] = {
@@ -62,13 +61,13 @@ export const getAgGridProperties = (): [Properties, Properties, Properties] => {
 
             watch[propertyName] = {
                 handler(currentValue: any, previousValue: any) {
-                    changes[propertyName] =
+                    this.batchChanges[propertyName] =
                         currentValue === ComponentUtil.VUE_OMITTED_PROPERTY ? undefined : currentValue;
-                    if (timeout == null) {
-                        timeout = setTimeout(() => {
-                            _processOnChange(changes, this.api);
-                            timeout = null;
-                            changes = {};
+                    if (this.batchTimeout == null) {
+                        this.batchTimeout = setTimeout(() => {
+                            _processOnChange(this.batchChanges, this.api);
+                            this.batchTimeout = null;
+                            this.batchChanges = {};
                         }, 0);
                     }
                 },

--- a/packages/ag-grid-vue3/src/AgGridVue.ts
+++ b/packages/ag-grid-vue3/src/AgGridVue.ts
@@ -53,6 +53,8 @@ export const AgGridVue = defineComponent({
         isDestroyed: boolean;
         gridReadyFired: boolean;
         emitRowModel?: () => void | null;
+        batchTimeout: number | null;
+        batchChanges: { [key: string]: any };
     } {
         return {
             api: undefined,
@@ -60,6 +62,8 @@ export const AgGridVue = defineComponent({
             isDestroyed: false,
             gridReadyFired: false,
             emitRowModel: undefined,
+            batchTimeout: null,
+            batchChanges: {},
         };
     },
     computed,

--- a/packages/ag-grid-vue3/src/Utils.ts
+++ b/packages/ag-grid-vue3/src/Utils.ts
@@ -52,8 +52,7 @@ export const getAgGridProperties = (): [Properties, Properties, Properties] => {
             deep: true,
         },
     };
-    let timeout: number | null = null;
-    let changes: { [key: string]: any } = {};
+
     ComponentUtil.ALL_PROPERTIES.filter((propertyName: string) => propertyName != 'gridOptions') // dealt with in AgGridVue itself
         .forEach((propertyName: string) => {
             props[propertyName] = {
@@ -62,13 +61,13 @@ export const getAgGridProperties = (): [Properties, Properties, Properties] => {
 
             watch[propertyName] = {
                 handler(currentValue: any, previousValue: any) {
-                    changes[propertyName] =
+                    this.batchChanges[propertyName] =
                         currentValue === ComponentUtil.VUE_OMITTED_PROPERTY ? undefined : currentValue;
-                    if (timeout == null) {
-                        timeout = setTimeout(() => {
-                            _processOnChange(changes, this.api);
-                            timeout = null;
-                            changes = {};
+                    if (this.batchTimeout == null) {
+                        this.batchTimeout = setTimeout(() => {
+                            _processOnChange(this.batchChanges, this.api);
+                            this.batchTimeout = null;
+                            this.batchChanges = {};
                         }, 0);
                     }
                 },


### PR DESCRIPTION
Previously the `changes` and `timeout` properties where shared across all instances of the grid which meant that any property changes performed by one grid would be prevented from being fired for the other grid.

This change brings those properties onto the component instance so that they each have their own changes and timeout and are not overriding each other any more.