### PR TITLE
AG-12583 fix regression of group transactional updates with childrenMapped null

### DIFF
--- a/community-modules/core/src/entities/rowNode.ts
+++ b/community-modules/core/src/entities/rowNode.ts
@@ -203,11 +203,11 @@ export class RowNode<TData = any> implements IEventEmitter<RowNodeEventType>, IR
     /**
      * Children mapped by the pivot columns.
      *
-     * TODO: this field is currently used only by the GroupStrategy.
-     * TreeStrategy does not use it, creating a new object for every row
-     * consumes memory unnecessarily if not using grouping.
-     * Setting it to null however breaks transactional updates in group,
-     * so this requires a deeper investigation when we rework on the GroupStrategy.
+     * TODO: this field is currently used only by the GroupStrategy and Pivot.
+     * TreeStrategy does not use it, and pivot cannot be enabled with tree data.
+     * Creating a new object for every row when not pivoting and not grouping
+     * consumes memory unnecessarily. Setting it to null however currently breaks
+     * transactional updates in groups so this requires a deeper investigation on GroupStrategy.
      */
     public childrenMapped: { [key: string]: any } | null = {};
 

--- a/community-modules/core/src/entities/rowNode.ts
+++ b/community-modules/core/src/entities/rowNode.ts
@@ -200,8 +200,16 @@ export class RowNode<TData = any> implements IEventEmitter<RowNodeEventType>, IR
     /** Number of children and grand children. */
     public allChildrenCount: number | null;
 
-    /** Children mapped by the pivot columns. */
-    public childrenMapped: { [key: string]: any } | null = null;
+    /**
+     * Children mapped by the pivot columns.
+     *
+     * TODO: this field is currently used only by the GroupStrategy.
+     * TreeStrategy does not use it, creating a new object for every row
+     * consumes memory unnecessarily if not using grouping.
+     * Setting it to null however breaks transactional updates in group,
+     * so this requires a deeper investigation when we rework on the GroupStrategy.
+     */
+    public childrenMapped: { [key: string]: any } | null = {};
 
     /** The TreeNode associated to this row. Used only with tree data. */
     public readonly treeNode: ITreeNode | null = null;


### PR DESCRIPTION
Tthis field is currently used only by the GroupStrategy and Pivot.
TreeStrategy does not use it, and pivot cannot be enabled with tree data.
Creating a new object for every row when not pivoting and not grouping consumes memory unnecessarily. Setting it to null however currently breaks transactional updates in groups so this requires a deeper investigation on GroupStrategy.