### PR TITLE
AG-12198 (partial solution) remove duplicate key warning

### DIFF
--- a/enterprise-modules/row-grouping/src/rowGrouping/groupStage/treeStrategy/treeStrategy.ts
+++ b/enterprise-modules/row-grouping/src/rowGrouping/groupStage/treeStrategy/treeStrategy.ts
@@ -465,11 +465,6 @@ export class TreeStrategy extends BeanStub implements IRowNodeStage {
             }
         }
 
-        const existingNode = parentGroup.childrenAfterGroup?.find((node) => node.key === childNode.key);
-        if (existingNode) {
-            _warnOnce(`duplicate group keys for row data, keys should be unique`, [existingNode.data, childNode.data]);
-            return;
-        }
         childNode.parent = parentGroup;
         childNode.level = level;
         this.ensureRowNodeFields(childNode, key);


### PR DESCRIPTION
This removes a performance degradation and a duplicate key warning that solves also partially the problem of partial updates breaking the tree structure and slowing down the operations on the tree