### PR TITLE
AG-11844 Prevent group nodes from sticking to the bottom of the viewport

### DIFF
--- a/community-modules/core/src/rendering/features/stickyRowFeature.ts
+++ b/community-modules/core/src/rendering/features/stickyRowFeature.ts
@@ -261,6 +261,10 @@ export class StickyRowFeature extends BeanStub {
                 if (suppressGroupsSticky === true) {
                     return false;
                 }
+                if (container === 'bottom') {
+                    // Group rows should never stick to the bottom of the viewport
+                    return false;
+                }
                 const alreadySticking = newStickyRows.has(row);
                 return !alreadySticking && row.expanded;
             }


### PR DESCRIPTION
See https://ag-grid.atlassian.net/browse/AG-11844

Prevents group nodes from being marked as `sticky` when being scrolled into the bottom of viewport. They should never stick to the bottom of the viewport and this was also preventing them being navigated to with the keyboard.