### PR TITLE
AG-12464 remove ResizeObserver polyfill

### DIFF
--- a/community-modules/core/src/entities/gridOptions.ts
+++ b/community-modules/core/src/entities/gridOptions.ts
@@ -750,7 +750,7 @@ export interface GridOptions<TData = any> {
      */
     suppressAsyncEvents?: boolean;
     /**
-     * The grid will check for `ResizeObserver` and use it if it exists in the browser, otherwise it will use the grid's alternative implementation. Some users reported issues with Chrome's `ResizeObserver`. Use this property to always use the grid's alternative implementation should such problems exist.
+     * @deprecated As of v32.2 the grid always uses the browser's ResizeObserver, this grid option has no effect
      * @default false
      * @initial
      */

--- a/community-modules/core/src/misc/resizeObserverService.ts
+++ b/community-modules/core/src/misc/resizeObserverService.ts
@@ -2,83 +2,14 @@ import type { NamedBean } from '../context/bean';
 import { BeanStub } from '../context/beanStub';
 import { _getWindow } from '../gridOptionsUtils';
 
-const DEBOUNCE_DELAY = 50;
 export class ResizeObserverService extends BeanStub implements NamedBean {
     beanName = 'resizeObserverService' as const;
 
-    private polyfillFunctions: (() => void)[] = [];
-    private polyfillScheduled: boolean;
-
     public observeResize(element: HTMLElement, callback: () => void): () => void {
         const win = _getWindow(this.gos);
-        const useBrowserResizeObserver = () => {
-            const resizeObserver = new win.ResizeObserver(callback);
-            resizeObserver.observe(element);
-            return () => resizeObserver.disconnect();
-        };
-
-        const usePolyfill = () => {
-            // initialise to the current width and height, so first call will have no changes
-            let widthLastTime = element?.clientWidth ?? 0;
-            let heightLastTime = element?.clientHeight ?? 0;
-
-            // when finished, this gets turned to false.
-            let running = true;
-
-            const periodicallyCheckWidthAndHeight = () => {
-                if (running) {
-                    const newWidth = element?.clientWidth ?? 0;
-                    const newHeight = element?.clientHeight ?? 0;
-
-                    const changed = newWidth !== widthLastTime || newHeight !== heightLastTime;
-                    if (changed) {
-                        widthLastTime = newWidth;
-                        heightLastTime = newHeight;
-                        callback();
-                    }
-
-                    this.doNextPolyfillTurn(periodicallyCheckWidthAndHeight);
-                }
-            };
-
-            periodicallyCheckWidthAndHeight();
-
-            // the callback function we return sets running to false
-            return () => (running = false);
-        };
-
-        const suppressResize = this.gos.get('suppressBrowserResizeObserver');
-        const resizeObserverExists = !!win.ResizeObserver;
-
-        if (resizeObserverExists && !suppressResize) {
-            return useBrowserResizeObserver();
-        }
-
-        return this.getFrameworkOverrides().wrapIncoming(() => usePolyfill(), 'resize-observer');
-    }
-
-    private doNextPolyfillTurn(func: () => void): void {
-        this.polyfillFunctions.push(func);
-        this.schedulePolyfill();
-    }
-
-    private schedulePolyfill(): void {
-        if (this.polyfillScheduled) {
-            return;
-        }
-
-        const executeAllFuncs = () => {
-            const funcs = this.polyfillFunctions;
-
-            // make sure set scheduled to false and clear clear array
-            // before executing the funcs, as the funcs could add more funcs
-            this.polyfillScheduled = false;
-            this.polyfillFunctions = [];
-
-            funcs.forEach((f) => f());
-        };
-
-        this.polyfillScheduled = true;
-        window.setTimeout(executeAllFuncs, DEBOUNCE_DELAY);
+        const ResizeObserverImpl = win.ResizeObserver;
+        const resizeObserver = ResizeObserverImpl ? new ResizeObserverImpl(callback) : null;
+        resizeObserver?.observe(element);
+        return () => resizeObserver?.disconnect();
     }
 }

--- a/community-modules/core/src/validation/rules/gridOptionsValidations.ts
+++ b/community-modules/core/src/validation/rules/gridOptionsValidations.ts
@@ -31,6 +31,11 @@ const GRID_OPTION_DEPRECATIONS: () => Deprecations<GridOptions> = () => ({
 
     suppressLoadingOverlay: { version: '32', message: 'Use `loading`=false instead.' },
 
+    suppressBrowserResizeObserver: {
+        version: '32.2',
+        message: "The grid always uses the browser's ResizeObserver, this grid option has no effect.",
+    },
+
     onColumnEverythingChanged: {
         version: '32.2',
         message:

--- a/documentation/ag-grid-docs/src/content/api-documentation/grid-options/properties.json
+++ b/documentation/ag-grid-docs/src/content/api-documentation/grid-options/properties.json
@@ -787,7 +787,6 @@
             }
         },
         "suppressFocusAfterRefresh": {},
-        "suppressBrowserResizeObserver": {},
         "suppressPropertyNamesCheck": {},
         "suppressChangeDetection": {
             "more": {


### PR DESCRIPTION
This PR:

1. Removes the ResizeObserver polyfill
2. Deprecates gridOptions.suppressBrowserResizeObserver and turns it into a no-op