### PR TITLE
AG-12765 allow vscode integration with behavioural tests

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -19,6 +19,8 @@
     // prettier
     "esbenp.prettier-vscode",
     // markdoc
-    "stripe.markdoc-language-support"
+    "stripe.markdoc-language-support",
+    // vitest test runner, used for behavioural tests
+    "vitest.explorer"
   ]
 }

--- a/testing/behavioural/vitest.config.js
+++ b/testing/behavioural/vitest.config.js
@@ -2,7 +2,10 @@ import pluginReact from '@vitejs/plugin-react';
 import { existsSync } from 'fs';
 import { readFile, readdir } from 'fs/promises';
 import path from 'path';
+import { fileURLToPath } from 'url';
 import { defineConfig } from 'vitest/config';
+
+const workspaceRootPath = path.resolve(fileURLToPath(import.meta.url), '../../../');
 
 /** Resolve aliases */
 const resolveAlias = {};
@@ -65,5 +68,8 @@ async function loadSourceCodeAliases(modulesDirectories) {
         }
         await Promise.all(promises);
     };
-    await Promise.all(modulesDirectories.map((name) => processSourceDirectory(name, 0)));
+
+    await Promise.all(
+        modulesDirectories.map((name) => processSourceDirectory(path.resolve(workspaceRootPath, name), 0))
+    );
 }


### PR DESCRIPTION
…testsEnables vscode supports for vitest behavioural tests.

Add the recommended extension “vitest.explorer” for vscode,

fix the configuration so it loads properly also when not running via nx