### PR TITLE
AG-12359 handle empty string input overlayLoadingTemplate / overlayNoRowsTemplate

### DIFF
--- a/community-modules/core/src/rendering/overlays/loadingOverlayComponent.ts
+++ b/community-modules/core/src/rendering/overlays/loadingOverlayComponent.ts
@@ -1,5 +1,6 @@
-import { OverlayComponent } from './overlayComponent';
+import { _makeNull } from '../../utils/generic';
 import type { IOverlay, IOverlayComp, IOverlayParams } from './overlayComponent';
+import { OverlayComponent } from './overlayComponent';
 
 export interface ILoadingOverlayParams<TData = any, TContext = any> extends IOverlayParams<TData, TContext> {}
 
@@ -14,7 +15,7 @@ export class LoadingOverlayComponent
     implements ILoadingOverlayComp<any, any>
 {
     public init(): void {
-        const customTemplate = this.gos.get('overlayLoadingTemplate');
+        const customTemplate = _makeNull(this.gos.get('overlayLoadingTemplate')?.trim());
 
         this.setTemplate(
             customTemplate ??

--- a/community-modules/core/src/rendering/overlays/noRowsOverlayComponent.ts
+++ b/community-modules/core/src/rendering/overlays/noRowsOverlayComponent.ts
@@ -1,5 +1,6 @@
-import { OverlayComponent } from './overlayComponent';
+import { _makeNull } from '../../utils/generic';
 import type { IOverlay, IOverlayComp, IOverlayParams } from './overlayComponent';
+import { OverlayComponent } from './overlayComponent';
 
 export interface INoRowsOverlayParams<TData = any, TContext = any> extends IOverlayParams<TData, TContext> {}
 
@@ -13,7 +14,7 @@ export class NoRowsOverlayComponent
     implements INoRowsOverlayComp<any, any>
 {
     public init(): void {
-        const customTemplate = this.gos.get('overlayNoRowsTemplate');
+        const customTemplate = _makeNull(this.gos.get('overlayNoRowsTemplate')?.trim());
 
         this.setTemplate(customTemplate ?? /* html */ `<span class="ag-overlay-no-rows-center"></span>`);
 


### PR DESCRIPTION
This change avoids the grid crashing when trying to create a dom element for an empty string.

Now empty strings are treated the same as providing undefined and so the grid displays the default loading / no rows templates. 