### PR TITLE
[AG-10370] Feat(column-sizing): reuse autoSizeStrategy for UI actions and grid events

### DIFF
--- a/documentation/ag-grid-docs/src/content/api-documentation/grid-api/api.json
+++ b/documentation/ag-grid-docs/src/content/api-documentation/grid-api/api.json
@@ -75,6 +75,12 @@
                 "name": "Auto-Size Columns to Fit Cell Contents",
                 "url": "./column-sizing/#auto-size-columns-to-fit-cell-contents"
             }
+        },
+        "applyAutoSizeStrategy": {
+            "more": {
+                "name": "Re-Applying the Auto-Size Strategy",
+                "url": "./column-sizing/#re-applying-the-auto-size-strategy"
+            }
         }
     },
     "columnMoving": {

--- a/documentation/ag-grid-docs/src/content/docs/column-sizing/_examples/auto-size-strategy-events/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/column-sizing/_examples/auto-size-strategy-events/example.spec.ts
@@ -1,0 +1,78 @@
+import { expect, test, waitForGridContent } from '@utils/grid/test-utils';
+import type { Locator, Page } from 'playwright/test';
+
+async function getWidth(locator: Locator): Promise<number> {
+    return (await locator.boundingBox())?.width ?? 0;
+}
+
+// wait twice as long as the animation so we know widths have settled
+async function waitForAnimation(page: Page): Promise<void> {
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    await expect(page.locator('.ag-animate-autosize')).not.toBeVisible();
+}
+
+test.agExample(import.meta, () => {
+    test.eachFramework('paginationChanged re-runs the strategy', async ({ page, agIdFor, remoteGrid }) => {
+        await waitForGridContent(page);
+        await waitForAnimation(page);
+
+        const remoteApi = remoteGrid(page, '1');
+        // shrink away from the strategy's widths so a re-run is observable
+        await remoteApi.setColumnWidths([{ key: 'athlete', newWidth: 90 }]);
+        await waitForAnimation(page);
+        expect(await getWidth(agIdFor.headerCell('athlete'))).toBeLessThan(100);
+
+        await page.locator('.ag-paging-button[data-ref="btNext"]').click();
+        await waitForAnimation(page);
+
+        expect(await getWidth(agIdFor.headerCell('athlete'))).toBeGreaterThan(100);
+    });
+
+    test.eachFramework('columnVisible re-runs the strategy for a newly shown column', async ({ page, agIdFor }) => {
+        await waitForGridContent(page);
+        await waitForAnimation(page);
+
+        await page.locator('button.toggle-button').click(); // hide
+        await waitForAnimation(page);
+        await expect(agIdFor.headerCell('country')).toHaveCount(0);
+
+        await page.locator('button.toggle-button').click(); // show
+        await waitForAnimation(page);
+
+        await expect(agIdFor.headerCell('country')).toBeVisible();
+        // sized to its content, not left at the 80 px minWidth
+        expect(await getWidth(agIdFor.headerCell('country'))).toBeGreaterThan(80);
+    });
+
+    test.eachFramework('a manual resize survives an event-driven re-run', async ({ page, agIdFor, remoteGrid }) => {
+        await waitForGridContent(page);
+        await waitForAnimation(page);
+
+        const remoteApi = remoteGrid(page, '1');
+        // 'uiColumnResized' is the source a header-handle drag reports
+        await remoteApi.setColumnWidths([{ key: 'athlete', newWidth: 300 }], true, 'uiColumnResized');
+        await waitForAnimation(page);
+
+        await page.locator('.ag-paging-button[data-ref="btNext"]').click();
+        await waitForAnimation(page);
+
+        expect(await getWidth(agIdFor.headerCell('athlete'))).toBe(300);
+    });
+
+    test.eachFramework(
+        'Re-Apply Strategy reclaims a manually resized column',
+        async ({ page, agIdFor, remoteGrid }) => {
+            await waitForGridContent(page);
+            await waitForAnimation(page);
+
+            const remoteApi = remoteGrid(page, '1');
+            await remoteApi.setColumnWidths([{ key: 'athlete', newWidth: 300 }], true, 'uiColumnResized');
+            await waitForAnimation(page);
+
+            await page.locator('button.reapply-button').click();
+            await waitForAnimation(page);
+
+            expect(await getWidth(agIdFor.headerCell('athlete'))).not.toBe(300);
+        }
+    );
+});

--- a/documentation/ag-grid-docs/src/content/docs/column-sizing/_examples/auto-size-strategy-events/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/column-sizing/_examples/auto-size-strategy-events/example.spec.ts
@@ -1,43 +1,32 @@
-import { expect, test, waitForGridContent } from '@utils/grid/test-utils';
-import type { Locator, Page } from 'playwright/test';
-
-async function getWidth(locator: Locator): Promise<number> {
-    return (await locator.boundingBox())?.width ?? 0;
-}
-
-// wait twice as long as the animation so we know widths have settled
-async function waitForAnimation(page: Page): Promise<void> {
-    await new Promise((resolve) => setTimeout(resolve, 200));
-    await expect(page.locator('.ag-animate-autosize')).not.toBeVisible();
-}
+import { expect, getWidth, test, waitForColumnWidthsToSettle, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
     test.eachFramework('paginationChanged re-runs the strategy', async ({ page, agIdFor, remoteGrid }) => {
         await waitForGridContent(page);
-        await waitForAnimation(page);
+        await waitForColumnWidthsToSettle(page);
 
         const remoteApi = remoteGrid(page, '1');
         // shrink away from the strategy's widths so a re-run is observable
         await remoteApi.setColumnWidths([{ key: 'athlete', newWidth: 90 }]);
-        await waitForAnimation(page);
+        await waitForColumnWidthsToSettle(page);
         expect(await getWidth(agIdFor.headerCell('athlete'))).toBeLessThan(100);
 
         await page.locator('.ag-paging-button[data-ref="btNext"]').click();
-        await waitForAnimation(page);
+        await waitForColumnWidthsToSettle(page);
 
         expect(await getWidth(agIdFor.headerCell('athlete'))).toBeGreaterThan(100);
     });
 
     test.eachFramework('columnVisible re-runs the strategy for a newly shown column', async ({ page, agIdFor }) => {
         await waitForGridContent(page);
-        await waitForAnimation(page);
+        await waitForColumnWidthsToSettle(page);
 
         await page.locator('button.toggle-button').click(); // hide
-        await waitForAnimation(page);
+        await waitForColumnWidthsToSettle(page);
         await expect(agIdFor.headerCell('country')).toHaveCount(0);
 
         await page.locator('button.toggle-button').click(); // show
-        await waitForAnimation(page);
+        await waitForColumnWidthsToSettle(page);
 
         await expect(agIdFor.headerCell('country')).toBeVisible();
         // sized to its content, not left at the 80 px minWidth
@@ -46,15 +35,15 @@ test.agExample(import.meta, () => {
 
     test.eachFramework('a manual resize survives an event-driven re-run', async ({ page, agIdFor, remoteGrid }) => {
         await waitForGridContent(page);
-        await waitForAnimation(page);
+        await waitForColumnWidthsToSettle(page);
 
         const remoteApi = remoteGrid(page, '1');
         // 'uiColumnResized' is the source a header-handle drag reports
         await remoteApi.setColumnWidths([{ key: 'athlete', newWidth: 300 }], true, 'uiColumnResized');
-        await waitForAnimation(page);
+        await waitForColumnWidthsToSettle(page);
 
         await page.locator('.ag-paging-button[data-ref="btNext"]').click();
-        await waitForAnimation(page);
+        await waitForColumnWidthsToSettle(page);
 
         expect(await getWidth(agIdFor.headerCell('athlete'))).toBe(300);
     });
@@ -63,14 +52,14 @@ test.agExample(import.meta, () => {
         'Re-Apply Strategy reclaims a manually resized column',
         async ({ page, agIdFor, remoteGrid }) => {
             await waitForGridContent(page);
-            await waitForAnimation(page);
+            await waitForColumnWidthsToSettle(page);
 
             const remoteApi = remoteGrid(page, '1');
             await remoteApi.setColumnWidths([{ key: 'athlete', newWidth: 300 }], true, 'uiColumnResized');
-            await waitForAnimation(page);
+            await waitForColumnWidthsToSettle(page);
 
             await page.locator('button.reapply-button').click();
-            await waitForAnimation(page);
+            await waitForColumnWidthsToSettle(page);
 
             expect(await getWidth(agIdFor.headerCell('athlete'))).not.toBe(300);
         }

--- a/documentation/ag-grid-docs/src/content/docs/column-sizing/_examples/auto-size-strategy-events/index.html
+++ b/documentation/ag-grid-docs/src/content/docs/column-sizing/_examples/auto-size-strategy-events/index.html
@@ -1,0 +1,8 @@
+<div class="example-wrapper">
+    <div class="interaction-bar">
+        <button class="toggle-button" onclick="toggleCountry()">Toggle Country Column</button>
+        <button class="reapply-button" onclick="reapplyStrategy()">Re-Apply Strategy</button>
+        <span>Change the page or page size to auto-size against the newly rendered rows.</span>
+    </div>
+    <div id="myGrid"></div>
+</div>

--- a/documentation/ag-grid-docs/src/content/docs/column-sizing/_examples/auto-size-strategy-events/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/column-sizing/_examples/auto-size-strategy-events/main.ts
@@ -1,0 +1,57 @@
+import type { ColDef, GridApi, GridOptions } from 'ag-grid-community';
+import {
+    ClientSideRowModelModule,
+    ColumnApiModule,
+    ColumnAutoSizeModule,
+    ModuleRegistry,
+    PaginationModule,
+    createGrid,
+    enableDevValidations,
+} from 'ag-grid-community';
+
+if (process.env.NODE_ENV !== 'production') {
+    // Enable extended validations only for development
+    enableDevValidations();
+}
+
+ModuleRegistry.registerModules([ColumnApiModule, ColumnAutoSizeModule, PaginationModule, ClientSideRowModelModule]);
+
+const columnDefs: ColDef[] = [
+    { field: 'athlete', minWidth: 80 },
+    { field: 'age', minWidth: 80 },
+    { field: 'country', minWidth: 80 },
+    { field: 'year', minWidth: 80 },
+    { field: 'date', minWidth: 80 },
+];
+
+let gridApi: GridApi<IOlympicData>;
+
+const gridOptions: GridOptions<IOlympicData> = {
+    columnDefs: columnDefs,
+    pagination: true,
+    paginationPageSize: 10,
+    paginationPageSizeSelector: [10, 20, 50],
+    autoSizeStrategy: {
+        type: 'fitCellContents',
+        events: ['paginationChanged', 'columnVisible'],
+    },
+};
+
+function toggleCountry() {
+    const column = gridApi!.getColumn('country');
+    gridApi!.setColumnsVisible(['country'], !column!.isVisible());
+}
+
+function reapplyStrategy() {
+    gridApi!.applyAutoSizeStrategy();
+}
+
+// setup the grid after the page has finished loading
+document.addEventListener('DOMContentLoaded', () => {
+    const gridDiv = document.querySelector<HTMLElement>('#myGrid')!;
+    gridApi = createGrid(gridDiv, gridOptions);
+
+    fetch('https://www.ag-grid.com/example-assets/olympic-winners.json')
+        .then((response) => response.json())
+        .then((data: IOlympicData[]) => gridApi!.setGridOption('rowData', data));
+});

--- a/documentation/ag-grid-docs/src/content/docs/column-sizing/_examples/auto-size-strategy-events/styles.css
+++ b/documentation/ag-grid-docs/src/content/docs/column-sizing/_examples/auto-size-strategy-events/styles.css
@@ -1,0 +1,22 @@
+.example-wrapper {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+}
+
+.interaction-bar {
+    margin-bottom: 1rem;
+    display: flex;
+    gap: 1em;
+    align-items: center;
+}
+
+.toggle-button,
+.reapply-button {
+    margin: 0px !important;
+}
+
+#myGrid {
+    flex: 1 1 0px;
+    width: 100%;
+}

--- a/documentation/ag-grid-docs/src/content/docs/column-sizing/_examples/auto-size-strategy-events/styles.css
+++ b/documentation/ag-grid-docs/src/content/docs/column-sizing/_examples/auto-size-strategy-events/styles.css
@@ -11,9 +11,8 @@
     align-items: center;
 }
 
-.toggle-button,
-.reapply-button {
-    margin: 0px !important;
+.interaction-bar button {
+    margin: 0 !important;
 }
 
 #myGrid {

--- a/documentation/ag-grid-docs/src/content/docs/column-sizing/_examples/auto-size-ui-actions/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/column-sizing/_examples/auto-size-ui-actions/example.spec.ts
@@ -1,0 +1,91 @@
+import { expect, test, waitForGridContent } from '@utils/grid/test-utils';
+import type { Locator, Page } from 'playwright/test';
+
+async function getWidth(locator: Locator): Promise<number> {
+    return (await locator.boundingBox())?.width ?? 0;
+}
+
+// wait twice as long as the animation so we know widths have settled
+async function waitForAnimation(page: Page): Promise<void> {
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    await expect(page.locator('.ag-animate-autosize')).not.toBeVisible();
+}
+
+function centerHeaderSection(page: Page): Locator {
+    return page.locator('.ag-header-row .ag-grid-scrolling-cells').first();
+}
+
+test.agExample(import.meta, () => {
+    test.eachFramework('column menu autosize applies scaleUpToFitGridWidth', async ({ page, agIdFor }) => {
+        await waitForGridContent(page);
+        await waitForAnimation(page);
+
+        const gridWidth = await getWidth(page.locator('.ag-root').first());
+
+        await page.locator('button.reset-button').click();
+        await waitForAnimation(page);
+        expect(await getWidth(centerHeaderSection(page))).toBeLessThan(gridWidth);
+
+        await agIdFor.headerCell('athlete').locator('.ag-header-cell-menu-button').click();
+        await page.getByText('Autosize All Columns').click();
+        await waitForAnimation(page);
+
+        // the strategy's scaleUpToFitGridWidth fills the grid, which a default autosize would not
+        expect(await getWidth(centerHeaderSection(page))).toBeGreaterThanOrEqual(gridWidth - 1);
+    });
+
+    test.eachFramework('context menu autosize applies scaleUpToFitGridWidth', async ({ page, agIdFor }) => {
+        await waitForGridContent(page);
+        await waitForAnimation(page);
+
+        const gridWidth = await getWidth(page.locator('.ag-root').first());
+
+        await page.locator('button.reset-button').click();
+        await waitForAnimation(page);
+
+        await agIdFor.cell({ colId: 'athlete', rowIndex: 0 }).click({ button: 'right' });
+        await page.getByText('Autosize All Columns').click();
+        await waitForAnimation(page);
+
+        expect(await getWidth(centerHeaderSection(page))).toBeGreaterThanOrEqual(gridWidth - 1);
+    });
+
+    test.eachFramework('double-clicking a header edge applies the strategy', async ({ page, agIdFor }) => {
+        await waitForGridContent(page);
+        await waitForAnimation(page);
+
+        await page.locator('button.reset-button').click();
+        await waitForAnimation(page);
+        const shrunkWidth = await getWidth(agIdFor.headerCell('country'));
+
+        await agIdFor.headerCell('country').locator('.ag-header-cell-resize').dblclick();
+        await waitForAnimation(page);
+
+        expect(await getWidth(agIdFor.headerCell('country'))).toBeGreaterThan(shrunkWidth);
+    });
+
+    test.describe('without applyToUiActions', () => {
+        test.eachFramework('menu autosize does not fill the grid width', async ({ page, remoteGrid, agIdFor }) => {
+            await waitForGridContent(page);
+
+            const remoteApi = remoteGrid(page, '1');
+            await remoteApi.setGridOption('autoSizeStrategy', {
+                type: 'fitCellContents',
+                scaleUpToFitGridWidth: true,
+            });
+            await waitForAnimation(page);
+
+            const gridWidth = await getWidth(page.locator('.ag-root').first());
+
+            await page.locator('button.reset-button').click();
+            await waitForAnimation(page);
+
+            await agIdFor.headerCell('athlete').locator('.ag-header-cell-menu-button').click();
+            await page.getByText('Autosize All Columns').click();
+            await waitForAnimation(page);
+
+            // content fit only — the columns do not stretch to fill the grid
+            expect(await getWidth(centerHeaderSection(page))).toBeLessThan(gridWidth);
+        });
+    });
+});

--- a/documentation/ag-grid-docs/src/content/docs/column-sizing/_examples/auto-size-ui-actions/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/column-sizing/_examples/auto-size-ui-actions/example.spec.ts
@@ -1,15 +1,5 @@
-import { expect, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, getWidth, test, waitForColumnWidthsToSettle, waitForGridContent } from '@utils/grid/test-utils';
 import type { Locator, Page } from 'playwright/test';
-
-async function getWidth(locator: Locator): Promise<number> {
-    return (await locator.boundingBox())?.width ?? 0;
-}
-
-// wait twice as long as the animation so we know widths have settled
-async function waitForAnimation(page: Page): Promise<void> {
-    await new Promise((resolve) => setTimeout(resolve, 200));
-    await expect(page.locator('.ag-animate-autosize')).not.toBeVisible();
-}
 
 function centerHeaderSection(page: Page): Locator {
     return page.locator('.ag-header-row .ag-grid-scrolling-cells').first();
@@ -18,48 +8,49 @@ function centerHeaderSection(page: Page): Locator {
 test.agExample(import.meta, () => {
     test.eachFramework('column menu autosize applies scaleUpToFitGridWidth', async ({ page, agIdFor }) => {
         await waitForGridContent(page);
-        await waitForAnimation(page);
+        await waitForColumnWidthsToSettle(page);
 
         const gridWidth = await getWidth(page.locator('.ag-root').first());
 
         await page.locator('button.reset-button').click();
-        await waitForAnimation(page);
+        await waitForColumnWidthsToSettle(page);
         expect(await getWidth(centerHeaderSection(page))).toBeLessThan(gridWidth);
 
         await agIdFor.headerCell('athlete').locator('.ag-header-cell-menu-button').click();
         await page.getByText('Autosize All Columns').click();
-        await waitForAnimation(page);
+        await waitForColumnWidthsToSettle(page);
 
         // the strategy's scaleUpToFitGridWidth fills the grid, which a default autosize would not
+        // (a pixel of slack for the rounding in the width distribution)
         expect(await getWidth(centerHeaderSection(page))).toBeGreaterThanOrEqual(gridWidth - 1);
     });
 
     test.eachFramework('context menu autosize applies scaleUpToFitGridWidth', async ({ page, agIdFor }) => {
         await waitForGridContent(page);
-        await waitForAnimation(page);
+        await waitForColumnWidthsToSettle(page);
 
         const gridWidth = await getWidth(page.locator('.ag-root').first());
 
         await page.locator('button.reset-button').click();
-        await waitForAnimation(page);
+        await waitForColumnWidthsToSettle(page);
 
         await agIdFor.cell({ colId: 'athlete', rowIndex: 0 }).click({ button: 'right' });
         await page.getByText('Autosize All Columns').click();
-        await waitForAnimation(page);
+        await waitForColumnWidthsToSettle(page);
 
         expect(await getWidth(centerHeaderSection(page))).toBeGreaterThanOrEqual(gridWidth - 1);
     });
 
     test.eachFramework('double-clicking a header edge applies the strategy', async ({ page, agIdFor }) => {
         await waitForGridContent(page);
-        await waitForAnimation(page);
+        await waitForColumnWidthsToSettle(page);
 
         await page.locator('button.reset-button').click();
-        await waitForAnimation(page);
+        await waitForColumnWidthsToSettle(page);
         const shrunkWidth = await getWidth(agIdFor.headerCell('country'));
 
         await agIdFor.headerCell('country').locator('.ag-header-cell-resize').dblclick();
-        await waitForAnimation(page);
+        await waitForColumnWidthsToSettle(page);
 
         expect(await getWidth(agIdFor.headerCell('country'))).toBeGreaterThan(shrunkWidth);
     });
@@ -73,16 +64,16 @@ test.agExample(import.meta, () => {
                 type: 'fitCellContents',
                 scaleUpToFitGridWidth: true,
             });
-            await waitForAnimation(page);
+            await waitForColumnWidthsToSettle(page);
 
             const gridWidth = await getWidth(page.locator('.ag-root').first());
 
             await page.locator('button.reset-button').click();
-            await waitForAnimation(page);
+            await waitForColumnWidthsToSettle(page);
 
             await agIdFor.headerCell('athlete').locator('.ag-header-cell-menu-button').click();
             await page.getByText('Autosize All Columns').click();
-            await waitForAnimation(page);
+            await waitForColumnWidthsToSettle(page);
 
             // content fit only — the columns do not stretch to fill the grid
             expect(await getWidth(centerHeaderSection(page))).toBeLessThan(gridWidth);

--- a/documentation/ag-grid-docs/src/content/docs/column-sizing/_examples/auto-size-ui-actions/index.html
+++ b/documentation/ag-grid-docs/src/content/docs/column-sizing/_examples/auto-size-ui-actions/index.html
@@ -1,0 +1,7 @@
+<div class="example-wrapper">
+    <div class="interaction-bar">
+        <button class="reset-button" onclick="resetWidths()">Shrink All Columns</button>
+        <span>Then use <b>Autosize All Columns</b> in the column or context menu.</span>
+    </div>
+    <div id="myGrid"></div>
+</div>

--- a/documentation/ag-grid-docs/src/content/docs/column-sizing/_examples/auto-size-ui-actions/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/column-sizing/_examples/auto-size-ui-actions/main.ts
@@ -1,0 +1,56 @@
+import type { ColDef, GridApi, GridOptions } from 'ag-grid-community';
+import {
+    ClientSideRowModelModule,
+    ColumnApiModule,
+    ColumnAutoSizeModule,
+    ModuleRegistry,
+    createGrid,
+    enableDevValidations,
+} from 'ag-grid-community';
+import { ColumnMenuModule, ContextMenuModule } from 'ag-grid-enterprise';
+
+if (process.env.NODE_ENV !== 'production') {
+    // Enable extended validations only for development
+    enableDevValidations();
+}
+
+ModuleRegistry.registerModules([
+    ColumnApiModule,
+    ColumnAutoSizeModule,
+    ColumnMenuModule,
+    ContextMenuModule,
+    ClientSideRowModelModule,
+]);
+
+const columnDefs: ColDef[] = [
+    { field: 'athlete', width: 150 },
+    { field: 'age', width: 90 },
+    { field: 'country', width: 120 },
+    { field: 'year', width: 90 },
+    { field: 'date', width: 110 },
+];
+
+let gridApi: GridApi<IOlympicData>;
+
+const gridOptions: GridOptions<IOlympicData> = {
+    columnDefs: columnDefs,
+    autoSizeStrategy: {
+        type: 'fitCellContents',
+        scaleUpToFitGridWidth: true,
+        applyToUiActions: true,
+    },
+};
+
+function resetWidths() {
+    gridApi!.setColumnWidths(columnDefs.map((colDef) => ({ key: colDef.field!, newWidth: 100 })));
+}
+
+// setup the grid after the page has finished loading
+document.addEventListener('DOMContentLoaded', () => {
+    const gridDiv = document.querySelector<HTMLElement>('#myGrid')!;
+    gridApi = createGrid(gridDiv, gridOptions);
+
+    fetch('https://www.ag-grid.com/example-assets/olympic-winners.json')
+        .then((response) => response.json())
+        .then((data: IOlympicData[]) => gridApi!.setGridOption('rowData', data));
+});

--- a/documentation/ag-grid-docs/src/content/docs/column-sizing/_examples/auto-size-ui-actions/styles.css
+++ b/documentation/ag-grid-docs/src/content/docs/column-sizing/_examples/auto-size-ui-actions/styles.css
@@ -11,8 +11,8 @@
     align-items: center;
 }
 
-.reset-button {
-    margin: 0px !important;
+.interaction-bar button {
+    margin: 0 !important;
 }
 
 #myGrid {

--- a/documentation/ag-grid-docs/src/content/docs/column-sizing/_examples/auto-size-ui-actions/styles.css
+++ b/documentation/ag-grid-docs/src/content/docs/column-sizing/_examples/auto-size-ui-actions/styles.css
@@ -1,0 +1,21 @@
+.example-wrapper {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+}
+
+.interaction-bar {
+    margin-bottom: 1rem;
+    display: flex;
+    gap: 1em;
+    align-items: center;
+}
+
+.reset-button {
+    margin: 0px !important;
+}
+
+#myGrid {
+    flex: 1 1 0px;
+    width: 100%;
+}

--- a/documentation/ag-grid-docs/src/content/docs/column-sizing/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/column-sizing/index.mdoc
@@ -179,6 +179,45 @@ Just like Excel, each column can also be auto-resized by double clicking the rig
 
 {% /note %}
 
+### Auto-Sizing from the Menus
+
+By default the **Autosize This Column** and **Autosize All Columns** actions in the [Column Menu](./column-menu/) and [Context Menu](./context-menu/) size columns to their contents with default options, ignoring the configured `autoSizeStrategy`. Set `applyToUiActions = true` to have them reuse the strategy's options instead, such as `scaleUpToFitGridWidth` and `skipHeader`. Double-clicking a header edge follows the same setting.
+
+```{% frameworkTransform=true %}
+const gridOptions = {
+    autoSizeStrategy: {
+        type: 'fitCellContents',
+        scaleUpToFitGridWidth: true,
+        applyToUiActions: true,
+    }
+}
+```
+
+{% gridExampleRunner title="Auto-Sizing from the Menus" name="auto-size-ui-actions" /%}
+
+`applyToUiActions` is only supported by the `fitCellContents` strategy, since the built-in actions size columns to their contents.
+
+### Re-Applying the Auto-Size Strategy
+
+`autoSizeStrategy` is applied when the grid first renders. To re-apply it when the grid changes, list the [Grid Events](./grid-events/) that should trigger it:
+
+```{% frameworkTransform=true %}
+const gridOptions = {
+    autoSizeStrategy: {
+        type: 'fitCellContents',
+        events: ['paginationChanged', 'columnVisible', 'virtualColumnsChanged'],
+    }
+}
+```
+
+Events fired in the same frame are coalesced into one auto-size pass. Columns the user has resized by hand keep their width, so a re-run does not undo a manual drag.
+
+{% gridExampleRunner title="Re-Applying the Auto-Size Strategy" name="auto-size-strategy-events" /%}
+
+The strategy can also be re-applied on demand, which sizes every column including any the user has resized:
+
+{% apiDocumentation source="grid-api/api.json" section="columnSizing" names=["applyAutoSizeStrategy"] /%}
+
 ## Resize via Keyboard
 
 Column headers can be resized using the keyboard. When a column header is focused, press {% kbd "⌥ Alt" /%} + {% kbd "←" /%} / {% kbd "→" /%} to resize the column in that direction.

--- a/documentation/ag-grid-docs/src/content/docs/column-sizing/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/column-sizing/index.mdoc
@@ -181,7 +181,9 @@ Just like Excel, each column can also be auto-resized by double clicking the rig
 
 ### Auto-Sizing from the Menus
 
-By default the **Autosize This Column** and **Autosize All Columns** actions in the [Column Menu](./column-menu/) and [Context Menu](./context-menu/) size columns to their contents with default options, ignoring the configured `autoSizeStrategy`. Set `applyToUiActions = true` to have them reuse the strategy's options instead, such as `scaleUpToFitGridWidth` and `skipHeader`. Double-clicking a header edge follows the same setting.
+By default the **Autosize This Column** and **Autosize All Columns** actions in the [Column Menu](./column-menu/) and [Context Menu](./context-menu/) size columns to their contents with default options, ignoring the configured `autoSizeStrategy`. Set `applyToUiActions = true` to have them reuse the strategy's options instead, such as `skipHeader` and the width limits. Double-clicking a header edge, or a column group's edge, follows the same setting.
+
+`scaleUpToFitGridWidth` applies only to **Autosize All Columns**. The single-column and column-group actions never stretch a column to fill the grid.
 
 ```{% frameworkTransform=true %}
 const gridOptions = {
@@ -205,12 +207,12 @@ const gridOptions = {
 const gridOptions = {
     autoSizeStrategy: {
         type: 'fitCellContents',
-        events: ['paginationChanged', 'columnVisible', 'virtualColumnsChanged'],
+        events: ['paginationChanged', 'columnVisible'],
     }
 }
 ```
 
-Events fired in the same frame are coalesced into one auto-size pass. Columns the user has resized by hand keep their width, so a re-run does not undo a manual drag.
+Events fired in the same tick are coalesced into one auto-size pass, and events that auto-sizing itself dispatches are ignored. Columns the user has resized by hand keep their width, so a re-run does not undo a manual drag.
 
 {% gridExampleRunner title="Re-Applying the Auto-Size Strategy" name="auto-size-strategy-events" /%}
 

--- a/documentation/ag-grid-docs/src/utils/grid/test-utils.ts
+++ b/documentation/ag-grid-docs/src/utils/grid/test-utils.ts
@@ -601,6 +601,40 @@ export async function waitForRowAnimations(page: Page) {
     });
 }
 
+export async function getWidth(locator: Locator): Promise<number> {
+    return (await locator.boundingBox())?.width ?? 0;
+}
+
+/** The class the grid body carries while column widths are animating to their new values. */
+export const WIDTH_ANIMATION_CLASS = 'ag-animate-autosize';
+
+/**
+ * Wait until column widths stop changing, so an auto-size or resize has fully landed.
+ *
+ * Asserting the animation class is absent is not enough on its own: it passes when nothing matches,
+ * which is also true before the resize has started. Two consecutive identical samples of the header
+ * widths, with no animation in progress, mean the sizing is finished.
+ */
+export async function waitForColumnWidthsToSettle(page: Page) {
+    await page.waitForFunction(
+        ({ animationClass, stateKey }) => {
+            const state = window as unknown as Record<string, string | undefined>;
+            const header = document.querySelector('.ag-header-row');
+            if (!header || document.querySelector(`.${animationClass}`)) {
+                state[stateKey] = undefined;
+                return false;
+            }
+            const widths = Array.from(header.querySelectorAll('.ag-header-cell'))
+                .map((cell) => Math.round(cell.getBoundingClientRect().width))
+                .join(',');
+            const settled = state[stateKey] === widths;
+            state[stateKey] = widths;
+            return settled;
+        },
+        { animationClass: WIDTH_ANIMATION_CLASS, stateKey: '__agHeaderWidthSample' }
+    );
+}
+
 /**
  * Assert which row-id occupies a given `row-index` once the grid has settled after a sort.
  *

--- a/packages/ag-grid-angular/projects/ag-grid-angular/src/lib/ag-grid-angular.component.ts
+++ b/packages/ag-grid-angular/projects/ag-grid-angular/src/lib/ag-grid-angular.component.ts
@@ -684,7 +684,7 @@ export class AgGridAngular<TData = any, TColDef extends ColDef<TData> = ColDef<a
      */
     @Input({ transform: booleanAttribute }) public skipHeaderOnAutoSize: boolean | undefined = undefined;
     /** Auto-size the columns when the grid is loaded. Can size to fit the grid width, fit a provided width, or fit the cell contents.
-     * @initial
+     * Provide `events` to re-run the strategy when those grid events fire, and use `api.applyAutoSizeStrategy()` to re-run it on demand.
      * @agModule `ColumnAutoSizeModule`
      */
     @Input() public autoSizeStrategy: AutoSizeStrategy | undefined = undefined;

--- a/packages/ag-grid-community/src/api/gridApi.ts
+++ b/packages/ag-grid-community/src/api/gridApi.ts
@@ -649,6 +649,13 @@ export interface _ColumnAutosizeApi {
      * @agModule `ColumnAutoSizeModule`
      */
     autoSizeAllColumns(params: ISizeAllColumnsToContentParams): void;
+
+    /**
+     * Re-applies the configured `autoSizeStrategy`, including to columns the user has resized by hand.
+     * Does nothing if no `autoSizeStrategy` is configured.
+     * @agModule `ColumnAutoSizeModule`
+     */
+    applyAutoSizeStrategy(): void;
 }
 
 export interface _ColumnResizeApi {

--- a/packages/ag-grid-community/src/api/gridApiFunctions.ts
+++ b/packages/ag-grid-community/src/api/gridApiFunctions.ts
@@ -197,6 +197,7 @@ export const gridApiFunctionsMap: Record<keyof GridApi, ValidationModuleName> = 
         sizeColumnsToFit: 0,
         autoSizeColumns: 0,
         autoSizeAllColumns: 0,
+        applyAutoSizeStrategy: 0,
     }),
     ...mod<_ColumnGroupGridApi>('ColumnGroup', {
         setColumnGroupOpened: 0,

--- a/packages/ag-grid-community/src/columnAutosize/columnAutosizeApi.ts
+++ b/packages/ag-grid-community/src/columnAutosize/columnAutosizeApi.ts
@@ -6,6 +6,10 @@ import type {
     ISizeColumnsToFitParams,
 } from '../interfaces/autoSize';
 
+export function applyAutoSizeStrategy(beans: BeanCollection): void {
+    beans.colAutosize?.applyAutoSizeStrategy();
+}
+
 export function sizeColumnsToFit(beans: BeanCollection, paramsOrGridWidth?: ISizeColumnsToFitParams | number) {
     if (typeof paramsOrGridWidth === 'number') {
         beans.colAutosize?.sizeColumnsToFit(paramsOrGridWidth, 'api');

--- a/packages/ag-grid-community/src/columnAutosize/columnAutosizeModule.ts
+++ b/packages/ag-grid-community/src/columnAutosize/columnAutosizeModule.ts
@@ -3,7 +3,7 @@ import type { _ModuleWithApi } from '../interfaces/iModule';
 import { AutoWidthModule } from '../rendering/autoWidthModule';
 import { VERSION } from '../version';
 import columnAutoSizeCSS from './columnAutoSize.css';
-import { autoSizeAllColumns, autoSizeColumns, sizeColumnsToFit } from './columnAutosizeApi';
+import { applyAutoSizeStrategy, autoSizeAllColumns, autoSizeColumns, sizeColumnsToFit } from './columnAutosizeApi';
 import { ColumnAutosizeService } from './columnAutosizeService';
 
 /**
@@ -18,6 +18,7 @@ export const ColumnAutoSizeModule: _ModuleWithApi<_ColumnAutosizeApi> = {
         sizeColumnsToFit,
         autoSizeColumns,
         autoSizeAllColumns,
+        applyAutoSizeStrategy,
     },
     dependsOn: [AutoWidthModule],
     css: [columnAutoSizeCSS],

--- a/packages/ag-grid-community/src/columnAutosize/columnAutosizeService.ts
+++ b/packages/ag-grid-community/src/columnAutosize/columnAutosizeService.ts
@@ -40,15 +40,39 @@ interface AutoSizeColumnParams {
 
 type UiActionAutoSizeParams = Omit<ISizeAllColumnsToContentParams, 'colIds'>;
 
-type AutoSizeAllColumnsParams = UiActionAutoSizeParams & Pick<AutoSizeColumnParams, 'source' | 'eventSource'>;
+type AutoSizeAllColumnsParams = UiActionAutoSizeParams &
+    Pick<AutoSizeColumnParams, 'source' | 'eventSource'> & {
+        /** Columns to leave at their current width, resolved after any deferred resize queue drains. */
+        excludeColIds?: Set<string>;
+    };
 
-type SizeColumnsToFitGridBodyParams = ISizeColumnsToFitParams & { colKeys?: ColKey[] };
+type SizeColumnsToFitParams = ISizeColumnsToFitParams & {
+    colKeys?: ColKey[];
+    onlyScaleUp?: boolean;
+    animate?: boolean;
+    /** Called once the sizing has actually been applied, which may be several timeouts later. */
+    onComplete?: () => void;
+};
 
-/** Width changes from this source mean the user has taken manual control of a column's width. */
-const USER_RESIZE_SOURCE: ColumnEventType = 'uiColumnResized';
-const STRATEGY_SOURCE: ColumnEventType = 'autoSizeStrategy';
+type SizeColumnsToFitGridBodyParams = ISizeColumnsToFitParams & Pick<SizeColumnsToFitParams, 'colKeys' | 'onComplete'>;
+
+/** The source a resize driven from the header UI reports; a finished one is a manual column width. */
+const UI_RESIZE_SOURCE: ColumnEventType = 'uiColumnResized';
+const STRATEGY_SOURCE: ColumnEventType = 'autosizeStrategy';
 /** Sources that mean a sizing pass caused the event, so a strategy re-run would chase its own tail. */
-const SIZING_SOURCES = new Set<string>([STRATEGY_SOURCE, 'autosizeColumns', 'sizeColumnsToFit']);
+// declared as `ColumnEventType` so a typo is caught, read as `string` because not every event's
+// `source` is a `ColumnEventType`
+const SIZING_SOURCES: ReadonlySet<string> = new Set<ColumnEventType>([
+    STRATEGY_SOURCE,
+    'autosizeColumns',
+    'sizeColumnsToFit',
+]);
+/** Back-to-back event-driven runs beyond this are a feedback loop, not a settling grid. */
+const MAX_CONSECUTIVE_STRATEGY_RUNS = 10;
+/** A run whose sizing never lands must not silence event-driven re-runs for the grid's lifetime. */
+const STRATEGY_RUN_TIMEOUT = 5000;
+/** Longer than the re-run debounce, so a run's own echo lands inside the chain rather than after it. */
+const STRATEGY_QUIET_DELAY = 100;
 
 export class ColumnAutosizeService extends BeanStub implements NamedBean {
     beanName = 'colAutosize' as const;
@@ -63,19 +87,33 @@ export class ColumnAutosizeService extends BeanStub implements NamedBean {
     private readonly userResizedColIds = new Set<string>();
     /** Non-zero while strategy runs are in flight; a run can be queued, so this outlives the tick. */
     private strategyRunsInFlight = 0;
-    /** A trigger that arrived while a run was still in flight, to be honoured once it finishes. */
-    private strategyRerunPending = false;
+    /** Event-driven runs since the grid last went quiet, so a feedback loop can be broken. */
+    private consecutiveStrategyRuns = 0;
+    private strategyRunsCapped = false;
+    /** Bumped when a stalled run is force-released, so the run's own late release is ignored. */
+    private strategyRunGeneration = 0;
+    private strategyQuietTimeout?: number;
+    private strategyWatchdogTimeout?: number;
+    /** True while a UI auto-size gesture dispatches its resize events, which are not manual widths. */
+    private withinUiAutoSize = false;
     private removeStrategyEventListeners?: () => void;
 
     private readonly scheduleStrategyRerun = _debounce(
         this,
         () => {
-            // a run whose sizing is still to come (queued, or awaiting a render) would not observe the
-            // change that triggered us, so hold the trigger rather than dropping it
+            // a run dispatches the very events that can trigger it, so anything arriving before the
+            // previous run has finished sizing is that run's own echo
             if (this.strategyRunsInFlight > 0) {
-                this.strategyRerunPending = true;
                 return;
             }
+            if (this.consecutiveStrategyRuns >= MAX_CONSECUTIVE_STRATEGY_RUNS) {
+                if (!this.strategyRunsCapped) {
+                    this.strategyRunsCapped = true;
+                    this.warn(326, { events: this.gos.get('autoSizeStrategy')?.events ?? [] });
+                }
+                return;
+            }
+            this.consecutiveStrategyRuns++;
             const strategy = this.gos.get('autoSizeStrategy');
             if (strategy) {
                 this.applyStrategy(strategy, STRATEGY_SOURCE);
@@ -109,24 +147,43 @@ export class ColumnAutosizeService extends BeanStub implements NamedBean {
 
         this.addManagedEventListeners({
             columnResized: ({ finished, source, columns }) => {
-                if (!finished || source !== USER_RESIZE_SOURCE || !columns) {
+                if (this.withinUiAutoSize || !finished || source !== UI_RESIZE_SOURCE || !columns) {
                     return;
                 }
                 const userResizedColIds = this.userResizedColIds;
-                for (const column of columns) {
-                    userResizedColIds.add(column.getColId());
+                for (let i = 0, len = columns.length; i < len; ++i) {
+                    userResizedColIds.add(columns[i].getColId());
                 }
             },
+            // a colId dropped by new column defs would otherwise leak, and come back pre-excluded
+            gridColumnsChanged: () => this.pruneUserResizedColIds(),
         });
 
         this.addManagedPropertyListener('autoSizeStrategy', ({ currentValue, previousValue }) => {
             // object-valued options re-fire on every framework re-render, so only act on a real change
-            if (_jsonEquals(currentValue, previousValue)) {
+            if (autoSizeStrategiesEqual(currentValue, previousValue)) {
                 return;
             }
             this.setupStrategyRerun(currentValue);
-            this.applyAutoSizeStrategy();
+            if (currentValue) {
+                // manual widths survive an option update; only the explicit API call reclaims them
+                this.applyStrategy(currentValue, STRATEGY_SOURCE);
+            }
         });
+    }
+
+    /** Drops ids of columns that no longer exist, so a later column reusing an id is not pre-excluded. */
+    private pruneUserResizedColIds(): void {
+        const userResizedColIds = this.userResizedColIds;
+        if (!userResizedColIds.size) {
+            return;
+        }
+        const { colModel } = this.beans;
+        for (const colId of userResizedColIds) {
+            if (!colModel.getCol(colId)) {
+                userResizedColIds.delete(colId);
+            }
+        }
     }
 
     private setupStrategyRerun(strategy: AutoSizeStrategy | undefined): void {
@@ -146,8 +203,14 @@ export class ColumnAutosizeService extends BeanStub implements NamedBean {
             }
             this.scheduleStrategyRerun();
         };
+        // `fitCellContents` already sizes on first data render, so listening would run a second pass
+        const alreadyRunOnFirstDataRendered = strategy?.type === 'fitCellContents';
         for (let i = 0, len = events.length; i < len; ++i) {
-            handlers[events[i]] = onEvent;
+            const event = events[i];
+            if (event === 'firstDataRendered' && alreadyRunOnFirstDataRendered) {
+                continue;
+            }
+            handlers[event] = onEvent;
         }
 
         const destroyFuncs = this.addManagedEventListeners(handlers);
@@ -173,27 +236,40 @@ export class ColumnAutosizeService extends BeanStub implements NamedBean {
      * application keeps reporting the sources it always has.
      */
     private applyStrategy(strategy: AutoSizeStrategy, eventSource?: ColumnEventType): void {
+        if (this.strategyRunsInFlight === 0) {
+            this.strategyWatchdogTimeout = window.setTimeout(
+                () => this.releaseStalledStrategyRuns(),
+                STRATEGY_RUN_TIMEOUT
+            );
+        }
         this.strategyRunsInFlight++;
-        const release = () => this.finishStrategyRun();
+        const generation = this.strategyRunGeneration;
+        let released = false;
+        const release = () => {
+            if (released || generation !== this.strategyRunGeneration) {
+                return;
+            }
+            released = true;
+            this.finishStrategyRun();
+        };
 
         const type = strategy.type;
         if (type === 'fitCellContents') {
             const { colIds, skipHeader, columnLimits, defaultMinWidth, defaultMaxWidth, scaleUpToFitGridWidth } =
                 strategy;
-            const params: AutoSizeAllColumnsParams = {
+            const params = {
                 skipHeader,
                 columnLimits,
                 defaultMinWidth,
                 defaultMaxWidth,
                 scaleUpToFitGridWidth,
-                source: 'autosizeColumns',
+                source: 'autosizeColumns' as ColumnEventType,
                 eventSource,
             };
-            // autoSizeAllColumns resolves the column list after any deferred resize queue drains
-            const sized =
-                colIds || this.userResizedColIds.size
-                    ? this.autoSizeCols({ ...params, colKeys: this.strategyColKeys(colIds) })
-                    : this.autoSizeAllColumns(params);
+            // autoSizeAllColumns resolves the column list, and the exclusions, after any queue drains
+            const sized = colIds
+                ? this.autoSizeCols({ ...params, colKeys: this.strategyColKeys(colIds) })
+                : this.autoSizeAllColumns({ ...params, excludeColIds: this.userResizedColIds });
             sized.then(release, release);
             return;
         }
@@ -212,26 +288,46 @@ export class ColumnAutosizeService extends BeanStub implements NamedBean {
                         maxWidth,
                     })),
                     colKeys,
+                    onComplete: release,
                 },
                 undefined,
                 source
             );
         } else {
-            this.sizeColumnsToFit(strategy.width, source, false, { colKeys });
+            this.sizeColumnsToFit(strategy.width, source, false, { colKeys, onComplete: release });
         }
-        release();
+    }
+
+    /** Ends a run, and starts the timer that decides whether the next run belongs to the same chain. */
+    private finishStrategyRun(): void {
+        this.strategyRunsInFlight--;
+        if (this.strategyRunsInFlight > 0) {
+            return;
+        }
+        clearTimeout(this.strategyWatchdogTimeout);
+        if (!this.isAlive()) {
+            return;
+        }
+        clearTimeout(this.strategyQuietTimeout);
+        this.strategyQuietTimeout = window.setTimeout(() => {
+            this.consecutiveStrategyRuns = 0;
+            this.strategyRunsCapped = false;
+        }, STRATEGY_QUIET_DELAY);
     }
 
     /**
-     * Ends a run, then honours any trigger held while it was in flight — a run whose sizing was
-     * queued never observed the change that held the trigger, so it needs a run of its own.
+     * A sizing pass that never reports completion — its deferred resize queue never drained, say —
+     * would leave the re-entrancy fence closed for the grid's lifetime, silently.
      */
-    private finishStrategyRun(): void {
-        this.strategyRunsInFlight--;
-        if (this.strategyRerunPending && this.strategyRunsInFlight === 0) {
-            this.strategyRerunPending = false;
-            this.scheduleStrategyRerun();
+    private releaseStalledStrategyRuns(): void {
+        if (this.strategyRunsInFlight === 0) {
+            return;
         }
+        this.warn(327);
+        // a stalled run may still complete later; that release must not take the count negative
+        this.strategyRunGeneration++;
+        this.strategyRunsInFlight = 1;
+        this.finishStrategyRun();
     }
 
     /** The columns a strategy targets, minus any the user has since resized by hand. */
@@ -264,6 +360,16 @@ export class ColumnAutosizeService extends BeanStub implements NamedBean {
             defaultMaxWidth,
             scaleUpToFitGridWidth,
         };
+    }
+
+    /**
+     * As {@link getUiActionAutoSizeParams}, minus `scaleUpToFitGridWidth` — spreading the grid's spare
+     * width over a single column, or one group, would leave it far wider than its contents.
+     */
+    private getUiActionColAutoSizeParams(): UiActionAutoSizeParams {
+        const params = this.getUiActionAutoSizeParams();
+        params.scaleUpToFitGridWidth = undefined;
+        return params;
     }
 
     public autoSizeCols(params: AutoSizeColumnParams): Promise<void> {
@@ -420,7 +526,7 @@ export class ColumnAutosizeService extends BeanStub implements NamedBean {
 
     /** Auto-sizes a single column for a built-in UI action. */
     public autoSizeColumn(key: ColKey, source: ColumnEventType): void {
-        this.autoSizeCols({ ...this.getUiActionAutoSizeParams(), colKeys: [key], skipHeaderGroups: true, source });
+        this.autoSizeCols({ ...this.getUiActionColAutoSizeParams(), colKeys: [key], skipHeaderGroups: true, source });
     }
 
     private autoSizeColumnGroupsByColumns(keys: ColKey[], source: ColumnEventType, stopAtGroup?: AgColumnGroup): void {
@@ -458,12 +564,15 @@ export class ColumnAutosizeService extends BeanStub implements NamedBean {
             });
         }
 
-        return this.autoSizeCols({ colKeys: this.beans.visibleCols.allCols, ...params });
+        const { excludeColIds, ...autoSizeParams } = params;
+        const allCols = this.beans.visibleCols.allCols;
+        const colKeys = excludeColIds?.size ? allCols.filter((col) => !excludeColIds.has(col.colId)) : allCols;
+        return this.autoSizeCols({ colKeys, ...autoSizeParams });
     }
 
     public addColumnAutosizeListeners(element: HTMLElement, column: AgColumn): () => void {
         const autoSizeColListener = () => {
-            this.autoSizeColumn(column, 'uiColumnResized');
+            this.autoSizeColumn(column, UI_RESIZE_SOURCE);
         };
 
         element.addEventListener('dblclick', autoSizeColListener);
@@ -491,14 +600,21 @@ export class ColumnAutosizeService extends BeanStub implements NamedBean {
 
             if (keys.length > 0) {
                 this.autoSizeCols({
-                    ...this.getUiActionAutoSizeParams(),
+                    ...this.getUiActionColAutoSizeParams(),
                     colKeys: keys,
                     stopAtGroup: columnGroup,
-                    source: 'uiColumnResized',
+                    source: UI_RESIZE_SOURCE,
                 });
             }
 
-            callback();
+            // the callback fits the group's leaves, reporting `uiColumnResized` — an auto-size gesture,
+            // not a width the user chose, so it must not mark the columns as manually resized
+            this.withinUiAutoSize = true;
+            try {
+                callback();
+            } finally {
+                this.withinUiAutoSize = false;
+            }
         };
 
         element.addEventListener('dblclick', listener);
@@ -549,6 +665,7 @@ export class ColumnAutosizeService extends BeanStub implements NamedBean {
         } else {
             // Grid coming back with zero width, maybe the grid is not visible yet on the screen?
             this.warn(29);
+            params?.onComplete?.();
         }
     }
 
@@ -557,13 +674,24 @@ export class ColumnAutosizeService extends BeanStub implements NamedBean {
         gridWidth: number,
         source: ColumnEventType = 'sizeColumnsToFit',
         silent?: boolean,
-        params?: ISizeColumnsToFitParams & { colKeys?: ColKey[]; onlyScaleUp?: boolean; animate?: boolean }
+        params?: SizeColumnsToFitParams
     ): void {
         if (this.shouldQueueResizeOperations) {
+            // the requeued call reports completion, so callers see the sizing that actually happened
             this.pushResizeOperation(() => this.sizeColumnsToFit(gridWidth, source, silent, params));
             return;
         }
 
+        this.sizeColumnsToFitNow(gridWidth, source, silent, params);
+        params?.onComplete?.();
+    }
+
+    private sizeColumnsToFitNow(
+        gridWidth: number,
+        source: ColumnEventType,
+        silent?: boolean,
+        params?: SizeColumnsToFitParams
+    ): void {
         const { beans } = this;
         const animate = params?.animate ?? true;
         if (animate) {
@@ -729,6 +857,8 @@ export class ColumnAutosizeService extends BeanStub implements NamedBean {
             return;
         }
         const type = strategy.type;
+        // `fitCellContents` has nothing to measure until the cells exist, so it runs from
+        // `onFirstDataRendered` instead
         if (type !== 'fitGridWidth' && type !== 'fitProvidedWidth') {
             return;
         }
@@ -769,8 +899,56 @@ export class ColumnAutosizeService extends BeanStub implements NamedBean {
 
     public override destroy(): void {
         this.resizeOperationQueue.length = 0;
+        clearTimeout(this.strategyQuietTimeout);
+        clearTimeout(this.strategyWatchdogTimeout);
         super.destroy();
     }
+}
+
+/** Every field an {@link AutoSizeStrategy} member can carry, flattened so two can be compared. */
+interface AutoSizeStrategyFields {
+    type?: string;
+    width?: number;
+    events?: readonly string[];
+    skipHeader?: boolean;
+    colIds?: readonly string[];
+    columnLimits?: readonly unknown[];
+    defaultMinWidth?: number;
+    defaultMaxWidth?: number;
+    scaleUpToFitGridWidth?: boolean;
+    applyToUiActions?: boolean;
+}
+
+const AUTO_SIZE_STRATEGY_KEYS: (keyof AutoSizeStrategyFields)[] = [
+    'type',
+    'width',
+    'events',
+    'skipHeader',
+    'colIds',
+    'columnLimits',
+    'defaultMinWidth',
+    'defaultMaxWidth',
+    'scaleUpToFitGridWidth',
+    'applyToUiActions',
+];
+
+/** Compares the known keys, so a framework wrapper re-passing them in another order is not a change. */
+function autoSizeStrategiesEqual(a?: AutoSizeStrategyFields, b?: AutoSizeStrategyFields): boolean {
+    if (a === b) {
+        return true;
+    }
+    if (!a || !b) {
+        return false;
+    }
+    for (let i = 0, len = AUTO_SIZE_STRATEGY_KEYS.length; i < len; ++i) {
+        const key = AUTO_SIZE_STRATEGY_KEYS[i];
+        const aValue = a[key];
+        const bValue = b[key];
+        if (aValue !== bValue && !_jsonEquals(aValue, bValue)) {
+            return false;
+        }
+    }
+    return true;
 }
 
 /** returns the width we can set to this col, taking into consideration min and max widths */
@@ -796,7 +974,7 @@ function normaliseColumnWidth(
 function getAvailableWidth({ ctrlsSvc, scrollVisibleSvc }: BeanCollection): number {
     const gridBodyCtrl = ctrlsSvc.getGridBodyCtrl();
     const removeScrollWidth = scrollVisibleSvc.isVerticalScrollShowing();
-    // the scrollbar width is unknown until the DOM can be measured; subtracting it then would give NaN
+    // `getScrollbarWidth` is null until the DOM can be measured; subtracting that would give NaN
     const scrollWidthToRemove = removeScrollWidth ? (scrollVisibleSvc.getScrollbarWidth() ?? 0) : 0;
     // bodyViewportWidth should be calculated from eGridBody, not eBodyViewport
     // because we change the width of the bodyViewport to hide the real browser scrollbar

--- a/packages/ag-grid-community/src/columnAutosize/columnAutosizeService.ts
+++ b/packages/ag-grid-community/src/columnAutosize/columnAutosizeService.ts
@@ -1,4 +1,4 @@
-import { _getInnerWidth, _removeFromArray } from 'ag-stack';
+import { _debounce, _getInnerWidth, _jsonEquals, _removeFromArray } from 'ag-stack';
 
 import { dispatchColumnResizedEvent } from '../columns/columnEventUtils';
 import { getWidthOfColsInList, isSpecialCol } from '../columns/columnUtils';
@@ -8,11 +8,14 @@ import type { BeanCollection } from '../context/context';
 import type { AgColumn } from '../entities/agColumn';
 import type { AgColumnGroup } from '../entities/agColumnGroup';
 import type { ColKey } from '../entities/colDef';
-import type { ColumnEventType } from '../events';
+import type { AgEventTypeParams, ColumnEventType } from '../events';
 import { _isClientSideRowModel } from '../gridOptionsUtils';
 import type { HeaderGroupCellCtrl } from '../headerRendering/cells/columnGroup/headerGroupCellCtrl';
 import type {
+    AutoSizeStrategy,
+    AutoSizeStrategyEvent,
     IColumnLimit,
+    ISizeAllColumnsToContentParams,
     ISizeColumnsToFitParams,
     SizeColumnsToContentColumnLimits,
     SizeColumnsToContentStrategy,
@@ -31,7 +34,21 @@ interface AutoSizeColumnParams {
     columnLimits?: SizeColumnsToContentColumnLimits[];
     scaleUpToFitGridWidth?: boolean;
     source?: ColumnEventType;
+    /** Source reported by the resulting `columnResized` event. Defaults to `autosizeColumns`. */
+    eventSource?: ColumnEventType;
 }
+
+type UiActionAutoSizeParams = Omit<ISizeAllColumnsToContentParams, 'colIds'>;
+
+type AutoSizeAllColumnsParams = UiActionAutoSizeParams & Pick<AutoSizeColumnParams, 'source' | 'eventSource'>;
+
+type SizeColumnsToFitGridBodyParams = ISizeColumnsToFitParams & { colKeys?: ColKey[] };
+
+/** Width changes from this source mean the user has taken manual control of a column's width. */
+const USER_RESIZE_SOURCE: ColumnEventType = 'uiColumnResized';
+const STRATEGY_SOURCE: ColumnEventType = 'autoSizeStrategy';
+/** Sources that mean a sizing pass caused the event, so a strategy re-run would chase its own tail. */
+const SIZING_SOURCES = new Set<string>([STRATEGY_SOURCE, 'autosizeColumns', 'sizeColumnsToFit']);
 
 export class ColumnAutosizeService extends BeanStub implements NamedBean {
     beanName = 'colAutosize' as const;
@@ -41,6 +58,31 @@ export class ColumnAutosizeService extends BeanStub implements NamedBean {
     /** when we're waiting for cell data types to be inferred, we need to defer column resizing */
     public shouldQueueResizeOperations: boolean = false;
     private resizeOperationQueue: (() => void)[] = [];
+
+    /** Columns the user has resized by hand, which strategy re-runs leave at their manual width. */
+    private readonly userResizedColIds = new Set<string>();
+    /** Non-zero while strategy runs are in flight; a run can be queued, so this outlives the tick. */
+    private strategyRunsInFlight = 0;
+    /** A trigger that arrived while a run was still in flight, to be honoured once it finishes. */
+    private strategyRerunPending = false;
+    private removeStrategyEventListeners?: () => void;
+
+    private readonly scheduleStrategyRerun = _debounce(
+        this,
+        () => {
+            // a run whose sizing is still to come (queued, or awaiting a render) would not observe the
+            // change that triggered us, so hold the trigger rather than dropping it
+            if (this.strategyRunsInFlight > 0) {
+                this.strategyRerunPending = true;
+                return;
+            }
+            const strategy = this.gos.get('autoSizeStrategy');
+            if (strategy) {
+                this.applyStrategy(strategy, STRATEGY_SOURCE);
+            }
+        },
+        0
+    );
 
     public postConstruct(): void {
         const { gos } = this;
@@ -62,16 +104,176 @@ export class ColumnAutosizeService extends BeanStub implements NamedBean {
                 this.beans.colDelayRenderSvc?.hideColumns(type);
             }
         }
+
+        this.setupStrategyRerun(autoSizeStrategy);
+
+        this.addManagedEventListeners({
+            columnResized: ({ finished, source, columns }) => {
+                if (!finished || source !== USER_RESIZE_SOURCE || !columns) {
+                    return;
+                }
+                const userResizedColIds = this.userResizedColIds;
+                for (const column of columns) {
+                    userResizedColIds.add(column.getColId());
+                }
+            },
+        });
+
+        this.addManagedPropertyListener('autoSizeStrategy', ({ currentValue, previousValue }) => {
+            // object-valued options re-fire on every framework re-render, so only act on a real change
+            if (_jsonEquals(currentValue, previousValue)) {
+                return;
+            }
+            this.setupStrategyRerun(currentValue);
+            this.applyAutoSizeStrategy();
+        });
     }
 
-    public autoSizeCols(params: AutoSizeColumnParams): void {
+    private setupStrategyRerun(strategy: AutoSizeStrategy | undefined): void {
+        this.removeStrategyEventListeners?.();
+        this.removeStrategyEventListeners = undefined;
+
+        const events = strategy?.events;
+        if (!events?.length) {
+            return;
+        }
+
+        const handlers: { [K in AutoSizeStrategyEvent]?: (event: AgEventTypeParams[K]) => void } = {};
+        const onEvent = (event: AgEventTypeParams[AutoSizeStrategyEvent]) => {
+            // a run re-dispatches column events long after it finishes; re-running for those never settles
+            if ('source' in event && event.source != null && SIZING_SOURCES.has(event.source)) {
+                return;
+            }
+            this.scheduleStrategyRerun();
+        };
+        for (let i = 0, len = events.length; i < len; ++i) {
+            handlers[events[i]] = onEvent;
+        }
+
+        const destroyFuncs = this.addManagedEventListeners(handlers);
+        this.removeStrategyEventListeners = () => {
+            for (let i = 0, len = destroyFuncs.length; i < len; ++i) {
+                destroyFuncs[i]();
+            }
+        };
+    }
+
+    /** Re-applies the configured strategy, reclaiming columns the user had resized by hand. */
+    public applyAutoSizeStrategy(): void {
+        const strategy = this.gos.get('autoSizeStrategy');
+        if (!strategy) {
+            return;
+        }
+        this.userResizedColIds.clear();
+        this.applyStrategy(strategy, STRATEGY_SOURCE);
+    }
+
+    /**
+     * Sizes columns per the given strategy. `eventSource` is only set for re-runs, so the initial
+     * application keeps reporting the sources it always has.
+     */
+    private applyStrategy(strategy: AutoSizeStrategy, eventSource?: ColumnEventType): void {
+        this.strategyRunsInFlight++;
+        const release = () => this.finishStrategyRun();
+
+        const type = strategy.type;
+        if (type === 'fitCellContents') {
+            const { colIds, skipHeader, columnLimits, defaultMinWidth, defaultMaxWidth, scaleUpToFitGridWidth } =
+                strategy;
+            const params: AutoSizeAllColumnsParams = {
+                skipHeader,
+                columnLimits,
+                defaultMinWidth,
+                defaultMaxWidth,
+                scaleUpToFitGridWidth,
+                source: 'autosizeColumns',
+                eventSource,
+            };
+            // autoSizeAllColumns resolves the column list after any deferred resize queue drains
+            const sized =
+                colIds || this.userResizedColIds.size
+                    ? this.autoSizeCols({ ...params, colKeys: this.strategyColKeys(colIds) })
+                    : this.autoSizeAllColumns(params);
+            sized.then(release, release);
+            return;
+        }
+
+        const source = eventSource ?? 'sizeColumnsToFit';
+        const colKeys = this.userResizedColIds.size ? this.strategyColKeys() : undefined;
+        if (type === 'fitGridWidth') {
+            const { columnLimits: propColumnLimits, defaultMinWidth, defaultMaxWidth } = strategy;
+            this.sizeColumnsToFitGridBody(
+                {
+                    defaultMinWidth,
+                    defaultMaxWidth,
+                    columnLimits: propColumnLimits?.map(({ colId: key, minWidth, maxWidth }) => ({
+                        key,
+                        minWidth,
+                        maxWidth,
+                    })),
+                    colKeys,
+                },
+                undefined,
+                source
+            );
+        } else {
+            this.sizeColumnsToFit(strategy.width, source, false, { colKeys });
+        }
+        release();
+    }
+
+    /**
+     * Ends a run, then honours any trigger held while it was in flight — a run whose sizing was
+     * queued never observed the change that held the trigger, so it needs a run of its own.
+     */
+    private finishStrategyRun(): void {
+        this.strategyRunsInFlight--;
+        if (this.strategyRerunPending && this.strategyRunsInFlight === 0) {
+            this.strategyRerunPending = false;
+            this.scheduleStrategyRerun();
+        }
+    }
+
+    /** The columns a strategy targets, minus any the user has since resized by hand. */
+    private strategyColKeys(colIds?: string[]): AgColumn[] {
+        const { colModel, visibleCols } = this.beans;
+        const cols = colIds
+            ? colIds.map((colId) => colModel.getCol(colId)).filter((col): col is AgColumn => col != null)
+            : visibleCols.allCols;
+        const userResizedColIds = this.userResizedColIds;
+        return userResizedColIds.size ? cols.filter((col) => !userResizedColIds.has(col.colId)) : cols;
+    }
+
+    /**
+     * Auto-size params for the built-in UI actions — the column and context menu items, and header
+     * double-click. These reuse `autoSizeStrategy` only when it has opted in via `applyToUiActions`.
+     */
+    public getUiActionAutoSizeParams(): UiActionAutoSizeParams {
+        const { gos } = this;
+        const skipHeader = gos.get('skipHeaderOnAutoSize');
+        const strategy = gos.get('autoSizeStrategy');
+        if (strategy?.type !== 'fitCellContents' || !strategy.applyToUiActions) {
+            return { skipHeader };
+        }
+
+        const { columnLimits, defaultMinWidth, defaultMaxWidth, scaleUpToFitGridWidth } = strategy;
+        return {
+            skipHeader: strategy.skipHeader ?? skipHeader,
+            columnLimits,
+            defaultMinWidth,
+            defaultMaxWidth,
+            scaleUpToFitGridWidth,
+        };
+    }
+
+    public autoSizeCols(params: AutoSizeColumnParams): Promise<void> {
         const { eventSvc, colModel } = this.beans;
 
         setWidthAnimation(this.beans, true);
 
-        this.innerAutoSizeCols(params).then((columnsAutoSized) => {
+        return this.innerAutoSizeCols(params).then((columnsAutoSized) => {
             const dispatch = (cols: Set<AgColumn>) =>
-                dispatchColumnResizedEvent(eventSvc, Array.from(cols), true, 'autosizeColumns');
+                dispatchColumnResizedEvent(eventSvc, Array.from(cols), true, params.eventSource ?? 'autosizeColumns');
 
             if (!params.scaleUpToFitGridWidth) {
                 setWidthAnimation(this.beans, false);
@@ -216,8 +418,9 @@ export class ColumnAutosizeService extends BeanStub implements NamedBean {
         });
     }
 
-    public autoSizeColumn(key: ColKey, source: ColumnEventType, skipHeader?: boolean): void {
-        this.autoSizeCols({ colKeys: [key], skipHeader, skipHeaderGroups: true, source });
+    /** Auto-sizes a single column for a built-in UI action. */
+    public autoSizeColumn(key: ColKey, source: ColumnEventType): void {
+        this.autoSizeCols({ ...this.getUiActionAutoSizeParams(), colKeys: [key], skipHeaderGroups: true, source });
     }
 
     private autoSizeColumnGroupsByColumns(keys: ColKey[], source: ColumnEventType, stopAtGroup?: AgColumnGroup): void {
@@ -248,26 +451,19 @@ export class ColumnAutosizeService extends BeanStub implements NamedBean {
         }
     }
 
-    public autoSizeAllColumns(params: {
-        skipHeader?: boolean;
-        defaultMinWidth?: number;
-        defaultMaxWidth?: number;
-        columnLimits?: SizeColumnsToContentColumnLimits[];
-        source?: ColumnEventType;
-    }): void {
+    public autoSizeAllColumns(params: AutoSizeAllColumnsParams): Promise<void> {
         if (this.shouldQueueResizeOperations) {
-            this.pushResizeOperation(() => this.autoSizeAllColumns(params));
-            return;
+            return new Promise((resolve, reject) => {
+                this.pushResizeOperation(() => this.autoSizeAllColumns(params).then(resolve, reject));
+            });
         }
 
-        this.autoSizeCols({ colKeys: this.beans.visibleCols.allCols, ...params });
+        return this.autoSizeCols({ colKeys: this.beans.visibleCols.allCols, ...params });
     }
 
     public addColumnAutosizeListeners(element: HTMLElement, column: AgColumn): () => void {
-        const skipHeaderOnAutoSize = this.gos.get('skipHeaderOnAutoSize');
-
         const autoSizeColListener = () => {
-            this.autoSizeColumn(column, 'uiColumnResized', skipHeaderOnAutoSize);
+            this.autoSizeColumn(column, 'uiColumnResized');
         };
 
         element.addEventListener('dblclick', autoSizeColListener);
@@ -281,8 +477,6 @@ export class ColumnAutosizeService extends BeanStub implements NamedBean {
     }
 
     public addColumnGroupResize(element: HTMLElement, columnGroup: AgColumnGroup, callback: () => void): () => void {
-        const skipHeaderOnAutoSize = this.gos.get('skipHeaderOnAutoSize');
-
         const listener = () => {
             // get list of all the column keys we are responsible for
             const keys: string[] = [];
@@ -297,8 +491,8 @@ export class ColumnAutosizeService extends BeanStub implements NamedBean {
 
             if (keys.length > 0) {
                 this.autoSizeCols({
+                    ...this.getUiActionAutoSizeParams(),
                     colKeys: keys,
-                    skipHeader: skipHeaderOnAutoSize,
                     stopAtGroup: columnGroup,
                     source: 'uiColumnResized',
                 });
@@ -314,7 +508,11 @@ export class ColumnAutosizeService extends BeanStub implements NamedBean {
 
     // method will call itself if no available width. this covers if the grid
     // isn't visible, but is just about to be visible.
-    public sizeColumnsToFitGridBody(params?: ISizeColumnsToFitParams, nextTimeout?: number): void {
+    public sizeColumnsToFitGridBody(
+        params?: SizeColumnsToFitGridBodyParams,
+        nextTimeout?: number,
+        source: ColumnEventType = 'sizeColumnsToFit'
+    ): void {
         if (!this.isAlive()) {
             return;
         }
@@ -329,24 +527,24 @@ export class ColumnAutosizeService extends BeanStub implements NamedBean {
         }
 
         if (availableWidth > 0) {
-            this.sizeColumnsToFit(availableWidth, 'sizeColumnsToFit', false, params);
+            this.sizeColumnsToFit(availableWidth, source, false, params);
             return;
         }
 
         if (nextTimeout === undefined) {
             window.setTimeout(() => {
-                this.sizeColumnsToFitGridBody(params, 100);
+                this.sizeColumnsToFitGridBody(params, 100, source);
             }, 0);
         } else if (nextTimeout === 100) {
             window.setTimeout(() => {
-                this.sizeColumnsToFitGridBody(params, 500);
+                this.sizeColumnsToFitGridBody(params, 500, source);
             }, 100);
         } else if (nextTimeout === 500) {
             // IMPORTANT! in gridCtrl we add content-visibility:auto `contentVisibilityAutoDelay` ms (default 1000) after
             // first rendering data to avoid breaking size-to-fit. We're relying on the maximum timeout here being less
             // than the default 1000ms. If you increase this timeout, update the default `contentVisibilityAutoDelay` too.
             window.setTimeout(() => {
-                this.sizeColumnsToFitGridBody(params, -1);
+                this.sizeColumnsToFitGridBody(params, -1, source);
             }, 500);
         } else {
             // Grid coming back with zero width, maybe the grid is not visible yet on the screen?
@@ -380,7 +578,8 @@ export class ColumnAutosizeService extends BeanStub implements NamedBean {
         // avoid divide by zero
         const allDisplayedColumns = beans.visibleCols.allCols;
 
-        if (gridWidth <= 0 || !allDisplayedColumns.length) {
+        // a non-finite width comes from an unmeasurable grid body, and would spread NaN column widths
+        if (gridWidth <= 0 || !Number.isFinite(gridWidth) || !allDisplayedColumns.length) {
             return;
         }
 
@@ -524,10 +723,13 @@ export class ColumnAutosizeService extends BeanStub implements NamedBean {
         }
     }
 
-    public applyAutosizeStrategy(): void {
-        const { gos, colDelayRenderSvc } = this.beans;
-        const autoSizeStrategy = gos.get('autoSizeStrategy');
-        if (autoSizeStrategy?.type !== 'fitGridWidth' && autoSizeStrategy?.type !== 'fitProvidedWidth') {
+    public applyInitialAutoSizeStrategy(): void {
+        const strategy = this.gos.get('autoSizeStrategy');
+        if (!strategy) {
+            return;
+        }
+        const type = strategy.type;
+        if (type !== 'fitGridWidth' && type !== 'fitProvidedWidth') {
             return;
         }
 
@@ -536,40 +738,19 @@ export class ColumnAutosizeService extends BeanStub implements NamedBean {
             if (!this.isAlive()) {
                 return;
             }
-            const type = autoSizeStrategy.type;
-            if (type === 'fitGridWidth') {
-                const { columnLimits: propColumnLimits, defaultMinWidth, defaultMaxWidth } = autoSizeStrategy;
-                const columnLimits = propColumnLimits?.map(({ colId: key, minWidth, maxWidth }) => ({
-                    key,
-                    minWidth,
-                    maxWidth,
-                }));
-                this.sizeColumnsToFitGridBody({
-                    defaultMinWidth,
-                    defaultMaxWidth,
-                    columnLimits,
-                });
-            } else if (type === 'fitProvidedWidth') {
-                this.sizeColumnsToFit(autoSizeStrategy.width, 'sizeColumnsToFit');
-            }
-            colDelayRenderSvc?.revealColumns(type);
+            this.applyStrategy(strategy);
+            this.beans.colDelayRenderSvc?.revealColumns(type);
         });
     }
 
-    private onFirstDataRendered({ colIds: colKeys, ...params }: SizeColumnsToContentStrategy): void {
+    private onFirstDataRendered(strategy: SizeColumnsToContentStrategy): void {
         // ensure render has finished
         setTimeout(() => {
             if (!this.isAlive()) {
                 return;
             }
-            const source = 'autosizeColumns';
-
-            if (colKeys) {
-                this.autoSizeCols({ ...params, source, colKeys });
-            } else {
-                this.autoSizeAllColumns({ ...params, source });
-            }
-            this.beans.colDelayRenderSvc?.revealColumns(params.type);
+            this.applyStrategy(strategy);
+            this.beans.colDelayRenderSvc?.revealColumns(strategy.type);
         });
     }
 
@@ -615,7 +796,8 @@ function normaliseColumnWidth(
 function getAvailableWidth({ ctrlsSvc, scrollVisibleSvc }: BeanCollection): number {
     const gridBodyCtrl = ctrlsSvc.getGridBodyCtrl();
     const removeScrollWidth = scrollVisibleSvc.isVerticalScrollShowing();
-    const scrollWidthToRemove = removeScrollWidth ? scrollVisibleSvc.getScrollbarWidth() : 0;
+    // the scrollbar width is unknown until the DOM can be measured; subtracting it then would give NaN
+    const scrollWidthToRemove = removeScrollWidth ? (scrollVisibleSvc.getScrollbarWidth() ?? 0) : 0;
     // bodyViewportWidth should be calculated from eGridBody, not eBodyViewport
     // because we change the width of the bodyViewport to hide the real browser scrollbar
     const bodyViewportWidth = _getInnerWidth(gridBodyCtrl.eGridBody);

--- a/packages/ag-grid-community/src/columnAutosize/columnAutosizeService.ts
+++ b/packages/ag-grid-community/src/columnAutosize/columnAutosizeService.ts
@@ -56,6 +56,20 @@ type SizeColumnsToFitParams = ISizeColumnsToFitParams & {
 
 type SizeColumnsToFitGridBodyParams = ISizeColumnsToFitParams & Pick<SizeColumnsToFitParams, 'colKeys' | 'onComplete'>;
 
+/** Per-column width limits for a `sizeColumnsToFit` run, keyed by col id. */
+type ColumnLimitsMap = { [colId: string]: Omit<IColumnLimit, 'key'> };
+
+interface SpreadColsParams {
+    gridWidth: number;
+    colsToSpread: AgColumn[];
+    colsToNotSpread: AgColumn[];
+    /** Widths captured before the reset, acting as minimums when `onlyScaleUp` is set. */
+    currentWidths: Partial<Record<string, number>>;
+    limitsMap: ColumnLimitsMap;
+    params: SizeColumnsToFitParams | undefined;
+    source: ColumnEventType;
+}
+
 /** The source a resize driven from the header UI reports; a finished one is a manual column width. */
 const UI_RESIZE_SOURCE: ColumnEventType = 'uiColumnResized';
 const STRATEGY_SOURCE: ColumnEventType = 'autosizeStrategy';
@@ -698,10 +712,7 @@ export class ColumnAutosizeService extends BeanStub implements NamedBean {
             setWidthAnimation(beans, true);
         }
 
-        const limitsMap: { [colId: string]: Omit<IColumnLimit, 'key'> } = Object.create(null);
-        for (const { key, ...dimensions } of params?.columnLimits ?? []) {
-            limitsMap[typeof key === 'string' ? key : key.getColId()] = dimensions;
-        }
+        const limitsMap = buildColumnLimitsMap(params?.columnLimits);
 
         // avoid divide by zero
         const allDisplayedColumns = beans.visibleCols.allCols;
@@ -717,122 +728,21 @@ export class ColumnAutosizeService extends BeanStub implements NamedBean {
             return;
         }
 
+        // if all columns fit, check they are within the min and max widths - if so, can quit early.
         const doColumnsAlreadyFit = gridWidth === currentTotalColumnWidth;
-        if (doColumnsAlreadyFit) {
-            // if all columns fit, check they are within the min and max widths - if so, can quit early.
-            const doAllColumnsSatisfyConstraints = allDisplayedColumns.every((column) => {
-                if (column.colDef.suppressSizeToFit) {
-                    return true;
-                }
-                const widthOverride = limitsMap?.[column.getId()];
-                const minWidth = widthOverride?.minWidth ?? params?.defaultMinWidth;
-                const maxWidth = widthOverride?.maxWidth ?? params?.defaultMaxWidth;
-                const colWidth = column.getActualWidth();
-                return (minWidth == null || colWidth >= minWidth) && (maxWidth == null || colWidth <= maxWidth);
-            });
-            if (doAllColumnsSatisfyConstraints) {
-                return;
-            }
+        if (doColumnsAlreadyFit && allColsWithinLimits(allDisplayedColumns, limitsMap, params)) {
+            return;
         }
 
-        const colsToSpread: AgColumn[] = [];
-        const colsToNotSpread: AgColumn[] = [];
-
-        for (const column of allDisplayedColumns) {
-            const isIncluded = params?.colKeys?.some((key) => columnsMatch(column, key)) ?? true;
-            if (column.colDef.suppressSizeToFit || !isIncluded) {
-                colsToNotSpread.push(column);
-            } else {
-                colsToSpread.push(column);
-            }
-        }
+        const { colsToSpread, colsToNotSpread } = partitionColsToSpread(allDisplayedColumns, params);
 
         // make a copy of the cols that are going to be resized
         const colsToDispatchEventFor = colsToSpread.slice(0);
-        let finishedResizing = false;
 
-        const moveToNotSpread = (column: AgColumn) => {
-            _removeFromArray(colsToSpread, column);
-            colsToNotSpread.push(column);
-        };
+        const currentWidths = resetColsToLimits(colsToSpread, limitsMap, params, source);
+        spreadColsToFit({ gridWidth, colsToSpread, colsToNotSpread, currentWidths, limitsMap, params, source });
 
-        const currentWidths: Partial<Record<string, number>> = Object.create(null);
-
-        // resetting cols to their original width makes the sizeColumnsToFit more deterministic,
-        // rather than depending on the current size of the columns. most users call sizeColumnsToFit
-        // immediately after grid is created, so will make no difference. however if application is calling
-        // sizeColumnsToFit repeatedly (eg after column group is opened / closed repeatedly) we don't want
-        // the columns to start shrinking / growing over time.
-        for (const column of colsToSpread) {
-            if (params?.onlyScaleUp) {
-                // When `onlyScaleUp`, we store the current widths to act as a true minimum because we don't
-                // want any columns to get smaller
-                currentWidths[column.colId] = column.getActualWidth();
-            }
-            column.resetActualWidth(source);
-
-            const widthOverride = limitsMap?.[column.getId()];
-            const minOverride = widthOverride?.minWidth ?? params?.defaultMinWidth ?? -Infinity;
-            const maxOverride = widthOverride?.maxWidth ?? params?.defaultMaxWidth ?? Infinity;
-
-            const colWidth = column.getActualWidth();
-            const targetWidth = _clamp(colWidth, minOverride, maxOverride);
-
-            // NOTE: we assign values to `this.actualWidth` of each column without firing events
-            // for this reason we need to manually dispatch resize events after the resize has been done for each column.
-            if (targetWidth != colWidth) {
-                column.setActualWidth(targetWidth, source, true);
-            }
-        }
-
-        while (!finishedResizing) {
-            finishedResizing = true;
-            const availablePixels = gridWidth - getWidthOfColsInList(colsToNotSpread);
-            if (availablePixels <= 0) {
-                // no width, set everything to minimum
-                for (const column of colsToSpread) {
-                    const newWidth =
-                        limitsMap?.[column.getId()]?.minWidth ?? params?.defaultMinWidth ?? column.minWidth;
-                    column.setActualWidth(newWidth, source, true);
-                }
-            } else {
-                const scale = availablePixels / getWidthOfColsInList(colsToSpread);
-                // we set the pixels for the last col based on what's left, as otherwise
-                // we could be a pixel or two short or extra because of rounding errors.
-                let pixelsForLastCol = availablePixels;
-                // backwards through loop, as we are removing items as we go
-                for (let i = colsToSpread.length - 1; i >= 0; i--) {
-                    const column = colsToSpread[i];
-
-                    const id = column.colId;
-                    const prevWidth = currentWidths[id];
-                    const widthOverride = limitsMap?.[id];
-                    const minOverride = widthOverride?.minWidth ?? params?.defaultMinWidth ?? prevWidth;
-                    const maxOverride = widthOverride?.maxWidth ?? params?.defaultMaxWidth;
-                    const minWidth = Math.max(minOverride ?? -Infinity, column.getMinWidth());
-                    const maxWidth = Math.min(maxOverride ?? Infinity, column.getMaxWidth());
-                    let newWidth = Math.round(column.getActualWidth() * scale);
-
-                    if (newWidth < minWidth) {
-                        newWidth = minWidth;
-                        moveToNotSpread(column);
-                        finishedResizing = false;
-                    } else if (newWidth > maxWidth) {
-                        newWidth = maxWidth;
-                        moveToNotSpread(column);
-                        finishedResizing = false;
-                    } else if (i === 0) {
-                        // if this is the last column
-                        newWidth = pixelsForLastCol;
-                    }
-
-                    column.setActualWidth(newWidth, source, true);
-                    pixelsForLastCol -= newWidth;
-                }
-            }
-        }
-
-        // see NOTE above
+        // see NOTE in resetColsToLimits
         for (const col of colsToDispatchEventFor) {
             col.fireColumnWidthChangedEvent(source);
         }
@@ -995,6 +905,164 @@ function setWidthAnimation({ ctrlsSvc, gos }: BeanCollection, enable: boolean): 
     } else {
         classList.remove(WIDTH_ANIMATION_CLASS);
     }
+}
+
+function buildColumnLimitsMap(columnLimits?: IColumnLimit[]): ColumnLimitsMap {
+    const limitsMap: ColumnLimitsMap = Object.create(null);
+    for (const { key, ...dimensions } of columnLimits ?? []) {
+        limitsMap[typeof key === 'string' ? key : key.getColId()] = dimensions;
+    }
+    return limitsMap;
+}
+
+/** The limits applying to a column, combining its own entry in `limitsMap` with the run-wide defaults. */
+function getColLimits(
+    limitsMap: ColumnLimitsMap,
+    params: SizeColumnsToFitParams | undefined,
+    colId: string
+): { minWidth?: number; maxWidth?: number } {
+    const widthOverride = limitsMap[colId];
+    return {
+        minWidth: widthOverride?.minWidth ?? params?.defaultMinWidth,
+        maxWidth: widthOverride?.maxWidth ?? params?.defaultMaxWidth,
+    };
+}
+
+function allColsWithinLimits(
+    columns: AgColumn[],
+    limitsMap: ColumnLimitsMap,
+    params: SizeColumnsToFitParams | undefined
+): boolean {
+    return columns.every((column) => {
+        if (column.colDef.suppressSizeToFit) {
+            return true;
+        }
+        const { minWidth, maxWidth } = getColLimits(limitsMap, params, column.getId());
+        const colWidth = column.getActualWidth();
+        const aboveMin = minWidth == null || colWidth >= minWidth;
+        return aboveMin && (maxWidth == null || colWidth <= maxWidth);
+    });
+}
+
+function partitionColsToSpread(
+    columns: AgColumn[],
+    params: SizeColumnsToFitParams | undefined
+): { colsToSpread: AgColumn[]; colsToNotSpread: AgColumn[] } {
+    const colsToSpread: AgColumn[] = [];
+    const colsToNotSpread: AgColumn[] = [];
+
+    for (const column of columns) {
+        const isIncluded = params?.colKeys?.some((key) => columnsMatch(column, key)) ?? true;
+        if (column.colDef.suppressSizeToFit || !isIncluded) {
+            colsToNotSpread.push(column);
+        } else {
+            colsToSpread.push(column);
+        }
+    }
+
+    return { colsToSpread, colsToNotSpread };
+}
+
+/**
+ * Resetting cols to their original width makes the sizeColumnsToFit more deterministic,
+ * rather than depending on the current size of the columns. most users call sizeColumnsToFit
+ * immediately after grid is created, so will make no difference. however if application is calling
+ * sizeColumnsToFit repeatedly (eg after column group is opened / closed repeatedly) we don't want
+ * the columns to start shrinking / growing over time.
+ *
+ * NOTE: we assign values to `this.actualWidth` of each column without firing events,
+ * for this reason we need to manually dispatch resize events after the resize has been done for each column.
+ *
+ * @returns the widths held before the reset, populated only when `onlyScaleUp` is set.
+ */
+function resetColsToLimits(
+    colsToSpread: AgColumn[],
+    limitsMap: ColumnLimitsMap,
+    params: SizeColumnsToFitParams | undefined,
+    source: ColumnEventType
+): Partial<Record<string, number>> {
+    const currentWidths: Partial<Record<string, number>> = Object.create(null);
+
+    for (const column of colsToSpread) {
+        if (params?.onlyScaleUp) {
+            // When `onlyScaleUp`, we store the current widths to act as a true minimum because we don't
+            // want any columns to get smaller
+            currentWidths[column.colId] = column.getActualWidth();
+        }
+        column.resetActualWidth(source);
+
+        const { minWidth, maxWidth } = getColLimits(limitsMap, params, column.getId());
+        const colWidth = column.getActualWidth();
+        const targetWidth = _clamp(colWidth, minWidth ?? -Infinity, maxWidth ?? Infinity);
+
+        if (targetWidth != colWidth) {
+            column.setActualWidth(targetWidth, source, true);
+        }
+    }
+
+    return currentWidths;
+}
+
+/** Grows / shrinks `colsToSpread` until every column is within its limits and they fill `gridWidth`. */
+function spreadColsToFit(spreadParams: SpreadColsParams): void {
+    const { gridWidth, colsToNotSpread } = spreadParams;
+    let finishedResizing = false;
+
+    while (!finishedResizing) {
+        const availablePixels = gridWidth - getWidthOfColsInList(colsToNotSpread);
+        finishedResizing =
+            availablePixels <= 0 ? setColsToMinWidth(spreadParams) : scaleColsToFit(spreadParams, availablePixels);
+    }
+}
+
+/** No width available, so set everything to minimum. */
+function setColsToMinWidth({ colsToSpread, limitsMap, params, source }: SpreadColsParams): boolean {
+    for (const column of colsToSpread) {
+        const newWidth = getColLimits(limitsMap, params, column.getId()).minWidth ?? column.minWidth;
+        column.setActualWidth(newWidth, source, true);
+    }
+    return true;
+}
+
+/**
+ * Scales the spreadable columns to fill `availablePixels`, moving any column that hits a limit out of
+ * `colsToSpread`.
+ *
+ * @returns whether all columns landed within their limits, i.e. no further pass is needed.
+ */
+function scaleColsToFit(spreadParams: SpreadColsParams, availablePixels: number): boolean {
+    const { colsToSpread, colsToNotSpread, currentWidths, limitsMap, params, source } = spreadParams;
+    const scale = availablePixels / getWidthOfColsInList(colsToSpread);
+    // we set the pixels for the last col based on what's left, as otherwise
+    // we could be a pixel or two short or extra because of rounding errors.
+    let pixelsForLastCol = availablePixels;
+    let finishedResizing = true;
+
+    // backwards through loop, as we are removing items as we go
+    for (let i = colsToSpread.length - 1; i >= 0; i--) {
+        const column = colsToSpread[i];
+
+        const limits = getColLimits(limitsMap, params, column.colId);
+        const minWidth = Math.max(limits.minWidth ?? currentWidths[column.colId] ?? -Infinity, column.getMinWidth());
+        const maxWidth = Math.min(limits.maxWidth ?? Infinity, column.getMaxWidth());
+        let newWidth = Math.round(column.getActualWidth() * scale);
+
+        const isOutsideLimits = newWidth < minWidth || newWidth > maxWidth;
+        if (isOutsideLimits) {
+            newWidth = newWidth < minWidth ? minWidth : maxWidth;
+            _removeFromArray(colsToSpread, column);
+            colsToNotSpread.push(column);
+            finishedResizing = false;
+        } else if (i === 0) {
+            // if this is the last column
+            newWidth = pixelsForLastCol;
+        }
+
+        column.setActualWidth(newWidth, source, true);
+        pixelsForLastCol -= newWidth;
+    }
+
+    return finishedResizing;
 }
 
 function columnsMatch(column: AgColumn, key: ColKey): boolean {

--- a/packages/ag-grid-community/src/columns/columnModel.ts
+++ b/packages/ag-grid-community/src/columns/columnModel.ts
@@ -283,7 +283,7 @@ export class ColumnModel extends BeanStub implements NamedBean {
         eventSvc.dispatchEvent({ type: 'newColumnsLoaded', source });
 
         if (source === 'gridInitializing') {
-            colAutosize?.applyAutosizeStrategy();
+            colAutosize?.applyInitialAutoSizeStrategy();
         }
     }
 

--- a/packages/ag-grid-community/src/entities/gridOptions.ts
+++ b/packages/ag-grid-community/src/entities/gridOptions.ts
@@ -546,7 +546,7 @@ export interface GridOptions<TData = any> {
     skipHeaderOnAutoSize?: boolean;
     /**
      * Auto-size the columns when the grid is loaded. Can size to fit the grid width, fit a provided width, or fit the cell contents.
-     * @initial
+     * Provide `events` to re-run the strategy when those grid events fire, and use `api.applyAutoSizeStrategy()` to re-run it on demand.
      * @agModule `ColumnAutoSizeModule`
      */
     autoSizeStrategy?: AutoSizeStrategy;

--- a/packages/ag-grid-community/src/events.ts
+++ b/packages/ag-grid-community/src/events.ts
@@ -1040,7 +1040,7 @@ export interface ExpandOrCollapseAllEvent<TData = any, TContext = any> extends A
 export type ColumnEventType =
     | 'sizeColumnsToFit'
     | 'autosizeColumns'
-    | 'autoSizeStrategy'
+    | 'autosizeStrategy'
     | 'autosizeColumnHeaderHeight'
     | 'alignedGridChanged'
     | 'filterChanged'

--- a/packages/ag-grid-community/src/events.ts
+++ b/packages/ag-grid-community/src/events.ts
@@ -1040,6 +1040,7 @@ export interface ExpandOrCollapseAllEvent<TData = any, TContext = any> extends A
 export type ColumnEventType =
     | 'sizeColumnsToFit'
     | 'autosizeColumns'
+    | 'autoSizeStrategy'
     | 'autosizeColumnHeaderHeight'
     | 'alignedGridChanged'
     | 'filterChanged'

--- a/packages/ag-grid-community/src/gridOptionsInitial.ts
+++ b/packages/ag-grid-community/src/gridOptionsInitial.ts
@@ -9,7 +9,6 @@ export const INITIAL_GRID_OPTION_KEYS = {
     defaultColGroupDef: true,
     suppressAutoSize: true,
     skipHeaderOnAutoSize: true,
-    autoSizeStrategy: true,
     components: true,
     stopEditingWhenCellsLoseFocus: true,
     undoRedoCellEditing: true,

--- a/packages/ag-grid-community/src/interfaces/autoSize.ts
+++ b/packages/ag-grid-community/src/interfaces/autoSize.ts
@@ -30,21 +30,9 @@ export interface ISizeColumnsToFitParams extends DefaultWidthLimits {
  * Excludes events which auto-sizing itself dispatches unconditionally (such as `columnResized`),
  * as those would re-trigger the strategy indefinitely.
  */
-export type AutoSizeStrategyEvent =
-    | 'cellValueChanged'
-    | 'columnGroupOpened'
-    | 'columnVisible'
-    | 'displayedColumnsChanged'
-    | 'firstDataRendered'
-    | 'gridColumnsChanged'
-    | 'modelUpdated'
-    | 'paginationChanged'
-    | 'rowDataUpdated'
-    | 'rowGroupOpened'
-    | 'viewportChanged'
-    | 'virtualColumnsChanged';
+export type AutoSizeStrategyEvent = (typeof AUTO_SIZE_STRATEGY_EVENTS)[number];
 
-/** Keep in step with {@link AutoSizeStrategyEvent} — used to validate user-provided event names. */
+/** Also validates user-provided event names, so it must list every allowed event. */
 export const AUTO_SIZE_STRATEGY_EVENTS = [
     'cellValueChanged',
     'columnGroupOpened',
@@ -58,7 +46,7 @@ export const AUTO_SIZE_STRATEGY_EVENTS = [
     'rowGroupOpened',
     'viewportChanged',
     'virtualColumnsChanged',
-] as const satisfies readonly AutoSizeStrategyEvent[];
+] as const;
 
 interface AutoSizeStrategyEvents {
     /**

--- a/packages/ag-grid-community/src/interfaces/autoSize.ts
+++ b/packages/ag-grid-community/src/interfaces/autoSize.ts
@@ -24,20 +24,64 @@ export interface ISizeColumnsToFitParams extends DefaultWidthLimits {
     columnLimits?: IColumnLimit[];
 }
 
+/**
+ * Grid events which can re-apply the configured `autoSizeStrategy`.
+ *
+ * Excludes events which auto-sizing itself dispatches unconditionally (such as `columnResized`),
+ * as those would re-trigger the strategy indefinitely.
+ */
+export type AutoSizeStrategyEvent =
+    | 'cellValueChanged'
+    | 'columnGroupOpened'
+    | 'columnVisible'
+    | 'displayedColumnsChanged'
+    | 'firstDataRendered'
+    | 'gridColumnsChanged'
+    | 'modelUpdated'
+    | 'paginationChanged'
+    | 'rowDataUpdated'
+    | 'rowGroupOpened'
+    | 'viewportChanged'
+    | 'virtualColumnsChanged';
+
+/** Keep in step with {@link AutoSizeStrategyEvent} — used to validate user-provided event names. */
+export const AUTO_SIZE_STRATEGY_EVENTS = [
+    'cellValueChanged',
+    'columnGroupOpened',
+    'columnVisible',
+    'displayedColumnsChanged',
+    'firstDataRendered',
+    'gridColumnsChanged',
+    'modelUpdated',
+    'paginationChanged',
+    'rowDataUpdated',
+    'rowGroupOpened',
+    'viewportChanged',
+    'virtualColumnsChanged',
+] as const satisfies readonly AutoSizeStrategyEvent[];
+
+interface AutoSizeStrategyEvents {
+    /**
+     * Grid events which re-apply this auto-size strategy when fired. Columns the user has resized
+     * manually since the strategy last ran are left at their manual width.
+     */
+    events?: AutoSizeStrategyEvent[];
+}
+
 /** Limit a column width when auto-sizing to fit grid width. */
 export interface SizeColumnsToFitGridColumnLimits extends WidthLimits {
     colId: string;
 }
 
 /** Auto-size columns to fit the grid width. */
-export interface SizeColumnsToFitGridStrategy extends DefaultWidthLimits {
+export interface SizeColumnsToFitGridStrategy extends DefaultWidthLimits, AutoSizeStrategyEvents {
     type: 'fitGridWidth';
     /** Provide to limit specific column widths when sizing. */
     columnLimits?: SizeColumnsToFitGridColumnLimits[];
 }
 
 /** Auto-size columns to fit a provided width. */
-export interface SizeColumnsToFitProvidedWidthStrategy {
+export interface SizeColumnsToFitProvidedWidthStrategy extends AutoSizeStrategyEvents {
     type: 'fitProvidedWidth';
     width: number;
 }
@@ -51,8 +95,14 @@ export interface SizeColumnsToContentColumnLimits extends WidthLimits {
  *
  * Not supported by the Viewport Row Model
  */
-export interface SizeColumnsToContentStrategy extends ISizeAllColumnsToContentParams {
+export interface SizeColumnsToContentStrategy extends ISizeAllColumnsToContentParams, AutoSizeStrategyEvents {
     type: 'fitCellContents';
+    /**
+     * If true, the auto-size actions in the column menu and context menu, and header double-click,
+     * reuse this strategy's options instead of auto-sizing with default options.
+     * @default false
+     */
+    applyToUiActions?: boolean;
 }
 
 export interface ISizeAllColumnsToContentParams extends DefaultWidthLimits {

--- a/packages/ag-grid-community/src/main.ts
+++ b/packages/ag-grid-community/src/main.ts
@@ -12,6 +12,7 @@ export { isProvidedColumnGroup } from './entities/agProvidedColumnGroup';
 
 export type {
     AutoSizeStrategy,
+    AutoSizeStrategyEvent,
     IColumnLimit,
     ISizeAllColumnsToContentParams,
     ISizeColumnsToContentParams,

--- a/packages/ag-grid-community/src/validation/errorMessages/errorText.ts
+++ b/packages/ag-grid-community/src/validation/errorMessages/errorText.ts
@@ -947,6 +947,10 @@ export const AG_GRID_ERRORS = {
     },
     325: ({ property, value }: { property: string; value?: unknown }) =>
         `\`${property}\` must be an array with at least one element, currently it is \`[${String(value)}]\``,
+    326: ({ events }: { events?: string[] }) =>
+        `\`autoSizeStrategy\` stopped re-running: the events \`[${(events ?? []).join(', ')}]\` are being dispatched by the auto-sizing itself. Remove the events which auto-sizing causes, such as \`virtualColumnsChanged\`.`,
+    327: () =>
+        '`autoSizeStrategy` timed out waiting for a sizing pass to complete, so later events may not have re-applied it.' as const,
 };
 
 export type ErrorMap = typeof AG_GRID_ERRORS;

--- a/packages/ag-grid-community/src/validation/rules/gridOptionsValidations.ts
+++ b/packages/ag-grid-community/src/validation/rules/gridOptionsValidations.ts
@@ -768,12 +768,21 @@ const GRID_OPTION_VALIDATIONS: () => Validations<GridOptions> = () => {
                 if (type === 'fitProvidedWidth' && typeof autoSizeStrategy.width != 'number') {
                     return `When using the 'fitProvidedWidth' auto-size strategy, must provide a numeric \`width\`. You provided ${autoSizeStrategy.width}`;
                 }
-                if (type !== 'fitCellContents' && 'applyToUiActions' in autoSizeStrategy) {
-                    return `\`applyToUiActions\` is only supported by the 'fitCellContents' auto-size strategy, as the built-in auto-size actions size columns to their contents. You provided '${type}'.`;
+                if (
+                    type !== 'fitCellContents' &&
+                    'applyToUiActions' in autoSizeStrategy &&
+                    autoSizeStrategy.applyToUiActions != null
+                ) {
+                    return _createValidationWarning(318, {
+                        feature: '`applyToUiActions`',
+                        conflictsWith: `the '${type}' auto-size strategy`,
+                        advice: 'The built-in auto-size actions size columns to their contents.',
+                    });
                 }
                 const events = autoSizeStrategy.events;
                 if (events) {
-                    for (const event of events) {
+                    for (let i = 0, len = events.length; i < len; ++i) {
+                        const event = events[i];
                         if (!AUTO_SIZE_STRATEGY_EVENTS.includes(event)) {
                             return _createValidationWarning(320, {
                                 property: 'autoSizeStrategy.events',

--- a/packages/ag-grid-community/src/validation/rules/gridOptionsValidations.ts
+++ b/packages/ag-grid-community/src/validation/rules/gridOptionsValidations.ts
@@ -1,5 +1,6 @@
 import { getSortDefFromInput } from '../../entities/agColumn';
 import type { DomLayoutType, GridOptions } from '../../entities/gridOptions';
+import { AUTO_SIZE_STRATEGY_EVENTS } from '../../interfaces/autoSize';
 import { _BOOLEAN_GRID_OPTIONS, _GET_ALL_GRID_OPTIONS, _NUMBER_GRID_OPTIONS } from '../../propertyKeys';
 import { _PUBLIC_EVENT_HANDLERS_MAP } from '../../publicEventHandlersMap';
 import { _mergeDeep } from '../../utils/mergeDeep';
@@ -766,6 +767,21 @@ const GRID_OPTION_VALIDATIONS: () => Validations<GridOptions> = () => {
                 }
                 if (type === 'fitProvidedWidth' && typeof autoSizeStrategy.width != 'number') {
                     return `When using the 'fitProvidedWidth' auto-size strategy, must provide a numeric \`width\`. You provided ${autoSizeStrategy.width}`;
+                }
+                if (type !== 'fitCellContents' && 'applyToUiActions' in autoSizeStrategy) {
+                    return `\`applyToUiActions\` is only supported by the 'fitCellContents' auto-size strategy, as the built-in auto-size actions size columns to their contents. You provided '${type}'.`;
+                }
+                const events = autoSizeStrategy.events;
+                if (events) {
+                    for (const event of events) {
+                        if (!AUTO_SIZE_STRATEGY_EVENTS.includes(event)) {
+                            return _createValidationWarning(320, {
+                                property: 'autoSizeStrategy.events',
+                                allowed: [...AUTO_SIZE_STRATEGY_EVENTS],
+                                value: event,
+                            });
+                        }
+                    }
                 }
                 return null;
             },

--- a/packages/ag-grid-enterprise/src/menu/menuItemMapper.ts
+++ b/packages/ag-grid-enterprise/src/menu/menuItemMapper.ts
@@ -231,8 +231,7 @@ export class MenuItemMapper extends BeanStub implements NamedBean {
                     return colAutosize
                         ? {
                               name: localeTextFunc('autosizeThisColumn', 'Autosize This Column'),
-                              action: () =>
-                                  column && colAutosize.autoSizeColumn(column, source, gos.get('skipHeaderOnAutoSize')),
+                              action: () => column && colAutosize.autoSizeColumn(column, source),
                           }
                         : null;
                 case 'autoSizeAll':
@@ -241,8 +240,8 @@ export class MenuItemMapper extends BeanStub implements NamedBean {
                               name: localeTextFunc('autosizeAllColumns', 'Autosize All Columns'),
                               action: () =>
                                   colAutosize.autoSizeAllColumns({
+                                      ...colAutosize.getUiActionAutoSizeParams(),
                                       source,
-                                      skipHeader: gos.get('skipHeaderOnAutoSize'),
                                   }),
                           }
                         : null;

--- a/packages/ag-grid-vue3/src/components/utils.ts
+++ b/packages/ag-grid-vue3/src/components/utils.ts
@@ -514,7 +514,7 @@ export interface Props<TData> {
          */
     skipHeaderOnAutoSize?: boolean,
     /** Auto-size the columns when the grid is loaded. Can size to fit the grid width, fit a provided width, or fit the cell contents.
-         * @initial
+         * Provide `events` to re-run the strategy when those grid events fire, and use `api.applyAutoSizeStrategy()` to re-run it on demand.
          * @agModule `ColumnAutoSizeModule`
          */
     autoSizeStrategy?: AutoSizeStrategy,

--- a/testing/behavioural/src/columns/autosize-strategy-events.test.ts
+++ b/testing/behavioural/src/columns/autosize-strategy-events.test.ts
@@ -1,0 +1,418 @@
+/**
+ * `autoSizeStrategy.events` — re-runs the configured auto-size strategy when the listed grid
+ * events fire, and `api.applyAutoSizeStrategy()` for the imperative case.
+ *
+ * jsdom returns 0 px for the fixed-position autosize dummy container, so `autoWidthCalc` falls back
+ * to each column's `minWidth`; changing a column's `minWidth` is therefore the lever for "the
+ * content got wider". `mockGridLayout` gives the grid root a 1000 px width.
+ *
+ * Each test widens a column's width away from what the strategy produces, then fires the event and
+ * asserts the strategy pulled it back — so a strategy that never re-ran fails the test.
+ */
+import { waitFor } from '@testing-library/dom';
+
+import type { ColumnEventType, GridApi } from 'ag-grid-community';
+import {
+    ClientSideRowModelModule,
+    ColumnAutoSizeModule,
+    PaginationModule,
+    ValidationModule,
+    enableDevValidations,
+} from 'ag-grid-community';
+import { ColumnsToolPanelModule, RowGroupingModule } from 'ag-grid-enterprise';
+
+import { ALL_SEVERITIES, TestGridsManager } from '../test-utils';
+
+const GRID_WIDTH = 1000;
+const NUDGED_WIDTH = 220;
+
+describe('autoSizeStrategy events', () => {
+    const gridsManager = new TestGridsManager({
+        modules: [
+            ClientSideRowModelModule,
+            ColumnAutoSizeModule,
+            ColumnsToolPanelModule,
+            PaginationModule,
+            RowGroupingModule,
+            ValidationModule,
+        ],
+    });
+
+    afterEach(() => {
+        gridsManager.reset();
+        vi.restoreAllMocks();
+    });
+
+    const rowData = [
+        { a: 'x', b: 'y', c: 'z' },
+        { a: 'xx', b: 'yy', c: 'zz' },
+    ];
+
+    const columnDefs = [
+        { colId: 'a', field: 'a', minWidth: 100 },
+        { colId: 'b', field: 'b', minWidth: 100 },
+        { colId: 'c', field: 'c', minWidth: 100 },
+    ];
+
+    const totalWidth = (api: GridApi): number =>
+        api.getAllDisplayedColumns().reduce((total, col) => total + col.getActualWidth(), 0);
+
+    /** Collects the `columnResized(finished)` sources so re-runs can be counted and attributed. */
+    const captureResizeSources = (api: GridApi): ColumnEventType[] => {
+        const sources: ColumnEventType[] = [];
+        api.addEventListener('columnResized', (e) => {
+            if (e.finished) {
+                sources.push(e.source);
+            }
+        });
+        return sources;
+    };
+
+    /** Moves a column off its strategy width via the API, so a re-run is observable. */
+    const nudge = (api: GridApi, colId: string): void => {
+        api.setColumnWidths([{ key: colId, newWidth: NUDGED_WIDTH }]);
+        expect(api.getColumn(colId)!.getActualWidth()).toBe(NUDGED_WIDTH);
+    };
+
+    describe('opt-in', () => {
+        test('no events configured — the strategy runs once at init and never again', async () => {
+            const api = await gridsManager.createGridAndWait('myGrid', {
+                columnDefs,
+                rowData,
+                autoSizeStrategy: { type: 'fitCellContents' },
+            });
+            await waitFor(() => expect(api.getColumn('a')!.getActualWidth()).toBe(100));
+
+            nudge(api, 'a');
+            api.setColumnsVisible(['b'], false);
+            api.setGridOption('rowData', [...rowData]);
+
+            await waitFor(() => expect(api.getColumn('a')!.getActualWidth()).toBe(NUDGED_WIDTH));
+        });
+
+        test('events not listed do not trigger a re-run', async () => {
+            const api = await gridsManager.createGridAndWait('myGrid', {
+                columnDefs,
+                rowData,
+                autoSizeStrategy: { type: 'fitCellContents', events: ['paginationChanged'] },
+            });
+            await waitFor(() => expect(api.getColumn('a')!.getActualWidth()).toBe(100));
+
+            nudge(api, 'a');
+            api.setColumnsVisible(['c'], false);
+
+            await waitFor(() => expect(api.getColumn('a')!.getActualWidth()).toBe(NUDGED_WIDTH));
+        });
+    });
+
+    describe('per-event triggers', () => {
+        test('columnVisible re-runs the strategy — a newly shown column is sized', async () => {
+            const api = await gridsManager.createGridAndWait('myGrid', {
+                columnDefs: [
+                    { colId: 'a', field: 'a', minWidth: 100 },
+                    { colId: 'b', field: 'b', minWidth: 100, hide: true },
+                ],
+                rowData,
+                autoSizeStrategy: { type: 'fitCellContents', events: ['columnVisible'] },
+            });
+            await waitFor(() => expect(api.getColumn('a')!.getActualWidth()).toBe(100));
+
+            api.setColumnsVisible(['b'], true);
+
+            await waitFor(() => expect(api.getColumn('b')!.getActualWidth()).toBe(100));
+        });
+
+        test('paginationChanged re-runs the strategy on a page change', async () => {
+            const api = await gridsManager.createGridAndWait('myGrid', {
+                columnDefs,
+                rowData,
+                pagination: true,
+                paginationPageSize: 1,
+                paginationPageSizeSelector: [1, 20],
+                autoSizeStrategy: { type: 'fitCellContents', events: ['paginationChanged'] },
+            });
+            await waitFor(() => expect(api.getColumn('a')!.getActualWidth()).toBe(100));
+
+            nudge(api, 'a');
+            api.paginationGoToNextPage();
+
+            await waitFor(() => expect(api.getColumn('a')!.getActualWidth()).toBe(100));
+        });
+
+        test('rowDataUpdated re-runs the strategy after a transaction', async () => {
+            const api = await gridsManager.createGridAndWait('myGrid', {
+                columnDefs,
+                rowData,
+                autoSizeStrategy: { type: 'fitCellContents', events: ['rowDataUpdated'] },
+            });
+            await waitFor(() => expect(api.getColumn('a')!.getActualWidth()).toBe(100));
+
+            nudge(api, 'a');
+            api.applyTransaction({ add: [{ a: 'a much longer value', b: 'b', c: 'c' }] });
+
+            await waitFor(() => expect(api.getColumn('a')!.getActualWidth()).toBe(100));
+        });
+
+        test('gridColumnsChanged re-runs the strategy after new column defs', async () => {
+            const api = await gridsManager.createGridAndWait('myGrid', {
+                columnDefs,
+                rowData,
+                autoSizeStrategy: { type: 'fitCellContents', events: ['gridColumnsChanged'] },
+            });
+            await waitFor(() => expect(api.getColumn('a')!.getActualWidth()).toBe(100));
+
+            api.setGridOption('columnDefs', [{ colId: 'c', field: 'c', minWidth: 130 }]);
+
+            await waitFor(() => expect(api.getColumn('c')!.getActualWidth()).toBe(130));
+        });
+
+        test('rowGroupOpened re-runs the strategy when a group is expanded', async () => {
+            const api = await gridsManager.createGridAndWait('myGrid', {
+                columnDefs: [
+                    { colId: 'a', field: 'a', rowGroup: true },
+                    { colId: 'b', field: 'b', minWidth: 100 },
+                ],
+                rowData,
+                autoSizeStrategy: { type: 'fitCellContents', events: ['rowGroupOpened'] },
+            });
+            await waitFor(() => expect(api.getColumn('b')!.getActualWidth()).toBe(100));
+
+            nudge(api, 'b');
+            api.setRowNodeExpanded(api.getDisplayedRowAtIndex(0)!, true);
+
+            await waitFor(() => expect(api.getColumn('b')!.getActualWidth()).toBe(100));
+        });
+
+        test('columnGroupOpened re-runs the strategy when a column group is expanded', async () => {
+            const api = await gridsManager.createGridAndWait('myGrid', {
+                columnDefs: [
+                    {
+                        groupId: 'grp',
+                        openByDefault: false,
+                        children: [
+                            { colId: 'a', field: 'a', minWidth: 100 },
+                            { colId: 'b', field: 'b', minWidth: 100, columnGroupShow: 'open' },
+                        ],
+                    },
+                ],
+                rowData,
+                autoSizeStrategy: { type: 'fitCellContents', events: ['columnGroupOpened'] },
+            });
+            await waitFor(() => expect(api.getColumn('a')!.getActualWidth()).toBe(100));
+
+            api.setColumnGroupOpened('grp', true);
+
+            await waitFor(() => expect(api.getColumn('b')!.getActualWidth()).toBe(100));
+        });
+    });
+
+    describe('all strategy types re-run', () => {
+        test('fitProvidedWidth', async () => {
+            const api = await gridsManager.createGridAndWait('myGrid', {
+                columnDefs,
+                rowData,
+                autoSizeStrategy: { type: 'fitProvidedWidth', width: 600, events: ['paginationChanged'] },
+            });
+            await waitFor(() => expect(totalWidth(api)).toBe(600));
+
+            nudge(api, 'a');
+            api.setGridOption('pagination', true);
+
+            await waitFor(() => expect(totalWidth(api)).toBe(600));
+        });
+
+        test('fitGridWidth', async () => {
+            const api = await gridsManager.createGridAndWait('myGrid', {
+                columnDefs,
+                rowData,
+                autoSizeStrategy: { type: 'fitGridWidth', events: ['paginationChanged'] },
+            });
+            await waitFor(() => expect(totalWidth(api)).toBe(GRID_WIDTH));
+
+            nudge(api, 'a');
+            api.setGridOption('pagination', true);
+
+            await waitFor(() => expect(totalWidth(api)).toBe(GRID_WIDTH));
+        });
+    });
+
+    describe('coalescing and termination', () => {
+        test('several configured events in one tick produce a single re-run', async () => {
+            const api = await gridsManager.createGridAndWait('myGrid', {
+                columnDefs,
+                rowData,
+                autoSizeStrategy: {
+                    type: 'fitCellContents',
+                    events: ['columnVisible', 'displayedColumnsChanged', 'modelUpdated'],
+                },
+            });
+            await waitFor(() => expect(api.getColumn('a')!.getActualWidth()).toBe(100));
+
+            const sources = captureResizeSources(api);
+            api.setColumnsVisible(['b'], false);
+            api.setColumnsVisible(['b'], true);
+
+            await waitFor(() => expect(sources).toContain('autoSizeStrategy'));
+            await waitFor(() => expect(sources.filter((source) => source === 'autoSizeStrategy')).toHaveLength(1));
+        });
+
+        test('self-dispatched events settle instead of looping', async () => {
+            const api = await gridsManager.createGridAndWait('myGrid', {
+                columnDefs,
+                rowData,
+                autoSizeStrategy: {
+                    type: 'fitCellContents',
+                    events: ['displayedColumnsChanged', 'virtualColumnsChanged', 'modelUpdated'],
+                },
+            });
+            await waitFor(() => expect(api.getColumn('a')!.getActualWidth()).toBe(100));
+
+            const sources = captureResizeSources(api);
+            api.setColumnsVisible(['b'], false);
+
+            await waitFor(() => expect(sources).toContain('autoSizeStrategy'));
+            // give any feedback loop several ticks to run away
+            for (let i = 0; i < 5; ++i) {
+                await new Promise((resolve) => setTimeout(resolve));
+            }
+            expect(sources.filter((source) => source === 'autoSizeStrategy').length).toBeLessThan(3);
+        });
+    });
+
+    describe('manual resizes are preserved', () => {
+        test('a column the user dragged keeps its width; the others re-run', async () => {
+            const api = await gridsManager.createGridAndWait('myGrid', {
+                columnDefs,
+                rowData,
+                autoSizeStrategy: { type: 'fitCellContents', events: ['paginationChanged'] },
+            });
+            await waitFor(() => expect(api.getColumn('a')!.getActualWidth()).toBe(100));
+
+            // 'uiColumnResized' is the source a header-handle drag reports
+            api.setColumnWidths([{ key: 'a', newWidth: 320 }], true, 'uiColumnResized');
+            nudge(api, 'b');
+            api.setGridOption('pagination', true);
+
+            await waitFor(() => expect(api.getColumn('b')!.getActualWidth()).toBe(100));
+            expect(api.getColumn('a')!.getActualWidth()).toBe(320);
+        });
+
+        test('applyAutoSizeStrategy reclaims a manually resized column', async () => {
+            const api = await gridsManager.createGridAndWait('myGrid', {
+                columnDefs,
+                rowData,
+                autoSizeStrategy: { type: 'fitCellContents' },
+            });
+            await waitFor(() => expect(api.getColumn('a')!.getActualWidth()).toBe(100));
+
+            api.setColumnWidths([{ key: 'a', newWidth: 320 }], true, 'uiColumnResized');
+            api.applyAutoSizeStrategy();
+
+            await waitFor(() => expect(api.getColumn('a')!.getActualWidth()).toBe(100));
+        });
+    });
+
+    describe('applyAutoSizeStrategy', () => {
+        test('re-applies each strategy type on demand', async () => {
+            const api = await gridsManager.createGridAndWait('myGrid', {
+                columnDefs,
+                rowData,
+                autoSizeStrategy: { type: 'fitProvidedWidth', width: 750 },
+            });
+            await waitFor(() => expect(totalWidth(api)).toBe(750));
+
+            nudge(api, 'a');
+            api.applyAutoSizeStrategy();
+
+            await waitFor(() => expect(totalWidth(api)).toBe(750));
+        });
+
+        test('is a no-op when no strategy is configured', async () => {
+            const api = await gridsManager.createGridAndWait('myGrid', { columnDefs, rowData });
+            const widthBefore = api.getColumn('a')!.getActualWidth();
+
+            api.applyAutoSizeStrategy();
+
+            await new Promise((resolve) => setTimeout(resolve));
+            expect(api.getColumn('a')!.getActualWidth()).toBe(widthBefore);
+        });
+    });
+
+    describe('runtime updates', () => {
+        test('setGridOption re-registers the listeners and re-applies, without an initial-property warning', async () => {
+            const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+            const api = await gridsManager.createGridAndWait('myGrid', {
+                columnDefs,
+                rowData,
+                autoSizeStrategy: { type: 'fitCellContents', events: ['paginationChanged'] },
+            });
+            await waitFor(() => expect(api.getColumn('a')!.getActualWidth()).toBe(100));
+
+            nudge(api, 'a');
+            api.setGridOption('autoSizeStrategy', { type: 'fitProvidedWidth', width: 900, events: ['columnVisible'] });
+
+            // changing the option re-applies it straight away
+            await waitFor(() => expect(totalWidth(api)).toBe(900));
+            expect(warn.mock.calls.flat().join(' ')).not.toContain('autoSizeStrategy');
+
+            // the new event is live
+            nudge(api, 'a');
+            api.setColumnsVisible(['c'], false);
+            await waitFor(() => expect(totalWidth(api)).toBe(900));
+
+            // and the old one is not
+            nudge(api, 'a');
+            api.setGridOption('pagination', true);
+            await waitFor(() => expect(api.getColumn('a')!.getActualWidth()).toBe(NUDGED_WIDTH));
+        });
+
+        test('re-passing an equal strategy object does not re-apply', async () => {
+            const api = await gridsManager.createGridAndWait('myGrid', {
+                columnDefs,
+                rowData,
+                autoSizeStrategy: { type: 'fitCellContents' },
+            });
+            await waitFor(() => expect(api.getColumn('a')!.getActualWidth()).toBe(100));
+
+            nudge(api, 'a');
+            // frameworks re-pass an inline options object on every render
+            api.setGridOption('autoSizeStrategy', { type: 'fitCellContents' });
+
+            await waitFor(() => expect(api.getColumn('a')!.getActualWidth()).toBe(NUDGED_WIDTH));
+        });
+    });
+
+    describe('validation', () => {
+        test('an unrecognised event name warns', async () => {
+            // this test deliberately configures an invalid event name, which warns #320
+            enableDevValidations({ throwOn: ALL_SEVERITIES, suppress: [320] });
+            const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+            await gridsManager.createGridAndWait('myGrid', {
+                columnDefs,
+                rowData,
+                // deliberately not valid TypeScript — this guards the JavaScript path
+                autoSizeStrategy: { type: 'fitCellContents', events: ['columnResized'] } as any,
+            });
+
+            expect(warn.mock.calls.flat().join(' ')).toContain('autoSizeStrategy.events');
+        });
+    });
+
+    describe('teardown', () => {
+        test('a configured event firing after destroy does not throw', async () => {
+            const api = await gridsManager.createGridAndWait('myGrid', {
+                columnDefs,
+                rowData,
+                autoSizeStrategy: { type: 'fitCellContents', events: ['paginationChanged'] },
+            });
+            await waitFor(() => expect(api.getColumn('a')!.getActualWidth()).toBe(100));
+
+            api.setGridOption('pagination', true);
+            api.destroy();
+
+            await expect(new Promise((resolve) => setTimeout(resolve))).resolves.toBeUndefined();
+        });
+    });
+});

--- a/testing/behavioural/src/columns/autosize-strategy-events.test.ts
+++ b/testing/behavioural/src/columns/autosize-strategy-events.test.ts
@@ -21,9 +21,8 @@ import {
 } from 'ag-grid-community';
 import { ColumnsToolPanelModule, RowGroupingModule } from 'ag-grid-enterprise';
 
-import { ALL_SEVERITIES, TestGridsManager } from '../test-utils';
+import { ALL_SEVERITIES, TestGridsManager, mockGridLayout } from '../test-utils';
 
-const GRID_WIDTH = 1000;
 const NUDGED_WIDTH = 220;
 
 describe('autoSizeStrategy events', () => {
@@ -227,12 +226,12 @@ describe('autoSizeStrategy events', () => {
                 rowData,
                 autoSizeStrategy: { type: 'fitGridWidth', events: ['paginationChanged'] },
             });
-            await waitFor(() => expect(totalWidth(api)).toBe(GRID_WIDTH));
+            await waitFor(() => expect(totalWidth(api)).toBe(mockGridLayout.gridWidth));
 
             nudge(api, 'a');
             api.setGridOption('pagination', true);
 
-            await waitFor(() => expect(totalWidth(api)).toBe(GRID_WIDTH));
+            await waitFor(() => expect(totalWidth(api)).toBe(mockGridLayout.gridWidth));
         });
     });
 
@@ -252,17 +251,20 @@ describe('autoSizeStrategy events', () => {
             api.setColumnsVisible(['b'], false);
             api.setColumnsVisible(['b'], true);
 
-            await waitFor(() => expect(sources).toContain('autoSizeStrategy'));
-            await waitFor(() => expect(sources.filter((source) => source === 'autoSizeStrategy')).toHaveLength(1));
+            await waitFor(() => expect(sources).toContain('autosizeStrategy'));
+            await waitFor(() => expect(sources.filter((source) => source === 'autosizeStrategy')).toHaveLength(1));
         });
 
-        test('self-dispatched events settle instead of looping', async () => {
+        test('self-dispatched events run exactly once, then the next real trigger still runs', async () => {
             const api = await gridsManager.createGridAndWait('myGrid', {
                 columnDefs,
                 rowData,
+                pagination: true,
+                paginationPageSize: 1,
                 autoSizeStrategy: {
                     type: 'fitCellContents',
-                    events: ['displayedColumnsChanged', 'virtualColumnsChanged', 'modelUpdated'],
+                    // every one of these is dispatched by auto-sizing itself
+                    events: ['displayedColumnsChanged', 'virtualColumnsChanged', 'modelUpdated', 'paginationChanged'],
                 },
             });
             await waitFor(() => expect(api.getColumn('a')!.getActualWidth()).toBe(100));
@@ -270,12 +272,45 @@ describe('autoSizeStrategy events', () => {
             const sources = captureResizeSources(api);
             api.setColumnsVisible(['b'], false);
 
-            await waitFor(() => expect(sources).toContain('autoSizeStrategy'));
+            await waitFor(() => expect(sources).toContain('autosizeStrategy'));
             // give any feedback loop several ticks to run away
             for (let i = 0; i < 5; ++i) {
                 await new Promise((resolve) => setTimeout(resolve));
             }
-            expect(sources.filter((source) => source === 'autoSizeStrategy').length).toBeLessThan(3);
+            // a run dispatches `columnResized` whether or not it changed a width, so an echoed run counts
+            expect(sources.filter((source) => source === 'autosizeStrategy')).toHaveLength(1);
+
+            // the fence must not outlive the run it guards
+            nudge(api, 'a');
+            api.paginationGoToNextPage();
+
+            await waitFor(() => expect(api.getColumn('a')!.getActualWidth()).toBe(100));
+            expect(sources.filter((source) => source === 'autosizeStrategy')).toHaveLength(2);
+        });
+
+        test('a runaway re-run loop is capped and warns', async () => {
+            enableDevValidations({ throwOn: ALL_SEVERITIES, suppress: [326] });
+            const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+            const api = await gridsManager.createGridAndWait('myGrid', {
+                columnDefs,
+                rowData,
+                autoSizeStrategy: { type: 'fitCellContents', events: ['columnVisible'] },
+            });
+            await waitFor(() => expect(api.getColumn('a')!.getActualWidth()).toBe(100));
+
+            const sources = captureResizeSources(api);
+            // stand in for a grid whose own sizing re-dispatches a configured event forever; deferring
+            // to the next tick puts the echo past the run's re-entrancy fence, as a queued run would
+            api.addEventListener('columnResized', ({ finished, source }) => {
+                if (finished && source === 'autosizeStrategy') {
+                    setTimeout(() => api.setColumnsVisible(['b'], !api.getColumn('b')!.isVisible()));
+                }
+            });
+            api.setColumnsVisible(['c'], false);
+
+            await waitFor(() => expect(warn.mock.calls.flat().join(' ')).toContain('stopped re-running'));
+            expect(sources.filter((source) => source === 'autosizeStrategy').length).toBeLessThanOrEqual(11);
         });
     });
 
@@ -294,6 +329,41 @@ describe('autoSizeStrategy events', () => {
             api.setGridOption('pagination', true);
 
             await waitFor(() => expect(api.getColumn('b')!.getActualWidth()).toBe(100));
+            expect(api.getColumn('a')!.getActualWidth()).toBe(320);
+        });
+
+        test('a column dropped from the column defs stops being excluded when its id comes back', async () => {
+            const api = await gridsManager.createGridAndWait('myGrid', {
+                columnDefs,
+                rowData,
+                autoSizeStrategy: { type: 'fitCellContents', events: ['paginationChanged'] },
+            });
+            await waitFor(() => expect(api.getColumn('a')!.getActualWidth()).toBe(100));
+
+            api.setColumnWidths([{ key: 'a', newWidth: 320 }], true, 'uiColumnResized');
+            // 'a' leaves and comes back, so it is a new column that nobody has resized
+            api.setGridOption('columnDefs', [{ colId: 'b', field: 'b', minWidth: 100 }]);
+            api.setGridOption('columnDefs', [{ colId: 'a', field: 'a', minWidth: 140 }]);
+
+            nudge(api, 'a');
+            api.setGridOption('pagination', true);
+
+            await waitFor(() => expect(api.getColumn('a')!.getActualWidth()).toBe(140));
+        });
+
+        test('updating the option re-applies the strategy without discarding manual widths', async () => {
+            const api = await gridsManager.createGridAndWait('myGrid', {
+                columnDefs,
+                rowData,
+                autoSizeStrategy: { type: 'fitCellContents', defaultMinWidth: 150 },
+            });
+            await waitFor(() => expect(api.getColumn('a')!.getActualWidth()).toBe(150));
+
+            api.setColumnWidths([{ key: 'a', newWidth: 320 }], true, 'uiColumnResized');
+            nudge(api, 'b');
+            api.setGridOption('autoSizeStrategy', { type: 'fitCellContents', defaultMinWidth: 180 });
+
+            await waitFor(() => expect(api.getColumn('b')!.getActualWidth()).toBe(180));
             expect(api.getColumn('a')!.getActualWidth()).toBe(320);
         });
 
@@ -367,17 +437,17 @@ describe('autoSizeStrategy events', () => {
             await waitFor(() => expect(api.getColumn('a')!.getActualWidth()).toBe(NUDGED_WIDTH));
         });
 
-        test('re-passing an equal strategy object does not re-apply', async () => {
+        test('re-passing an equal strategy object does not re-apply, whatever the key order', async () => {
             const api = await gridsManager.createGridAndWait('myGrid', {
                 columnDefs,
                 rowData,
-                autoSizeStrategy: { type: 'fitCellContents' },
+                autoSizeStrategy: { type: 'fitCellContents', skipHeader: true, defaultMinWidth: 120 },
             });
-            await waitFor(() => expect(api.getColumn('a')!.getActualWidth()).toBe(100));
+            await waitFor(() => expect(api.getColumn('a')!.getActualWidth()).toBe(120));
 
             nudge(api, 'a');
-            // frameworks re-pass an inline options object on every render
-            api.setGridOption('autoSizeStrategy', { type: 'fitCellContents' });
+            // frameworks re-pass an inline options object on every render, in no guaranteed order
+            api.setGridOption('autoSizeStrategy', { defaultMinWidth: 120, type: 'fitCellContents', skipHeader: true });
 
             await waitFor(() => expect(api.getColumn('a')!.getActualWidth()).toBe(NUDGED_WIDTH));
         });

--- a/testing/behavioural/src/columns/autosize-strategy-ui-actions.test.ts
+++ b/testing/behavioural/src/columns/autosize-strategy-ui-actions.test.ts
@@ -1,0 +1,237 @@
+/**
+ * `autoSizeStrategy.applyToUiActions` — the built-in auto-size UI actions reuse the configured
+ * strategy instead of auto-sizing with default options. Covers the column menu, the context menu
+ * and header double-click.
+ *
+ * jsdom returns 0 px for the fixed-position autosize dummy container, so `autoWidthCalc` falls back
+ * to each column's `minWidth`. With explicit `minWidth`s the content pass is deterministic.
+ * `mockGridLayout` gives the grid root a 1000 px width, so the `scaleUpToFitGridWidth` second pass
+ * has a real grid width to spread into.
+ *
+ * Each test resets the widths after grid creation, because the initial strategy run has already
+ * applied the same options — without the reset a broken UI action would still look correct.
+ */
+import { waitFor } from '@testing-library/dom';
+import userEvent from '@testing-library/user-event';
+
+import type { GridApi } from 'ag-grid-community';
+import {
+    ClientSideRowModelModule,
+    ColumnAutoSizeModule,
+    ValidationModule,
+    enableDevValidations,
+} from 'ag-grid-community';
+import { ColumnMenuModule, ContextMenuModule } from 'ag-grid-enterprise';
+
+import { ALL_SEVERITIES, GridColumns, TestGridsManager, openMenuOption, polyfillOffsetParent } from '../test-utils';
+
+const GRID_WIDTH = 1000;
+const RESET_WIDTH = 220;
+
+describe('autoSizeStrategy applyToUiActions', () => {
+    const gridsManager = new TestGridsManager({
+        modules: [
+            ClientSideRowModelModule,
+            ColumnAutoSizeModule,
+            ColumnMenuModule,
+            ContextMenuModule,
+            ValidationModule,
+        ],
+    });
+
+    let restoreOffsetParent: (() => void) | undefined;
+
+    beforeEach(() => {
+        restoreOffsetParent = polyfillOffsetParent();
+    });
+
+    afterEach(() => {
+        restoreOffsetParent?.();
+        restoreOffsetParent = undefined;
+        gridsManager.reset();
+        vi.restoreAllMocks();
+    });
+
+    const rowData = [{ a: 'x', b: 'y', c: 'z' }];
+
+    const columnDefs = [
+        { colId: 'a', field: 'a', minWidth: 100 },
+        { colId: 'b', field: 'b', minWidth: 100 },
+        { colId: 'c', field: 'c', minWidth: 100 },
+    ];
+
+    const totalWidth = (api: GridApi): number =>
+        api.getAllDisplayedColumns().reduce((total, col) => total + col.getActualWidth(), 0);
+
+    /** Puts every column at a width no auto-size pass would produce, so a no-op is visible. */
+    const resetWidths = (api: GridApi): void => {
+        api.setColumnWidths(columnDefs.map(({ colId }) => ({ key: colId, newWidth: RESET_WIDTH })));
+    };
+
+    describe('column menu', () => {
+        test('Autosize All Columns honours scaleUpToFitGridWidth', async () => {
+            const api = await gridsManager.createGridAndWait('myGrid', {
+                columnDefs,
+                rowData,
+                autoSizeStrategy: { type: 'fitCellContents', scaleUpToFitGridWidth: true, applyToUiActions: true },
+            });
+            resetWidths(api);
+
+            api.showColumnMenu('a');
+            await userEvent.click(await openMenuOption('Autosize All Columns'));
+
+            // the content pass shrinks each col to its 100 px minWidth, then the scale-up pass fills the grid
+            await waitFor(() => expect(totalWidth(api)).toBe(GRID_WIDTH));
+            await new GridColumns(api, 'column menu autosize all scaled up to grid width').checkColumns(`
+                CENTER
+                ├── a "A" width:334
+                ├── b "B" width:333
+                └── c "C" width:333
+            `);
+        });
+
+        test('Autosize All Columns honours columnLimits and defaultMinWidth', async () => {
+            const api = await gridsManager.createGridAndWait('myGrid', {
+                columnDefs,
+                rowData,
+                autoSizeStrategy: {
+                    type: 'fitCellContents',
+                    applyToUiActions: true,
+                    defaultMinWidth: 150,
+                    columnLimits: [{ colId: 'b', minWidth: 400 }],
+                },
+            });
+            resetWidths(api);
+
+            api.showColumnMenu('a');
+            await userEvent.click(await openMenuOption('Autosize All Columns'));
+
+            await waitFor(() => expect(api.getColumn('b')!.getActualWidth()).toBe(400));
+            expect(api.getColumn('a')!.getActualWidth()).toBe(150);
+            expect(api.getColumn('c')!.getActualWidth()).toBe(150);
+        });
+
+        test('Autosize This Column applies the strategy to the clicked column only', async () => {
+            const api = await gridsManager.createGridAndWait('myGrid', {
+                columnDefs,
+                rowData,
+                autoSizeStrategy: {
+                    type: 'fitCellContents',
+                    applyToUiActions: true,
+                    defaultMinWidth: 250,
+                    // colIds targets the initial run; a single-column UI action sizes what was clicked
+                    colIds: ['c'],
+                },
+            });
+            // the initial run targets `colIds` asynchronously — let it land before resetting
+            await waitFor(() => expect(api.getColumn('c')!.getActualWidth()).toBe(250));
+            resetWidths(api);
+
+            api.showColumnMenu('a');
+            await userEvent.click(await openMenuOption('Autosize This Column'));
+
+            await waitFor(() => expect(api.getColumn('a')!.getActualWidth()).toBe(250));
+            expect(api.getColumn('b')!.getActualWidth()).toBe(RESET_WIDTH);
+            expect(api.getColumn('c')!.getActualWidth()).toBe(RESET_WIDTH);
+        });
+
+        test('widths match the default auto-size when applyToUiActions is not set', async () => {
+            const api = await gridsManager.createGridAndWait('myGrid', {
+                columnDefs,
+                rowData,
+                autoSizeStrategy: { type: 'fitCellContents', scaleUpToFitGridWidth: true, defaultMinWidth: 150 },
+            });
+            resetWidths(api);
+
+            api.showColumnMenu('a');
+            await userEvent.click(await openMenuOption('Autosize All Columns'));
+
+            // plain content fit: each col at its own 100 px minWidth — no scale-up, no defaultMinWidth
+            await waitFor(() => expect(api.getColumn('a')!.getActualWidth()).toBe(100));
+            expect(totalWidth(api)).toBe(300);
+        });
+    });
+
+    describe('context menu', () => {
+        test('Autosize All Columns honours the strategy options', async () => {
+            const api = await gridsManager.createGridAndWait('myGrid', {
+                columnDefs,
+                rowData,
+                // the default context menu has no autosize items
+                getContextMenuItems: () => ['autoSizeAll'],
+                autoSizeStrategy: { type: 'fitCellContents', applyToUiActions: true, defaultMinWidth: 300 },
+            });
+            resetWidths(api);
+
+            api.showContextMenu({
+                rowNode: api.getDisplayedRowAtIndex(0)!,
+                column: api.getColumn('a')!,
+                value: 'x',
+                source: 'api',
+            });
+            await userEvent.click(await openMenuOption('Autosize All Columns'));
+
+            await waitFor(() => expect(api.getColumn('a')!.getActualWidth()).toBe(300));
+            expect(totalWidth(api)).toBe(900);
+        });
+    });
+
+    describe('header double-click', () => {
+        test('honours the strategy options', async () => {
+            const api = await gridsManager.createGridAndWait('myGrid', {
+                columnDefs,
+                rowData,
+                autoSizeStrategy: { type: 'fitCellContents', applyToUiActions: true, defaultMinWidth: 300 },
+            });
+            resetWidths(api);
+
+            const resizeHandle = document.querySelector<HTMLElement>(
+                '.ag-header-cell[col-id="a"] .ag-header-cell-resize'
+            )!;
+            resizeHandle.dispatchEvent(new MouseEvent('dblclick', { bubbles: true }));
+
+            await waitFor(() => expect(api.getColumn('a')!.getActualWidth()).toBe(300));
+            expect(api.getColumn('b')!.getActualWidth()).toBe(RESET_WIDTH);
+        });
+    });
+
+    describe('the auto-size API is unaffected', () => {
+        test('autoSizeAllColumns uses only the params it was given', async () => {
+            const api = await gridsManager.createGridAndWait('myGrid', {
+                columnDefs,
+                rowData,
+                autoSizeStrategy: { type: 'fitCellContents', applyToUiActions: true, defaultMinWidth: 300 },
+            });
+            resetWidths(api);
+
+            api.autoSizeAllColumns({});
+
+            await waitFor(() => expect(api.getColumn('a')!.getActualWidth()).toBe(100));
+        });
+    });
+
+    describe('validation', () => {
+        test('applyToUiActions on a non-fitCellContents strategy warns and leaves UI actions alone', async () => {
+            // this test deliberately misconfigures the strategy, which warns #322
+            enableDevValidations({ throwOn: ALL_SEVERITIES, suppress: [322] });
+            const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+            const api = await gridsManager.createGridAndWait('myGrid', {
+                columnDefs,
+                rowData,
+                // deliberately not valid TypeScript — this guards the JavaScript path
+                autoSizeStrategy: { type: 'fitProvidedWidth', width: 600, applyToUiActions: true } as any,
+            });
+
+            expect(warn.mock.calls.flat().join(' ')).toContain('applyToUiActions');
+            resetWidths(api);
+
+            api.showColumnMenu('a');
+            await userEvent.click(await openMenuOption('Autosize All Columns'));
+
+            // plain content fit, not a re-run of fitProvidedWidth
+            await waitFor(() => expect(api.getColumn('a')!.getActualWidth()).toBe(100));
+            expect(totalWidth(api)).toBe(300);
+        });
+    });
+});

--- a/testing/behavioural/src/columns/autosize-strategy-ui-actions.test.ts
+++ b/testing/behavioural/src/columns/autosize-strategy-ui-actions.test.ts
@@ -23,9 +23,15 @@ import {
 } from 'ag-grid-community';
 import { ColumnMenuModule, ContextMenuModule } from 'ag-grid-enterprise';
 
-import { ALL_SEVERITIES, GridColumns, TestGridsManager, openMenuOption, polyfillOffsetParent } from '../test-utils';
+import {
+    ALL_SEVERITIES,
+    GridColumns,
+    TestGridsManager,
+    mockGridLayout,
+    openMenuOption,
+    polyfillOffsetParent,
+} from '../test-utils';
 
-const GRID_WIDTH = 1000;
 const RESET_WIDTH = 220;
 
 describe('autoSizeStrategy applyToUiActions', () => {
@@ -81,7 +87,7 @@ describe('autoSizeStrategy applyToUiActions', () => {
             await userEvent.click(await openMenuOption('Autosize All Columns'));
 
             // the content pass shrinks each col to its 100 px minWidth, then the scale-up pass fills the grid
-            await waitFor(() => expect(totalWidth(api)).toBe(GRID_WIDTH));
+            await waitFor(() => expect(totalWidth(api)).toBe(mockGridLayout.gridWidth));
             await new GridColumns(api, 'column menu autosize all scaled up to grid width').checkColumns(`
                 CENTER
                 ├── a "A" width:334
@@ -133,6 +139,23 @@ describe('autoSizeStrategy applyToUiActions', () => {
             await waitFor(() => expect(api.getColumn('a')!.getActualWidth()).toBe(250));
             expect(api.getColumn('b')!.getActualWidth()).toBe(RESET_WIDTH);
             expect(api.getColumn('c')!.getActualWidth()).toBe(RESET_WIDTH);
+        });
+
+        test('Autosize This Column does not absorb the grid width', async () => {
+            const api = await gridsManager.createGridAndWait('myGrid', {
+                columnDefs,
+                rowData,
+                autoSizeStrategy: { type: 'fitCellContents', scaleUpToFitGridWidth: true, applyToUiActions: true },
+            });
+            await waitFor(() => expect(totalWidth(api)).toBe(mockGridLayout.gridWidth));
+            resetWidths(api);
+
+            api.showColumnMenu('a');
+            await userEvent.click(await openMenuOption('Autosize This Column'));
+
+            // sized to its content, not stretched over the space the other columns leave
+            await waitFor(() => expect(api.getColumn('a')!.getActualWidth()).toBe(100));
+            expect(api.getColumn('b')!.getActualWidth()).toBe(RESET_WIDTH);
         });
 
         test('widths match the default auto-size when applyToUiActions is not set', async () => {
@@ -212,8 +235,8 @@ describe('autoSizeStrategy applyToUiActions', () => {
 
     describe('validation', () => {
         test('applyToUiActions on a non-fitCellContents strategy warns and leaves UI actions alone', async () => {
-            // this test deliberately misconfigures the strategy, which warns #322
-            enableDevValidations({ throwOn: ALL_SEVERITIES, suppress: [322] });
+            // this test deliberately misconfigures the strategy, which warns #318
+            enableDevValidations({ throwOn: ALL_SEVERITIES, suppress: [318] });
             const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
             const api = await gridsManager.createGridAndWait('myGrid', {


### PR DESCRIPTION
Fix [AG-10370](https://ag-grid.atlassian.net/browse/AG-10370)
Fix [AG-4093](https://ag-grid.atlassian.net/browse/AG-4093)

- `autoSizeStrategy` is no longer an initial-only option; it can be updated via `setGridOption`.
- `fitCellContents` gains `applyToUiActions` — column/context menu auto-size actions and header double-click reuse the strategy's options.
- All strategies gain `events` — grid events which re-apply the strategy. Columns the user resized manually are left at their width.
- New `api.applyAutoSizeStrategy()` re-applies the strategy on demand (and clears manual-resize ownership).
