### PR TITLE
AG-12283 Cannot edit tree data group rows without setting `enableGroupEdit`

### DIFF
--- a/community-modules/core/src/entities/agColumn.ts
+++ b/community-modules/core/src/entities/agColumn.ts
@@ -360,8 +360,8 @@ export class AgColumn<TValue = any> extends BeanStub<ColumnEventName> implements
     }
 
     public isCellEditable(rowNode: IRowNode): boolean {
-        // only allow editing of groups if the user has this option enabled
-        if (rowNode.group && !this.gos.get('enableGroupEdit')) {
+        // only allow editing of groups if the user has this option enabled, and if this is not a tree
+        if (rowNode.group && !this.gos.get('enableGroupEdit') && !this.gos.get('treeData')) {
             return false;
         }
 

--- a/community-modules/core/src/entities/agColumn.ts
+++ b/community-modules/core/src/entities/agColumn.ts
@@ -360,9 +360,20 @@ export class AgColumn<TValue = any> extends BeanStub<ColumnEventName> implements
     }
 
     public isCellEditable(rowNode: IRowNode): boolean {
-        // only allow editing of groups if the user has this option enabled, and if this is not a tree
-        if (rowNode.group && !this.gos.get('enableGroupEdit') && !this.gos.get('treeData')) {
-            return false;
+        if (rowNode.group) {
+            // This is a group - it could be a tree group or a grouping group...
+            if (this.gos.get('treeData')) {
+                // tree - allow editing of groups with data by default.
+                // Allow editing filler nodes (node without data) only if enableGroupEdit is true.
+                if (!rowNode.data && !this.gos.get('enableGroupEdit')) {
+                    return false;
+                }
+            } else {
+                // grouping - allow editing of groups if the user has enableGroupEdit option enabled
+                if (!this.gos.get('enableGroupEdit')) {
+                    return false;
+                }
+            }
         }
 
         return this.isColumnFunc(rowNode, this.colDef.editable);


### PR DESCRIPTION
Tree groups should be editable by default.
The check for editable tree group was not correct.

It seems that in version 32 the "group" field of the row is now correct for tree row groups, but it wasn't before