### PR TITLE
[AG-115] Fix(column-header): balance and enlarge the edit column name dialog

### DIFF
--- a/community-modules/styles/src/internal/base/parts/_column-header-edit.scss
+++ b/community-modules/styles/src/internal/base/parts/_column-header-edit.scss
@@ -5,8 +5,7 @@
         display: flex;
         flex-direction: column;
         gap: var(--ag-widget-vertical-spacing);
-        padding: var(--ag-widget-container-vertical-padding) var(--ag-widget-container-horizontal-padding)
-            var(--ag-widget-vertical-spacing);
+        padding: var(--ag-widget-container-vertical-padding) var(--ag-widget-container-horizontal-padding);
         box-sizing: border-box;
         height: 100%;
     }

--- a/packages/ag-grid-enterprise/src/columnHeaderEdit/columnHeaderEdit.css
+++ b/packages/ag-grid-enterprise/src/columnHeaderEdit/columnHeaderEdit.css
@@ -2,8 +2,7 @@
     display: flex;
     flex-direction: column;
     gap: var(--ag-widget-vertical-spacing);
-    padding: var(--ag-widget-container-vertical-padding) var(--ag-widget-container-horizontal-padding)
-        var(--ag-widget-vertical-spacing);
+    padding: var(--ag-widget-container-vertical-padding) var(--ag-widget-container-horizontal-padding);
     box-sizing: border-box;
     height: 100%;
 }

--- a/packages/ag-grid-enterprise/src/columnHeaderEdit/columnHeaderEditPopup.ts
+++ b/packages/ag-grid-enterprise/src/columnHeaderEdit/columnHeaderEditPopup.ts
@@ -5,11 +5,11 @@ import { AgInputTextFieldSelector, BeanStub, Component, KeyCode } from 'ag-grid-
 
 import { Dialog } from '../widgets/dialog';
 
-const WIDTH = 210;
-const MIN_WIDTH = 210;
+const WIDTH = 300;
+const MIN_WIDTH = 300;
 // Deferred mode adds the Apply/Cancel actions row, so the dialog needs more height.
-const LIVE_HEIGHT = 110;
-const DEFERRED_HEIGHT = 160;
+const LIVE_HEIGHT = 130;
+const DEFERRED_HEIGHT = 190;
 
 const ColumnHeaderEditContentElement: ElementParams = {
     tag: 'div',


### PR DESCRIPTION
Addresses AG-115 issue #6 (dialog layout).

- Equal, larger padding above and below the editor input (was container padding on top, widget spacing on the bottom).
- Increased the dialog's default width and height so it is more noticeable.