### PR TITLE
RTI-2313 scroll into view example logs warning

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/grouping-opening-groups/_examples/row-group-scroll/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/grouping-opening-groups/_examples/row-group-scroll/main.ts
@@ -30,11 +30,13 @@ const gridOptions: GridOptions<IOlympicData> = {
 };
 
 function onRowGroupOpened(event: RowGroupOpenedEvent<IOlympicData>) {
-    var rowNodeIndex = event.node.rowIndex!;
-    // factor in child nodes so we can scroll to correct position
-    var childCount = event.node.childrenAfterSort ? event.node.childrenAfterSort.length : 0;
-    var newIndex = rowNodeIndex + childCount;
-    gridApi!.ensureIndexVisible(newIndex);
+    if (event.expanded) {
+        var rowNodeIndex = event.node.rowIndex!;
+        // factor in child nodes so we can scroll to correct position
+        var childCount = event.node.childrenAfterSort ? event.node.childrenAfterSort.length : 0;
+        var newIndex = rowNodeIndex + childCount;
+        gridApi!.ensureIndexVisible(newIndex);
+    }
 }
 
 // setup the grid after the page has finished loading

--- a/documentation/ag-grid-docs/src/content/docs/tree-data-opening-groups/_examples/row-group-scroll/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/tree-data-opening-groups/_examples/row-group-scroll/main.ts
@@ -49,11 +49,13 @@ const gridOptions: GridOptions = {
 };
 
 function onRowGroupOpened(event: RowGroupOpenedEvent<IOlympicData>) {
-    var rowNodeIndex = event.node.rowIndex!;
-    // factor in child nodes so we can scroll to correct position
-    var childCount = event.node.childrenAfterSort ? event.node.childrenAfterSort.length : 0;
-    var newIndex = rowNodeIndex + childCount;
-    gridApi!.ensureIndexVisible(newIndex);
+    if (event.expanded) {
+        var rowNodeIndex = event.node.rowIndex!;
+        // factor in child nodes so we can scroll to correct position
+        var childCount = event.node.childrenAfterSort ? event.node.childrenAfterSort.length : 0;
+        var newIndex = rowNodeIndex + childCount;
+        gridApi!.ensureIndexVisible(newIndex);
+    }
 }
 
 // setup the grid after the page has finished loading


### PR DESCRIPTION
Steps to repro:

Open URL [JavaScript Grid: Tree Data - Expanding Groups | AG Grid](https://www.ag-grid.com/archive/32.2.0/javascript-data-grid/tree-data-opening-groups/#scrolling-child-rows-into-view) 

- Click to Expand Downloads
- Click to Collapse Downloads

** Actual:

function.ts:22 AG Grid: Invalid row index for ensureIndexVisible: 7

** Expected: 

Should be no warning

Counterintuitively, the event onRowGroupOpened is raised both on expand and unexpand, but we are not checking the event.expanded state when trying to select the right rowindex.

We should call ensureIndexVisible only if event.expanded is true in the example itself