### PR TITLE
AG-12201 - more standard gridApi object - change the way Proxy is used

### DIFF
--- a/community-modules/core/src/api/apiFunctionService.ts
+++ b/community-modules/core/src/api/apiFunctionService.ts
@@ -4,23 +4,60 @@ import type { BeanCollection } from '../context/context';
 import type { AgEventType } from '../eventTypes';
 import type { AgEvent } from '../events';
 import { _warnOnce } from '../utils/function';
+import type { GridApi } from './gridApi';
 import type { ApiFunction, ApiFunctionName } from './iApiFunction';
 
-function dispatchEvent(beans: BeanCollection, event: AgEvent<AgEventType>): void {
+const dispatchEvent = (beans: BeanCollection, event: AgEvent<AgEventType>): void => {
     beans.eventService.dispatchEvent(event);
-}
+};
 
 export class ApiFunctionService extends BeanStub implements NamedBean {
     beanName = 'apiFunctionService' as const;
 
-    private beans: BeanCollection;
-    private functions: { [key in ApiFunctionName]?: (beans: BeanCollection, ...args: any[]) => any } = {
-        // this is used by frameworks
-        // also used by aligned grids to identify a grid api instance
-        dispatchEvent,
-    };
-    private isDestroyed = false;
+    public readonly gridApi: GridApi;
+    private beans: BeanCollection | undefined;
     private preDestroyLink: string;
+    private functions: Record<string, (beans: BeanCollection, ...args: unknown[]) => unknown> | undefined = {};
+    private getGridApiProp: (target: any, prop: string | symbol) => any;
+
+    public constructor() {
+        super();
+
+        const apis: Record<string | symbol, any> = {
+            // Add here identifiers to be excluded.
+            // It includes implicitly all Object.prototype methods (valueOf, toString, hasOwnProperty, etc)
+            __proto__: Object.prototype,
+            toJSON: undefined,
+            then: undefined,
+            catch: undefined,
+            finally: undefined,
+
+            beanName: undefined,
+
+            preWireBeans() {},
+            wireBeans() {},
+            preConstruct() {},
+            postConstruct() {},
+        };
+
+        const getGridApiProp = (_target: never, name: string | symbol): unknown => {
+            if (name in apis || typeof name !== 'string') {
+                return apis[name];
+            }
+            return (apis[name] = this.makeApi(name)[name]);
+        };
+
+        this.getGridApiProp = getGridApiProp;
+
+        // GridApi is a plain object that extends a Proxy.
+        // In this way, GridApi will behave like a normal object,
+        // but with the ability to intercept property access for properties not found.
+        // This also removes the performance penalty of using a Proxy for registered functions.
+        this.gridApi = Object.create(Object.freeze(new Proxy({}, { get: getGridApiProp }))) as any;
+
+        // this is used by frameworks also used by aligned grids to identify a grid api instance
+        this.addFunction('dispatchEvent', dispatchEvent);
+    }
 
     public wireBeans(beans: BeanCollection): void {
         this.beans = beans;
@@ -30,56 +67,51 @@ export class ApiFunctionService extends BeanStub implements NamedBean {
         this.preDestroyLink = this.frameworkOverrides.getDocLink('grid-lifecycle/#grid-pre-destroyed');
     }
 
-    public callFunction(functionName: ApiFunctionName, args: any[]): any {
-        const func = this.functions[functionName];
-
-        if (func) {
-            return func.apply(func, [this.beans, ...args]);
-        }
-
-        if (this.isDestroyed) {
-            return this.destroyedHandler(functionName);
-        }
-        if (this.isFrameworkMethod(functionName)) {
-            return undefined;
-        }
-        this.beans.validationService?.warnMissingApiFunction(functionName);
-        return undefined;
-    }
-
     public addFunction<TFunctionName extends ApiFunctionName>(
-        functionName: TFunctionName,
-        func: ApiFunction<TFunctionName>
+        name: TFunctionName,
+        fn: ApiFunction<TFunctionName>
     ): void {
-        const { validationService } = this.beans;
-        if (validationService) {
-            func = validationService.validateApiFunction(functionName, func);
+        const { functions, gridApi } = this;
+        if (functions) {
+            functions[name] = this.beans?.validationService?.validateApiFunction(name, fn) ?? fn;
         }
-        this.functions[functionName] = func;
+        gridApi[name] = this.getGridApiProp(0, name);
     }
 
     public override destroy(): void {
-        this.functions = {};
-        this.isDestroyed = true;
+        this.functions = undefined;
         super.destroy();
+        this.beans = undefined;
     }
 
-    private destroyedHandler(functionName: ApiFunctionName): any {
-        if (functionName === 'isDestroyed') {
-            return true;
-        }
-        if (functionName === 'destroy') {
-            return;
-        }
-        _warnOnce(
-            `Grid API function ${functionName}() cannot be called as the grid has been destroyed.\n` +
-                `Either clear local references to the grid api, when it is destroyed, or check gridApi.isDestroyed() to avoid calling methods against a destroyed grid.\n` +
-                `To run logic when the grid is about to be destroyed use the gridPreDestroy event. See: ${this.preDestroyLink}`
-        );
-        return;
+    private makeApi<TName extends string>(name: TName) {
+        // We return an object here so function.toString returns the right function name
+        // This is faster and minifies better than calling Object.defineProperty(func, 'name', { value: name, configurable: true })
+        // Keep this function light and small for performance reasons.
+        return {
+            [name]: (...args: unknown[]) => {
+                const api = this.functions?.[name as ApiFunctionName];
+                return api ? api(this.beans!, ...args) : this.apiWarn(name);
+            },
+        };
     }
 
-    private isFrameworkMethod(functionName: string): boolean {
-        return ['preWireBeans', 'wireBeans', 'preConstruct', 'postConstruct'].includes(functionName);
+    private apiWarn(functionName: string): unknown {
+        if (!this.beans) {
+            if (functionName === 'isDestroyed') {
+                return true;
+            }
+            if (functionName === 'destroy') {
+                return undefined;
+            }
+            _warnOnce(
+                `Grid API function ${functionName}() cannot be called as the grid has been destroyed.\n` +
+                    `Either clear local references to the grid api, when it is destroyed, or check gridApi.isDestroyed() to avoid calling methods against a destroyed grid.\n` +
+                    `To run logic when the grid is about to be destroyed use the gridPreDestroy event. See: ${this.preDestroyLink}`
+            );
+            return undefined;
+        }
+
+        return this.beans.validationService?.warnMissingApiFunction(functionName as ApiFunctionName);
     }
 }

--- a/community-modules/core/src/api/apiUtils.ts
+++ b/community-modules/core/src/api/apiUtils.ts
@@ -1,22 +1,9 @@
 import type { Context } from '../context/context';
 import type { GridApi } from './gridApi';
 
-function createApi(context: Context): GridApi {
-    const apiFunctionService = context.getBean('apiFunctionService');
-    return new Proxy(apiFunctionService, {
-        get(target, prop) {
-            // allow api to work with async/await
-            if (prop === 'then') {
-                return;
-            }
-            return (...args: any[]) => target.callFunction(prop as any, args);
-        },
-    }) as any;
-}
-
 export function createApiProxy(context: Context): { beanName: 'gridApi'; bean: GridApi } {
     return {
         beanName: 'gridApi',
-        bean: createApi(context),
+        bean: context.getBean('apiFunctionService').gridApi,
     };
 }

--- a/testing/behavioural/src/api-proxy/api-proxy-add-methods.ts
+++ b/testing/behavioural/src/api-proxy/api-proxy-add-methods.ts
@@ -1,0 +1,39 @@
+import { ClientSideRowModelModule } from '@ag-grid-community/client-side-row-model';
+import type { GridOptions } from '@ag-grid-community/core';
+import { ModuleRegistry, createGrid } from '@ag-grid-community/core';
+
+describe('ag-grid api proxy', () => {
+    function createMyGrid(gridOptions: GridOptions) {
+        return createGrid(document.getElementById('myGrid')!, gridOptions);
+    }
+
+    function resetGrids() {
+        document.body.innerHTML = '<div id="myGrid"></div>';
+    }
+
+    beforeEach(() => {
+        resetGrids();
+    });
+
+    test('ModuleRegistry add methods, and keep the same reference', () => {
+        const gridApi = createMyGrid({});
+
+        const keysBefore = Object.keys(gridApi);
+        const applyTransactionBefore = gridApi.applyTransaction;
+        expect(typeof applyTransactionBefore).toBe('function');
+
+        expect('applyTransaction' in gridApi).toBe(false);
+        expect(keysBefore.includes('applyTransaction')).toBe(false);
+
+        ModuleRegistry.register(ClientSideRowModelModule);
+
+        expect('applyTransaction' in gridApi).toBe(true);
+        expect(typeof gridApi.applyTransaction).toBe('function');
+        expect(gridApi.applyTransaction).toBe(gridApi.applyTransaction);
+        expect(applyTransactionBefore).toBe(gridApi.applyTransaction);
+
+        const keysAfter = Object.keys(gridApi);
+
+        expect(keysAfter.includes('applyTransaction')).toBe(true);
+    });
+});

--- a/testing/behavioural/src/api-proxy/api-proxy.test.ts
+++ b/testing/behavioural/src/api-proxy/api-proxy.test.ts
@@ -1,0 +1,159 @@
+import { ClientSideRowModelModule } from '@ag-grid-community/client-side-row-model';
+import type { GridOptions } from '@ag-grid-community/core';
+import { ModuleRegistry, createGrid } from '@ag-grid-community/core';
+import { isProxy } from 'util/types';
+
+describe('ag-grid api proxy', () => {
+    let consoleWarnSpy: jest.SpyInstance | undefined;
+    let consoleErrorSpy: jest.SpyInstance | undefined;
+
+    function createMyGrid(gridOptions: GridOptions) {
+        return createGrid(document.getElementById('myGrid')!, gridOptions);
+    }
+
+    function resetGrids() {
+        document.body.innerHTML = '<div id="myGrid"></div>';
+    }
+
+    beforeAll(() => {
+        ModuleRegistry.register(ClientSideRowModelModule);
+    });
+
+    beforeEach(() => {
+        resetGrids();
+    });
+
+    afterEach(() => {
+        consoleWarnSpy?.mockRestore();
+        consoleErrorSpy?.mockRestore();
+    });
+
+    describe('gridApi as a normal JS object', () => {
+        test('prototype chain', () => {
+            const gridApi = createMyGrid({});
+            const gridApiProto = Object.getPrototypeOf(gridApi);
+
+            expect(isProxy(gridApi)).toBe(false);
+
+            expect(typeof gridApi).toBe('object');
+            expect(typeof gridApiProto).toBe('object');
+            expect(Object.getPrototypeOf(gridApiProto)).toBe(Object.prototype);
+            expect(gridApi).toBeInstanceOf(Object);
+            expect(gridApiProto).toBeInstanceOf(Object);
+        });
+
+        test('__proto__', () => {
+            const gridApi = createMyGrid({});
+            const gridApiProto = Object.getPrototypeOf(gridApi);
+
+            expect(gridApiProto.__proto__).toBe(Object.prototype);
+            expect((gridApi as any).__proto__).toBe(Object.prototype);
+
+            expect('__proto__' in {}).toBe(true);
+            expect('__proto__' in gridApi).toBe(true);
+            expect('__proto__' in gridApiProto).toBe(true);
+        });
+
+        test.each(Object.getOwnPropertyNames(Object.prototype))('Object.prototype.%s', (key) => {
+            const gridApi = createMyGrid({});
+            const gridApiProto = Object.getPrototypeOf(gridApi);
+
+            expect(key in gridApi).toBe(true);
+            expect(key in gridApiProto).toBe(true);
+
+            // The property must be defined in the parent parent prototype
+            expect(Object.getOwnPropertyDescriptor({}, key)).toBeUndefined();
+            expect(Object.getOwnPropertyDescriptor(gridApi, key)).toBeUndefined();
+            expect(Object.getOwnPropertyDescriptor(gridApiProto, key)).toBeUndefined();
+
+            expect(gridApi[key]).toBe(key === '__proto__' ? Object.prototype : Object.prototype[key]);
+        });
+
+        test('bean property beanName', () => {
+            const gridApi = createMyGrid({});
+            const gridApiProto = Object.getPrototypeOf(gridApi);
+
+            expect('beanName' in gridApi).toBe(false);
+            expect((gridApi as any).beanName).toBeUndefined();
+
+            expect('beanName' in gridApiProto).toBe(false);
+            expect((gridApiProto as any).beanName).toBeUndefined();
+        });
+
+        test.each(['preWireBeans', 'wireBeans', 'preConstruct', 'postConstruct'])('Bean method %s', (key) => {
+            const gridApi = createMyGrid({});
+
+            expect(key in gridApi).toBe(false);
+            expect(typeof (gridApi as any)[key]).toBe('function');
+
+            // Check that the function name is correct
+            expect((gridApi as any)[key].name).toEqual(key);
+
+            // Check it is always the same instance
+            expect((gridApi as any)[key]).toBe((gridApi as any)[key]);
+        });
+
+        test('gridApi prototype is a frozen proxy', () => {
+            const gridApi = createMyGrid({});
+            const gridApiProto = Object.getPrototypeOf(gridApi);
+
+            expect(Object.isFrozen(gridApiProto)).toBe(true);
+            expect(isProxy(gridApiProto)).toBe(true);
+            expect(() => {
+                gridApiProto.foo = 'bar';
+            }).toThrow(new TypeError('Cannot define property foo, object is not extensible'));
+            expect('foo' in gridApiProto).toBe(false);
+        });
+
+        test('gridApi is writable', () => {
+            const gridApi = createMyGrid({});
+            const gridApiProto = Object.getPrototypeOf(gridApi);
+
+            (gridApi as any).foo = 'bar';
+            expect('foo' in gridApi).toBe(true);
+            expect((gridApi as any).foo).toBe('bar');
+
+            expect('foo' in gridApiProto).toBe(false);
+        });
+
+        test.each(['toJSON', 'then', 'catch', 'finally'])('Forbidden method %s', (key) => {
+            const gridApi = createMyGrid({});
+
+            expect(key in gridApi).toBe(false);
+            expect((gridApi as any)[key]).toBeUndefined();
+            expect((gridApi as any)[key]).toBeUndefined();
+        });
+    });
+
+    test('dispatchEvent', () => {
+        const gridApi = createMyGrid({});
+
+        expect('dispatchEvent' in gridApi).toBe(true);
+        expect(typeof gridApi.dispatchEvent).toBe('function');
+
+        expect(gridApi.dispatchEvent).toBe(gridApi.dispatchEvent); // same instance check
+    });
+
+    test('unknown API function', () => {
+        consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+        const gridApi = createMyGrid({});
+
+        expect('unknownFn' in gridApi).toBe(false);
+
+        const unknownFn = (gridApi as any).unknownFn;
+        expect(typeof unknownFn).toBe('function');
+        expect((gridApi as any).unknownFn).toBe(unknownFn); // same instance check
+
+        expect('unknownFn' in gridApi).toBe(false);
+
+        unknownFn();
+
+        expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+
+        unknownFn();
+        unknownFn();
+
+        expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+    });
+});


### PR DESCRIPTION
With this PR, gridApi is now an object that inherits a Proxy
This means that if a method is not found, JS will just walk up in the prototype chain and use the proxy getter only for unregistered methods.

Implement also a cache so the same function instance is always returned instead of creating a new function at every get.