### PR TITLE
AG-12744 refactor new tests to use TestGridsManager and to not print warnings and license errors in the console

### DIFF
--- a/testing/behavioural/src/columns/column-test-utils.ts
+++ b/testing/behavioural/src/columns/column-test-utils.ts
@@ -1,12 +1,4 @@
-import { createGrid } from '@ag-grid-community/core';
-import type {
-    ColDef,
-    ColGroupDef,
-    Column,
-    GridApi,
-    GridOptions,
-    RowGroupingDisplayType,
-} from '@ag-grid-community/core';
+import type { ColDef, ColGroupDef, Column, GridApi, RowGroupingDisplayType } from '@ag-grid-community/core';
 
 export const GROUP_AUTO_COLUMN_ID = 'ag-Grid-AutoColumn';
 
@@ -61,9 +53,4 @@ export function getColumnOrder(gridApi: GridApi, viewport: 'all' | 'left' | 'cen
             columns = gridApi.getDisplayedCenterColumns();
     }
     return columns.map((col) => col.getColId());
-}
-
-export function createMyGrid(gridOptions: GridOptions) {
-    document.body.innerHTML = '<div id="myGrid"></div>';
-    return createGrid(document.getElementById('myGrid')!, gridOptions);
 }

--- a/testing/behavioural/src/columns/order/auto-group-cols.test.ts
+++ b/testing/behavioural/src/columns/order/auto-group-cols.test.ts
@@ -1,25 +1,20 @@
 import { ClientSideRowModelModule } from '@ag-grid-community/client-side-row-model';
-import type { ColDef, ColGroupDef, GridApi, RowGroupingDisplayType } from '@ag-grid-community/core';
-import { ModuleRegistry } from '@ag-grid-community/core';
+import type { ColDef, ColGroupDef, RowGroupingDisplayType } from '@ag-grid-community/core';
 import { RowGroupingModule } from '@ag-grid-enterprise/row-grouping';
 
+import { TestGridsManager } from '../../test-utils';
 import {
     GROUP_AUTO_COLUMN_ID,
-    createMyGrid,
     getAutoGroupColumnIds,
     getColumnOrder,
     getColumnOrderFromState,
 } from '../column-test-utils';
 
 describe('Auto Group Column Order', () => {
-    beforeAll(() => {
-        ModuleRegistry.registerModules([ClientSideRowModelModule, RowGroupingModule]);
-    });
-
-    let gridApi: GridApi;
+    const gridsManager = new TestGridsManager({ modules: [ClientSideRowModelModule, RowGroupingModule] });
 
     afterEach(() => {
-        gridApi.destroy();
+        gridsManager.reset();
     });
 
     describe('groupDisplayType=groupRows', () => {
@@ -34,7 +29,7 @@ describe('Auto Group Column Order', () => {
                 { colId: 'g', aggFunc: 'sum' },
             ];
 
-            gridApi = createMyGrid({ columnDefs, groupDisplayType: 'groupRows' });
+            const gridApi = gridsManager.createGrid('myGrid', { columnDefs, groupDisplayType: 'groupRows' });
 
             const expected = ['a', 'b', 'c', 'd', 'e', 'f', 'g'];
             expect(getColumnOrderFromState(gridApi)).toEqual(expected);
@@ -49,7 +44,7 @@ describe('Auto Group Column Order', () => {
             test('omits row group column when no grouping', () => {
                 const columnDefs: (ColDef | ColGroupDef)[] = [{ colId: 'a' }, { colId: 'b' }];
 
-                gridApi = createMyGrid({ columnDefs, groupDisplayType });
+                const gridApi = gridsManager.createGrid('myGrid', { columnDefs, groupDisplayType });
 
                 const expected = ['a', 'b'];
                 expect(getColumnOrderFromState(gridApi)).toEqual(expected);
@@ -64,7 +59,7 @@ describe('Auto Group Column Order', () => {
                     { colId: 'c', rowGroup: true },
                 ];
 
-                gridApi = createMyGrid({ columnDefs, groupDisplayType, enableRtl });
+                const gridApi = gridsManager.createGrid('myGrid', { columnDefs, groupDisplayType, enableRtl });
 
                 const groupColIds = getAutoGroupColumnIds(columnDefs, groupDisplayType);
                 const expected = [...groupColIds, 'a', 'b', 'c'];
@@ -82,7 +77,7 @@ describe('Auto Group Column Order', () => {
                         { colId: 'c', rowGroupIndex: 0 },
                     ];
 
-                    gridApi = createMyGrid({ columnDefs, groupDisplayType, enableRtl });
+                    const gridApi = gridsManager.createGrid('myGrid', { columnDefs, groupDisplayType, enableRtl });
 
                     let groupColIds = [GROUP_AUTO_COLUMN_ID];
                     if (groupDisplayType === 'multipleColumns') {
@@ -106,7 +101,7 @@ describe('Auto Group Column Order', () => {
                     { colId: 'c', lockPosition: 'left' },
                 ];
 
-                gridApi = createMyGrid({ columnDefs, groupDisplayType });
+                const gridApi = gridsManager.createGrid('myGrid', { columnDefs, groupDisplayType });
 
                 const groupColIds = getAutoGroupColumnIds(columnDefs, groupDisplayType);
                 const expected = ['c', ...groupColIds, 'b', 'a'];
@@ -125,7 +120,7 @@ describe('Auto Group Column Order', () => {
                         { colId: 'c' },
                     ];
 
-                    gridApi = createMyGrid({ columnDefs, defaultColDef, groupDisplayType });
+                    const gridApi = gridsManager.createGrid('myGrid', { columnDefs, defaultColDef, groupDisplayType });
 
                     const groupColIds = getAutoGroupColumnIds(columnDefs, groupDisplayType);
                     const expected = [...groupColIds, 'a', 'b', 'c'];
@@ -142,7 +137,11 @@ describe('Auto Group Column Order', () => {
                         { colId: 'c', rowGroup: true },
                     ];
 
-                    gridApi = createMyGrid({ columnDefs, groupDisplayType, autoGroupColumnDef });
+                    const gridApi = gridsManager.createGrid('myGrid', {
+                        columnDefs,
+                        groupDisplayType,
+                        autoGroupColumnDef,
+                    });
 
                     const groupColIds = getAutoGroupColumnIds(columnDefs, groupDisplayType);
                     expect(getColumnOrder(gridApi, 'center')).toEqual(['a', 'b', 'c']);
@@ -157,7 +156,11 @@ describe('Auto Group Column Order', () => {
                         { colId: 'c', pinned, rowGroup: true },
                     ];
 
-                    gridApi = createMyGrid({ columnDefs, groupDisplayType, autoGroupColumnDef });
+                    const gridApi = gridsManager.createGrid('myGrid', {
+                        columnDefs,
+                        groupDisplayType,
+                        autoGroupColumnDef,
+                    });
 
                     const groupColIds = getAutoGroupColumnIds(columnDefs, groupDisplayType);
                     expect(getColumnOrder(gridApi, pinned)).toEqual([...groupColIds, 'a', 'b', 'c']);
@@ -169,7 +172,11 @@ describe('Auto Group Column Order', () => {
                 (maintainColumnOrder) => {
                     const columnDefs: (ColDef | ColGroupDef)[] = [{ colId: 'a' }, { colId: 'b' }, { colId: 'c' }];
 
-                    gridApi = createMyGrid({ columnDefs, groupDisplayType, maintainColumnOrder });
+                    const gridApi = gridsManager.createGrid('myGrid', {
+                        columnDefs,
+                        groupDisplayType,
+                        maintainColumnOrder,
+                    });
 
                     const columnDefsNew: (ColDef | ColGroupDef)[] = [
                         { colId: 'a' },
@@ -193,7 +200,11 @@ describe('Auto Group Column Order', () => {
                         { colId: 'c' },
                     ];
 
-                    gridApi = createMyGrid({ columnDefs, groupDisplayType, maintainColumnOrder });
+                    const gridApi = gridsManager.createGrid('myGrid', {
+                        columnDefs,
+                        groupDisplayType,
+                        maintainColumnOrder,
+                    });
 
                     gridApi.moveColumns(['a'], 0);
 
@@ -213,7 +224,11 @@ describe('Auto Group Column Order', () => {
                         { colId: 'c' },
                     ];
 
-                    gridApi = createMyGrid({ columnDefs, groupDisplayType, maintainColumnOrder });
+                    const gridApi = gridsManager.createGrid('myGrid', {
+                        columnDefs,
+                        groupDisplayType,
+                        maintainColumnOrder,
+                    });
 
                     gridApi.moveColumns(['a'], 0);
 
@@ -231,7 +246,7 @@ describe('Auto Group Column Order', () => {
                     { colId: 'c' },
                 ];
 
-                gridApi = createMyGrid({ columnDefs, groupDisplayType });
+                const gridApi = gridsManager.createGrid('myGrid', { columnDefs, groupDisplayType });
                 const groupColIds = getAutoGroupColumnIds(columnDefs, groupDisplayType);
                 gridApi.moveColumns(groupColIds, 2);
 

--- a/testing/behavioural/src/columns/order/column-order.test.ts
+++ b/testing/behavioural/src/columns/order/column-order.test.ts
@@ -1,19 +1,15 @@
 import { ClientSideRowModelModule } from '@ag-grid-community/client-side-row-model';
-import type { ColDef, ColGroupDef, GridApi } from '@ag-grid-community/core';
-import { ModuleRegistry } from '@ag-grid-community/core';
+import type { ColDef, ColGroupDef } from '@ag-grid-community/core';
 import { RowGroupingModule } from '@ag-grid-enterprise/row-grouping';
 
-import { createMyGrid, getColumnOrder, getColumnOrderFromState } from '../column-test-utils';
+import { TestGridsManager } from '../../test-utils';
+import { getColumnOrder, getColumnOrderFromState } from '../column-test-utils';
 
 describe('Column Order', () => {
-    beforeAll(() => {
-        ModuleRegistry.registerModules([ClientSideRowModelModule, RowGroupingModule]);
-    });
-
-    let gridApi: GridApi;
+    const gridsManager = new TestGridsManager({ modules: [ClientSideRowModelModule, RowGroupingModule] });
 
     afterEach(() => {
-        gridApi.destroy();
+        gridsManager.reset();
     });
 
     test('basic columns ordered as provided', () => {
@@ -27,7 +23,7 @@ describe('Column Order', () => {
             { colId: 'a' },
         ];
 
-        gridApi = createMyGrid({ columnDefs });
+        const gridApi = gridsManager.createGrid('myGrid', { columnDefs });
 
         expect(getColumnOrderFromState(gridApi)).toEqual(['g', 'f', 'e', 'd', 'c', 'b', 'a']);
         expect(getColumnOrder(gridApi, 'all')).toEqual(['g', 'f', 'e', 'd', 'c', 'b', 'a']);
@@ -55,7 +51,7 @@ describe('Column Order', () => {
             { colId: 'a' },
         ];
 
-        gridApi = createMyGrid({ columnDefs });
+        const gridApi = gridsManager.createGrid('myGrid', { columnDefs });
 
         expect(getColumnOrderFromState(gridApi)).toEqual(['g', 'f', 'e', 'd', 'c', 'b', 'a']);
         expect(getColumnOrder(gridApi, 'all')).toEqual(['g', 'f', 'e', 'd', 'c', 'b', 'a']);
@@ -75,7 +71,7 @@ describe('Column Order', () => {
             { colId: 'a' },
         ];
 
-        gridApi = createMyGrid({ columnDefs });
+        const gridApi = gridsManager.createGrid('myGrid', { columnDefs });
 
         expect(getColumnOrderFromState(gridApi)).toEqual(['g', 'f', 'e', 'd', 'c', 'b', 'a']);
         expect(getColumnOrder(gridApi, 'all')).toEqual(['g', 'f', 'e', 'd', 'c', 'b', 'a']);
@@ -95,7 +91,7 @@ describe('Column Order', () => {
                 test('preserves initial column order, inserting new cols at tail', () => {
                     const columnDefs: (ColDef | ColGroupDef)[] = [{ colId: 'g' }, { colId: 'f' }, { colId: 'e' }];
 
-                    gridApi = createMyGrid({ columnDefs, maintainColumnOrder });
+                    const gridApi = gridsManager.createGrid('myGrid', { columnDefs, maintainColumnOrder });
 
                     const columnDefsNew: (ColDef | ColGroupDef)[] = [
                         { colId: 'e' },
@@ -121,7 +117,7 @@ describe('Column Order', () => {
                         { colId: 'f' },
                     ];
 
-                    gridApi = createMyGrid({ columnDefs, maintainColumnOrder });
+                    const gridApi = gridsManager.createGrid('myGrid', { columnDefs, maintainColumnOrder });
                     expect(getColumnOrder(gridApi, 'center')).toEqual(['a', 'b', 'c', 'd', 'e', 'f']);
 
                     const columnDefsNew: (ColDef | ColGroupDef)[] = [
@@ -152,7 +148,7 @@ describe('Column Order', () => {
                         { colId: 'f' },
                     ];
 
-                    gridApi = createMyGrid({ columnDefs, maintainColumnOrder });
+                    const gridApi = gridsManager.createGrid('myGrid', { columnDefs, maintainColumnOrder });
                     expect(getColumnOrder(gridApi, 'center')).toEqual(['a', 'b', 'c', 'd', 'e', 'f']);
 
                     gridApi.moveColumns(['b'], 3);
@@ -176,7 +172,7 @@ describe('Column Order', () => {
                 test('inserts new auto columns at head', () => {
                     const columnDefs: (ColDef | ColGroupDef)[] = [{ colId: 'g' }, { colId: 'f' }, { colId: 'e' }];
 
-                    gridApi = createMyGrid({ columnDefs, maintainColumnOrder });
+                    const gridApi = gridsManager.createGrid('myGrid', { columnDefs, maintainColumnOrder });
 
                     const columnDefsNew: (ColDef | ColGroupDef)[] = [
                         { colId: 'e' },
@@ -193,7 +189,7 @@ describe('Column Order', () => {
                 test('preserves user order changes', () => {
                     const columnDefs: (ColDef | ColGroupDef)[] = [{ colId: 'g' }, { colId: 'f' }, { colId: 'e' }];
 
-                    gridApi = createMyGrid({ columnDefs, maintainColumnOrder });
+                    const gridApi = gridsManager.createGrid('myGrid', { columnDefs, maintainColumnOrder });
                     expect(getColumnOrder(gridApi, 'center')).toEqual(['g', 'f', 'e']);
 
                     gridApi.moveColumns(['e', 'f'], 0);
@@ -225,7 +221,7 @@ describe('Column Order', () => {
             { colId: 'g' },
         ];
 
-        gridApi = createMyGrid({ columnDefs });
+        const gridApi = gridsManager.createGrid('myGrid', { columnDefs });
 
         expect(getColumnOrderFromState(gridApi)).toEqual(['a', 'b', 'c', 'd', 'e', 'f', 'g']);
         expect(getColumnOrder(gridApi, 'all')).toEqual(['a', 'c', 'd', 'e', 'f', 'g']);

--- a/testing/behavioural/src/columns/order/pivot.test.ts
+++ b/testing/behavioural/src/columns/order/pivot.test.ts
@@ -1,26 +1,22 @@
 import { ClientSideRowModelModule } from '@ag-grid-community/client-side-row-model';
-import type { ColDef, ColGroupDef, GridApi } from '@ag-grid-community/core';
-import { ModuleRegistry } from '@ag-grid-community/core';
+import type { ColDef, ColGroupDef } from '@ag-grid-community/core';
 import { RowGroupingModule } from '@ag-grid-enterprise/row-grouping';
 
-import { createMyGrid, getAutoGroupColumnIds, getColumnOrder } from '../column-test-utils';
+import { TestGridsManager } from '../../test-utils';
+import { getAutoGroupColumnIds, getColumnOrder } from '../column-test-utils';
 
 describe('pivotMode=true', () => {
-    beforeAll(() => {
-        ModuleRegistry.registerModules([ClientSideRowModelModule, RowGroupingModule]);
-    });
-
-    let gridApi: GridApi;
+    const gridsManager = new TestGridsManager({ modules: [ClientSideRowModelModule, RowGroupingModule] });
 
     afterEach(() => {
-        gridApi.destroy();
+        gridsManager.reset();
     });
 
     describe('without a pivoted column', () => {
         test('hides primary cols that do not have aggregations', () => {
             const columnDefs: (ColDef | ColGroupDef)[] = [{ colId: 'a' }];
 
-            gridApi = createMyGrid({ columnDefs, pivotMode: true });
+            const gridApi = gridsManager.createGrid('myGrid', { columnDefs, pivotMode: true });
 
             const expected = [];
             expect(getColumnOrder(gridApi, 'all')).toEqual(expected);
@@ -30,7 +26,7 @@ describe('pivotMode=true', () => {
         test('displays aggFunc primary columns when no pivot columns', () => {
             const columnDefs: (ColDef | ColGroupDef)[] = [{ colId: 'a', aggFunc: 'sum' }];
 
-            gridApi = createMyGrid({ columnDefs, pivotMode: true });
+            const gridApi = gridsManager.createGrid('myGrid', { columnDefs, pivotMode: true });
 
             const expected = ['a'];
             expect(getColumnOrder(gridApi, 'all')).toEqual(expected);
@@ -45,7 +41,7 @@ describe('pivotMode=true', () => {
                     { colId: 'b', rowGroup: true },
                 ];
 
-                gridApi = createMyGrid({ columnDefs, groupDisplayType, pivotMode: true });
+                const gridApi = gridsManager.createGrid('myGrid', { columnDefs, groupDisplayType, pivotMode: true });
 
                 const expected = getAutoGroupColumnIds(columnDefs, groupDisplayType, true);
                 expect(getColumnOrder(gridApi, 'all')).toEqual(expected);
@@ -71,7 +67,7 @@ describe('pivotMode=true', () => {
                 { colId: 'c', pivot: true, rowGroup: true },
             ];
 
-            gridApi = createMyGrid({ columnDefs, rowData, pivotMode: true });
+            const gridApi = gridsManager.createGrid('myGrid', { columnDefs, rowData, pivotMode: true });
 
             const expected = ['ag-Grid-AutoColumn', 'pivot_c__b'];
             expect(getColumnOrder(gridApi, 'all')).toEqual(expected);
@@ -84,7 +80,7 @@ describe('pivotMode=true', () => {
                 { field: 'c', aggFunc: 'sum' },
             ];
 
-            gridApi = createMyGrid({ columnDefs, rowData, pivotMode: true });
+            const gridApi = gridsManager.createGrid('myGrid', { columnDefs, rowData, pivotMode: true });
 
             const expected = ['pivot_b_1_c', 'pivot_b_2_c', 'pivot_b_3_c'];
             expect(getColumnOrder(gridApi, 'center')).toEqual(expected);
@@ -98,15 +94,15 @@ describe('pivotMode=true', () => {
             ];
 
             const rowData = [
-                    { a: 1, b: 'aa' },
-                    { a: 1, b: '5' },
-                    { a: 1, b: '51' },
-                    { a: 1, b: 'an' },
-                    { a: 1, b: '1' },
-                    { a: 1, b: 'd' },
-                    { a: 1, b: 'a' },
-                ],
-                gridApi = createMyGrid({ columnDefs, rowData, pivotMode: true });
+                { a: 1, b: 'aa' },
+                { a: 1, b: '5' },
+                { a: 1, b: '51' },
+                { a: 1, b: 'an' },
+                { a: 1, b: '1' },
+                { a: 1, b: 'd' },
+                { a: 1, b: 'a' },
+            ];
+            const gridApi = gridsManager.createGrid('myGrid', { columnDefs, rowData, pivotMode: true });
 
             const expected = [
                 'ag-Grid-AutoColumn',
@@ -137,7 +133,7 @@ describe('pivotMode=true', () => {
                 { a: 1, b: 'd' },
                 { a: 1, b: 'a' },
             ];
-            gridApi = createMyGrid({ columnDefs, rowData, pivotMode: true });
+            const gridApi = gridsManager.createGrid('myGrid', { columnDefs, rowData, pivotMode: true });
 
             const expected = [
                 'ag-Grid-AutoColumn',
@@ -159,7 +155,7 @@ describe('pivotMode=true', () => {
                 { field: 'c', aggFunc: 'sum' },
             ];
 
-            gridApi = createMyGrid({ columnDefs, rowData, pivotMode: true });
+            const gridApi = gridsManager.createGrid('myGrid', { columnDefs, rowData, pivotMode: true });
 
             const groupColIds = getAutoGroupColumnIds(columnDefs, 'singleColumn', true);
             const expected = [...groupColIds, 'pivot_b_1_c', 'pivot_b_2_c', 'pivot_b_3_c'];
@@ -173,7 +169,7 @@ describe('pivotMode=true', () => {
                 { field: 'c', aggFunc: 'sum' },
             ];
 
-            gridApi = createMyGrid({
+            const gridApi = gridsManager.createGrid('myGrid', {
                 columnDefs,
                 rowData,
                 pivotMode: true,
@@ -194,7 +190,7 @@ describe('pivotMode=true', () => {
                 { field: 'c', aggFunc: 'sum' },
             ];
 
-            gridApi = createMyGrid({
+            const gridApi = gridsManager.createGrid('myGrid', {
                 columnDefs,
                 rowData,
                 pivotMode: true,
@@ -220,7 +216,7 @@ describe('pivotMode=true', () => {
                         { field: 'c', aggFunc: 'sum' },
                     ];
 
-                    gridApi = createMyGrid({
+                    const gridApi = gridsManager.createGrid('myGrid', {
                         columnDefs,
                         rowData,
                         pivotMode: true,
@@ -250,7 +246,7 @@ describe('pivotMode=true', () => {
                         { field: 'c', aggFunc: 'sum' },
                     ];
 
-                    gridApi = createMyGrid({
+                    const gridApi = gridsManager.createGrid('myGrid', {
                         columnDefs,
                         rowData,
                         pivotMode: false,
@@ -280,7 +276,7 @@ describe('pivotMode=true', () => {
                         { field: 'c', aggFunc: 'sum' },
                     ];
 
-                    gridApi = createMyGrid({
+                    const gridApi = gridsManager.createGrid('myGrid', {
                         columnDefs,
                         rowData,
                         pivotMode: true,
@@ -309,7 +305,7 @@ describe('pivotMode=true', () => {
                         { field: 'c', aggFunc: 'sum' },
                     ];
 
-                    gridApi = createMyGrid({
+                    const gridApi = gridsManager.createGrid('myGrid', {
                         columnDefs,
                         rowData,
                         maintainColumnOrder,
@@ -345,7 +341,7 @@ describe('pivotMode=true', () => {
                     { field: 'c', aggFunc: 'sum' },
                 ];
 
-                gridApi = createMyGrid({
+                const gridApi = gridsManager.createGrid('myGrid', {
                     columnDefs,
                     defaultColDef: {
                         filter: true,
@@ -376,7 +372,7 @@ describe('pivotMode=true', () => {
                     { field: 'c', aggFunc: 'sum' },
                 ];
 
-                gridApi = createMyGrid({
+                const gridApi = gridsManager.createGrid('myGrid', {
                     columnDefs,
                     rowData,
                     pivotMode: true,
@@ -402,7 +398,7 @@ describe('pivotMode=true', () => {
                     { field: 'c', aggFunc: 'sum' },
                 ];
 
-                gridApi = createMyGrid({
+                const gridApi = gridsManager.createGrid('myGrid', {
                     columnDefs,
                     defaultColDef: {
                         filter: true,
@@ -432,7 +428,7 @@ describe('pivotMode=true', () => {
                     { field: 'c', aggFunc: 'sum' },
                 ];
 
-                gridApi = createMyGrid({
+                const gridApi = gridsManager.createGrid('myGrid', {
                     columnDefs,
                     rowData,
                     pivotMode: true,


### PR DESCRIPTION
In one of the previous iteration, I added a TestGridsManager class that does:

- properly manages creation and destruction of grids and their html element
- allow to access the html element where a grid was created into
- do not print the license error message

In this PR I propose the use of TestGridsManager also for the new column tests, and a console.warn spy to avoid printing expected warnings to the console

In this way running the tests leaves a cleaner output, that is easier to debug, and, we are more consistent

![image](https://github.com/user-attachments/assets/bd03fa40-91cd-4306-9b26-61ee616d369d)
