### PR TITLE
RTI-2276 cell selection api docs methods links broken

### DIFF
--- a/documentation/ag-grid-docs/src/content/api-documentation/grid-api/api.json
+++ b/documentation/ag-grid-docs/src/content/api-documentation/grid-api/api.json
@@ -293,19 +293,19 @@
         "getCellRanges": {
             "more": {
                 "name": "getCellRanges",
-                "url": "./cell-selection/#reference--getCellRanges"
+                "url": "./cell-selection-api-reference/#reference-selection-getCellRanges"
             }
         },
         "addCellRange": {
             "more": {
                 "name": "addCellRange",
-                "url": "./cell-selection/#reference--addCellRange"
+                "url": "./cell-selection-api-reference/#reference-selection-addCellRange"
             }
         },
         "clearCellSelection": {
             "more": {
                 "name": "clearCellSelection",
-                "url": "./cell-selection/#reference--clearCellSelection"
+                "url": "./cell-selection-api-reference/#reference-selection-clearCellSelection"
             }
         }
     },

--- a/documentation/ag-grid-docs/src/content/api-documentation/grid-events/events.json
+++ b/documentation/ag-grid-docs/src/content/api-documentation/grid-events/events.json
@@ -233,13 +233,13 @@
         "cellSelectionDeleteStart": {
             "more": {
                 "name": "Delete Cell Selection",
-                "url": "./cell-selection/#reference--cellSelectionDeleteStart"
+                "url": "./cell-selection-api-reference/#reference-editing-cellSelectionDeleteStart"
             }
         },
         "cellSelectionDeleteEnd": {
             "more": {
                 "name": "Delete Cell Selection",
-                "url": "./cell-selection/#reference--cellSelectionDeleteEnd"
+                "url": "./cell-selection-api-reference/#reference-editing-cellSelectionDeleteEnd"
             }
         }
     },

--- a/documentation/ag-grid-docs/src/content/interface-documentation/integrated-charts-api-range-chart/chart-api.json
+++ b/documentation/ag-grid-docs/src/content/interface-documentation/integrated-charts-api-range-chart/chart-api.json
@@ -13,7 +13,7 @@
         },
         "cellRange": {
             "isRequired": true,
-            "description": "Defines the range of cells to be charted. A range is normally defined with start and end rows and a list of columns. If the start and end rows are omitted, the range covers all rows (i.e. entire column contents are selected). The columns can either be defined using a start and end column (the range will cover the start and end columns and all columns in between), or columns can be supplied specifically in cases where the required columns are not adjacent to each other. See [Add Cell Range](./cell-selection/#reference--addCellRange) for more information."
+            "description": "Defines the range of cells to be charted. A range is normally defined with start and end rows and a list of columns. If the start and end rows are omitted, the range covers all rows (i.e. entire column contents are selected). The columns can either be defined using a start and end column (the range will cover the start and end columns and all columns in between), or columns can be supplied specifically in cases where the required columns are not adjacent to each other. See [Add Cell Range](./cell-selection-api-reference/#reference-selection-addCellRange) for more information."
         },
         "chartThemeName": {
             "options": [


### PR DESCRIPTION
Description

Steps to repro:

Open 
- https://www.ag-grid.com/archive/32.2.0/javascript-data-grid/grid-api/#reference-selection-getCellRanges
- https://www.ag-grid.com/archive/32.2.0/javascript-data-grid/grid-api/#reference-selection-addCellRange
- https://www.ag-grid.com/archive/32.2.0/javascript-data-grid/grid-api/#reference-selection-clearCellSelection

See links in the description of these methods

Actual: Links are broken
Expected: Links point to the Selection API page instead where these methods are actually documented


Also:

searched and fixed all links to the old api reference section and fixed them