### PR TITLE
AG-11982 allow overlays to be focusable and prevent header cells from focus when using loading overlay

### DIFF
--- a/community-modules/core/src/focusService.ts
+++ b/community-modules/core/src/focusService.ts
@@ -735,6 +735,12 @@ export class FocusService extends BeanStub implements NamedBean {
         return true;
     }
 
+    /** Returns true if an element inside the grid has focus */
+    public isGridFocused(): boolean {
+        const activeEl = this.gos.getActiveDomElement();
+        return !!activeEl && this.eGridDiv.contains(activeEl);
+    }
+
     public focusNextGridCoreContainer(backwards: boolean, forceOut: boolean = false): boolean {
         if (!forceOut && this.gridCtrl.focusNextInnerContainer(backwards)) {
             return true;

--- a/community-modules/core/src/gridComp/gridCtrl.ts
+++ b/community-modules/core/src/gridComp/gridCtrl.ts
@@ -159,7 +159,7 @@ export class GridCtrl extends BeanStub {
 
         const overlayService = this.overlayService;
         if (overlayService.isExclusive()) {
-            return this.focusContainer(overlayService.getOverlayComponent(), fromBottom);
+            return this.focusContainer(overlayService.getOverlayWrapper(), fromBottom);
         }
 
         const focusableContainers = this.getFocusableContainers();
@@ -215,19 +215,15 @@ export class GridCtrl extends BeanStub {
         const overlayService = this.overlayService;
 
         if (overlayService.isExclusive()) {
-            // When loading overlay is visible, focus should be on the overlay only
-            return [overlayService.getOverlayComponent()];
+            // An exclusive overlay takes precedence over all other focusable containers
+            return [overlayService.getOverlayWrapper()];
         }
 
-        const result = this.view.getFocusableContainers().slice();
-
-        for (const c of this.additionalFocusableContainers) {
-            result.push(c);
-        }
+        const result = [...this.view.getFocusableContainers(), ...this.additionalFocusableContainers];
 
         if (overlayService.isVisible()) {
             // We allow focusing on the no-rows overlay
-            result.push(overlayService.getOverlayComponent());
+            result.push(overlayService.getOverlayWrapper());
         }
 
         return result;

--- a/community-modules/core/src/gridComp/gridCtrl.ts
+++ b/community-modules/core/src/gridComp/gridCtrl.ts
@@ -7,6 +7,7 @@ import type { FocusService } from '../focusService';
 import type { WithoutGridCommon } from '../interfaces/iCommon';
 import type { FocusableContainer } from '../interfaces/iFocusableContainer';
 import type { IWatermark } from '../interfaces/iWatermark';
+import type { OverlayService } from '../rendering/overlays/overlayService';
 import type { LayoutView } from '../styling/layoutFeature';
 import { LayoutFeature } from '../styling/layoutFeature';
 import { _last } from '../utils/array';
@@ -32,12 +33,14 @@ export interface OptionalGridComponents {
 export class GridCtrl extends BeanStub {
     private beans: BeanCollection;
     private focusService: FocusService;
+    private overlayService: OverlayService;
     private visibleColsService: VisibleColsService;
 
     public wireBeans(beans: BeanCollection) {
         this.beans = beans;
         this.focusService = beans.focusService;
         this.visibleColsService = beans.visibleColsService;
+        this.overlayService = beans.overlayService;
     }
 
     private view: IGridComp;
@@ -149,14 +152,18 @@ export class GridCtrl extends BeanStub {
     }
 
     public focusInnerElement(fromBottom?: boolean): boolean {
-        const focusableContainers = this.getFocusableContainers();
-        const allColumns = this.visibleColsService.getAllCols();
-
         const userCallbackFunction = this.gos.getCallback('focusGridInnerElement');
-
         if (userCallbackFunction && userCallbackFunction({ fromBottom: !!fromBottom })) {
             return true;
         }
+
+        const overlayService = this.overlayService;
+        if (overlayService.isExclusive()) {
+            return this.focusContainer(overlayService.getOverlayComponent(), fromBottom);
+        }
+
+        const focusableContainers = this.getFocusableContainers();
+        const allColumns = this.visibleColsService.getAllCols();
 
         if (fromBottom) {
             if (focusableContainers.length > 1) {
@@ -198,14 +205,32 @@ export class GridCtrl extends BeanStub {
     }
 
     private focusContainer(comp: FocusableContainer, up?: boolean): boolean {
-        comp?.setAllowFocus?.(true);
+        comp.setAllowFocus?.(true);
         const result = this.focusService.focusInto(comp.getGui(), up);
-        comp?.setAllowFocus?.(false);
+        comp.setAllowFocus?.(false);
         return result;
     }
 
     private getFocusableContainers(): FocusableContainer[] {
-        return [...this.view.getFocusableContainers(), ...this.additionalFocusableContainers.values()];
+        const overlayService = this.overlayService;
+
+        if (overlayService.isExclusive()) {
+            // When loading overlay is visible, focus should be on the overlay only
+            return [overlayService.getOverlayComponent()];
+        }
+
+        const result = this.view.getFocusableContainers().slice();
+
+        for (const c of this.additionalFocusableContainers) {
+            result.push(c);
+        }
+
+        if (overlayService.isVisible()) {
+            // We allow focusing on the no-rows overlay
+            result.push(overlayService.getOverlayComponent());
+        }
+
+        return result;
     }
 
     public override destroy(): void {

--- a/community-modules/core/src/rendering/overlays/overlayService.ts
+++ b/community-modules/core/src/rendering/overlays/overlayService.ts
@@ -47,15 +47,18 @@ export class OverlayService extends BeanStub implements NamedBean {
         this.updateOverlayVisibility();
     }
 
-    public isExclusive(): boolean {
-        return this.state === OverlayServiceState.Loading;
-    }
-
+    /** Returns true if the overlay is visible. */
     public isVisible(): boolean {
         return this.state !== OverlayServiceState.Hidden;
     }
 
-    public getOverlayComponent(): OverlayWrapperComponent {
+    /** Returns true if the overlay is visible and is exclusive (popup over the grid) */
+    public isExclusive(): boolean {
+        return this.state === OverlayServiceState.Loading;
+    }
+
+    /** Gets the overlay wrapper component */
+    public getOverlayWrapper(): OverlayWrapperComponent {
         return this.overlayWrapperComp;
     }
 
@@ -145,6 +148,6 @@ export class OverlayService extends BeanStub implements NamedBean {
 
     private showOverlay(compDetails: UserCompDetails, wrapperCssClass: string, gridOption: keyof GridOptions): void {
         const promise = compDetails.newAgStackInstance();
-        this.overlayWrapperComp.showOverlay(promise, wrapperCssClass, gridOption);
+        this.overlayWrapperComp.showOverlay(promise, wrapperCssClass, this.isExclusive(), gridOption);
     }
 }

--- a/community-modules/core/src/rendering/overlays/overlayService.ts
+++ b/community-modules/core/src/rendering/overlays/overlayService.ts
@@ -47,6 +47,18 @@ export class OverlayService extends BeanStub implements NamedBean {
         this.updateOverlayVisibility();
     }
 
+    public isExclusive(): boolean {
+        return this.state === OverlayServiceState.Loading;
+    }
+
+    public isVisible(): boolean {
+        return this.state !== OverlayServiceState.Hidden;
+    }
+
+    public getOverlayComponent(): OverlayWrapperComponent {
+        return this.overlayWrapperComp;
+    }
+
     public showLoadingOverlay(): void {
         this.showInitialOverlay = false;
 

--- a/community-modules/core/src/rendering/overlays/overlayWrapperComponent.ts
+++ b/community-modules/core/src/rendering/overlays/overlayWrapperComponent.ts
@@ -148,7 +148,7 @@ export class OverlayWrapperComponent extends Component implements LayoutView {
         _clearElement(this.eOverlayWrapper);
 
         // Focus the element that was focused before the exclusive overlay was shown
-        elementToFocus?.focus();
+        elementToFocus?.focus({ preventScroll: true });
     }
 
     public hideOverlay(): void {

--- a/community-modules/core/src/rendering/overlays/overlayWrapperComponent.ts
+++ b/community-modules/core/src/rendering/overlays/overlayWrapperComponent.ts
@@ -1,5 +1,6 @@
 import type { BeanCollection } from '../../context/context';
 import type { GridOptions } from '../../entities/gridOptions';
+import type { FocusService } from '../../focusService';
 import type { LayoutView, UpdateLayoutClassesParams } from '../../styling/layoutFeature';
 import { LayoutCssClasses, LayoutFeature } from '../../styling/layoutFeature';
 import { _clearElement } from '../../utils/dom';
@@ -11,9 +12,11 @@ import type { OverlayService } from './overlayService';
 
 export class OverlayWrapperComponent extends Component implements LayoutView {
     private overlayService: OverlayService;
+    private focusService: FocusService;
 
     public wireBeans(beans: BeanCollection): void {
         this.overlayService = beans.overlayService;
+        this.focusService = beans.focusService;
     }
 
     private readonly eOverlayWrapper: HTMLElement = RefPlaceholder;
@@ -22,6 +25,7 @@ export class OverlayWrapperComponent extends Component implements LayoutView {
     private activeOverlay: IOverlayComp | null = null;
     private updateListenerDestroyFunc: (() => null) | null = null;
     private activeOverlayWrapperCssClass: string | null = null;
+    private elToFocusAfter: HTMLElement | null = null;
 
     constructor() {
         // wrapping in outer div, and wrapper, is needed to center the loading icon
@@ -59,14 +63,29 @@ export class OverlayWrapperComponent extends Component implements LayoutView {
     public showOverlay(
         overlayComponentPromise: AgPromise<IOverlayComp> | null,
         overlayWrapperCssClass: string,
+        exclusive: boolean,
         gridOption?: keyof GridOptions
     ): void {
         this.setWrapperTypeClass(overlayWrapperCssClass);
         this.destroyActiveOverlay();
 
+        this.elToFocusAfter = null;
         this.activePromise = overlayComponentPromise;
 
-        overlayComponentPromise?.then((comp) => {
+        if (!overlayComponentPromise) {
+            return;
+        }
+
+        this.setDisplayed(true, { skipAriaHidden: true });
+
+        if (exclusive && this.focusService.isGridFocused()) {
+            const activeElement = this.gos.getActiveDomElement();
+            if (activeElement && 'focus' in activeElement) {
+                this.elToFocusAfter = activeElement as HTMLElement;
+            }
+        }
+
+        overlayComponentPromise.then((comp) => {
             if (this.activePromise !== overlayComponentPromise) {
                 // Another promise was started, we need to cancel this old operation
                 if (this.activeOverlay !== comp) {
@@ -83,22 +102,23 @@ export class OverlayWrapperComponent extends Component implements LayoutView {
                 return; // Error handling
             }
 
-            if (this.activeOverlay == comp) {
-                return; // same component, already active
+            if (this.activeOverlay !== comp) {
+                this.eOverlayWrapper.appendChild(comp.getGui());
+                this.activeOverlay = comp;
+
+                if (gridOption) {
+                    const component = comp;
+                    this.updateListenerDestroyFunc = this.addManagedPropertyListener(gridOption, ({ currentValue }) => {
+                        component.refresh?.(this.gos.addGridCommonParams({ ...(currentValue ?? {}) }));
+                    });
+                }
             }
 
-            this.eOverlayWrapper.appendChild(comp.getGui());
-            this.activeOverlay = comp;
-
-            if (gridOption) {
-                const component = comp;
-                this.updateListenerDestroyFunc = this.addManagedPropertyListener(gridOption, ({ currentValue }) => {
-                    component.refresh?.(this.gos.addGridCommonParams({ ...(currentValue ?? {}) }));
-                });
+            const focusService = this.focusService;
+            if (exclusive && focusService.isGridFocused()) {
+                focusService.focusInto(this.eOverlayWrapper);
             }
         });
-
-        this.setDisplayed(true, { skipAriaHidden: true });
     }
 
     private destroyActiveOverlay(): void {
@@ -109,7 +129,13 @@ export class OverlayWrapperComponent extends Component implements LayoutView {
             return; // Nothing to destroy
         }
 
+        let elementToFocus = this.elToFocusAfter;
         this.activeOverlay = null;
+        this.elToFocusAfter = null;
+
+        if (elementToFocus && !this.focusService.isGridFocused()) {
+            elementToFocus = null;
+        }
 
         const updateListenerDestroyFunc = this.updateListenerDestroyFunc;
         if (updateListenerDestroyFunc) {
@@ -120,6 +146,9 @@ export class OverlayWrapperComponent extends Component implements LayoutView {
         this.destroyBean(activeOverlay);
 
         _clearElement(this.eOverlayWrapper);
+
+        // Focus the element that was focused before the exclusive overlay was shown
+        elementToFocus?.focus();
     }
 
     public hideOverlay(): void {
@@ -128,6 +157,7 @@ export class OverlayWrapperComponent extends Component implements LayoutView {
     }
 
     public override destroy(): void {
+        this.elToFocusAfter = null;
         this.destroyActiveOverlay();
         super.destroy();
     }

--- a/community-modules/core/src/rendering/overlays/overlayWrapperComponent.ts
+++ b/community-modules/core/src/rendering/overlays/overlayWrapperComponent.ts
@@ -80,7 +80,7 @@ export class OverlayWrapperComponent extends Component implements LayoutView {
 
         if (exclusive && this.focusService.isGridFocused()) {
             const activeElement = this.gos.getActiveDomElement();
-            if (activeElement && 'focus' in activeElement) {
+            if (activeElement && !this.gos.isNothingFocused()) {
                 this.elToFocusAfter = activeElement as HTMLElement;
             }
         }
@@ -148,7 +148,7 @@ export class OverlayWrapperComponent extends Component implements LayoutView {
         _clearElement(this.eOverlayWrapper);
 
         // Focus the element that was focused before the exclusive overlay was shown
-        elementToFocus?.focus({ preventScroll: true });
+        elementToFocus?.focus?.({ preventScroll: true });
     }
 
     public hideOverlay(): void {

--- a/documentation/ag-grid-docs/src/content/docs/overlays/_examples/loading-overlay/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/overlays/_examples/loading-overlay/main.ts
@@ -14,8 +14,6 @@ let gridApi: GridApi<IAthlete>;
 const gridOptions: GridOptions<IAthlete> = {
     loading: true,
     columnDefs: [{ field: 'athlete' }, { field: 'country' }],
-    overlayLoadingTemplate: '<button>loading</button>',
-    overlayNoRowsTemplate: '<button>no rows</button>',
 };
 
 function setLoading(value: boolean) {
@@ -34,16 +32,4 @@ function onBtnSetRowData() {
 document.addEventListener('DOMContentLoaded', function () {
     const gridDiv = document.querySelector<HTMLElement>('#myGrid')!;
     gridApi = createGrid(gridDiv, gridOptions);
-});
-
-window.addEventListener('keydown', (e) => {
-    if (e.key === 'l') {
-        setLoading(true);
-    } else if (e.key === 'u') {
-        setLoading(false);
-    } else if (e.key === 'c') {
-        onBtnClearRowData();
-    } else if (e.key === 's') {
-        onBtnSetRowData();
-    }
 });

--- a/documentation/ag-grid-docs/src/content/docs/overlays/_examples/loading-overlay/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/overlays/_examples/loading-overlay/main.ts
@@ -14,6 +14,8 @@ let gridApi: GridApi<IAthlete>;
 const gridOptions: GridOptions<IAthlete> = {
     loading: true,
     columnDefs: [{ field: 'athlete' }, { field: 'country' }],
+    overlayLoadingTemplate: '<button>loading</button>',
+    overlayNoRowsTemplate: '<button>no rows</button>',
 };
 
 function setLoading(value: boolean) {
@@ -32,4 +34,16 @@ function onBtnSetRowData() {
 document.addEventListener('DOMContentLoaded', function () {
     const gridDiv = document.querySelector<HTMLElement>('#myGrid')!;
     gridApi = createGrid(gridDiv, gridOptions);
+});
+
+window.addEventListener('keydown', (e) => {
+    if (e.key === 'l') {
+        setLoading(true);
+    } else if (e.key === 'u') {
+        setLoading(false);
+    } else if (e.key === 'c') {
+        onBtnClearRowData();
+    } else if (e.key === 's') {
+        onBtnSetRowData();
+    }
 });


### PR DESCRIPTION
- add a new utility method isGridFocused in FocusService that returns true if an element in the grid has focus
- change focusable containers logic in grid controller, so that the exclusive loading overlays are the only focusable thing, and the non exclusive no-rows overlay is focusable
- change the overlay wrapper component so when the exclusive loading overlay is visible, and the grid was focused, the focus goes to the loading overlay
- change the overlay wrapper component so that when the exclusive loading overlay is closed, the focus goes back to the previous focused element, if still exists