### PR TITLE
AG-12193 Correctly update Pinned rows on data change

### DIFF
--- a/community-modules/client-side-row-model/src/clientSideRowModel/immutableService.ts
+++ b/community-modules/client-side-row-model/src/clientSideRowModel/immutableService.ts
@@ -87,8 +87,8 @@ export class ImmutableService extends BeanStub implements NamedBean, IImmutableS
             // if update, push to 'update'
             // if not changed, do not include in the transaction
             rowData.forEach((data: any, index: number) => {
-                const id: string = getRowIdFunc({ data, level: 0 });
-                const existingNode: RowNode | undefined = existingNodesMap[id];
+                const id = getRowIdFunc({ data, level: 0 });
+                const existingNode = existingNodesMap[id];
 
                 if (orderMap) {
                     orderMap[id] = index;
@@ -110,7 +110,7 @@ export class ImmutableService extends BeanStub implements NamedBean, IImmutableS
         }
 
         // at this point, all rows that are left, should be removed
-        _iterateObject(existingNodesMap, (id: string, rowNode: RowNode) => {
+        _iterateObject(existingNodesMap, (id, rowNode) => {
             if (rowNode) {
                 transaction.remove!.push(rowNode.data);
             }

--- a/community-modules/core/src/cellNavigationService.ts
+++ b/community-modules/core/src/cellNavigationService.ts
@@ -271,12 +271,12 @@ export class CellNavigationService extends BeanStub implements NamedBean {
         const index = rowPosition.rowIndex;
 
         if (pinned === 'top') {
-            const lastTopIndex = this.pinnedRowModel.getPinnedTopRowNodes().length - 1;
+            const lastTopIndex = this.pinnedRowModel.getPinnedTopRowCount() - 1;
             return lastTopIndex <= index;
         }
 
         if (pinned === 'bottom') {
-            const lastBottomIndex = this.pinnedRowModel.getPinnedBottomRowNodes().length - 1;
+            const lastBottomIndex = this.pinnedRowModel.getPinnedBottomRowCount() - 1;
             return lastBottomIndex <= index;
         }
 
@@ -350,7 +350,7 @@ export class CellNavigationService extends BeanStub implements NamedBean {
     }
 
     private getLastFloatingTopRow(): RowPosition {
-        const lastFloatingRow = this.pinnedRowModel.getPinnedTopRowNodes().length - 1;
+        const lastFloatingRow = this.pinnedRowModel.getPinnedTopRowCount() - 1;
 
         return { rowIndex: lastFloatingRow, rowPinned: 'top' } as RowPosition;
     }

--- a/community-modules/core/src/entities/rowNode.ts
+++ b/community-modules/core/src/entities/rowNode.ts
@@ -457,13 +457,6 @@ export class RowNode<TData = any> implements IEventEmitter<RowNodeEventType>, IR
         this.setDisplayed(rowTop !== null);
     }
 
-    public setRowTopAndRowIndex(rowTop: number, rowIndex: number): number {
-        this.setRowTop(rowTop);
-        this.setRowHeight(this.beans.gos.getRowHeightForNode(this).height);
-        this.setRowIndex(rowIndex);
-        return this.rowHeight!;
-    }
-
     public clearRowTopAndRowIndex(): void {
         this.oldRowTop = null;
         this.setRowTop(null);

--- a/community-modules/core/src/entities/rowNode.ts
+++ b/community-modules/core/src/entities/rowNode.ts
@@ -457,6 +457,13 @@ export class RowNode<TData = any> implements IEventEmitter<RowNodeEventType>, IR
         this.setDisplayed(rowTop !== null);
     }
 
+    public setRowTopAndRowIndex(rowTop: number, rowIndex: number): number {
+        this.setRowTop(rowTop);
+        this.setRowHeight(this.beans.gos.getRowHeightForNode(this).height);
+        this.setRowIndex(rowIndex);
+        return this.rowHeight!;
+    }
+
     public clearRowTopAndRowIndex(): void {
         this.oldRowTop = null;
         this.setRowTop(null);

--- a/community-modules/core/src/entities/rowPositionUtils.ts
+++ b/community-modules/core/src/entities/rowPositionUtils.ts
@@ -70,9 +70,9 @@ export class RowPositionUtils extends BeanStub implements NamedBean {
     public getRowNode(gridRow: RowPosition): RowNode | undefined {
         switch (gridRow.rowPinned) {
             case 'top':
-                return this.pinnedRowModel.getPinnedTopRowNodes()[gridRow.rowIndex];
+                return this.pinnedRowModel.getPinnedTopRow(gridRow.rowIndex);
             case 'bottom':
-                return this.pinnedRowModel.getPinnedBottomRowNodes()[gridRow.rowIndex];
+                return this.pinnedRowModel.getPinnedBottomRow(gridRow.rowIndex);
             default:
                 return this.rowModel.getRow(gridRow.rowIndex);
         }

--- a/community-modules/core/src/gridBodyComp/rowContainer/rowContainerEventsFeature.ts
+++ b/community-modules/core/src/gridBodyComp/rowContainer/rowContainerEventsFeature.ts
@@ -329,7 +329,7 @@ export class RowContainerEventsFeature extends BeanStub {
                 rowEnd = rowModel.getRowCount() - 1;
             } else {
                 floatingEnd = 'bottom';
-                rowEnd = pinnedRowModel.getPinnedBottomRowNodes().length - 1;
+                rowEnd = pinnedRowModel.getPinnedBottomRowCount() - 1;
             }
 
             const allDisplayedColumns = this.visibleColsService.getAllCols();

--- a/community-modules/core/src/pinnedRowModel/pinnedRowModel.ts
+++ b/community-modules/core/src/pinnedRowModel/pinnedRowModel.ts
@@ -138,14 +138,6 @@ export class PinnedRowModel extends BeanStub implements NamedBean {
         nodes.setOrder(newOrder);
     }
 
-    public getPinnedTopRowNodes(): RowNode[] {
-        return this.pinnedTopRows.asArray();
-    }
-
-    public getPinnedBottomRowNodes(): RowNode[] {
-        return this.pinnedBottomRows.asArray();
-    }
-
     public getPinnedTopTotalHeight(): number {
         return this.getTotalHeight(this.pinnedTopRows);
     }
@@ -170,12 +162,15 @@ export class PinnedRowModel extends BeanStub implements NamedBean {
         return this.pinnedBottomRows.getByIndex(index);
     }
 
-    public forEachPinnedTopRow(callback: (rowNode: RowNode, index: number) => void): void {
-        this.pinnedTopRows.forEach(callback);
+    public getPinnedRowById(id: string, floating: NonNullable<RowPinnedType>): RowNode | undefined {
+        return floating === 'top' ? this.pinnedTopRows.getById(id) : this.pinnedBottomRows.getById(id);
     }
 
-    public forEachPinnedBottomRow(callback: (rowNode: RowNode, index: number) => void): void {
-        this.pinnedBottomRows.forEach(callback);
+    public forEachPinnedRow(
+        floating: NonNullable<RowPinnedType>,
+        callback: (node: RowNode, index: number) => void
+    ): void {
+        return floating === 'top' ? this.pinnedTopRows.forEach(callback) : this.pinnedBottomRows.forEach(callback);
     }
 
     private getTotalHeight(rowNodes: OrderedCache<RowNode>): number {
@@ -233,10 +228,6 @@ class OrderedCache<T extends { id: string | undefined }> {
             const node = this.cache[id];
             node && callback(node, index);
         });
-    }
-
-    public asArray(): T[] {
-        return this.ordering.map((id) => this.cache[id]!);
     }
 
     public clear(): void {

--- a/community-modules/core/src/pinnedRowModel/pinnedRowModel.ts
+++ b/community-modules/core/src/pinnedRowModel/pinnedRowModel.ts
@@ -36,27 +36,6 @@ export class PinnedRowModel extends BeanStub implements NamedBean {
         return !this.isEmpty(floating);
     }
 
-    /** @deprecated */
-    public getRowAtPixel(pixel: number, floating: RowPinnedType): number {
-        const rows = floating === 'top' ? this.pinnedTopRows : this.pinnedBottomRows;
-        if (rows.isEmpty()) {
-            return 0; // this should never happen, just in case, 0 is graceful failure
-        }
-
-        let rowNumber = rows.getSize() - 1;
-
-        rows.forEach((rowNode, i) => {
-            const rowTopPixel = rowNode.rowTop! + rowNode.rowHeight! - 1;
-            // only need to range check against the top pixel, as we are going through the list
-            // in order, first row to hit the pixel wins
-            if (rowTopPixel >= pixel) {
-                rowNumber = Math.min(rowNumber, i);
-            }
-        });
-
-        return rowNumber;
-    }
-
     private onGridStylesChanges(e: CssVariablesChanged) {
         if (e.rowHeightChanged) {
             const estimateRowHeight = (rowNode: RowNode) => {

--- a/community-modules/core/src/pinnedRowModel/pinnedRowModel.ts
+++ b/community-modules/core/src/pinnedRowModel/pinnedRowModel.ts
@@ -5,8 +5,6 @@ import { RowNode } from '../entities/rowNode';
 import type { CssVariablesChanged, PinnedHeightChangedEvent, PinnedRowDataChangedEvent } from '../events';
 import type { WithoutGridCommon } from '../interfaces/iCommon';
 import type { RowPinnedType } from '../interfaces/iRowNode';
-import { _last } from '../utils/array';
-import { _missingOrEmpty } from '../utils/generic';
 
 export class PinnedRowModel extends BeanStub implements NamedBean {
     beanName = 'pinnedRowModel' as const;
@@ -18,8 +16,8 @@ export class PinnedRowModel extends BeanStub implements NamedBean {
     }
 
     private nextId = 0;
-    private pinnedTopRows: RowNode[];
-    private pinnedBottomRows: RowNode[];
+    private pinnedTopRows = new OrderedCache<RowNode>();
+    private pinnedBottomRows = new OrderedCache<RowNode>();
 
     public postConstruct(): void {
         this.setPinnedTopRowData();
@@ -31,28 +29,32 @@ export class PinnedRowModel extends BeanStub implements NamedBean {
 
     public isEmpty(floating: RowPinnedType): boolean {
         const rows = floating === 'top' ? this.pinnedTopRows : this.pinnedBottomRows;
-        return _missingOrEmpty(rows);
+        return rows.isEmpty();
     }
 
     public isRowsToRender(floating: RowPinnedType): boolean {
         return !this.isEmpty(floating);
     }
 
+    /** @deprecated */
     public getRowAtPixel(pixel: number, floating: RowPinnedType): number {
         const rows = floating === 'top' ? this.pinnedTopRows : this.pinnedBottomRows;
-        if (_missingOrEmpty(rows)) {
+        if (rows.isEmpty()) {
             return 0; // this should never happen, just in case, 0 is graceful failure
         }
-        for (let i = 0; i < rows.length; i++) {
-            const rowNode = rows[i];
+
+        let rowNumber = rows.getSize() - 1;
+
+        rows.forEach((rowNode, i) => {
             const rowTopPixel = rowNode.rowTop! + rowNode.rowHeight! - 1;
             // only need to range check against the top pixel, as we are going through the list
             // in order, first row to hit the pixel wins
             if (rowTopPixel >= pixel) {
-                return i;
+                rowNumber = Math.min(rowNumber, i);
             }
-        }
-        return rows.length - 1;
+        });
+
+        return rowNumber;
     }
 
     private onGridStylesChanges(e: CssVariablesChanged) {
@@ -91,7 +93,7 @@ export class PinnedRowModel extends BeanStub implements NamedBean {
 
     private setPinnedTopRowData(): void {
         const rowData = this.gos.get('pinnedTopRowData');
-        this.pinnedTopRows = this.createNodesFromData(rowData, true);
+        this.updateNodesFromRowData(rowData, 'top');
         const event: WithoutGridCommon<PinnedRowDataChangedEvent> = {
             type: 'pinnedRowDataChanged',
         };
@@ -100,44 +102,72 @@ export class PinnedRowModel extends BeanStub implements NamedBean {
 
     private setPinnedBottomRowData(): void {
         const rowData = this.gos.get('pinnedBottomRowData');
-        this.pinnedBottomRows = this.createNodesFromData(rowData, false);
+        this.updateNodesFromRowData(rowData, 'bottom');
         const event: WithoutGridCommon<PinnedRowDataChangedEvent> = {
             type: 'pinnedRowDataChanged',
         };
         this.eventService.dispatchEvent(event);
     }
 
-    private createNodesFromData(allData: any[] | undefined, isTop: boolean): RowNode[] {
-        const rowNodes: RowNode[] = [];
-        if (allData) {
-            const getRowId = this.gos.getRowIdCallback();
-            const idPrefix = isTop ? RowNode.ID_PREFIX_TOP_PINNED : RowNode.ID_PREFIX_BOTTOM_PINNED;
+    private updateNodesFromRowData(allData: any[] | undefined, container: NonNullable<RowPinnedType>): void {
+        const nodes = container === 'top' ? this.pinnedTopRows : this.pinnedBottomRows;
 
-            let nextRowTop = 0;
-            const pinned = isTop ? 'top' : 'bottom';
-            allData.forEach((dataItem: any, index: number) => {
+        if (allData === undefined) {
+            nodes.clear();
+            return;
+        }
+
+        const nodesToRemove = nodes.getIds();
+        const getRowId = this.gos.getRowIdCallback();
+        const idPrefix = container === 'top' ? RowNode.ID_PREFIX_TOP_PINNED : RowNode.ID_PREFIX_BOTTOM_PINNED;
+
+        const newOrder: string[] = [];
+        let nextRowTop = 0;
+        for (const [i, data] of allData.entries()) {
+            const id = getRowId?.({ data, level: 0, rowPinned: container }) ?? idPrefix + this.nextId++;
+
+            newOrder.push(id);
+
+            const existingNode = nodes.getById(id);
+            if (existingNode !== undefined) {
+                if (existingNode.data !== data) {
+                    existingNode.setData(data);
+                }
+                existingNode.setRowTop(nextRowTop);
+                existingNode.setRowHeight(this.gos.getRowHeightForNode(existingNode).height);
+                existingNode.setRowIndex(i);
+                nextRowTop += existingNode.rowHeight!;
+
+                // don't want to remove these ones
+                nodesToRemove.delete(id);
+            } else {
+                // new node
                 const rowNode = new RowNode(this.beans);
-                rowNode.data = dataItem;
-
-                rowNode.id = getRowId?.({ data: dataItem, level: 0, rowPinned: pinned }) ?? idPrefix + this.nextId++;
-
-                rowNode.rowPinned = pinned;
+                rowNode.id = id;
+                rowNode.data = data;
+                rowNode.rowPinned = container;
                 rowNode.setRowTop(nextRowTop);
                 rowNode.setRowHeight(this.gos.getRowHeightForNode(rowNode).height);
-                rowNode.setRowIndex(index);
+                rowNode.setRowIndex(i);
                 nextRowTop += rowNode.rowHeight!;
-                rowNodes.push(rowNode);
-            });
+                nodes.push(rowNode);
+            }
         }
-        return rowNodes;
+
+        nodesToRemove.forEach((id) => {
+            nodes.getById(id)?.clearRowTopAndRowIndex();
+        });
+        nodes.removeAllById(nodesToRemove);
+
+        nodes.setOrder(newOrder);
     }
 
     public getPinnedTopRowNodes(): RowNode[] {
-        return this.pinnedTopRows;
+        return this.pinnedTopRows.asArray();
     }
 
     public getPinnedBottomRowNodes(): RowNode[] {
-        return this.pinnedBottomRows;
+        return this.pinnedBottomRows.asArray();
     }
 
     public getPinnedTopTotalHeight(): number {
@@ -145,32 +175,26 @@ export class PinnedRowModel extends BeanStub implements NamedBean {
     }
 
     public getPinnedTopRowCount(): number {
-        return this.pinnedTopRows ? this.pinnedTopRows.length : 0;
+        return this.pinnedTopRows.getSize();
     }
 
     public getPinnedBottomRowCount(): number {
-        return this.pinnedBottomRows ? this.pinnedBottomRows.length : 0;
+        return this.pinnedBottomRows.getSize();
     }
 
     public getPinnedTopRow(index: number): RowNode | undefined {
-        return this.pinnedTopRows[index];
+        return this.pinnedTopRows.getByIndex(index);
     }
 
     public getPinnedBottomRow(index: number): RowNode | undefined {
-        return this.pinnedBottomRows[index];
+        return this.pinnedBottomRows.getByIndex(index);
     }
 
     public forEachPinnedTopRow(callback: (rowNode: RowNode, index: number) => void): void {
-        if (_missingOrEmpty(this.pinnedTopRows)) {
-            return;
-        }
         this.pinnedTopRows.forEach(callback);
     }
 
     public forEachPinnedBottomRow(callback: (rowNode: RowNode, index: number) => void): void {
-        if (_missingOrEmpty(this.pinnedBottomRows)) {
-            return;
-        }
         this.pinnedBottomRows.forEach(callback);
     }
 
@@ -178,12 +202,76 @@ export class PinnedRowModel extends BeanStub implements NamedBean {
         return this.getTotalHeight(this.pinnedBottomRows);
     }
 
-    private getTotalHeight(rowNodes: RowNode[]): number {
-        if (!rowNodes || rowNodes.length === 0) {
+    private getTotalHeight(rowNodes: OrderedCache<RowNode>): number {
+        const size = rowNodes.getSize();
+        if (size === 0) {
             return 0;
         }
 
-        const lastNode = _last(rowNodes);
-        return lastNode.rowTop! + lastNode.rowHeight!;
+        const node = rowNodes.getByIndex(size - 1);
+        if (node === undefined) {
+            return 0;
+        }
+
+        return node.rowTop! + node.rowHeight!;
+    }
+}
+
+class OrderedCache<T extends { id: string | undefined }> {
+    private cache: Partial<Record<string, T>> = {};
+    private ordering: string[] = [];
+
+    public getById(id: string): T | undefined {
+        return this.cache[id];
+    }
+
+    public getByIndex(i: number): T | undefined {
+        const id = this.ordering[i];
+        return this.cache[id];
+    }
+
+    public push(item: T): void {
+        this.cache[item.id!] = item;
+        this.ordering.push(item.id!);
+    }
+
+    public removeAllById(ids: Set<string>): void {
+        for (const id of ids) {
+            delete this.cache[id];
+        }
+
+        this.ordering = this.ordering.filter((id) => !ids.has(id));
+    }
+
+    public setOrder(orderedIds: string[]): void {
+        this.ordering = orderedIds;
+    }
+
+    public forEach(callback: (item: T, index: number) => void): void {
+        this.ordering.forEach((id, index) => {
+            const node = this.cache[id];
+            node && callback(node, index);
+        });
+    }
+
+    public asArray(): T[] {
+        return this.ordering.map((id) => this.cache[id]!);
+    }
+
+    public clear(): void {
+        this.ordering.length = 0;
+        this.cache = {};
+    }
+
+    public isEmpty(): boolean {
+        return this.ordering.length === 0;
+    }
+
+    public getSize(): number {
+        return this.ordering.length;
+    }
+
+    public getIds(): Set<string> {
+        return new Set(this.ordering);
     }
 }

--- a/community-modules/core/src/pinnedRowModel/pinnedRowModel.ts
+++ b/community-modules/core/src/pinnedRowModel/pinnedRowModel.ts
@@ -22,12 +22,8 @@ export class PinnedRowModel extends BeanStub implements NamedBean {
     public postConstruct(): void {
         this.setPinnedRowData(this.gos.get('pinnedTopRowData'), 'top');
         this.setPinnedRowData(this.gos.get('pinnedBottomRowData'), 'bottom');
-        this.addManagedPropertyListener('pinnedTopRowData', () =>
-            this.setPinnedRowData(this.gos.get('pinnedTopRowData'), 'top')
-        );
-        this.addManagedPropertyListener('pinnedBottomRowData', () =>
-            this.setPinnedRowData(this.gos.get('pinnedBottomRowData'), 'bottom')
-        );
+        this.addManagedPropertyListener('pinnedTopRowData', (e) => this.setPinnedRowData(e.currentValue, 'top'));
+        this.addManagedPropertyListener('pinnedBottomRowData', (e) => this.setPinnedRowData(e.currentValue, 'bottom'));
         this.addManagedEventListeners({ gridStylesChanged: this.onGridStylesChanges.bind(this) });
     }
 
@@ -115,7 +111,7 @@ export class PinnedRowModel extends BeanStub implements NamedBean {
                 if (existingNode.data !== data) {
                     existingNode.setData(data);
                 }
-                nextRowTop += existingNode.setRowTopAndRowIndex(nextRowTop, i);
+                nextRowTop += this.setRowTopAndRowIndex(existingNode, nextRowTop, i);
 
                 // existing nodes that are re-used/updated shouldn't be deleted
                 nodesToRemove.delete(id);
@@ -125,7 +121,7 @@ export class PinnedRowModel extends BeanStub implements NamedBean {
                 rowNode.id = id;
                 rowNode.data = data;
                 rowNode.rowPinned = floating;
-                nextRowTop += rowNode.setRowTopAndRowIndex(nextRowTop, i);
+                nextRowTop += this.setRowTopAndRowIndex(rowNode, nextRowTop, i);
                 nodes.push(rowNode);
             }
         }
@@ -136,6 +132,13 @@ export class PinnedRowModel extends BeanStub implements NamedBean {
         nodes.removeAllById(nodesToRemove);
 
         nodes.setOrder(newOrder);
+    }
+
+    private setRowTopAndRowIndex(rowNode: RowNode, rowTop: number, rowIndex: number): number {
+        rowNode.setRowTop(rowTop);
+        rowNode.setRowHeight(this.gos.getRowHeightForNode(rowNode).height);
+        rowNode.setRowIndex(rowIndex);
+        return rowNode.rowHeight!;
     }
 
     public getPinnedTopTotalHeight(): number {

--- a/community-modules/core/src/pinnedRowModel/pinnedRowModel.ts
+++ b/community-modules/core/src/pinnedRowModel/pinnedRowModel.ts
@@ -115,10 +115,7 @@ export class PinnedRowModel extends BeanStub implements NamedBean {
                 if (existingNode.data !== data) {
                     existingNode.setData(data);
                 }
-                existingNode.setRowTop(nextRowTop);
-                existingNode.setRowHeight(this.gos.getRowHeightForNode(existingNode).height);
-                existingNode.setRowIndex(i);
-                nextRowTop += existingNode.rowHeight!;
+                nextRowTop += existingNode.setRowTopAndRowIndex(nextRowTop, i);
 
                 // existing nodes that are re-used/updated shouldn't be deleted
                 nodesToRemove.delete(id);
@@ -128,10 +125,7 @@ export class PinnedRowModel extends BeanStub implements NamedBean {
                 rowNode.id = id;
                 rowNode.data = data;
                 rowNode.rowPinned = floating;
-                rowNode.setRowTop(nextRowTop);
-                rowNode.setRowHeight(this.gos.getRowHeightForNode(rowNode).height);
-                rowNode.setRowIndex(i);
-                nextRowTop += rowNode.rowHeight!;
+                nextRowTop += rowNode.setRowTopAndRowIndex(nextRowTop, i);
                 nodes.push(rowNode);
             }
         }

--- a/community-modules/core/src/pinnedRowModel/pinnedRowModel.ts
+++ b/community-modules/core/src/pinnedRowModel/pinnedRowModel.ts
@@ -20,10 +20,14 @@ export class PinnedRowModel extends BeanStub implements NamedBean {
     private pinnedBottomRows = new OrderedCache<RowNode>();
 
     public postConstruct(): void {
-        this.setPinnedTopRowData();
-        this.setPinnedBottomRowData();
-        this.addManagedPropertyListener('pinnedTopRowData', () => this.setPinnedTopRowData());
-        this.addManagedPropertyListener('pinnedBottomRowData', () => this.setPinnedBottomRowData());
+        this.setPinnedRowData(this.gos.get('pinnedTopRowData'), 'top');
+        this.setPinnedRowData(this.gos.get('pinnedBottomRowData'), 'bottom');
+        this.addManagedPropertyListener('pinnedTopRowData', () =>
+            this.setPinnedRowData(this.gos.get('pinnedTopRowData'), 'top')
+        );
+        this.addManagedPropertyListener('pinnedBottomRowData', () =>
+            this.setPinnedRowData(this.gos.get('pinnedBottomRowData'), 'bottom')
+        );
         this.addManagedEventListeners({ gridStylesChanged: this.onGridStylesChanges.bind(this) });
     }
 
@@ -70,18 +74,8 @@ export class PinnedRowModel extends BeanStub implements NamedBean {
         return anyChange;
     }
 
-    private setPinnedTopRowData(): void {
-        const rowData = this.gos.get('pinnedTopRowData');
-        this.updateNodesFromRowData(rowData, 'top');
-        const event: WithoutGridCommon<PinnedRowDataChangedEvent> = {
-            type: 'pinnedRowDataChanged',
-        };
-        this.eventService.dispatchEvent(event);
-    }
-
-    private setPinnedBottomRowData(): void {
-        const rowData = this.gos.get('pinnedBottomRowData');
-        this.updateNodesFromRowData(rowData, 'bottom');
+    private setPinnedRowData(rowData: any[] | undefined, floating: NonNullable<RowPinnedType>): void {
+        this.updateNodesFromRowData(rowData, floating);
         const event: WithoutGridCommon<PinnedRowDataChangedEvent> = {
             type: 'pinnedRowDataChanged',
         };

--- a/community-modules/core/src/rendering/rowRenderer.ts
+++ b/community-modules/core/src/rendering/rowRenderer.ts
@@ -480,12 +480,13 @@ export class RowRenderer extends BeanStub implements NamedBean {
      * @param rowNodes The canonical list of row nodes that should have associated controllers
      */
     private refreshFloatingRows(rowCtrls: RowCtrl[], floating: NonNullable<RowPinnedType>): void {
+        const { pinnedRowModel, beans, printLayout } = this;
         const rowCtrlMap = Object.fromEntries(rowCtrls.map((ctrl) => [ctrl.getRowNode().id!, ctrl]));
 
-        this.pinnedRowModel.forEachPinnedRow(floating, (node, i) => {
+        pinnedRowModel.forEachPinnedRow(floating, (node, i) => {
             const rowCtrl = rowCtrls[i];
             const rowCtrlDoesNotExist =
-                rowCtrl && this.pinnedRowModel.getPinnedRowById(rowCtrl.getRowNode().id!, floating) === undefined;
+                rowCtrl && pinnedRowModel.getPinnedRowById(rowCtrl.getRowNode().id!, floating) === undefined;
 
             if (rowCtrlDoesNotExist) {
                 // ctrl not in new nodes list, destroy
@@ -499,14 +500,12 @@ export class RowRenderer extends BeanStub implements NamedBean {
                 delete rowCtrlMap[node.id!];
             } else {
                 // ctrl doesn't exist, create it
-                rowCtrls[i] = new RowCtrl(node, this.beans, false, false, this.printLayout);
+                rowCtrls[i] = new RowCtrl(node, beans, false, false, printLayout);
             }
         });
 
         const rowNodeCount =
-            floating === 'top'
-                ? this.pinnedRowModel.getPinnedTopRowCount()
-                : this.pinnedRowModel.getPinnedBottomRowCount();
+            floating === 'top' ? pinnedRowModel.getPinnedTopRowCount() : pinnedRowModel.getPinnedBottomRowCount();
 
         // Truncate array if rowCtrls is longer than rowNodes
         rowCtrls.length = rowNodeCount;

--- a/community-modules/core/src/rendering/rowRenderer.ts
+++ b/community-modules/core/src/rendering/rowRenderer.ts
@@ -1103,7 +1103,7 @@ export class RowRenderer extends BeanStub implements NamedBean {
         indexesToDraw.forEach((index) => (indexesToDrawMap[index] = true));
 
         const existingIndexes = Object.keys(this.rowCtrlsByRowIndex);
-        const indexesNotToDraw: string[] = existingIndexes.filter((index) => !indexesToDrawMap[index]);
+        const indexesNotToDraw = existingIndexes.filter((index) => !indexesToDrawMap[index]);
 
         this.removeRowCtrls(indexesNotToDraw, suppressAnimation);
     }
@@ -1130,7 +1130,7 @@ export class RowRenderer extends BeanStub implements NamedBean {
         // if we are redrawing due to model update, then old rows are in rowsToRecycle
         _iterateObject(rowsToRecycle, checkRowToDraw);
 
-        indexesToDraw.sort((a: number, b: number) => a - b);
+        indexesToDraw.sort((a, b) => a - b);
 
         const ret: number[] = [];
 
@@ -1297,7 +1297,7 @@ export class RowRenderer extends BeanStub implements NamedBean {
 
     private destroyRowCtrls(rowCtrlsMap: RowCtrlIdMap | null | undefined, animate: boolean): void {
         const executeInAWhileFuncs: (() => void)[] = [];
-        _iterateObject(rowCtrlsMap, (nodeId: string, rowCtrl: RowCtrl) => {
+        _iterateObject(rowCtrlsMap, (nodeId, rowCtrl) => {
             // if row was used, then it's null
             if (!rowCtrl) {
                 return;

--- a/community-modules/csv-export/src/csvExport/gridSerializer.ts
+++ b/community-modules/csv-export/src/csvExport/gridSerializer.ts
@@ -228,7 +228,7 @@ export class GridSerializer extends BeanStub implements NamedBean {
                     .map((position) => this.pinnedRowModel.getPinnedTopRow(position.rowIndex))
                     .forEach(processRow);
             } else {
-                this.pinnedRowModel.forEachPinnedTopRow(processRow);
+                this.pinnedRowModel.forEachPinnedRow('top', processRow);
             }
             return gridSerializingSession;
         };
@@ -348,7 +348,7 @@ export class GridSerializer extends BeanStub implements NamedBean {
                     .map((position) => this.pinnedRowModel.getPinnedBottomRow(position.rowIndex))
                     .forEach(processRow);
             } else {
-                this.pinnedRowModel.forEachPinnedBottomRow(processRow);
+                this.pinnedRowModel.forEachPinnedRow('bottom', processRow);
             }
             return gridSerializingSession;
         };

--- a/testing/behavioural/src/rows/pinned-rows.test.ts
+++ b/testing/behavioural/src/rows/pinned-rows.test.ts
@@ -21,6 +21,8 @@ describe('pinned rows', () => {
         expect(pinnedRows.length).toBe(data.length);
 
         Array.from(pinnedRows)
+            // Have to sort because DOM order of nodes is not necessarily the same as the logical
+            // order (because rows are positioned absolutely)
             .sort((a, b) => {
                 const rowIndexA = a.getAttribute('row-index').split('-')[1];
                 const rowIndexB = b.getAttribute('row-index').split('-')[1];

--- a/testing/behavioural/src/rows/pinned-rows.test.ts
+++ b/testing/behavioural/src/rows/pinned-rows.test.ts
@@ -16,12 +16,21 @@ describe('pinned rows', () => {
     }
 
     function assertPinnedRowData(data: any[], location: 'top' | 'bottom') {
-        document
-            .querySelector(`.ag-floating-${location}`)
-            .querySelector('.ag-row-pinned')
-            .querySelectorAll('.ag-cell')
-            .forEach((cell, index) => {
-                expect(cell.textContent).toBe(data[0][columnDefs[index].field].toString());
+        const pinnedRows = document.querySelectorAll(`.ag-floating-${location} .ag-row-pinned`);
+
+        expect(pinnedRows.length).toBe(data.length);
+
+        Array.from(pinnedRows)
+            .sort((a, b) => {
+                const rowIndexA = a.getAttribute('row-index').split('-')[1];
+                const rowIndexB = b.getAttribute('row-index').split('-')[1];
+                return Number(rowIndexA) - Number(rowIndexB);
+            })
+            .forEach((row, i) => {
+                const rowData = data[i];
+                row.querySelectorAll('.ag-cell').forEach((cell, colIndex) => {
+                    expect(cell.textContent).toBe(rowData[columnDefs[colIndex].field].toString());
+                });
             });
     }
 
@@ -32,8 +41,6 @@ describe('pinned rows', () => {
     beforeEach(() => {
         resetGrids();
     });
-
-    afterEach(() => {});
 
     describe('top', () => {
         test('are shown', () => {
@@ -53,9 +60,7 @@ describe('pinned rows', () => {
         });
 
         test('are shown then updated with getRowId', () => {
-            const getRowId = jest.fn((p) => {
-                return p.data.athlete;
-            });
+            const getRowId = jest.fn((p) => p.data.athlete);
 
             const api = createMyGrid({
                 columnDefs,
@@ -72,6 +77,62 @@ describe('pinned rows', () => {
 
             expect(getRowId).toHaveBeenLastCalledWith(
                 expect.objectContaining({ data: updatedTopData[0], rowPinned: 'top' })
+            );
+        });
+
+        test('row data with matching ID is correctly updated', () => {
+            const getRowId = jest.fn((p) => p.data.id);
+            const pinnedTopRowData = [{ id: '3', athlete: 'Jake', sport: 'Top sport', age: 11 }];
+
+            const api = createMyGrid({
+                columnDefs,
+                pinnedTopRowData,
+                getRowId,
+            });
+
+            assertPinnedRowData(pinnedTopRowData, 'top');
+            expect(getRowId).toHaveBeenLastCalledWith(
+                expect.objectContaining({ data: pinnedTopRowData[0], rowPinned: 'top' })
+            );
+
+            const updatedTop = [
+                { id: '3', athlete: 'Peter', sport: 'Updated top sport', age: 12 },
+                { id: '4', athlete: 'Victor', sport: 'new sport', age: 22 },
+            ];
+
+            api.setGridOption('pinnedTopRowData', updatedTop);
+
+            assertPinnedRowData(updatedTop, 'top');
+            expect(getRowId).toHaveBeenLastCalledWith(
+                expect.objectContaining({ data: updatedTop[1], rowPinned: 'top' })
+            );
+        });
+
+        test('row data with matching ID is correctly updated with a new row order', () => {
+            const getRowId = jest.fn((p) => p.data.id);
+            const pinnedTopRowData = [{ id: '3', athlete: 'Jake', sport: 'Top sport', age: 11 }];
+
+            const api = createMyGrid({
+                columnDefs,
+                pinnedTopRowData,
+                getRowId,
+            });
+
+            assertPinnedRowData(pinnedTopRowData, 'top');
+            expect(getRowId).toHaveBeenLastCalledWith(
+                expect.objectContaining({ data: pinnedTopRowData[0], rowPinned: 'top' })
+            );
+
+            const updatedTop = [
+                { id: '4', athlete: 'Victor', sport: 'new sport', age: 22 },
+                { id: '3', athlete: 'Peter', sport: 'Updated top sport', age: 12 },
+            ];
+
+            api.setGridOption('pinnedTopRowData', updatedTop);
+
+            assertPinnedRowData(updatedTop, 'top');
+            expect(getRowId).toHaveBeenLastCalledWith(
+                expect.objectContaining({ data: updatedTop[1], rowPinned: 'top' })
             );
         });
     });
@@ -94,9 +155,7 @@ describe('pinned rows', () => {
         });
 
         test('are shown then updated with getRowId', () => {
-            const getRowId = jest.fn((p) => {
-                return p.data.athlete;
-            });
+            const getRowId = jest.fn((p) => p.data.athlete);
 
             const api = createMyGrid({
                 columnDefs,
@@ -116,6 +175,62 @@ describe('pinned rows', () => {
 
             expect(getRowId).toHaveBeenLastCalledWith(
                 expect.objectContaining({ data: updatedBottom[0], rowPinned: 'bottom' })
+            );
+        });
+
+        test('row data with matching ID is correctly updated', () => {
+            const getRowId = jest.fn((p) => p.data.id);
+            const pinnedBottomRowData = [{ id: '3', athlete: 'Jake', sport: 'Top sport', age: 11 }];
+
+            const api = createMyGrid({
+                columnDefs,
+                pinnedBottomRowData,
+                getRowId,
+            });
+
+            assertPinnedRowData(pinnedBottomRowData, 'bottom');
+            expect(getRowId).toHaveBeenLastCalledWith(
+                expect.objectContaining({ data: pinnedBottomRowData[0], rowPinned: 'bottom' })
+            );
+
+            const updatedBottom = [
+                { id: '3', athlete: 'Peter', sport: 'Updated bottom sport', age: 12 },
+                { id: '4', athlete: 'Victor', sport: 'new sport', age: 22 },
+            ];
+
+            api.setGridOption('pinnedBottomRowData', updatedBottom);
+
+            assertPinnedRowData(updatedBottom, 'bottom');
+            expect(getRowId).toHaveBeenLastCalledWith(
+                expect.objectContaining({ data: updatedBottom[1], rowPinned: 'bottom' })
+            );
+        });
+
+        test('row data with matching ID is correctly updated with a new row order', () => {
+            const getRowId = jest.fn((p) => p.data.id);
+            const pinnedBottomRowData = [{ id: '3', athlete: 'Jake', sport: 'Top sport', age: 11 }];
+
+            const api = createMyGrid({
+                columnDefs,
+                pinnedBottomRowData,
+                getRowId,
+            });
+
+            assertPinnedRowData(pinnedBottomRowData, 'bottom');
+            expect(getRowId).toHaveBeenLastCalledWith(
+                expect.objectContaining({ data: pinnedBottomRowData[0], rowPinned: 'bottom' })
+            );
+
+            const updatedBottom = [
+                { id: '4', athlete: 'Victor', sport: 'new sport', age: 22 },
+                { id: '3', athlete: 'Peter', sport: 'Updated bottom sport', age: 12 },
+            ];
+
+            api.setGridOption('pinnedBottomRowData', updatedBottom);
+
+            assertPinnedRowData(updatedBottom, 'bottom');
+            expect(getRowId).toHaveBeenLastCalledWith(
+                expect.objectContaining({ data: updatedBottom[1], rowPinned: 'bottom' })
             );
         });
     });

--- a/testing/behavioural/src/rows/pinned-rows.test.ts
+++ b/testing/behavioural/src/rows/pinned-rows.test.ts
@@ -135,6 +135,47 @@ describe('pinned rows', () => {
                 expect.objectContaining({ data: updatedTop[1], rowPinned: 'top' })
             );
         });
+
+        test('remove and re-order rows', () => {
+            const getRowId = jest.fn((p) => p.data.id);
+            const pinnedTopRowData = [
+                { id: '3', athlete: 'Jake', sport: 'Top sport 0', age: 11 },
+                { id: '4', athlete: 'Peter', sport: 'Top sport 1', age: 12 },
+                { id: '5', athlete: 'Victor', sport: 'Top sport 2', age: 22 },
+            ];
+
+            const api = createMyGrid({
+                columnDefs,
+                pinnedTopRowData,
+                getRowId,
+            });
+
+            assertPinnedRowData(pinnedTopRowData, 'top');
+            expect(getRowId).toHaveBeenLastCalledWith(
+                expect.objectContaining({ data: pinnedTopRowData[2], rowPinned: 'top' })
+            );
+
+            const updatedTop = [
+                { id: '5', athlete: 'Charles', sport: 'new sport 0', age: 22 },
+                { id: '3', athlete: 'Jake', sport: 'new sport 1', age: 14 },
+            ];
+
+            api.setGridOption('pinnedTopRowData', updatedTop);
+
+            assertPinnedRowData(updatedTop, 'top');
+            expect(getRowId).toHaveBeenLastCalledWith(
+                expect.objectContaining({ data: updatedTop[1], rowPinned: 'top' })
+            );
+        });
+
+        test('rows are cleared on setting undefined rowData', () => {
+            const api = createMyGrid({ columnDefs, pinnedTopRowData: topData });
+
+            assertPinnedRowData(topData, 'top');
+
+            api.setGridOption('pinnedTopRowData', undefined);
+            assertPinnedRowData([], 'top');
+        });
     });
 
     describe('bottom', () => {
@@ -232,6 +273,47 @@ describe('pinned rows', () => {
             expect(getRowId).toHaveBeenLastCalledWith(
                 expect.objectContaining({ data: updatedBottom[1], rowPinned: 'bottom' })
             );
+        });
+
+        test('remove and re-order rows', () => {
+            const getRowId = jest.fn((p) => p.data.id);
+            const pinnedBottomRowData = [
+                { id: '3', athlete: 'Jake', sport: 'Bottom sport 0', age: 11 },
+                { id: '4', athlete: 'Peter', sport: 'Bottom sport 1', age: 12 },
+                { id: '5', athlete: 'Victor', sport: 'Bottom sport 2', age: 22 },
+            ];
+
+            const api = createMyGrid({
+                columnDefs,
+                pinnedBottomRowData,
+                getRowId,
+            });
+
+            assertPinnedRowData(pinnedBottomRowData, 'bottom');
+            expect(getRowId).toHaveBeenLastCalledWith(
+                expect.objectContaining({ data: pinnedBottomRowData[2], rowPinned: 'bottom' })
+            );
+
+            const updatedBottom = [
+                { id: '5', athlete: 'Charles', sport: 'new sport 0', age: 22 },
+                { id: '3', athlete: 'Jake', sport: 'new sport 1', age: 14 },
+            ];
+
+            api.setGridOption('pinnedBottomRowData', updatedBottom);
+
+            assertPinnedRowData(updatedBottom, 'bottom');
+            expect(getRowId).toHaveBeenLastCalledWith(
+                expect.objectContaining({ data: updatedBottom[1], rowPinned: 'bottom' })
+            );
+        });
+
+        test('rows are cleared on setting undefined rowData', () => {
+            const api = createMyGrid({ columnDefs, pinnedBottomRowData: bottomData });
+
+            assertPinnedRowData(bottomData, 'bottom');
+
+            api.setGridOption('pinnedBottomRowData', undefined);
+            assertPinnedRowData([], 'bottom');
         });
     });
 });


### PR DESCRIPTION
See https://ag-grid.atlassian.net/browse/AG-12193

There was previously no update logic for pinned rows, which means they were either re-created entirely (if there was no matching ID found) or they were left intact (without updating associated row data).

This now adds update logic analogous to that in `ClientSideRowModel`, but a bit simpler.