### PR TITLE
AG-11965 - fix regression in code reference files generate

### DIFF
--- a/plugins/ag-grid-generate-code-reference-files/src/executors/generate/generate-code-reference-files.ts
+++ b/plugins/ag-grid-generate-code-reference-files/src/executors/generate/generate-code-reference-files.ts
@@ -467,17 +467,31 @@ export function getGridApi(gridApiFile: string) {
         members = { ...members, ...typesFromNode };
     };
 
-    gridApi.heritageClauses.forEach((h) => {
-        h.types.forEach((t) => {
-            const typeName = formatNode(t.expression, srcFile);
-            const typeNode = findNode(typeName, srcFile);
-            if (!typeNode) {
-                errors.push(`Could not find base interface for ${typeName}`);
-            } else {
-                ts.forEachChild(typeNode, (n) => addType(typeName, n));
-            }
+    const processedInterfaces = new Set<ts.InterfaceDeclaration>();
+
+    const processInterface = (declaration: ts.InterfaceDeclaration | undefined) => {
+        if (!declaration || processedInterfaces.has(declaration)) {
+            return;
+        }
+        processedInterfaces.add(declaration);
+
+        declaration.heritageClauses.forEach((h) => {
+            h.types.forEach((t) => {
+                const typeName = formatNode(t.expression, srcFile);
+                const typeNode = findNode(typeName, srcFile);
+                if (!typeNode) {
+                    errors.push(`Could not find base interface for ${typeName}`);
+                } else {
+                    if (ts.isInterfaceDeclaration(typeNode)) {
+                        processInterface(typeNode);
+                    }
+                    ts.forEachChild(typeNode, (n) => addType(typeName, n));
+                }
+            });
         });
-    });
+    };
+
+    processInterface(gridApi);
 
     ts.forEachChild(gridApi, (n) => addType('GridApi', n));
 


### PR DESCRIPTION
The implementation of getGridApi in docs generator was not recursive and was not processing all base interfaces.
The previous change merged in https://github.com/ag-grid/ag-grid/pull/8280 introduced a regression as it introduces a new base interface, so all core APIs were not included in the documentation generated json.

This fixes the issue by making getGridApi recursive