### PR TITLE
RTI-2202 Fix debug logging output

### DIFF
--- a/community-modules/core/src/gridOptionsService.ts
+++ b/community-modules/core/src/gridOptionsService.ts
@@ -255,7 +255,7 @@ export class GridOptionsService extends BeanStub implements NamedBean {
 
         events.forEach((event) => {
             if (this.gridOptions.debug) {
-                _log(`Updated property ${event.type} from ${event.previousValue} to ${event.currentValue}`);
+                _log(`Updated property ${event.type} from`, event.previousValue, ` to `, event.currentValue);
             }
             this.propertyEventService.dispatchEvent(event);
         });


### PR DESCRIPTION
Pass items as individual arguments to the log function so that they are not forced into strings and can be passed onto console.log as raw values.