### PR TITLE
CI: prime dependency install across jobs and cache yarn downloads offline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -308,7 +308,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     name: Lint & Format Check
-    needs: [ detect-changes ]
+    needs: [ detect-changes, init ]
     if: ${{ always() && needs.detect-changes.result == 'success' }}
     outputs:
       format: ${{ steps.format.outcome || '' }}
@@ -344,7 +344,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     name: Build
-    needs: [ detect-changes ]
+    needs: [ detect-changes, init ]
     if: needs.detect-changes.outputs.run_code_ci == 'true' &&
       (github.event.pull_request.draft == false || startsWith(github.head_ref, 'ghabot-ag-'))
     outputs:
@@ -472,7 +472,7 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     name: Docs Build & Link Checker
-    needs: [ detect-changes ]
+    needs: [ detect-changes, init ]
     if: ${{ (needs.detect-changes.outputs.run_code_ci == 'true' ||
       needs.detect-changes.outputs.run_docs_ci == 'true') &&
       (github.event.pull_request.draft == false || startsWith(github.head_ref, 'ghabot-ag-')) && !inputs.skip_docs }}

--- a/external/ag-shared/github/actions/setup-nx-core/action.yml
+++ b/external/ag-shared/github/actions/setup-nx-core/action.yml
@@ -209,6 +209,28 @@ runs:
               restore-keys: cache-nx-v20-${{ inputs.nx_cache_hash }}-
               # fail-on-cache-miss: true
 
+        # Persist yarn's global download cache (the fetched tarballs), keyed like node_modules
+        # but with a loose restore-keys fallback so it survives a dependency bump: the yarn cache
+        # is additive, so an older cache still holds almost every tarball and a bump only fetches
+        # the diff. This decouples "node_modules layout is stale" (needs a reinstall) from "must
+        # hit the network" (the flaky registry): a reinstall on a node_modules miss resolves from
+        # this cache offline instead of re-downloading everything from the registry.
+        - name: Cache yarn download cache
+          if: inputs.cache_mode == 'rw'
+          uses: actions/cache@v4
+          with:
+              path: ~/.cache/yarn
+              key: yarn-cache-${{ runner.os }}-${{ inputs.node_modules_hash }}
+              restore-keys: yarn-cache-${{ runner.os }}-
+
+        - name: Restore yarn download cache
+          if: inputs.cache_mode == 'ro'
+          uses: actions/cache/restore@v4
+          with:
+              path: ~/.cache/yarn
+              key: yarn-cache-${{ runner.os }}-${{ inputs.node_modules_hash }}
+              restore-keys: yarn-cache-${{ runner.os }}-
+
         - name: Setup Node.js
           id: setup_node
           uses: actions/setup-node@v4
@@ -239,12 +261,12 @@ runs:
                 if [[ -n "${NODE_MODULES_PATHS//[[:space:]]/}" ]] ; then
                   rm -rf ${NODE_MODULES_PATHS}
                 fi
-                yarn install --ci
+                yarn install --ci --prefer-offline --network-retries 5
                 yarn check --integrity
               elif (yarn check --integrity) ; then
                 yarn postinstall
               else
-                yarn install --ci
+                yarn install --ci --prefer-offline --network-retries 5
 
                 # Ensure that the integrity check passes after install to avoid
                 # cache polution with entries that will fail future integrity checks.
@@ -256,7 +278,7 @@ runs:
           id: yarn_install_fast
           shell: bash
           run: |
-              yarn check --integrity || yarn install --ci
+              yarn check --integrity || yarn install --ci --prefer-offline --network-retries 5
 
         - name: yarn install (skipping postinstall)
           if: inputs.cache_mode == 'rw' && inputs.yarn_postinstall == 'no-install' && steps.cache_ro.outputs.cache-hit != 'false'

--- a/external/ag-shared/github/actions/setup-nx-core/action.yml
+++ b/external/ag-shared/github/actions/setup-nx-core/action.yml
@@ -261,12 +261,12 @@ runs:
                 if [[ -n "${NODE_MODULES_PATHS//[[:space:]]/}" ]] ; then
                   rm -rf ${NODE_MODULES_PATHS}
                 fi
-                yarn install --ci --prefer-offline --network-retries 5
+                yarn install --ci --prefer-offline
                 yarn check --integrity
               elif (yarn check --integrity) ; then
                 yarn postinstall
               else
-                yarn install --ci --prefer-offline --network-retries 5
+                yarn install --ci --prefer-offline
 
                 # Ensure that the integrity check passes after install to avoid
                 # cache polution with entries that will fail future integrity checks.
@@ -278,7 +278,7 @@ runs:
           id: yarn_install_fast
           shell: bash
           run: |
-              yarn check --integrity || yarn install --ci --prefer-offline --network-retries 5
+              yarn check --integrity || yarn install --ci --prefer-offline
 
         - name: yarn install (skipping postinstall)
           if: inputs.cache_mode == 'rw' && inputs.yarn_postinstall == 'no-install' && steps.cache_ro.outputs.cache-hit != 'false'


### PR DESCRIPTION
## Why

Many CI jobs keep doing a full `yarn install`, and it intermittently fails with `504 Gateway Timeout` from `registry.ag-grid.com`. Two causes:

1. **Install stampede.** `lint`, `build`, `docs` depended only on `detect-changes`, so they raced ahead of the `init` cache-priming job. With no exact `node_modules` cache yet, they fell to the loose `restore-keys` fallback → `EXACT_CACHE_HIT=false` → wipe + full reinstall against the flaky registry. A failed `init` also cascades into skipped matrix jobs whose names then render unexpanded (`${{ matrix.shard }}`).
2. **Every miss hits the network.** A `node_modules` cache miss always meant re-downloading every tarball from the registry.

## Changes

- **`ci.yml`:** `lint`, `build`, `docs` now `needs: [ detect-changes, init ]` so they start after the primer has saved the exact-key cache and take the no-network `yarn postinstall` path.
- **`setup-nx-core` (shared, `external/ag-shared/`):**
  - Persist yarn's global download cache (`~/.cache/yarn`), keyed like `node_modules` with a loose fallback. The cache is additive, so even an inexact restore serves nearly every tarball — a reinstall on a miss resolves **offline** instead of depending on the registry.
  - Pass `--prefer-offline` to installs so cached tarballs are used before any network fetch. (Yarn Classic has no supported retry flag, and `--network-timeout` was deliberately left untouched — the offline cache is the defence.)

## Notes

- `setup-nx-core` is shared vendored code — this behaviour percolates to ag-charts / ag-studio via ag-shared and should get a sync-log entry.
- First CI after a large lockfile bump still does one real network install (cold caches).