### PR TITLE
AG-12030 - Upgrade react query

### DIFF
--- a/documentation/ag-grid-docs/package.json
+++ b/documentation/ag-grid-docs/package.json
@@ -71,7 +71,7 @@
     "react-gif-player": "0.5.1",
     "react-instantsearch": "^7.7.0",
     "react-markdown": "5.0.3",
-    "react-query": "^3.39.3",
+    "@tanstack/react-query": "4.36.1",
     "react-shadow": "^20.4.0",
     "sass": "^1.70.0",
     "typescript": "^5.3.3",

--- a/documentation/ag-grid-docs/package.json
+++ b/documentation/ag-grid-docs/package.json
@@ -71,7 +71,7 @@
     "react-gif-player": "0.5.1",
     "react-instantsearch": "^7.7.0",
     "react-markdown": "5.0.3",
-    "@tanstack/react-query": "4.36.1",
+    "@tanstack/react-query": "^5.51.1",
     "react-shadow": "^20.4.0",
     "sass": "^1.70.0",
     "typescript": "^5.3.3",

--- a/documentation/ag-grid-docs/src/components/reference-documentation/ApiDocumentationWithQuery.tsx
+++ b/documentation/ag-grid-docs/src/components/reference-documentation/ApiDocumentationWithQuery.tsx
@@ -25,14 +25,16 @@ export function ApiDocumentationWithQuery(props: Props) {
 }
 
 function ApiDocumentationWithLookups(props: Props) {
-    const { data: interfaceLookup } = useQuery(
-        ['resolved-interfaces'],
-        async () => {
+    const { data: interfaceLookup } = useQuery({
+        queryKey: ['resolved-interfaces'],
+
+        queryFn: async () => {
             const data = await fetchExtraFile('/reference/interfaces.AUTO.json');
             return data;
         },
-        queryOptions
-    );
+
+        ...queryOptions,
+    });
 
     return interfaceLookup && <ApiDocumentation {...props} interfaceLookup={interfaceLookup} />;
 }

--- a/documentation/ag-grid-docs/src/components/reference-documentation/ApiDocumentationWithQuery.tsx
+++ b/documentation/ag-grid-docs/src/components/reference-documentation/ApiDocumentationWithQuery.tsx
@@ -1,22 +1,15 @@
-import { QueryClient, QueryClientProvider, useQuery } from '@tanstack/react-query';
+import { useStore } from '@nanostores/react';
+import { $queryClient, defaultQueryOptions } from '@stores/queryClientStore';
+import { QueryClientProvider, useQuery } from '@tanstack/react-query';
 import { fetchExtraFile } from '@utils/client/fetchExtraFile';
 
 import { ApiDocumentation, type ApiDocumentationProps } from './ReferenceDocumentation';
 
-// NOTE: Not on the layout level, as that is generated at build time, and queryClient needs to be
-// loaded on the client side
-const queryClient = new QueryClient();
-
-const queryOptions = {
-    retry: false,
-    refetchOnMount: false,
-    refetchOnWindowFocus: false,
-    refetchOnReconnect: false,
-};
-
 type Props = Omit<ApiDocumentationProps, 'interfaceLookup'>;
 
 export function ApiDocumentationWithQuery(props: Props) {
+    const queryClient = useStore($queryClient);
+
     return (
         <QueryClientProvider client={queryClient}>
             <ApiDocumentationWithLookups {...props} />
@@ -33,7 +26,7 @@ function ApiDocumentationWithLookups(props: Props) {
             return data;
         },
 
-        ...queryOptions,
+        ...defaultQueryOptions,
     });
 
     return interfaceLookup && <ApiDocumentation {...props} interfaceLookup={interfaceLookup} />;

--- a/documentation/ag-grid-docs/src/components/reference-documentation/ApiDocumentationWithQuery.tsx
+++ b/documentation/ag-grid-docs/src/components/reference-documentation/ApiDocumentationWithQuery.tsx
@@ -1,5 +1,5 @@
+import { QueryClient, QueryClientProvider, useQuery } from '@tanstack/react-query';
 import { fetchExtraFile } from '@utils/client/fetchExtraFile';
-import { QueryClient, QueryClientProvider, useQuery } from 'react-query';
 
 import { ApiDocumentation, type ApiDocumentationProps } from './ReferenceDocumentation';
 

--- a/documentation/ag-grid-docs/src/components/reference-documentation/ApiDocumentationWithQuery.tsx
+++ b/documentation/ag-grid-docs/src/components/reference-documentation/ApiDocumentationWithQuery.tsx
@@ -1,9 +1,9 @@
 import { useStore } from '@nanostores/react';
-import { $queryClient, defaultQueryOptions } from '@stores/queryClientStore';
-import { QueryClientProvider, useQuery } from '@tanstack/react-query';
-import { fetchExtraFile } from '@utils/client/fetchExtraFile';
+import { $queryClient } from '@stores/queryClientStore';
+import { QueryClientProvider } from '@tanstack/react-query';
 
 import { ApiDocumentation, type ApiDocumentationProps } from './ReferenceDocumentation';
+import { useResolvedInterfaces } from './useResolvedInterfaces';
 
 type Props = Omit<ApiDocumentationProps, 'interfaceLookup'>;
 
@@ -18,16 +18,7 @@ export function ApiDocumentationWithQuery(props: Props) {
 }
 
 function ApiDocumentationWithLookups(props: Props) {
-    const { data: interfaceLookup } = useQuery({
-        queryKey: ['resolved-interfaces'],
-
-        queryFn: async () => {
-            const data = await fetchExtraFile('/reference/interfaces.AUTO.json');
-            return data;
-        },
-
-        ...defaultQueryOptions,
-    });
+    const interfaceLookup = useResolvedInterfaces();
 
     return interfaceLookup && <ApiDocumentation {...props} interfaceLookup={interfaceLookup} />;
 }

--- a/documentation/ag-grid-docs/src/components/reference-documentation/InterfaceDocumentationWithQuery.tsx
+++ b/documentation/ag-grid-docs/src/components/reference-documentation/InterfaceDocumentationWithQuery.tsx
@@ -1,22 +1,15 @@
-import { QueryClient, QueryClientProvider, useQuery } from '@tanstack/react-query';
+import { useStore } from '@nanostores/react';
+import { $queryClient, defaultQueryOptions } from '@stores/queryClientStore';
+import { QueryClientProvider, useQuery } from '@tanstack/react-query';
 import { fetchExtraFile } from '@utils/client/fetchExtraFile';
 
 import { InterfaceDocumentation, type InterfaceDocumentationProps } from './ReferenceDocumentation';
 
-// NOTE: Not on the layout level, as that is generated at build time, and queryClient needs to be
-// loaded on the client side
-const queryClient = new QueryClient();
-
-const queryOptions = {
-    retry: false,
-    refetchOnMount: false,
-    refetchOnWindowFocus: false,
-    refetchOnReconnect: false,
-};
-
 type Props = Omit<InterfaceDocumentationProps, 'interfaceLookup' | 'codeLookup'>;
 
 export function InterfaceDocumentationWithQuery(props: Props) {
+    const queryClient = useStore($queryClient);
+
     return (
         <QueryClientProvider client={queryClient}>
             <InterfaceDocumentationWithLookups {...props} />
@@ -26,7 +19,7 @@ export function InterfaceDocumentationWithQuery(props: Props) {
 
 function InterfaceDocumentationWithLookups(props: Props) {
     const { data: [interfaceLookup, codeLookup] = [] } = useQuery({
-        queryKey: ['resolved-interfaces'],
+        queryKey: ['resolved-interfaces-docs'],
 
         queryFn: async () => {
             return Promise.all([
@@ -35,7 +28,7 @@ function InterfaceDocumentationWithLookups(props: Props) {
             ]);
         },
 
-        ...queryOptions,
+        ...defaultQueryOptions,
     });
 
     return (

--- a/documentation/ag-grid-docs/src/components/reference-documentation/InterfaceDocumentationWithQuery.tsx
+++ b/documentation/ag-grid-docs/src/components/reference-documentation/InterfaceDocumentationWithQuery.tsx
@@ -1,9 +1,9 @@
 import { useStore } from '@nanostores/react';
-import { $queryClient, defaultQueryOptions } from '@stores/queryClientStore';
-import { QueryClientProvider, useQuery } from '@tanstack/react-query';
-import { fetchExtraFile } from '@utils/client/fetchExtraFile';
+import { $queryClient } from '@stores/queryClientStore';
+import { QueryClientProvider } from '@tanstack/react-query';
 
 import { InterfaceDocumentation, type InterfaceDocumentationProps } from './ReferenceDocumentation';
+import { useResolvedDocInterfaces, useResolvedInterfaces } from './useResolvedInterfaces';
 
 type Props = Omit<InterfaceDocumentationProps, 'interfaceLookup' | 'codeLookup'>;
 
@@ -18,18 +18,8 @@ export function InterfaceDocumentationWithQuery(props: Props) {
 }
 
 function InterfaceDocumentationWithLookups(props: Props) {
-    const { data: [interfaceLookup, codeLookup] = [] } = useQuery({
-        queryKey: ['resolved-interfaces-docs'],
-
-        queryFn: async () => {
-            return Promise.all([
-                fetchExtraFile('/reference/interfaces.AUTO.json'),
-                fetchExtraFile('/reference/doc-interfaces.AUTO.json'),
-            ]);
-        },
-
-        ...defaultQueryOptions,
-    });
+    const interfaceLookup = useResolvedInterfaces();
+    const codeLookup = useResolvedDocInterfaces();
 
     return (
         interfaceLookup &&

--- a/documentation/ag-grid-docs/src/components/reference-documentation/InterfaceDocumentationWithQuery.tsx
+++ b/documentation/ag-grid-docs/src/components/reference-documentation/InterfaceDocumentationWithQuery.tsx
@@ -1,5 +1,5 @@
+import { QueryClient, QueryClientProvider, useQuery } from '@tanstack/react-query';
 import { fetchExtraFile } from '@utils/client/fetchExtraFile';
-import { QueryClient, QueryClientProvider, useQuery } from 'react-query';
 
 import { InterfaceDocumentation, type InterfaceDocumentationProps } from './ReferenceDocumentation';
 

--- a/documentation/ag-grid-docs/src/components/reference-documentation/InterfaceDocumentationWithQuery.tsx
+++ b/documentation/ag-grid-docs/src/components/reference-documentation/InterfaceDocumentationWithQuery.tsx
@@ -25,16 +25,18 @@ export function InterfaceDocumentationWithQuery(props: Props) {
 }
 
 function InterfaceDocumentationWithLookups(props: Props) {
-    const { data: [interfaceLookup, codeLookup] = [] } = useQuery(
-        ['resolved-interfaces'],
-        async () => {
+    const { data: [interfaceLookup, codeLookup] = [] } = useQuery({
+        queryKey: ['resolved-interfaces'],
+
+        queryFn: async () => {
             return Promise.all([
                 fetchExtraFile('/reference/interfaces.AUTO.json'),
                 fetchExtraFile('/reference/doc-interfaces.AUTO.json'),
             ]);
         },
-        queryOptions
-    );
+
+        ...queryOptions,
+    });
 
     return (
         interfaceLookup &&

--- a/documentation/ag-grid-docs/src/components/reference-documentation/useResolvedInterfaces.ts
+++ b/documentation/ag-grid-docs/src/components/reference-documentation/useResolvedInterfaces.ts
@@ -1,0 +1,29 @@
+import { defaultQueryOptions } from '@stores/queryClientStore';
+import { useQuery } from '@tanstack/react-query';
+import { fetchExtraFile } from '@utils/client/fetchExtraFile';
+
+export function useResolvedInterfaces() {
+    const { data: interfaceLookup } = useQuery({
+        queryKey: ['resolved-interfaces'],
+        queryFn: () => {
+            return fetchExtraFile('/reference/interfaces.AUTO.json');
+        },
+
+        ...defaultQueryOptions,
+    });
+
+    return interfaceLookup;
+}
+
+export function useResolvedDocInterfaces() {
+    const { data: codeLookup } = useQuery({
+        queryKey: ['resolved-doc-interfaces'],
+        queryFn: () => {
+            return fetchExtraFile('/reference/doc-interfaces.AUTO.json');
+        },
+
+        ...defaultQueryOptions,
+    });
+
+    return codeLookup;
+}

--- a/documentation/ag-grid-docs/src/features/docs/components/DocsExampleRunner.tsx
+++ b/documentation/ag-grid-docs/src/features/docs/components/DocsExampleRunner.tsx
@@ -5,7 +5,8 @@ import { ExternalLinks } from '@features/example-runner/components/ExternalLinks
 import { getLoadingIFrameId } from '@features/example-runner/utils/getLoadingLogoId';
 import { useStore } from '@nanostores/react';
 import { $internalFramework, $internalFrameworkState } from '@stores/frameworkStore';
-import { QueryClient, QueryClientProvider, useQuery } from '@tanstack/react-query';
+import { $queryClient, defaultQueryOptions } from '@stores/queryClientStore';
+import { QueryClientProvider, useQuery } from '@tanstack/react-query';
 import { useImportType } from '@utils/hooks/useImportType';
 import { useEffect, useMemo, useState } from 'react';
 
@@ -29,17 +30,6 @@ interface Props {
     typescriptOnly?: boolean;
     overrideImportType?: ImportType;
 }
-
-// NOTE: Not on the layout level, as that is generated at build time, and queryClient needs to be
-// loaded on the client side
-const queryClient = new QueryClient();
-
-const queryOptions = {
-    retry: false,
-    refetchOnMount: false,
-    refetchOnWindowFocus: false,
-    refetchOnReconnect: false,
-};
 
 const getInternalFramework = (
     docsInternalFramework: InternalFramework,
@@ -131,7 +121,7 @@ const DocsExampleRunnerInner = ({
             ]) as Promise<[GeneratedContents]>;
         },
 
-        ...queryOptions,
+        ...defaultQueryOptions,
     });
     const urls = {
         exampleRunnerExampleUrl: getExampleRunnerExampleUrl(urlConfig),
@@ -190,6 +180,8 @@ const DocsExampleRunnerInner = ({
 };
 
 export const DocsExampleRunner = (props: Props) => {
+    const queryClient = useStore($queryClient);
+
     return (
         <QueryClientProvider client={queryClient}>
             <DocsExampleRunnerInner {...props} />

--- a/documentation/ag-grid-docs/src/features/docs/components/DocsExampleRunner.tsx
+++ b/documentation/ag-grid-docs/src/features/docs/components/DocsExampleRunner.tsx
@@ -98,9 +98,10 @@ const DocsExampleRunnerInner = ({
         [internalFramework, pageName, exampleName, importType]
     );
 
-    const { data: [contents] = [undefined, undefined], isError } = useQuery(
-        ['docsExampleContents', pageName, exampleName, internalFramework, importType, internalFrameworkState],
-        () => {
+    const { data: [contents] = [undefined, undefined], isError } = useQuery({
+        queryKey: ['docsExampleContents', pageName, exampleName, internalFramework, importType, internalFrameworkState],
+
+        queryFn: () => {
             if (internalFrameworkState !== 'synced') {
                 return [];
             }
@@ -129,8 +130,9 @@ const DocsExampleRunnerInner = ({
                     }),
             ]) as Promise<[GeneratedContents]>;
         },
-        queryOptions
-    );
+
+        ...queryOptions,
+    });
     const urls = {
         exampleRunnerExampleUrl: getExampleRunnerExampleUrl(urlConfig),
         exampleUrl: getExampleUrl(urlConfig),

--- a/documentation/ag-grid-docs/src/features/docs/components/DocsExampleRunner.tsx
+++ b/documentation/ag-grid-docs/src/features/docs/components/DocsExampleRunner.tsx
@@ -5,9 +5,9 @@ import { ExternalLinks } from '@features/example-runner/components/ExternalLinks
 import { getLoadingIFrameId } from '@features/example-runner/utils/getLoadingLogoId';
 import { useStore } from '@nanostores/react';
 import { $internalFramework, $internalFrameworkState } from '@stores/frameworkStore';
+import { QueryClient, QueryClientProvider, useQuery } from '@tanstack/react-query';
 import { useImportType } from '@utils/hooks/useImportType';
 import { useEffect, useMemo, useState } from 'react';
-import { QueryClient, QueryClientProvider, useQuery } from 'react-query';
 
 import {
     type UrlParams,
@@ -102,7 +102,7 @@ const DocsExampleRunnerInner = ({
         ['docsExampleContents', pageName, exampleName, internalFramework, importType, internalFrameworkState],
         () => {
             if (internalFrameworkState !== 'synced') {
-                return;
+                return [];
             }
 
             return Promise.all([

--- a/documentation/ag-grid-docs/src/stores/queryClientStore.ts
+++ b/documentation/ag-grid-docs/src/stores/queryClientStore.ts
@@ -1,0 +1,11 @@
+import { QueryClient } from '@tanstack/react-query';
+import { atom } from 'nanostores';
+
+export const $queryClient = atom(new QueryClient());
+
+export const defaultQueryOptions = {
+    retry: false,
+    refetchOnMount: false,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -5622,18 +5622,17 @@
   dependencies:
     defer-to-connect "^2.0.0"
 
-"@tanstack/query-core@4.36.1":
-  version "4.36.1"
-  resolved "http://52.50.158.57:4873/@tanstack/query-core/-/query-core-4.36.1.tgz#79f8c1a539d47c83104210be2388813a7af2e524"
-  integrity sha512-DJSilV5+ytBP1FbFcEJovv4rnnm/CokuVvrBEtW/Va9DvuJ3HksbXUJEpI0aV1KtuL4ZoO9AVE6PyNLzF7tLeA==
+"@tanstack/query-core@5.51.1":
+  version "5.51.1"
+  resolved "http://52.50.158.57:4873/@tanstack/query-core/-/query-core-5.51.1.tgz#55049ef0252c7d29de05e8219fd19b679509270e"
+  integrity sha512-fJBMQMpo8/KSsWW5ratJR5+IFr7YNJ3K2kfP9l5XObYHsgfVy1w3FJUWU4FT2fj7+JMaEg33zOcNDBo0LMwHnw==
 
-"@tanstack/react-query@4.36.1":
-  version "4.36.1"
-  resolved "http://52.50.158.57:4873/@tanstack/react-query/-/react-query-4.36.1.tgz#acb589fab4085060e2e78013164868c9c785e5d2"
-  integrity sha512-y7ySVHFyyQblPl3J3eQBWpXZkliroki3ARnBKsdJchlgt7yJLRDUcf4B8soufgiYt3pEQIkBWBx1N9/ZPIeUWw==
+"@tanstack/react-query@^5.51.1":
+  version "5.51.1"
+  resolved "http://52.50.158.57:4873/@tanstack/react-query/-/react-query-5.51.1.tgz#e483b9c9011e079b89cf73ce447b2e06340b3f41"
+  integrity sha512-s47HKFnQ4HOJAHoIiXcpna/roMMPZJPy6fJ6p4ZNVn8+/onlLBEDd1+xc8OnDuwgvecqkZD7Z2mnSRbcWefrKw==
   dependencies:
-    "@tanstack/query-core" "4.36.1"
-    use-sync-external-store "^1.2.0"
+    "@tanstack/query-core" "5.51.1"
 
 "@testing-library/dom@^10.1.0":
   version "10.1.0"
@@ -26516,7 +26515,7 @@ use-sidecar@^1.1.2:
     detect-node-es "^1.1.0"
     tslib "^2.0.0"
 
-use-sync-external-store@^1.0.0, use-sync-external-store@^1.2.0:
+use-sync-external-store@^1.0.0:
   version "1.2.2"
   resolved "http://52.50.158.57:4873/use-sync-external-store/-/use-sync-external-store-1.2.2.tgz#c3b6390f3a30eba13200d2302dcdf1e7b57b2ef9"
   integrity sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2018,7 +2018,7 @@
   dependencies:
     regenerator-runtime "^0.12.0"
 
-"@babel/runtime@^7.1.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.13.10", "@babel/runtime@^7.16.3", "@babel/runtime@^7.18.3", "@babel/runtime@^7.22.6", "@babel/runtime@^7.23.8", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.2", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4":
+"@babel/runtime@^7.1.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.13.10", "@babel/runtime@^7.16.3", "@babel/runtime@^7.18.3", "@babel/runtime@^7.22.6", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4":
   version "7.24.5"
   resolved "http://52.50.158.57:4873/@babel/runtime/-/runtime-7.24.5.tgz#230946857c053a36ccc66e1dd03b17dd0c4ed02c"
   integrity sha512-Nms86NXrsaeU9vbBJKni6gXiEXZ4CVpYVzEjDH9Sb8vmZ3UljyA1GSOJl/6LGPO8EHLuSF9H+IxNXHPX8QHJ4g==
@@ -5622,6 +5622,19 @@
   dependencies:
     defer-to-connect "^2.0.0"
 
+"@tanstack/query-core@4.36.1":
+  version "4.36.1"
+  resolved "http://52.50.158.57:4873/@tanstack/query-core/-/query-core-4.36.1.tgz#79f8c1a539d47c83104210be2388813a7af2e524"
+  integrity sha512-DJSilV5+ytBP1FbFcEJovv4rnnm/CokuVvrBEtW/Va9DvuJ3HksbXUJEpI0aV1KtuL4ZoO9AVE6PyNLzF7tLeA==
+
+"@tanstack/react-query@4.36.1":
+  version "4.36.1"
+  resolved "http://52.50.158.57:4873/@tanstack/react-query/-/react-query-4.36.1.tgz#acb589fab4085060e2e78013164868c9c785e5d2"
+  integrity sha512-y7ySVHFyyQblPl3J3eQBWpXZkliroki3ARnBKsdJchlgt7yJLRDUcf4B8soufgiYt3pEQIkBWBx1N9/ZPIeUWw==
+  dependencies:
+    "@tanstack/query-core" "4.36.1"
+    use-sync-external-store "^1.2.0"
+
 "@testing-library/dom@^10.1.0":
   version "10.1.0"
   resolved "http://52.50.158.57:4873/@testing-library/dom/-/dom-10.1.0.tgz#2d073e49771ad614da999ca48f199919e5176fb6"
@@ -8525,11 +8538,6 @@ before-after-hook@^2.2.0:
   resolved "http://52.50.158.57:4873/before-after-hook/-/before-after-hook-2.2.3.tgz#c51e809c81a4e354084422b9b26bad88249c517c"
   integrity sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==
 
-big-integer@^1.6.16:
-  version "1.6.52"
-  resolved "http://52.50.158.57:4873/big-integer/-/big-integer-1.6.52.tgz#60a887f3047614a8e1bffe5d7173490a97dc8c85"
-  integrity sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==
-
 big.js@^5.2.2:
   version "5.2.2"
   resolved "http://52.50.158.57:4873/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
@@ -8724,20 +8732,6 @@ braces@^3.0.2, braces@~3.0.2:
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
   dependencies:
     fill-range "^7.0.1"
-
-broadcast-channel@^3.4.1:
-  version "3.7.0"
-  resolved "http://52.50.158.57:4873/broadcast-channel/-/broadcast-channel-3.7.0.tgz#2dfa5c7b4289547ac3f6705f9c00af8723889937"
-  integrity sha512-cIAKJXAxGJceNZGTZSBzMxzyOn72cVgPnKx4dc6LRjQgbaJUQqhy5rzL3zbMxkMWsGKkv2hSFkPRMEXfoMZ2Mg==
-  dependencies:
-    "@babel/runtime" "^7.7.2"
-    detect-node "^2.1.0"
-    js-sha3 "0.8.0"
-    microseconds "0.2.0"
-    nano-time "1.0.0"
-    oblivious-set "1.0.0"
-    rimraf "3.0.2"
-    unload "2.2.0"
 
 brorand@^1.0.1, brorand@^1.1.0:
   version "1.1.0"
@@ -11348,7 +11342,7 @@ detect-node-es@^1.1.0:
   resolved "http://52.50.158.57:4873/detect-node-es/-/detect-node-es-1.1.0.tgz#163acdf643330caa0b4cd7c21e7ee7755d6fa493"
   integrity sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==
 
-detect-node@^2.0.4, detect-node@^2.1.0:
+detect-node@^2.0.4:
   version "2.1.0"
   resolved "http://52.50.158.57:4873/detect-node/-/detect-node-2.1.0.tgz#c9c70775a49c3d03bc2c06d9a73be550f978f8b1"
   integrity sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==
@@ -17399,11 +17393,6 @@ js-message@1.0.7:
   resolved "http://52.50.158.57:4873/js-message/-/js-message-1.0.7.tgz#fbddd053c7a47021871bb8b2c95397cc17c20e47"
   integrity sha512-efJLHhLjIyKRewNS9EGZ4UpI8NguuL6fKkhRxVuMmrGV2xN/0APGdQYwLFky5w9naebSZ0OwAGp0G6/2Cg90rA==
 
-js-sha3@0.8.0:
-  version "0.8.0"
-  resolved "http://52.50.158.57:4873/js-sha3/-/js-sha3-0.8.0.tgz#b9b7a5da73afad7dedd0f8c463954cbde6818840"
-  integrity sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==
-
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "http://52.50.158.57:4873/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -18505,14 +18494,6 @@ markdown-table@^3.0.0:
   resolved "http://52.50.158.57:4873/markdown-table/-/markdown-table-3.0.3.tgz#e6331d30e493127e031dd385488b5bd326e4a6bd"
   integrity sha512-Z1NL3Tb1M9wH4XESsCDEksWoKTdlUafKc4pt0GRwjUyXaCFZ+dc3g2erqB6zm3szA2IUSi7VnPI+o/9jnxh9hw==
 
-match-sorter@^6.0.2:
-  version "6.3.4"
-  resolved "http://52.50.158.57:4873/match-sorter/-/match-sorter-6.3.4.tgz#afa779d8e922c81971fbcb4781c7003ace781be7"
-  integrity sha512-jfZW7cWS5y/1xswZo8VBOdudUiSd9nifYRWphc9M5D/ee4w4AoXLgBEdRbgVaxbMuagBPeUC5y2Hi8DO6o9aDg==
-  dependencies:
-    "@babel/runtime" "^7.23.8"
-    remove-accents "0.5.0"
-
 matchdep@^2.0.0:
   version "2.0.0"
   resolved "http://52.50.158.57:4873/matchdep/-/matchdep-2.0.0.tgz#c6f34834a0d8dbc3b37c27ee8bbcb27c7775582e"
@@ -19106,11 +19087,6 @@ micromatch@^4.0.0, micromatch@^4.0.2, micromatch@^4.0.4, micromatch@^4.0.5:
     braces "^3.0.2"
     picomatch "^2.3.1"
 
-microseconds@0.2.0:
-  version "0.2.0"
-  resolved "http://52.50.158.57:4873/microseconds/-/microseconds-0.2.0.tgz#233b25f50c62a65d861f978a4a4f8ec18797dc39"
-  integrity sha512-n7DHHMjR1avBbSpsTBj6fmMGh2AGrifVV4e+WYc3Q9lO+xnSZ3NyhcBND3vzzatt05LFhoKFRxrIyklmLlUtyA==
-
 miller-rabin@^4.0.0:
   version "4.0.1"
   resolved "http://52.50.158.57:4873/miller-rabin/-/miller-rabin-4.0.1.tgz#f080351c865b0dc562a8462966daa53543c78a4d"
@@ -19589,13 +19565,6 @@ nan@^2.12.1, nan@^2.14.2, nan@^2.17.0:
   version "2.19.0"
   resolved "http://52.50.158.57:4873/nan/-/nan-2.19.0.tgz#bb58122ad55a6c5bc973303908d5b16cfdd5a8c0"
   integrity sha512-nO1xXxfh/RWNxfd/XPfbIfFk5vgLsAxUR9y5O0cHMJu/AW9U95JLXqthYHjEp+8gQ5p96K9jUp8nbVOxCdRbtw==
-
-nano-time@1.0.0:
-  version "1.0.0"
-  resolved "http://52.50.158.57:4873/nano-time/-/nano-time-1.0.0.tgz#b0554f69ad89e22d0907f7a12b0993a5d96137ef"
-  integrity sha512-flnngywOoQ0lLQOTRNexn2gGSNuM9bKj9RZAWSzhQ+UJYaAFG9bac4DW9VHjUAzrOaIcajHybCTHe/bkvozQqA==
-  dependencies:
-    big-integer "^1.6.16"
 
 nanoid@^2.1.0:
   version "2.1.11"
@@ -20335,11 +20304,6 @@ object.values@^1.1.1, object.values@^1.1.7:
     call-bind "^1.0.7"
     define-properties "^1.2.1"
     es-object-atoms "^1.0.0"
-
-oblivious-set@1.0.0:
-  version "1.0.0"
-  resolved "http://52.50.158.57:4873/oblivious-set/-/oblivious-set-1.0.0.tgz#c8316f2c2fb6ff7b11b6158db3234c49f733c566"
-  integrity sha512-z+pI07qxo4c2CulUHCDf9lcqDlMSo72N/4rLUpRXf6fu+q8vjt8y0xS+Tlf8NTJDdTXHbdeO1n3MlbctwEoXZw==
 
 obuf@^1.0.0, obuf@^1.1.2:
   version "1.1.2"
@@ -22664,15 +22628,6 @@ react-markdown@5.0.3:
     unist-util-visit "^2.0.0"
     xtend "^4.0.1"
 
-react-query@^3.39.3:
-  version "3.39.3"
-  resolved "http://52.50.158.57:4873/react-query/-/react-query-3.39.3.tgz#4cea7127c6c26bdea2de5fb63e51044330b03f35"
-  integrity sha512-nLfLz7GiohKTJDuT4us4X3h/8unOh+00MLb2yJoGTPjxKs2bc1iDhkNx2bd5MKklXnOD3NrVZ+J2UXujA5In4g==
-  dependencies:
-    "@babel/runtime" "^7.5.5"
-    broadcast-channel "^3.4.1"
-    match-sorter "^6.0.2"
-
 react-refresh@^0.14.0:
   version "0.14.2"
   resolved "http://52.50.158.57:4873/react-refresh/-/react-refresh-0.14.2.tgz#3833da01ce32da470f1f936b9d477da5c7028bf9"
@@ -23136,11 +23091,6 @@ remote-origin-url@^0.5.1:
   integrity sha512-crQ7Xk1m/F2IiwBx5oTqk/c0hjoumrEz+a36+ZoVupskQRE/q7pAwHKsTNeiZ31sbSTELvVlVv4h1W0Xo5szKg==
   dependencies:
     parse-git-config "^1.1.1"
-
-remove-accents@0.5.0:
-  version "0.5.0"
-  resolved "http://52.50.158.57:4873/remove-accents/-/remove-accents-0.5.0.tgz#77991f37ba212afba162e375b627631315bed687"
-  integrity sha512-8g3/Otx1eJaVD12e31UbJj1YzdtVvzH85HV7t+9MJYk/u3XmkOUJ5Ys9wQrf9PCPK8+xn4ymzqYCiZl6QWKn+A==
 
 remove-bom-buffer@^3.0.0:
   version "3.0.0"
@@ -26459,14 +26409,6 @@ universalify@^2.0.0:
   resolved "http://52.50.158.57:4873/universalify/-/universalify-2.0.1.tgz#168efc2180964e6386d061e094df61afe239b18d"
   integrity sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==
 
-unload@2.2.0:
-  version "2.2.0"
-  resolved "http://52.50.158.57:4873/unload/-/unload-2.2.0.tgz#ccc88fdcad345faa06a92039ec0f80b488880ef7"
-  integrity sha512-B60uB5TNBLtN6/LsgAf3udH9saB5p7gqJwcFfbOEZ8BcBHnGwCf6G/TGiEqkRAxX7zAFIUtzdrXQSdL3Q/wqNA==
-  dependencies:
-    "@babel/runtime" "^7.6.2"
-    detect-node "^2.0.4"
-
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"
   resolved "http://52.50.158.57:4873/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
@@ -26574,7 +26516,7 @@ use-sidecar@^1.1.2:
     detect-node-es "^1.1.0"
     tslib "^2.0.0"
 
-use-sync-external-store@^1.0.0:
+use-sync-external-store@^1.0.0, use-sync-external-store@^1.2.0:
   version "1.2.2"
   resolved "http://52.50.158.57:4873/use-sync-external-store/-/use-sync-external-store-1.2.2.tgz#c3b6390f3a30eba13200d2302dcdf1e7b57b2ef9"
   integrity sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==


### PR DESCRIPTION
* Upgrade react query to @tanstack/react-query v5
* Extract queryClient to nanostore atom so it can be reused
* Extract api and interface fetching and reuse them between fetches