### PR TITLE
RTI-2151 add Column Group Reference to the section Columns in the docs

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/reference/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/reference/index.mdoc
@@ -32,6 +32,7 @@ Reference pages list all column configurations and Column attributes, methods an
 
 * [Options Reference](./column-properties/): Properties and callbacks used to configure a column.
 * [Column Reference](./column-object/): Attributes and methods available on Columns.
+* [Column Group Reference](./column-object-group/): Attributes and methods available on Columns Groups.
 * [Events Reference](./column-events/): Events fired by Columns.
 
 ## Rows


### PR DESCRIPTION
Adds a Column Group reference in the docs

After:

![image](https://github.com/ag-grid/ag-grid/assets/6913178/97003818-37ba-47cb-911a-3f1e416414c5)
