### PR TITLE
AG-12433 Angular Consistent event firing order

### DIFF
--- a/community-modules/angular/projects/ag-grid-angular/src/lib/ag-grid-angular.component.ts
+++ b/community-modules/angular/projects/ag-grid-angular/src/lib/ag-grid-angular.component.ts
@@ -4,7 +4,7 @@ import type {
     AdvancedFilterBuilderVisibleChangedEvent,
     AdvancedFilterModel,
     AlignedGrid,
-    AsyncTransactionsFlushed,
+    AsyncTransactionsFlushedEvent,
     BodyScrollEndEvent,
     BodyScrollEvent,
     CellClickedEvent,
@@ -315,7 +315,7 @@ export class AgGridAngular<TData = any, TColDef extends ColDef<TData> = ColDef<a
             const fireEmitter = () => this.angularFrameworkOverrides.runInsideAngular(() => emitter.emit(event));
 
             if (this._holdEvents) {
-                // if the user is listening events, wait for ngAfterViewInit to fire first, then emit the grid events
+                // if the user is listening to events, wait for ngAfterViewInit to fire first, then emit the grid events
                 this._fullyReady.then(() => fireEmitter());
             } else {
                 fireEmitter();
@@ -1941,8 +1941,8 @@ export class AgGridAngular<TData = any, TColDef extends ColDef<TData> = ColDef<a
     >();
     /** Async transactions have been applied. Contains a list of all transaction results.
      */
-    @Output() public asyncTransactionsFlushed: EventEmitter<AsyncTransactionsFlushed<TData>> = new EventEmitter<
-        AsyncTransactionsFlushed<TData>
+    @Output() public asyncTransactionsFlushed: EventEmitter<AsyncTransactionsFlushedEvent<TData>> = new EventEmitter<
+        AsyncTransactionsFlushedEvent<TData>
     >();
     /** A server side store has finished refreshing.
      */

--- a/community-modules/core/src/entities/gridOptions.ts
+++ b/community-modules/core/src/entities/gridOptions.ts
@@ -5,7 +5,7 @@ import type { AgChartTheme, AgChartThemeOverrides } from 'ag-charts-types';
 
 import type {
     AdvancedFilterBuilderVisibleChangedEvent,
-    AsyncTransactionsFlushed,
+    AsyncTransactionsFlushedEvent,
     BodyScrollEndEvent,
     BodyScrollEvent,
     CellClickedEvent,
@@ -2190,7 +2190,7 @@ export interface GridOptions<TData = any> {
     /**
      * Async transactions have been applied. Contains a list of all transaction results.
      */
-    onAsyncTransactionsFlushed?(event: AsyncTransactionsFlushed<TData>): void;
+    onAsyncTransactionsFlushed?(event: AsyncTransactionsFlushedEvent<TData>): void;
 
     // *** Row Model: Server Side ***//
     /**

--- a/documentation/ag-grid-docs/src/content/docs/data-update-high-frequency/_examples/flush-transactions/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/data-update-high-frequency/_examples/flush-transactions/main.ts
@@ -1,6 +1,6 @@
 import { ClientSideRowModelModule } from '@ag-grid-community/client-side-row-model';
 import {
-    AsyncTransactionsFlushed,
+    AsyncTransactionsFlushedEvent,
     ColDef,
     GetRowIdParams,
     GridApi,
@@ -177,7 +177,7 @@ const gridOptions: GridOptions = {
         params.api.setGridOption('rowData', globalRowData);
         startFeed(params.api);
     },
-    onAsyncTransactionsFlushed: (e: AsyncTransactionsFlushed) => {
+    onAsyncTransactionsFlushed: (e: AsyncTransactionsFlushedEvent) => {
         console.log('========== onAsyncTransactionsFlushed: applied ' + e.results.length + ' transactions');
     },
 };

--- a/packages/ag-grid-angular/projects/ag-grid-angular/src/lib/ag-grid-angular.component.ts
+++ b/packages/ag-grid-angular/projects/ag-grid-angular/src/lib/ag-grid-angular.component.ts
@@ -4,7 +4,7 @@ import type {
     AdvancedFilterBuilderVisibleChangedEvent,
     AdvancedFilterModel,
     AlignedGrid,
-    AsyncTransactionsFlushed,
+    AsyncTransactionsFlushedEvent,
     BodyScrollEndEvent,
     BodyScrollEvent,
     CellClickedEvent,
@@ -315,7 +315,7 @@ export class AgGridAngular<TData = any, TColDef extends ColDef<TData> = ColDef<a
             const fireEmitter = () => this.angularFrameworkOverrides.runInsideAngular(() => emitter.emit(event));
 
             if (this._holdEvents) {
-                // if the user is listening events, wait for ngAfterViewInit to fire first, then emit the grid events
+                // if the user is listening to events, wait for ngAfterViewInit to fire first, then emit the grid events
                 this._fullyReady.then(() => fireEmitter());
             } else {
                 fireEmitter();
@@ -1941,8 +1941,8 @@ export class AgGridAngular<TData = any, TColDef extends ColDef<TData> = ColDef<a
     >();
     /** Async transactions have been applied. Contains a list of all transaction results.
      */
-    @Output() public asyncTransactionsFlushed: EventEmitter<AsyncTransactionsFlushed<TData>> = new EventEmitter<
-        AsyncTransactionsFlushed<TData>
+    @Output() public asyncTransactionsFlushed: EventEmitter<AsyncTransactionsFlushedEvent<TData>> = new EventEmitter<
+        AsyncTransactionsFlushedEvent<TData>
     >();
     /** A server side store has finished refreshing.
      */


### PR DESCRIPTION
The use of a promise for GridReady meant that event got fired async even though the grid was ready for it to be fired. Swapping the code to hold all events until ngAfterViewInit has been run so that we maintain a consistent ordering of events. 