### PR TITLE
fix syntax error in the undo-redo-edits code snippet

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/undo-redo-edits/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/undo-redo-edits/index.mdoc
@@ -86,7 +86,7 @@ const gridOptions = {
         handle: {
             mode: 'fill',
         }
-    }
+    },
 
     // enables undo / redo
     undoRedoCellEditing: true,


### PR DESCRIPTION
https://www.ag-grid.com/javascript-data-grid/undo-redo-edits/#example-undo--redo

![image](https://github.com/user-attachments/assets/42f0187a-b794-4b35-af3c-854866c4bf19)
