### PR TITLE
AG-11923 suppressCellFocus updates

### DIFF
--- a/community-modules/core/src/rendering/cell/cellComp.ts
+++ b/community-modules/core/src/rendering/cell/cellComp.ts
@@ -98,10 +98,6 @@ export class CellComp extends Component implements TooltipParentComp {
 
         _setAriaRole(eGui, cellCtrl.getCellAriaRole());
         setAttribute('col-id', cellCtrl.getColumnIdSanitised());
-        const tabIndex = cellCtrl.getTabIndex();
-        if (tabIndex !== undefined) {
-            setAttribute('tabindex', tabIndex.toString());
-        }
 
         const compProxy: ICellComp = {
             addOrRemoveCssClass: (cssClassName, on) => this.addOrRemoveCssClass(cssClassName, on),

--- a/community-modules/core/src/rendering/cell/cellCtrl.ts
+++ b/community-modules/core/src/rendering/cell/cellCtrl.ts
@@ -13,7 +13,7 @@ import type { BrandedType } from '../../interfaces/brandedType';
 import type { ICellEditor } from '../../interfaces/iCellEditor';
 import type { CellChangedEvent } from '../../interfaces/iRowNode';
 import { _setAriaColIndex } from '../../utils/aria';
-import { _getElementSize } from '../../utils/dom';
+import { _addOrRemoveAttribute, _getElementSize } from '../../utils/dom';
 import { _warnOnce } from '../../utils/function';
 import { _exists, _makeNull } from '../../utils/generic';
 import { _getValueUsingField } from '../../utils/object';
@@ -101,7 +101,6 @@ export class CellCtrl extends BeanStub {
     private includeDndSource: boolean;
     private includeRowDrag: boolean;
     private colIdSanitised: string;
-    private tabIndex: number | undefined;
     private isAutoHeight: boolean;
 
     private suppressRefreshCell = false;
@@ -123,9 +122,6 @@ export class CellCtrl extends BeanStub {
         this.instanceId = (column.getId() + '-' + instanceIdSequence++) as CellCtrlInstanceId;
 
         this.colIdSanitised = _escapeString(this.column.getId())!;
-        if (!beans.gos.get('suppressCellFocus')) {
-            this.tabIndex = -1;
-        }
 
         this.createCellPosition();
         this.addFeatures();
@@ -267,6 +263,8 @@ export class CellCtrl extends BeanStub {
 
         this.addDomData();
 
+        this.onSuppressCellFocusChanged(this.beans.gos.get('suppressCellFocus'));
+
         this.onCellFocused(this.focusEventToRestore);
         this.applyStaticCssClasses();
         this.setWrapText();
@@ -371,9 +369,6 @@ export class CellCtrl extends BeanStub {
     }
     public getColumnIdSanitised(): string {
         return this.colIdSanitised;
-    }
-    public getTabIndex(): number | undefined {
-        return this.tabIndex;
     }
     public isCellRenderer(): boolean {
         const colDef = this.column.getColDef();
@@ -914,6 +909,14 @@ export class CellCtrl extends BeanStub {
         if (this.cellRangeFeature) {
             this.cellRangeFeature.onRangeSelectionChanged();
         }
+    }
+
+    public onSuppressCellFocusChanged(value: boolean): void {
+        if (!this.eGui) {
+            return;
+        }
+        const tabIndex = value ? undefined : -1;
+        _addOrRemoveAttribute(this.eGui, 'tabindex', tabIndex);
     }
 
     public onFirstRightPinnedChanged(): void {

--- a/community-modules/core/src/rendering/cell/cellCtrl.ts
+++ b/community-modules/core/src/rendering/cell/cellCtrl.ts
@@ -911,12 +911,11 @@ export class CellCtrl extends BeanStub {
         }
     }
 
-    public onSuppressCellFocusChanged(value: boolean): void {
+    public onSuppressCellFocusChanged(suppressCellFocus: boolean): void {
         if (!this.eGui) {
             return;
         }
-        const tabIndex = value ? undefined : -1;
-        _addOrRemoveAttribute(this.eGui, 'tabindex', tabIndex);
+        _addOrRemoveAttribute(this.eGui, 'tabindex', suppressCellFocus ? undefined : -1);
     }
 
     public onFirstRightPinnedChanged(): void {

--- a/community-modules/core/src/rendering/row/rowComp.ts
+++ b/community-modules/core/src/rendering/row/rowComp.ts
@@ -37,10 +37,6 @@ export class RowComp extends Component {
         const style = eGui.style;
         this.domOrder = this.rowCtrl.getDomOrder();
         _setAriaRole(eGui, 'row');
-        const tabIndex = this.rowCtrl.getTabIndex();
-        if (tabIndex != null) {
-            eGui.setAttribute('tabindex', tabIndex.toString());
-        }
 
         const compProxy: IRowComp = {
             setDomOrder: (domOrder) => (this.domOrder = domOrder),

--- a/community-modules/core/src/rendering/row/rowCtrl.ts
+++ b/community-modules/core/src/rendering/row/rowCtrl.ts
@@ -917,8 +917,8 @@ export class RowCtrl extends BeanStub<RowCtrlEvent> {
         return 0;
     }
 
-    public onSuppressCellFocusChanged(value: boolean): void {
-        const tabIndex = this.isFullWidth() && value ? undefined : -1;
+    public onSuppressCellFocusChanged(suppressCellFocus: boolean): void {
+        const tabIndex = this.isFullWidth() && suppressCellFocus ? undefined : -1;
         this.allRowGuis.forEach((gui) => {
             _addOrRemoveAttribute(gui.element, 'tabindex', tabIndex);
         });

--- a/community-modules/core/src/rendering/row/rowCtrl.ts
+++ b/community-modules/core/src/rendering/row/rowCtrl.ts
@@ -28,7 +28,7 @@ import type { IServerSideRowModel } from '../../interfaces/iServerSideRowModel';
 import { ModuleNames } from '../../modules/moduleNames';
 import { ModuleRegistry } from '../../modules/moduleRegistry';
 import { _setAriaExpanded, _setAriaRowIndex, _setAriaSelected } from '../../utils/aria';
-import { _isElementChildOfClass, _isFocusableFormField, _isVisible } from '../../utils/dom';
+import { _addOrRemoveAttribute, _isElementChildOfClass, _isFocusableFormField, _isVisible } from '../../utils/dom';
 import { _isStopPropagationForAgGrid } from '../../utils/event';
 import { _executeNextVMTurn, _warnOnce } from '../../utils/function';
 import { _exists, _makeNull } from '../../utils/generic';
@@ -134,7 +134,6 @@ export class RowCtrl extends BeanStub<RowCtrlEvent> {
     private updateColumnListsPending = false;
 
     private rowId: string | null = null;
-    private tabIndex: number | undefined;
     private businessKeySanitised: string | null = null;
     private businessKeyForNodeFunc: ((node: IRowNode<any>) => string) | undefined;
 
@@ -166,11 +165,6 @@ export class RowCtrl extends BeanStub<RowCtrlEvent> {
         this.setAnimateFlags(animateIn);
         this.rowStyles = this.processStylesFromGridOptions();
 
-        // calls to `isFullWidth()` only work after `setRowType` has been called.
-        if (this.isFullWidth() && !this.gos.get('suppressCellFocus')) {
-            this.tabIndex = -1;
-        }
-
         this.addListeners();
     }
 
@@ -192,9 +186,6 @@ export class RowCtrl extends BeanStub<RowCtrlEvent> {
     }
     public getRowStyles() {
         return this.rowStyles;
-    }
-    public getTabIndex() {
-        return this.tabIndex;
     }
 
     private isSticky(): boolean {
@@ -249,6 +240,8 @@ export class RowCtrl extends BeanStub<RowCtrlEvent> {
 
     private initialiseRowComp(gui: RowGui): void {
         const gos = this.gos;
+
+        this.onSuppressCellFocusChanged(this.beans.gos.get('suppressCellFocus'));
 
         this.listenOnDomOrder(gui);
         if (this.beans.columnModel.wasAutoRowHeightEverActive()) {
@@ -922,6 +915,13 @@ export class RowCtrl extends BeanStub<RowCtrlEvent> {
         }
 
         return 0;
+    }
+
+    public onSuppressCellFocusChanged(value: boolean): void {
+        const tabIndex = this.isFullWidth() && value ? undefined : -1;
+        this.allRowGuis.forEach((gui) => {
+            _addOrRemoveAttribute(gui.element, 'tabindex', tabIndex);
+        });
     }
 
     public onFullWidthRowFocused(event?: CellFocusedEvent) {

--- a/community-modules/core/src/rendering/rowRenderer.ts
+++ b/community-modules/core/src/rendering/rowRenderer.ts
@@ -170,9 +170,9 @@ export class RowRenderer extends BeanStub implements NamedBean {
 
         this.addManagedPropertyListeners(['domLayout', 'embedFullWidthRows'], () => this.onDomLayoutChanged());
         this.addManagedPropertyListeners(['suppressMaxRenderedRowRestriction', 'rowBuffer'], () => this.redraw());
+        this.addManagedPropertyListener('suppressCellFocus', (e) => this.onSuppressCellFocusChanged(e.currentValue));
         this.addManagedPropertyListeners(
             [
-                'suppressCellFocus',
                 'getBusinessKeyForNode',
                 'fullWidthCellRenderer',
                 'fullWidthCellRendererParams',
@@ -258,6 +258,11 @@ export class RowRenderer extends BeanStub implements NamedBean {
     private onCellFocusChanged(event?: CellFocusedEvent) {
         this.getAllCellCtrls().forEach((cellCtrl) => cellCtrl.onCellFocused(event));
         this.getFullWidthRowCtrls().forEach((rowCtrl) => rowCtrl.onFullWidthRowFocused(event));
+    }
+
+    private onSuppressCellFocusChanged(suppressCellFocus: boolean): void {
+        this.getAllCellCtrls().forEach((cellCtrl) => cellCtrl.onSuppressCellFocusChanged(suppressCellFocus));
+        this.getFullWidthRowCtrls().forEach((rowCtrl) => rowCtrl.onSuppressCellFocusChanged(suppressCellFocus));
     }
 
     // in a clean design, each cell would register for each of these events. however when scrolling, all the cells

--- a/community-modules/core/src/utils/dom.ts
+++ b/community-modules/core/src/utils/dom.ts
@@ -458,8 +458,8 @@ export function _iterateNamedNodeMap(map: NamedNodeMap, callback: (key: string, 
     }
 }
 
-export function _addOrRemoveAttribute(element: HTMLElement, name: string, value: any) {
-    if (value == null) {
+export function _addOrRemoveAttribute(element: HTMLElement, name: string, value: string | number | null | undefined) {
+    if (value == null || value === '') {
         element.removeAttribute(name);
     } else {
         element.setAttribute(name, value.toString());

--- a/community-modules/react/src/reactUi/cells/cellComp.tsx
+++ b/community-modules/react/src/reactUi/cells/cellComp.tsx
@@ -167,7 +167,6 @@ const CellComp = (props: { cellCtrl: CellCtrl; printLayout: boolean; editingRow:
     const { context } = useContext(BeansContext);
     const { cellCtrl, printLayout, editingRow } = props;
 
-    const tabIndex = cellCtrl.getTabIndex();
     const colId = cellCtrl.getColumnIdSanitised();
     const cellInstanceId = cellCtrl.getInstanceId();
 
@@ -501,7 +500,7 @@ const CellComp = (props: { cellCtrl: CellCtrl; printLayout: boolean; editingRow:
     );
 
     return (
-        <div ref={setRef} style={userStyles} tabIndex={tabIndex} role={cellAriaRole} col-id={colId}>
+        <div ref={setRef} style={userStyles} role={cellAriaRole} col-id={colId}>
             {showCellWrapper ? (
                 <div className="ag-cell-wrapper" role="presentation" ref={setCellWrapperRef}>
                     {showContents()}

--- a/community-modules/react/src/reactUi/rows/rowComp.tsx
+++ b/community-modules/react/src/reactUi/rows/rowComp.tsx
@@ -19,7 +19,6 @@ const RowComp = (params: { rowCtrl: RowCtrl; containerType: RowContainerType }) 
     const { context, gos } = useContext(BeansContext);
     const { rowCtrl, containerType } = params;
 
-    const tabIndex = rowCtrl.getTabIndex();
     const domOrderRef = useRef<boolean>(rowCtrl.getDomOrder());
     const isFullWidth = rowCtrl.isFullWidth();
 
@@ -200,7 +199,6 @@ const RowComp = (params: { rowCtrl: RowCtrl; containerType: RowContainerType }) 
             row-index={rowIndex}
             row-id={rowId}
             row-business-key={rowBusinessKey}
-            tabIndex={tabIndex}
         >
             {showCells && showCellsJsx()}
             {showFullWidthFramework && showFullWidthFrameworkJsx()}

--- a/packages/ag-grid-react/src/reactUi/cells/cellComp.tsx
+++ b/packages/ag-grid-react/src/reactUi/cells/cellComp.tsx
@@ -167,7 +167,6 @@ const CellComp = (props: { cellCtrl: CellCtrl; printLayout: boolean; editingRow:
     const { context } = useContext(BeansContext);
     const { cellCtrl, printLayout, editingRow } = props;
 
-    const tabIndex = cellCtrl.getTabIndex();
     const colId = cellCtrl.getColumnIdSanitised();
     const cellInstanceId = cellCtrl.getInstanceId();
 
@@ -501,7 +500,7 @@ const CellComp = (props: { cellCtrl: CellCtrl; printLayout: boolean; editingRow:
     );
 
     return (
-        <div ref={setRef} style={userStyles} tabIndex={tabIndex} role={cellAriaRole} col-id={colId}>
+        <div ref={setRef} style={userStyles} role={cellAriaRole} col-id={colId}>
             {showCellWrapper ? (
                 <div className="ag-cell-wrapper" role="presentation" ref={setCellWrapperRef}>
                     {showContents()}

--- a/packages/ag-grid-react/src/reactUi/rows/rowComp.tsx
+++ b/packages/ag-grid-react/src/reactUi/rows/rowComp.tsx
@@ -19,7 +19,6 @@ const RowComp = (params: { rowCtrl: RowCtrl; containerType: RowContainerType }) 
     const { context, gos } = useContext(BeansContext);
     const { rowCtrl, containerType } = params;
 
-    const tabIndex = rowCtrl.getTabIndex();
     const domOrderRef = useRef<boolean>(rowCtrl.getDomOrder());
     const isFullWidth = rowCtrl.isFullWidth();
 
@@ -200,7 +199,6 @@ const RowComp = (params: { rowCtrl: RowCtrl; containerType: RowContainerType }) 
             row-index={rowIndex}
             row-id={rowId}
             row-business-key={rowBusinessKey}
-            tabIndex={tabIndex}
         >
             {showCells && showCellsJsx()}
             {showFullWidthFramework && showFullWidthFrameworkJsx()}


### PR DESCRIPTION
The aim is to update the `tabIndex` property for cells and fullwidth rows without triggering a React rerender. 

This is achieved by moving the management of the `tabIndex` attribute into the ctrls and out of the components. 