### PR TITLE
AG-12747 separate key from props in custom component wrapper to avoid react 18 key spread warning

### DIFF
--- a/community-modules/react/src/reactUi/customComp/customWrapperComp.tsx
+++ b/community-modules/react/src/reactUi/customComp/customWrapperComp.tsx
@@ -3,10 +3,10 @@ import React, { memo, useEffect, useState } from 'react';
 import type { WrapperParams } from '../../shared/customComp/customComponentWrapper';
 import { CustomContext } from '../../shared/customComp/customContext';
 
-const CustomWrapperComp = <P, M>(params: WrapperParams<P, M>) => {
+const CustomWrapperComp = <P extends { key?: string }, M>(params: WrapperParams<P, M>) => {
     const { initialProps, addUpdateCallback, CustomComponentClass, setMethods } = params;
 
-    const [props, setProps] = useState(initialProps);
+    const [{ key, ...props }, setProps] = useState(initialProps);
 
     useEffect(() => {
         // this allows the ts wrapper component to update the props passed into the custom component
@@ -15,7 +15,7 @@ const CustomWrapperComp = <P, M>(params: WrapperParams<P, M>) => {
 
     return (
         <CustomContext.Provider value={{ setMethods }}>
-            <CustomComponentClass {...props} />
+            <CustomComponentClass key={key} {...props} />
         </CustomContext.Provider>
     );
 };

--- a/community-modules/react/src/shared/customComp/customComponentWrapper.ts
+++ b/community-modules/react/src/shared/customComp/customComponentWrapper.ts
@@ -49,8 +49,8 @@ export class CustomComponentWrapper<TInputParams, TOutputParams, TMethods> exten
         return this;
     }
 
-    protected override createElement(reactComponent: any, props: TOutputParams): any {
-        return super.createElement(this.wrapperComponent, {
+    protected override createElement(reactComponent: any, key: string, props: TOutputParams): any {
+        return super.createElement(this.wrapperComponent, key, {
             initialProps: props,
             CustomComponentClass: reactComponent,
             setMethods: (methods: TMethods) => this.setMethods(methods),

--- a/community-modules/react/src/shared/customComp/customComponentWrapper.ts
+++ b/community-modules/react/src/shared/customComp/customComponentWrapper.ts
@@ -3,7 +3,7 @@ import { AgPromise } from '@ag-grid-community/core';
 import customWrapperComp from '../../reactUi/customComp/customWrapperComp';
 import { ReactComponent } from '../reactComponent';
 
-export type WrapperParams<P, M> = {
+export type WrapperParams<P extends { key?: string }, M> = {
     initialProps: P;
     CustomComponentClass: any;
     setMethods: (methods: M) => void;
@@ -19,11 +19,7 @@ export function addOptionalMethods<M, C>(optionalMethodNames: string[], provided
     });
 }
 
-export class CustomComponentWrapper<
-    TInputParams,
-    TOutputParams extends { key?: string },
-    TMethods,
-> extends ReactComponent {
+export class CustomComponentWrapper<TInputParams, TOutputParams, TMethods> extends ReactComponent {
     private updateCallback?: () => AgPromise<void>;
     private resolveUpdateCallback!: () => void;
     private awaitUpdateCallback = new AgPromise<void>((resolve) => {
@@ -53,9 +49,8 @@ export class CustomComponentWrapper<
         return this;
     }
 
-    protected override createElement(reactComponent: any, { key, ...props }: TOutputParams): any {
+    protected override createElement(reactComponent: any, props: TOutputParams): any {
         return super.createElement(this.wrapperComponent, {
-            key,
             initialProps: props,
             CustomComponentClass: reactComponent,
             setMethods: (methods: TMethods) => this.setMethods(methods),

--- a/community-modules/react/src/shared/customComp/customComponentWrapper.ts
+++ b/community-modules/react/src/shared/customComp/customComponentWrapper.ts
@@ -19,7 +19,11 @@ export function addOptionalMethods<M, C>(optionalMethodNames: string[], provided
     });
 }
 
-export class CustomComponentWrapper<TInputParams, TOutputParams, TMethods> extends ReactComponent {
+export class CustomComponentWrapper<
+    TInputParams,
+    TOutputParams extends { key?: string },
+    TMethods,
+> extends ReactComponent {
     private updateCallback?: () => AgPromise<void>;
     private resolveUpdateCallback!: () => void;
     private awaitUpdateCallback = new AgPromise<void>((resolve) => {
@@ -49,8 +53,9 @@ export class CustomComponentWrapper<TInputParams, TOutputParams, TMethods> exten
         return this;
     }
 
-    protected override createElement(reactComponent: any, key: string, props: TOutputParams): any {
-        return super.createElement(this.wrapperComponent, key, {
+    protected override createElement(reactComponent: any, { key, ...props }: TOutputParams): any {
+        return super.createElement(this.wrapperComponent, {
+            key,
             initialProps: props,
             CustomComponentClass: reactComponent,
             setMethods: (methods: TMethods) => this.setMethods(methods),

--- a/community-modules/react/src/shared/reactComponent.ts
+++ b/community-modules/react/src/shared/reactComponent.ts
@@ -189,7 +189,7 @@ export class ReactComponent implements IComponent<any>, WrappableInterface {
             params.ref = this.ref;
         }
 
-        this.reactElement = this.createElement(this.reactComponent, this.key, params);
+        this.reactElement = this.createElement(this.reactComponent, { ...params, key: this.key });
 
         this.portal = createPortal(
             this.reactElement,
@@ -198,8 +198,8 @@ export class ReactComponent implements IComponent<any>, WrappableInterface {
         );
     }
 
-    protected createElement(reactComponent: any, key: string, props: any): any {
-        return createElement(reactComponent, { ...props, key });
+    protected createElement(reactComponent: any, props: any): any {
+        return createElement(reactComponent, props);
     }
 
     private createReactComponent(resolve: (value: any) => void) {

--- a/community-modules/react/src/shared/reactComponent.ts
+++ b/community-modules/react/src/shared/reactComponent.ts
@@ -189,7 +189,7 @@ export class ReactComponent implements IComponent<any>, WrappableInterface {
             params.ref = this.ref;
         }
 
-        this.reactElement = this.createElement(this.reactComponent, { ...params, key: this.key });
+        this.reactElement = this.createElement(this.reactComponent, this.key, params);
 
         this.portal = createPortal(
             this.reactElement,
@@ -198,8 +198,8 @@ export class ReactComponent implements IComponent<any>, WrappableInterface {
         );
     }
 
-    protected createElement(reactComponent: any, props: any): any {
-        return createElement(reactComponent, props);
+    protected createElement(reactComponent: any, key: string, props: any): any {
+        return createElement(reactComponent, { ...props, key });
     }
 
     private createReactComponent(resolve: (value: any) => void) {

--- a/packages/ag-grid-react/src/reactUi/customComp/customWrapperComp.tsx
+++ b/packages/ag-grid-react/src/reactUi/customComp/customWrapperComp.tsx
@@ -3,10 +3,10 @@ import React, { memo, useEffect, useState } from 'react';
 import type { WrapperParams } from '../../shared/customComp/customComponentWrapper';
 import { CustomContext } from '../../shared/customComp/customContext';
 
-const CustomWrapperComp = <P, M>(params: WrapperParams<P, M>) => {
+const CustomWrapperComp = <P extends { key?: string }, M>(params: WrapperParams<P, M>) => {
     const { initialProps, addUpdateCallback, CustomComponentClass, setMethods } = params;
 
-    const [props, setProps] = useState(initialProps);
+    const [{ key, ...props }, setProps] = useState(initialProps);
 
     useEffect(() => {
         // this allows the ts wrapper component to update the props passed into the custom component
@@ -15,7 +15,7 @@ const CustomWrapperComp = <P, M>(params: WrapperParams<P, M>) => {
 
     return (
         <CustomContext.Provider value={{ setMethods }}>
-            <CustomComponentClass {...props} />
+            <CustomComponentClass key={key} {...props} />
         </CustomContext.Provider>
     );
 };

--- a/packages/ag-grid-react/src/shared/customComp/customComponentWrapper.ts
+++ b/packages/ag-grid-react/src/shared/customComp/customComponentWrapper.ts
@@ -3,7 +3,7 @@ import { AgPromise } from 'ag-grid-community';
 import customWrapperComp from '../../reactUi/customComp/customWrapperComp';
 import { ReactComponent } from '../reactComponent';
 
-export type WrapperParams<P, M> = {
+export type WrapperParams<P extends { key?: string }, M> = {
     initialProps: P;
     CustomComponentClass: any;
     setMethods: (methods: M) => void;

--- a/testing/behavioural/vitest.config.js
+++ b/testing/behavioural/vitest.config.js
@@ -48,9 +48,13 @@ async function loadSourceCodeAliases(modulesDirectories) {
                     if (existsSync(packageJsonPath)) {
                         const packageJson = JSON.parse(await readFile(packageJsonPath, 'utf-8'));
                         if (!(packageJson.name in resolveAlias)) {
-                            const mainTsPath = path.resolve(modulePath, dir.name, 'src/main.ts');
-                            if (existsSync(mainTsPath)) {
-                                resolveAlias[packageJson.name] = mainTsPath;
+                            const mainFiles = ['src/index.ts', 'src/index.tsx', 'src/main.ts', 'src/main.tsx'];
+                            for (const mainFile of mainFiles) {
+                                let mainTsPath = path.resolve(modulePath, dir.name, mainFile);
+                                if (existsSync(mainTsPath)) {
+                                    resolveAlias[packageJson.name] = mainTsPath;
+                                    break;
+                                }
                             }
                         }
                     } else if (level < 2) {


### PR DESCRIPTION
Running the behavioural tests with source code, a new warning surfaced:



```
Warning: A props object containing a "key" prop is being spread into JSX:
  let props = {key: someKey, api: ..., context: ..., ref: ..., reactContainer: ...};
  <loadingOverlayComponent {...props} />
React keys must be passed directly to JSX without using spread:
  let props = {api: ..., context: ..., ref: ..., reactContainer: ...};
  <loadingOverlayComponent key={someKey} {...props} />
    at CustomWrapperComp (ag-grid/community-modules/react/src/reactUi/customComp/customWrapperComp.tsx:8:11)
    at div
    at AgGridReactUi (ag-grid/community-modules/react/src/reactUi/agGridReactUi.tsx:44:40)
    at AgGridReact (ag-grid/community-modules/react/src/agGridReact.tsx:10:5)
Warning: A props object containing a "key" prop is being spread into JSX:
  let props = {key: someKey, api: ..., context: ..., ref: ..., reactContainer: ...};
  <noRowsOverlayComponent {...props} />
React keys must be passed directly to JSX without using spread:
  let props = {api: ..., context: ..., ref: ..., reactContainer: ...};
  <noRowsOverlayComponent key={someKey} {...props} />
    at CustomWrapperComp (ag-grid/community-modules/react/src/reactUi/customComp/customWrapperComp.tsx:8:11)
    at div
    at AgGridReactUi (ag-grid/community-modules/react/src/reactUi/agGridReactUi.tsx:44:40)
    at AgGridReact (ag-grid/community-modules/react/src/agGridReact.tsx:10:5)

```

- Fix the issue by using the key as a separate argument
- Enable loading react from source, by including index.ts when looking for source code in the aliases for vitest.config.ts 