### PR TITLE
AG-11987 Warn on invalid selection state

### DIFF
--- a/community-modules/core/src/api/gridApi.ts
+++ b/community-modules/core/src/api/gridApi.ts
@@ -298,16 +298,16 @@ export interface GridApi<TData = any> {
     /**
      * Returns an object containing rules matching the selected rows in the SSRM.
      *
-     * If `groupSelectsChildren=false` the returned object will be flat, and will conform to IServerSideSelectionState.
-     * If `groupSelectsChildren=true` the returned object will be hierarchical, and will conform to IServerSideGroupSelectionState.
+     * If `groupSelectsChildren=false` the returned object will be flat, and will conform to `IServerSideSelectionState`.
+     * If `groupSelectsChildren=true` the returned object will be hierarchical, and will conform to `IServerSideGroupSelectionState`.
      */
     getServerSideSelectionState(): IServerSideSelectionState | IServerSideGroupSelectionState | null;
 
     /**
      * Set the rules matching the selected rows in the SSRM.
      *
-     * If `groupSelectsChildren=false` the param will be flat, and should conform to IServerSideSelectionState.
-     * If `groupSelectsChildren=true` the param will be hierarchical, and should conform to IServerSideGroupSelectionState.
+     * If `groupSelectsChildren=false` the param will be flat, and should conform to `IServerSideSelectionState`.
+     * If `groupSelectsChildren=true` the param will be hierarchical, and should conform to `IServerSideGroupSelectionState`.
      */
     setServerSideSelectionState(state: IServerSideSelectionState | IServerSideGroupSelectionState): void;
 

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-selection/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-selection/index.mdoc
@@ -129,6 +129,10 @@ params.api.setServerSideSelectionState({
 });
 ```
 
+{% note %}
+The state being used here conforms to `IServerSideGroupSelectionState`, not `IServerSideSelectionState`. Invalid states will be ignored.
+{% /note %}
+
 In the example below, note the following;
 
 * The above snippet has been included inside of the `firstDataRendered` callback, which sets the initial selection state.

--- a/enterprise-modules/server-side-row-model/src/serverSideRowModel/services/selection/strategies/defaultStrategy.ts
+++ b/enterprise-modules/server-side-row-model/src/serverSideRowModel/services/selection/strategies/defaultStrategy.ts
@@ -58,15 +58,17 @@ export class DefaultStrategy extends BeanStub implements ISelectionStrategy {
         };
 
         if (typeof state !== 'object') {
-            _errorOnce('The provided selection state should be an object.');
-            return;
+            return _errorOnce('The provided selection state should be an object.');
         }
 
-        if ('selectAll' in state && typeof state.selectAll === 'boolean') {
+        if (!('selectAll' in state)) {
+            return _errorOnce('State must conform to `IServerSideSelectionState`.');
+        }
+
+        if (typeof state.selectAll === 'boolean') {
             newState.selectAll = state.selectAll;
         } else {
-            _errorOnce('Select all status should be of boolean type.');
-            return;
+            return _errorOnce('selectAll must be of boolean type.');
         }
 
         if ('toggledNodes' in state && Array.isArray(state.toggledNodes)) {
@@ -78,8 +80,7 @@ export class DefaultStrategy extends BeanStub implements ISelectionStrategy {
                 }
             });
         } else {
-            _warnOnce('`toggledNodes` must be an array of string ids.');
-            return;
+            return _warnOnce('`toggledNodes` must be an array of string ids.');
         }
 
         this.selectedState = newState;

--- a/enterprise-modules/server-side-row-model/src/serverSideRowModel/services/selection/strategies/defaultStrategy.ts
+++ b/enterprise-modules/server-side-row-model/src/serverSideRowModel/services/selection/strategies/defaultStrategy.ts
@@ -1,6 +1,7 @@
 import type {
     BeanCollection,
     IRowModel,
+    IServerSideGroupSelectionState,
     IServerSideSelectionState,
     ISetNodesSelectedParams,
     RowNode,
@@ -49,7 +50,7 @@ export class DefaultStrategy extends BeanStub implements ISelectionStrategy {
         };
     }
 
-    public setSelectedState(state: any) {
+    public setSelectedState(state: IServerSideSelectionState | IServerSideGroupSelectionState): void {
         // fire selection changed event
         const newState: SelectedState = {
             selectAll: false,

--- a/enterprise-modules/server-side-row-model/src/serverSideRowModel/services/selection/strategies/groupSelectsChildrenStrategy.ts
+++ b/enterprise-modules/server-side-row-model/src/serverSideRowModel/services/selection/strategies/groupSelectsChildrenStrategy.ts
@@ -76,10 +76,9 @@ export class GroupSelectsChildrenStrategy extends BeanStub implements ISelection
 
     public setSelectedState(state: IServerSideSelectionState | IServerSideGroupSelectionState): void {
         if ('selectAll' in state) {
-            _errorOnce(
+            return _errorOnce(
                 'Invalid selection state. When `groupSelectsChildren` is enabled, the state must conform to `IServerSideGroupSelectionState`.'
             );
-            return;
         }
 
         const recursivelyDeserializeState = (

--- a/enterprise-modules/server-side-row-model/src/serverSideRowModel/services/selection/strategies/groupSelectsChildrenStrategy.ts
+++ b/enterprise-modules/server-side-row-model/src/serverSideRowModel/services/selection/strategies/groupSelectsChildrenStrategy.ts
@@ -87,14 +87,14 @@ export class GroupSelectsChildrenStrategy extends BeanStub implements ISelection
             parentSelected: boolean
         ): SelectionState => {
             if (typeof normalisedState !== 'object') {
-                throw new Error('AG Grid: Each provided state object must be an object.');
+                throw new Error('Each provided state object must be an object.');
             }
             if ('selectAllChildren' in normalisedState && typeof normalisedState.selectAllChildren !== 'boolean') {
-                throw new Error('AG Grid: `selectAllChildren` must be a boolean value or undefined.');
+                throw new Error('`selectAllChildren` must be a boolean value or undefined.');
             }
             if ('toggledNodes' in normalisedState) {
                 if (!Array.isArray(normalisedState.toggledNodes)) {
-                    throw new Error('AG Grid: `toggledNodes` must be an array.');
+                    throw new Error('`toggledNodes` must be an array.');
                 }
                 const allHaveIds = normalisedState.toggledNodes.every(
                     (innerState) =>
@@ -103,7 +103,7 @@ export class GroupSelectsChildrenStrategy extends BeanStub implements ISelection
                         typeof innerState.nodeId === 'string'
                 );
                 if (!allHaveIds) {
-                    throw new Error('AG Grid: Every `toggledNode` requires an associated string id.');
+                    throw new Error('Every `toggledNode` requires an associated string id.');
                 }
             }
             const isThisNodeSelected = normalisedState.selectAllChildren ?? !parentSelected;
@@ -117,7 +117,7 @@ export class GroupSelectsChildrenStrategy extends BeanStub implements ISelection
             );
             if (doesRedundantStateExist) {
                 throw new Error(`
-                    AG Grid: AG Grid: Row selection state could not be parsed due to invalid data. Ensure all child state has toggledNodes or does not conform with the parent rule.
+                    Row selection state could not be parsed due to invalid data. Ensure all child state has toggledNodes or does not conform with the parent rule.
                     Please rebuild the selection state and reapply it.
                 `);
             }

--- a/enterprise-modules/server-side-row-model/src/serverSideRowModel/services/selection/strategies/groupSelectsChildrenStrategy.ts
+++ b/enterprise-modules/server-side-row-model/src/serverSideRowModel/services/selection/strategies/groupSelectsChildrenStrategy.ts
@@ -6,6 +6,7 @@ import type {
     IRowNode,
     ISelectionService,
     IServerSideGroupSelectionState,
+    IServerSideSelectionState,
     ISetNodesSelectedParams,
     RowNode,
     SelectionEventSourceType,
@@ -73,7 +74,7 @@ export class GroupSelectsChildrenStrategy extends BeanStub implements ISelection
         return recursivelySerializeState(this.selectedState, 0);
     }
 
-    public setSelectedState(state: IServerSideGroupSelectionState) {
+    public setSelectedState(state: IServerSideSelectionState | IServerSideGroupSelectionState): void {
         const recursivelyDeserializeState = (
             normalisedState: IServerSideGroupSelectionState,
             parentSelected: boolean

--- a/enterprise-modules/server-side-row-model/src/serverSideRowModel/services/selection/strategies/groupSelectsChildrenStrategy.ts
+++ b/enterprise-modules/server-side-row-model/src/serverSideRowModel/services/selection/strategies/groupSelectsChildrenStrategy.ts
@@ -75,6 +75,13 @@ export class GroupSelectsChildrenStrategy extends BeanStub implements ISelection
     }
 
     public setSelectedState(state: IServerSideSelectionState | IServerSideGroupSelectionState): void {
+        if ('selectAll' in state) {
+            _errorOnce(
+                'Invalid selection state. When `groupSelectsChildren` is enabled, the state must conform to `IServerSideGroupSelectionState`.'
+            );
+            return;
+        }
+
         const recursivelyDeserializeState = (
             normalisedState: IServerSideGroupSelectionState,
             parentSelected: boolean

--- a/enterprise-modules/server-side-row-model/src/serverSideRowModel/services/selection/strategies/iSelectionStrategy.ts
+++ b/enterprise-modules/server-side-row-model/src/serverSideRowModel/services/selection/strategies/iSelectionStrategy.ts
@@ -1,8 +1,15 @@
-import type { Bean, ISetNodesSelectedParams, RowNode, SelectionEventSourceType } from '@ag-grid-community/core';
+import type {
+    Bean,
+    IServerSideGroupSelectionState,
+    IServerSideSelectionState,
+    ISetNodesSelectedParams,
+    RowNode,
+    SelectionEventSourceType,
+} from '@ag-grid-community/core';
 
 export interface ISelectionStrategy extends Bean {
     getSelectedState(): any;
-    setSelectedState(state: any): void;
+    setSelectedState(state: IServerSideSelectionState | IServerSideGroupSelectionState): void;
     setNodesSelected(params: ISetNodesSelectedParams): number;
     isNodeSelected(node: RowNode): boolean | undefined;
     processNewRow(node: RowNode): void;


### PR DESCRIPTION
See https://ag-grid.atlassian.net/browse/AG-11987

The use of `any` in the method signature let this issue sneak through. Fix up the signatures and some log messages, add a warning for invalid states in `GroupSelectsChildrenStrategy`. The `DefaultStrategy` already covers this case, but I've made the messages a bit more granular.