### PR TITLE
AG-12272 - step 1 - simplify the relationship between csrm and immutable service

### DIFF
--- a/community-modules/client-side-row-model/src/clientSideRowModel/clientSideRowModel.ts
+++ b/community-modules/client-side-row-model/src/clientSideRowModel/clientSideRowModel.ts
@@ -1173,10 +1173,6 @@ export class ClientSideRowModel extends BeanStub implements IClientSideRowModel,
         this.pivotStage?.execute({ rowNode: this.rootNode, changedPath: changedPath });
     }
 
-    public getNodeManager(): ClientSideNodeManager {
-        return this.nodeManager;
-    }
-
     public getRowNode(id: string): RowNode | undefined {
         // although id is typed a string, this could be called by the user, and they could have passed a number
         const idIsGroup = typeof id == 'string' && id.indexOf(RowNode.ID_PREFIX_ROW_GROUP) == 0;
@@ -1196,6 +1192,14 @@ export class ClientSideRowModel extends BeanStub implements IClientSideRowModel,
         }
 
         return this.nodeManager.getRowNode(id);
+    }
+
+    public setImmutableRowData(rowData: any[]): void {
+        const updateRowDataResult = this.nodeManager.setImmutableRowData(rowData);
+        if (updateRowDataResult) {
+            const { rowNodeTransaction, rowsInserted, rowsOrderChanged } = updateRowDataResult;
+            this.commonUpdateRowData([rowNodeTransaction], rowsInserted || rowsOrderChanged);
+        }
     }
 
     // rows: the rows to put into the model
@@ -1303,17 +1307,10 @@ export class ClientSideRowModel extends BeanStub implements IClientSideRowModel,
     }
 
     /**
-     * Used to apply generated transaction
-     */
-    public afterImmutableDataChange(rowNodeTransaction: RowNodeTransaction, rowNodesOrderChanged: boolean): void {
-        this.commonUpdateRowData([rowNodeTransaction], rowNodesOrderChanged);
-    }
-
-    /**
      * Common to:
      * - executeBatchUpdateRowData (batch transactions)
      * - updateRowData (single transaction)
-     * - afterImmutableDataChange (generated transaction)
+     * - setImmutableRowData (generated transaction)
      *
      * @param rowNodeTrans - the transactions to apply
      * @param orderChanged - whether the order of the rows has changed, either via generated transaction or user provided addIndex

--- a/community-modules/client-side-row-model/src/clientSideRowModel/immutableService.ts
+++ b/community-modules/client-side-row-model/src/clientSideRowModel/immutableService.ts
@@ -1,20 +1,5 @@
-import type {
-    BeanCollection,
-    IImmutableService,
-    IRowModel,
-    ISelectionService,
-    NamedBean,
-    RowDataTransaction,
-    RowNode,
-} from '@ag-grid-community/core';
-import {
-    BeanStub,
-    _errorOnce,
-    _exists,
-    _getRowIdCallback,
-    _isClientSideRowModel,
-    _iterateObject,
-} from '@ag-grid-community/core';
+import type { BeanCollection, IImmutableService, IRowModel, NamedBean } from '@ag-grid-community/core';
+import { BeanStub, _errorOnce, _isClientSideRowModel } from '@ag-grid-community/core';
 
 import type { ClientSideRowModel } from './clientSideRowModel';
 
@@ -22,14 +7,12 @@ export class ImmutableService extends BeanStub implements NamedBean, IImmutableS
     beanName = 'immutableService' as const;
 
     private rowModel: IRowModel;
-    private selectionService: ISelectionService;
 
     public wireBeans(beans: BeanCollection): void {
         this.rowModel = beans.rowModel;
-        this.selectionService = beans.selectionService;
     }
 
-    private clientSideRowModel: ClientSideRowModel;
+    private clientSideRowModel: ClientSideRowModel | null = null;
 
     public postConstruct(): void {
         if (_isClientSideRowModel(this.gos)) {
@@ -52,96 +35,23 @@ export class ImmutableService extends BeanStub implements NamedBean, IImmutableS
     }
 
     public setRowData<TData>(rowData: TData[]): void {
-        // convert the setRowData data into a transaction object by working out adds, removes and updates
-
-        const rowDataTransaction = this.createTransactionForRowData(rowData);
-        if (!rowDataTransaction) {
-            return; // no transaction to apply
-        }
-
-        const nodeManager = this.clientSideRowModel.getNodeManager();
-
-        // Apply the transaction
-        const { rowNodeTransaction, rowsInserted } = nodeManager.updateRowData(rowDataTransaction);
-
-        let orderChanged = false;
-
-        // If true, we will not apply the new order specified in the rowData, but keep the old order.
-        const suppressSortOrder = this.gos.get('suppressMaintainUnsortedOrder');
-        if (!suppressSortOrder) {
-            // we need to reorder the nodes to match the new data order
-            orderChanged = nodeManager.updateRowOrderFromRowData(rowData);
-        }
-
-        this.clientSideRowModel.afterImmutableDataChange(rowNodeTransaction, orderChanged || rowsInserted);
-    }
-
-    /** Converts the setRowData() command to a transaction */
-    private createTransactionForRowData<TData>(rowData: TData[]): RowDataTransaction | null {
-        if (!_isClientSideRowModel(this.gos)) {
+        const clientSideRowModel = this.clientSideRowModel;
+        if (!clientSideRowModel) {
             _errorOnce('ImmutableService only works with ClientSideRowModel');
-            return null;
+            return;
         }
-
-        const getRowIdFunc = _getRowIdCallback(this.gos);
-        if (getRowIdFunc == null) {
-            _errorOnce('ImmutableService requires getRowId() callback to be implemented, your row data needs IDs!');
-            return null;
-        }
-
-        // get a map of the existing data, that we are going to modify as we find rows to not delete
-        const existingNodesMap: { [id: string]: RowNode | undefined } = this.clientSideRowModel
-            .getNodeManager()
-            .getCopyOfNodesMap();
-
-        const remove: TData[] = [];
-        const update: TData[] = [];
-        const add: TData[] = [];
-
-        if (_exists(rowData)) {
-            // split all the new data in the following:
-            // if new, push to 'add'
-            // if update, push to 'update'
-            // if not changed, do not include in the transaction
-            rowData.forEach((data: TData) => {
-                const id = getRowIdFunc({ data, level: 0 });
-                const existingNode = existingNodesMap[id];
-
-                if (existingNode) {
-                    const dataHasChanged = existingNode.data !== data;
-                    if (dataHasChanged) {
-                        update.push(data);
-                    }
-                    // otherwise, if data not changed, we just don't include it anywhere, as it's not a delta
-
-                    existingNodesMap[id] = undefined; // remove from list, so we know the item is not to be removed
-                } else {
-                    add.push(data);
-                }
-            });
-        }
-
-        // at this point, all rows that are left, should be removed
-        _iterateObject(existingNodesMap, (id, rowNode) => {
-            if (rowNode) {
-                remove.push(rowNode.data);
-            }
-        });
-
-        return { remove, update, add };
+        clientSideRowModel.setImmutableRowData(rowData);
     }
 
     private onRowDataUpdated(): void {
         const rowData = this.gos.get('rowData');
-        if (!rowData) {
-            return;
-        }
-
-        if (this.isActive()) {
-            this.setRowData(rowData);
-        } else {
-            this.selectionService.reset('rowDataChanged');
-            this.clientSideRowModel.setRowData(rowData);
+        const clientSideRowModel = this.clientSideRowModel!;
+        if (rowData) {
+            if (this.isActive()) {
+                clientSideRowModel.setImmutableRowData(rowData);
+            } else {
+                clientSideRowModel.setRowData(rowData);
+            }
         }
     }
 }


### PR DESCRIPTION
Background:

To switch between "flat" (traditional) row data and the new hierarchidal row data with a "children" property, we want to try the approach to have two different implementations of ClientSideNodeManager and ImmutableService for hierarchical data.

At the moment, Immutable service just invokes directly some operations from the ClientSideNodeManager, and contains logic that seems to be more suited to be handled by the ClientSideRowModel.

In this refactoring PR, I moved the generation and execution of transactions outside of the ImmutableService into the ClientSideNodeManager and exposed it through the ClientSideRowModule.

In this way, when we implement the other ClientSideNodeManager for hierarchical data we do not need to worry to select the right immutable service instance, as one will fit both.