### PR TITLE
RTI-2145 angular custom cell editor example broken

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/cell-editors/_examples/component-editor-2/simpleTextEditor.component_angular.ts
+++ b/documentation/ag-grid-docs/src/content/docs/cell-editors/_examples/component-editor-2/simpleTextEditor.component_angular.ts
@@ -1,10 +1,12 @@
 import { ICellEditorAngularComp } from '@ag-grid-community/angular';
 import { ICellEditorParams } from '@ag-grid-community/core';
 import { AfterViewInit, Component, ViewChild, ViewContainerRef } from '@angular/core';
+import { FormsModule } from '@angular/forms';
 
 @Component({
     standalone: true,
-    template: `<input class="my-simple-editor" [value]="value" #input /> `,
+    imports: [FormsModule],
+    template: `<input #input [(ngModel)]="value" class="my-simple-editor" />`,
 })
 export class SimpleTextEditor implements ICellEditorAngularComp, AfterViewInit {
     private params!: ICellEditorParams;
@@ -15,6 +17,7 @@ export class SimpleTextEditor implements ICellEditorAngularComp, AfterViewInit {
     agInit(params: ICellEditorParams): void {
         this.params = params;
         this.value = this.getInitialValue(params);
+        console.log('AGI INIT', this.value);
     }
 
     getValue(): any {

--- a/documentation/ag-grid-docs/src/content/docs/cell-editors/_examples/component-editor-2/simpleTextEditor.component_angular.ts
+++ b/documentation/ag-grid-docs/src/content/docs/cell-editors/_examples/component-editor-2/simpleTextEditor.component_angular.ts
@@ -17,7 +17,6 @@ export class SimpleTextEditor implements ICellEditorAngularComp, AfterViewInit {
     agInit(params: ICellEditorParams): void {
         this.params = params;
         this.value = this.getInitialValue(params);
-        console.log('AGI INIT', this.value);
     }
 
     getValue(): any {

--- a/documentation/ag-grid-docs/src/content/docs/cell-editors/_examples/get-editor-instance/provided/modules/angular/mySimple-editor.component.ts
+++ b/documentation/ag-grid-docs/src/content/docs/cell-editors/_examples/get-editor-instance/provided/modules/angular/mySimple-editor.component.ts
@@ -1,13 +1,15 @@
 import { ICellEditorAngularComp } from '@ag-grid-community/angular';
 import { ICellEditorParams } from '@ag-grid-community/core';
 import { AfterViewInit, Component, ViewChild, ViewContainerRef } from '@angular/core';
+import { FormsModule } from '@angular/forms';
 
 // backspace starts the editor on Windows
 const KEY_BACKSPACE = 'Backspace';
 
 @Component({
     standalone: true,
-    template: `<input class="my-simple-editor" [value]="value" #input /> `,
+    imports: [FormsModule],
+    template: `<input #input [(ngModel)]="value" class="my-simple-editor" /> `,
 })
 export class MySimpleEditor implements ICellEditorAngularComp, AfterViewInit {
     private params!: ICellEditorParams;


### PR DESCRIPTION
Fix to make editing cells works in angular examples in angular-data-grid/cell-editors/

changes:

- In both angular edit components `imports: [FormsModule],` was missing, and `[(ngModel)]` should be used instead of value=


Tested all angular examples in the page.