### PR TITLE
AG-11372 Ensure columnAnimations always flushed

### DIFF
--- a/community-modules/core/src/rendering/columnAnimationService.ts
+++ b/community-modules/core/src/rendering/columnAnimationService.ts
@@ -126,11 +126,7 @@ export class ColumnAnimationService extends BeanStub implements NamedBean {
                 // run the callback before executeLaterFuncs
                 // because some functions being executed later
                 // check if this service is `active`.
-<<<<<<< HEAD
                 callbackLater();
-=======
-                callback();
->>>>>>> latest
                 runFuncs(this.executeLaterFuncs);
             }, 200);
         });

--- a/community-modules/core/src/rendering/columnAnimationService.ts
+++ b/community-modules/core/src/rendering/columnAnimationService.ts
@@ -19,6 +19,9 @@ export class ColumnAnimationService extends BeanStub implements NamedBean {
     private executeLaterFuncs: ((...args: any[]) => any)[] = [];
 
     private active = false;
+    // this.activeNext starts with this.active but it is reset earlier after the nextFuncs are cleared
+    // to prevent calls made to executeNextVMTurn from queuing functions after executeNextFuncs has already been flushed,
+    private activeNext = false;
     private suppressAnimation = false;
 
     private animationThreadCount = 0;
@@ -54,19 +57,21 @@ export class ColumnAnimationService extends BeanStub implements NamedBean {
         this.ensureAnimationCssClassPresent();
 
         this.active = true;
+        this.activeNext = true;
     }
 
     public finish(): void {
         if (!this.active) {
             return;
         }
-        this.flush(() => {
-            this.active = false;
-        });
+        this.flush(
+            () => (this.activeNext = false),
+            () => (this.active = false)
+        );
     }
 
     public executeNextVMTurn(func: (...args: any[]) => any): void {
-        if (this.active) {
+        if (this.activeNext) {
             this.executeNextFuncs.push(func);
         } else {
             func();
@@ -96,9 +101,10 @@ export class ColumnAnimationService extends BeanStub implements NamedBean {
         });
     }
 
-    private flush(callback: () => void): void {
+    private flush(callbackNext: () => void, callbackLater: () => void): void {
         if (this.executeNextFuncs.length === 0 && this.executeLaterFuncs.length === 0) {
-            callback();
+            callbackNext();
+            callbackLater();
             return;
         }
 
@@ -112,15 +118,15 @@ export class ColumnAnimationService extends BeanStub implements NamedBean {
         };
 
         this.getFrameworkOverrides().wrapIncoming(() => {
-            window.setTimeout(() => runFuncs(this.executeNextFuncs), 0);
+            window.setTimeout(() => {
+                callbackNext();
+                runFuncs(this.executeNextFuncs);
+            }, 0);
             window.setTimeout(() => {
                 // run the callback before executeLaterFuncs
                 // because some functions being executed later
                 // check if this service is `active`.
-                callback();
-                // Make sure we clear any next funcs that were added after they were cleared initially
-                // but before we ran the callback to set active to false. Can happen in React.
-                runFuncs(this.executeNextFuncs);
+                callbackLater();
                 runFuncs(this.executeLaterFuncs);
             }, 200);
         });

--- a/community-modules/core/src/rendering/columnAnimationService.ts
+++ b/community-modules/core/src/rendering/columnAnimationService.ts
@@ -19,7 +19,7 @@ export class ColumnAnimationService extends BeanStub implements NamedBean {
     private executeLaterFuncs: ((...args: any[]) => any)[] = [];
 
     private active = false;
-    // this.activeNext starts with this.active but it is reset earlier after the nextFuncs are cleared
+    // activeNext starts with active but it is reset earlier after the nextFuncs are cleared
     // to prevent calls made to executeNextVMTurn from queuing functions after executeNextFuncs has already been flushed,
     private activeNext = false;
     private suppressAnimation = false;


### PR DESCRIPTION
There was a race condition in React that meant that a column animation could schedule a run `next` function after these had been cleared, but before the `active` flag had been set to false when the `later` funcs where run.

So now we have a `activeNext` flag which can be used to prevent queuing next functions after they have already been flushed as part of the finish step. 

This means that the previously dropped animations will be run immediately.