### PR TITLE
AG-15299: prepare line-height call sites for absolute px values

### DIFF
--- a/documentation/ag-grid-docs/public/styles/bryntum-demo.css
+++ b/documentation/ag-grid-docs/public/styles/bryntum-demo.css
@@ -21,7 +21,7 @@
     margin: 0 0 8px;
     font-size: var(--text-fs-lg);
     font-weight: var(--text-semibold);
-    line-height: 28px;
+    line-height: var(--text-lh-lg);
     color: var(--color-util-brand-600);
 }
 

--- a/documentation/ag-grid-docs/public/styles/bryntum-demo.css
+++ b/documentation/ag-grid-docs/public/styles/bryntum-demo.css
@@ -21,7 +21,7 @@
     margin: 0 0 8px;
     font-size: var(--text-fs-lg);
     font-weight: var(--text-semibold);
-    line-height: var(--text-lh-base);
+    line-height: 28px;
     color: var(--color-util-brand-600);
 }
 

--- a/documentation/ag-grid-docs/src/components/campaigns-components/BryntumCampaign.module.scss
+++ b/documentation/ag-grid-docs/src/components/campaigns-components/BryntumCampaign.module.scss
@@ -85,7 +85,7 @@
     margin: 0 0 $spacing-size-2;
     font-size: var(--text-fs-lg);
     font-weight: var(--text-semibold);
-    line-height: var(--text-lh-base);
+    line-height: 28px;
     color: var(--color-util-brand-600);
 
     #{$selector-darkmode} & {
@@ -100,7 +100,8 @@
 
 .heroHeading {
     font-size: 48px;
-    line-height: var(--text-lh-3xl);
+    // Ratio, not px: the font-size is fluid at the large breakpoint, so the line box must scale with it.
+    line-height: 1.1;
     color: var(--color-white);
     margin: 0 0 $spacing-size-4;
 
@@ -111,7 +112,7 @@
 
 .heroBody {
     font-size: var(--text-fs-lg);
-    line-height: var(--text-lh-base);
+    line-height: 28px;
     color: var(--color-white);
     opacity: 0.92;
     margin-bottom: $spacing-size-8;
@@ -248,7 +249,7 @@
 .textMediaCopy {
     h2 {
         font-size: var(--text-fs-2xl);
-        line-height: var(--text-lh-3xl);
+        line-height: 35px;
         margin: 0 0 $spacing-size-4;
     }
 
@@ -372,7 +373,7 @@
 
 .partnershipHeading {
     font-size: var(--text-fs-2xl);
-    line-height: var(--text-lh-3xl);
+    line-height: 35px;
     margin: 0 0 $spacing-size-4;
 }
 
@@ -466,7 +467,7 @@
 .miniDemoCopy {
     h2 {
         font-size: var(--text-fs-2xl);
-        line-height: var(--text-lh-3xl);
+        line-height: 35px;
         margin: 0 0 $spacing-size-4;
     }
 
@@ -618,7 +619,7 @@
 .exampleCardDescription {
     margin: $spacing-size-1 0 0;
     font-size: var(--text-fs-sm);
-    line-height: var(--text-lh-base);
+    line-height: 20px;
     color: var(--color-fg-secondary);
 }
 

--- a/documentation/ag-grid-docs/src/components/campaigns-components/BryntumCampaign.module.scss
+++ b/documentation/ag-grid-docs/src/components/campaigns-components/BryntumCampaign.module.scss
@@ -85,7 +85,7 @@
     margin: 0 0 $spacing-size-2;
     font-size: var(--text-fs-lg);
     font-weight: var(--text-semibold);
-    line-height: 28px;
+    line-height: var(--text-lh-lg);
     color: var(--color-util-brand-600);
 
     #{$selector-darkmode} & {
@@ -112,7 +112,7 @@
 
 .heroBody {
     font-size: var(--text-fs-lg);
-    line-height: 28px;
+    line-height: var(--text-lh-lg);
     color: var(--color-white);
     opacity: 0.92;
     margin-bottom: $spacing-size-8;
@@ -249,7 +249,7 @@
 .textMediaCopy {
     h2 {
         font-size: var(--text-fs-2xl);
-        line-height: 35px;
+        line-height: var(--text-lh-2xl);
         margin: 0 0 $spacing-size-4;
     }
 
@@ -373,7 +373,7 @@
 
 .partnershipHeading {
     font-size: var(--text-fs-2xl);
-    line-height: 35px;
+    line-height: var(--text-lh-2xl);
     margin: 0 0 $spacing-size-4;
 }
 
@@ -467,7 +467,7 @@
 .miniDemoCopy {
     h2 {
         font-size: var(--text-fs-2xl);
-        line-height: 35px;
+        line-height: var(--text-lh-2xl);
         margin: 0 0 $spacing-size-4;
     }
 
@@ -619,7 +619,7 @@
 .exampleCardDescription {
     margin: $spacing-size-1 0 0;
     font-size: var(--text-fs-sm);
-    line-height: 20px;
+    line-height: var(--text-lh-sm);
     color: var(--color-fg-secondary);
 }
 

--- a/documentation/ag-grid-docs/src/components/docs/components/Header.module.scss
+++ b/documentation/ag-grid-docs/src/components/docs/components/Header.module.scss
@@ -58,7 +58,7 @@
     justify-self: start;
     font-size: var(--text-fs-sm);
     font-weight: var(--text-regular);
-    line-height: 20px;
+    line-height: var(--text-lh-sm);
     color: var(--color-text-tertiary);
 }
 

--- a/documentation/ag-grid-docs/src/components/docs/components/Header.module.scss
+++ b/documentation/ag-grid-docs/src/components/docs/components/Header.module.scss
@@ -58,7 +58,7 @@
     justify-self: start;
     font-size: var(--text-fs-sm);
     font-weight: var(--text-regular);
-    line-height: var(--text-lh-base);
+    line-height: 20px;
     color: var(--color-text-tertiary);
 }
 

--- a/documentation/ag-grid-docs/src/components/landing-pages/sections/comparison/ComparisonTable.module.scss
+++ b/documentation/ag-grid-docs/src/components/landing-pages/sections/comparison/ComparisonTable.module.scss
@@ -55,7 +55,7 @@
 .headerTitle {
     font-size: var(--text-fs-lg);
     font-weight: var(--text-bold);
-    line-height: var(--text-lh-tight);
+    line-height: var(--text-lh-ratio-tight);
     color: var(--color-fg-primary);
 
     @media screen and (max-width: $breakpoint-landing-page-medium) {

--- a/documentation/ag-grid-docs/src/components/license-setup/components/LicenseSetup.module.scss
+++ b/documentation/ag-grid-docs/src/components/license-setup/components/LicenseSetup.module.scss
@@ -142,7 +142,7 @@
 
         td {
             padding: 0;
-            line-height: var(--text-lh-tight);
+            line-height: var(--text-lh-ratio-tight);
             font-weight: var(--text-bold);
 
             &:not(:last-child) {

--- a/documentation/ag-grid-docs/src/components/license-setup/components/LicenseSetup.module.scss
+++ b/documentation/ag-grid-docs/src/components/license-setup/components/LicenseSetup.module.scss
@@ -26,7 +26,7 @@
     word-break: break-all;
     font-family: var(--text-monospace-font-family);
     font-size: 15px;
-    line-height: var(--text-lh-base);
+    line-height: 21px;
 }
 
 .license {

--- a/documentation/ag-grid-docs/src/components/quotes/Quotes.module.scss
+++ b/documentation/ag-grid-docs/src/components/quotes/Quotes.module.scss
@@ -56,7 +56,7 @@
     flex-direction: column;
     justify-content: space-between;
     font-size: var(--text-fs-base);
-    line-height: var(--text-lh-2xl);
+    line-height: 24px;
     border: 1px solid var(--color-border-secondary);
     margin: -1px 0 0 -1px;
     padding: 24px;

--- a/documentation/ag-grid-docs/src/components/quotes/Quotes.module.scss
+++ b/documentation/ag-grid-docs/src/components/quotes/Quotes.module.scss
@@ -56,7 +56,7 @@
     flex-direction: column;
     justify-content: space-between;
     font-size: var(--text-fs-base);
-    line-height: 24px;
+    line-height: var(--text-lh-base);
     border: 1px solid var(--color-border-secondary);
     margin: -1px 0 0 -1px;
     padding: 24px;

--- a/documentation/ag-grid-docs/src/pages-styles/campaigns.module.scss
+++ b/documentation/ag-grid-docs/src/pages-styles/campaigns.module.scss
@@ -419,7 +419,7 @@
     justify-content: space-between;
     width: 33.33%;
     font-size: var(--text-fs-base);
-    line-height: var(--text-lh-2xl);
+    line-height: 24px;
     padding: $spacing-size-10;
 
     @media screen and (max-width: $breakpoint-pricing-medium) {
@@ -437,6 +437,7 @@
 
     blockquote {
         font-size: var(--text-fs-lg);
+        line-height: 30px;
         font-weight: var(--text-semibold);
         margin-bottom: $spacing-size-6;
         color: var(--color-fg-primary);

--- a/documentation/ag-grid-docs/src/pages-styles/campaigns.module.scss
+++ b/documentation/ag-grid-docs/src/pages-styles/campaigns.module.scss
@@ -419,7 +419,7 @@
     justify-content: space-between;
     width: 33.33%;
     font-size: var(--text-fs-base);
-    line-height: 24px;
+    line-height: var(--text-lh-base);
     padding: $spacing-size-10;
 
     @media screen and (max-width: $breakpoint-pricing-medium) {
@@ -437,7 +437,7 @@
 
     blockquote {
         font-size: var(--text-fs-lg);
-        line-height: 30px;
+        line-height: var(--text-lh-lg);
         font-weight: var(--text-semibold);
         margin-bottom: $spacing-size-6;
         color: var(--color-fg-primary);

--- a/documentation/ag-grid-docs/src/pages-styles/homepage.module.scss
+++ b/documentation/ag-grid-docs/src/pages-styles/homepage.module.scss
@@ -69,7 +69,7 @@ body {
 
     h1,
     h2 {
-        line-height: var(--text-lh-tight);
+        line-height: var(--text-lh-ratio-tight);
         color: var(--color-white);
     }
 
@@ -343,7 +343,7 @@ body {
     > div {
         text-align: center;
         margin-bottom: $spacing-size-10;
-        list-style: var(--text-lh-tight);
+        list-style: var(--text-lh-ratio-tight);
 
         @media screen and (min-width: $breakpoint-sponsorship-large) {
             text-align: unset;

--- a/external/ag-website-shared/src/components/automated-examples/AutomatedExampleDebug.module.scss
+++ b/external/ag-website-shared/src/components/automated-examples/AutomatedExampleDebug.module.scss
@@ -67,7 +67,7 @@ $z-index-debug-panel: $z-index-debug-canvas + 200;
 
         button:not([class^='ag-']) {
             padding: $spacing-size-1;
-            line-height: var(--text-lh-ultra-tight);
+            line-height: var(--text-lh-ratio-ultra-tight);
         }
     }
 

--- a/external/ag-website-shared/src/components/changelog/changelog.module.scss
+++ b/external/ag-website-shared/src/components/changelog/changelog.module.scss
@@ -58,7 +58,7 @@
 
 .searchExplainer,
 label.searchBreakingText {
-    line-height: var(--text-lh-tight);
+    line-height: var(--text-lh-ratio-tight);
 
     @media screen and (max-width: $breakpoint-changelog-pipeline-large) {
         display: none;

--- a/external/ag-website-shared/src/components/contact-form/ContactResultPage.module.scss
+++ b/external/ag-website-shared/src/components/contact-form/ContactResultPage.module.scss
@@ -43,13 +43,14 @@
 .heroHeading {
     font-size: 36px;
     font-weight: var(--text-bold);
-    line-height: var(--text-lh-tight);
+    line-height: 43px;
     margin: 0;
     color: var(--color-fg-primary);
 
     letter-spacing: -1px;
     @media screen and (min-width: $breakpoint-docs-nav-medium) {
         font-size: 48px;
+        line-height: 58px;
     }
 }
 

--- a/external/ag-website-shared/src/components/contact-form/ContactResultPage.module.scss
+++ b/external/ag-website-shared/src/components/contact-form/ContactResultPage.module.scss
@@ -192,7 +192,7 @@
 .heading {
     font-size: var(--text-fs-3xl);
     font-weight: var(--text-bold);
-    line-height: var(--text-lh-tight);
+    line-height: var(--text-lh-ratio-tight);
     margin: 0;
     color: var(--color-fg-primary);
 

--- a/external/ag-website-shared/src/components/license-pricing/Licenses.module.scss
+++ b/external/ag-website-shared/src/components/license-pricing/Licenses.module.scss
@@ -72,7 +72,7 @@
 
 p.name {
     font-size: 46px;
-    line-height: var(--text-lh-ultra-tight);
+    line-height: var(--text-lh-ratio-ultra-tight);
     margin-top: $spacing-size-1;
     margin-bottom: $spacing-size-2;
 
@@ -136,7 +136,7 @@ p.name {
     height: 52px;
     padding-bottom: $spacing-size-3;
     font-size: 30px;
-    line-height: var(--text-lh-ultra-tight);
+    line-height: var(--text-lh-ratio-ultra-tight);
     font-weight: var(--text-bold);
     letter-spacing: -0.05em;
 
@@ -164,7 +164,7 @@ p.name {
     margin-bottom: $spacing-size-4;
 
     p {
-        line-height: var(--text-lh-tight);
+        line-height: var(--text-lh-ratio-tight);
     }
 }
 

--- a/external/ag-website-shared/src/components/license-pricing/SocialProof.module.scss
+++ b/external/ag-website-shared/src/components/license-pricing/SocialProof.module.scss
@@ -130,7 +130,7 @@
     justify-content: space-between;
     width: 50%;
     font-size: var(--text-fs-base);
-    line-height: var(--text-lh-2xl);
+    line-height: 24px;
 
     @media screen and (max-width: $breakpoint-pricing-medium) {
         width: 100%;

--- a/external/ag-website-shared/src/components/license-pricing/SocialProof.module.scss
+++ b/external/ag-website-shared/src/components/license-pricing/SocialProof.module.scss
@@ -130,7 +130,7 @@
     justify-content: space-between;
     width: 50%;
     font-size: var(--text-fs-base);
-    line-height: 24px;
+    line-height: var(--text-lh-base);
 
     @media screen and (max-width: $breakpoint-pricing-medium) {
         width: 100%;

--- a/external/ag-website-shared/src/components/license-pricing/license-pricing.module.scss
+++ b/external/ag-website-shared/src/components/license-pricing/license-pricing.module.scss
@@ -266,7 +266,7 @@
 
 .price {
     font-size: 46px !important; // !important for font-size weirdness
-    line-height: var(--text-lh-tight);
+    line-height: 55px;
     font-weight: var(--text-bold);
     letter-spacing: -0.05em;
 }

--- a/external/ag-website-shared/src/components/license-pricing/license-pricing.module.scss
+++ b/external/ag-website-shared/src/components/license-pricing/license-pricing.module.scss
@@ -76,7 +76,7 @@
     gap: $spacing-size-2 $spacing-size-4;
     margin: 0 auto;
     margin-top: $spacing-size-12;
-    line-height: var(--text-lh-tight);
+    line-height: var(--text-lh-ratio-tight);
     max-width: 600px;
     padding: $spacing-size-3;
     border: 1px solid var(--color-border-primary);
@@ -182,7 +182,7 @@
     }
 
     p {
-        line-height: var(--text-lh-tight);
+        line-height: var(--text-lh-ratio-tight);
     }
 }
 
@@ -242,7 +242,7 @@
 
     p {
         font-weight: var(--text-bold);
-        line-height: var(--text-lh-ultra-tight);
+        line-height: var(--text-lh-ratio-ultra-tight);
     }
 
     p:first-child {
@@ -308,7 +308,7 @@
     }
 
     ul {
-        line-height: var(--text-lh-tight);
+        line-height: var(--text-lh-ratio-tight);
     }
 
     li:not(:last-child) {
@@ -465,7 +465,7 @@
 }
 
 .trialLicenceHeader {
-    line-height: var(--text-lh-tight);
+    line-height: var(--text-lh-ratio-tight);
 }
 
 .trialLicenceCopyItem {

--- a/external/ag-website-shared/src/components/major-table/MajorTable.module.scss
+++ b/external/ag-website-shared/src/components/major-table/MajorTable.module.scss
@@ -21,7 +21,7 @@
 
     td {
         padding: $spacing-size-4 $spacing-size-2;
-        line-height: var(--text-lh-tight);
+        line-height: var(--text-lh-ratio-tight);
     }
 
     a span {

--- a/external/ag-website-shared/src/components/page-styles/docs.module.scss
+++ b/external/ag-website-shared/src/components/page-styles/docs.module.scss
@@ -180,10 +180,11 @@ blockquote:where(:not(:last-child)) {
     font-size: var(--text-fs-lg);
     margin-bottom: $spacing-size-8;
     color: var(--color-text-secondary);
-    line-height: var(--text-lh-sm);
+    line-height: 28px;
 
     :global(code) {
         font-size: 0.8em;
+        line-height: 22px;
     }
 }
 

--- a/external/ag-website-shared/src/components/page-styles/docs.module.scss
+++ b/external/ag-website-shared/src/components/page-styles/docs.module.scss
@@ -180,11 +180,11 @@ blockquote:where(:not(:last-child)) {
     font-size: var(--text-fs-lg);
     margin-bottom: $spacing-size-8;
     color: var(--color-text-secondary);
-    line-height: 28px;
+    line-height: var(--text-lh-lg);
 
     :global(code) {
-        font-size: 0.8em;
-        line-height: 22px;
+        font-size: var(--text-fs-base);
+        line-height: var(--text-lh-base);
     }
 }
 

--- a/external/ag-website-shared/src/components/policies/policyPage.module.scss
+++ b/external/ag-website-shared/src/components/policies/policyPage.module.scss
@@ -30,7 +30,7 @@
 
         nav li:not(:last-child) {
             margin-bottom: $spacing-size-2;
-            line-height: var(--text-lh-tight);
+            line-height: var(--text-lh-ratio-tight);
         }
     }
 }

--- a/external/ag-website-shared/src/components/roadmap/Roadmap.module.scss
+++ b/external/ag-website-shared/src/components/roadmap/Roadmap.module.scss
@@ -49,7 +49,7 @@
 
     h1,
     h2 {
-        line-height: var(--text-lh-tight);
+        line-height: var(--text-lh-ratio-tight);
         color: var(--color-text-brand-primary);
 
         #{$selector-darkmode} & {

--- a/external/ag-website-shared/src/components/theme-builder/ParamSearchSelector.tsx
+++ b/external/ag-website-shared/src/components/theme-builder/ParamSearchSelector.tsx
@@ -359,6 +359,6 @@ const ItemLabel = styled('div')`
 
 const ItemDocs = styled('div')`
     font-size: var(--text-fs-xs);
-    line-height: 14px;
+    line-height: var(--text-lh-xs);
     color: var(--color-fg-secondary);
 `;

--- a/external/ag-website-shared/src/components/theme-builder/ParamSearchSelector.tsx
+++ b/external/ag-website-shared/src/components/theme-builder/ParamSearchSelector.tsx
@@ -359,6 +359,6 @@ const ItemLabel = styled('div')`
 
 const ItemDocs = styled('div')`
     font-size: var(--text-fs-xs);
-    line-height: var(--text-lh-tight);
+    line-height: 14px;
     color: var(--color-fg-secondary);
 `;

--- a/external/ag-website-shared/src/components/theme-builder/ParamSearchSelector.tsx
+++ b/external/ag-website-shared/src/components/theme-builder/ParamSearchSelector.tsx
@@ -354,7 +354,7 @@ const ItemContent = styled('div')`
 
 const ItemLabel = styled('div')`
     font-weight: var(--text-semibold);
-    line-height: var(--text-lh-tight);
+    line-height: var(--text-lh-ratio-tight);
 `;
 
 const ItemDocs = styled('div')`

--- a/external/ag-website-shared/src/design-system/_base.scss
+++ b/external/ag-website-shared/src/design-system/_base.scss
@@ -14,7 +14,8 @@ html {
 
     font-family: var(--text-font-family);
     font-size: var(--text-fs-base);
-    line-height: var(--text-lh-base);
+    // Ratio: every element without its own line-height inherits this and must re-multiply per font-size.
+    line-height: var(--text-lh-ratio-base);
     font-weight: var(--text-regular);
     background-color: var(--color-bg-primary);
     color: var(--color-text-primary);

--- a/external/ag-website-shared/src/design-system/_root.scss
+++ b/external/ag-website-shared/src/design-system/_root.scss
@@ -61,6 +61,10 @@
     --text-semibold: 600;
     --text-bold: 700;
 
+    // Ratios, for a line-height inherited by a subtree: a length is inherited as-is, so descendants
+    // with a different font-size would keep the ancestor's line box. Pair --text-lh-<step> with its
+    // own --text-fs-<step> only.
+    --text-lh-ratio-base: 1.4;
     --text-lh-tight: 1.2;
     --text-lh-ultra-tight: 1;
 

--- a/external/ag-website-shared/src/design-system/_root.scss
+++ b/external/ag-website-shared/src/design-system/_root.scss
@@ -61,12 +61,15 @@
     --text-semibold: 600;
     --text-bold: 700;
 
-    // Ratios, for a line-height inherited by a subtree: a length is inherited as-is, so descendants
-    // with a different font-size would keep the ancestor's line box. Pair --text-lh-<step> with its
-    // own --text-fs-<step> only.
+    // Ratios: a length is inherited as-is, so use these wherever the font-size is inherited, fluid or
+    // unknown. --text-lh-<step> is paired, and valid only alongside its own --text-fs-<step>.
     --text-lh-ratio-base: 1.4;
-    --text-lh-tight: 1.2;
-    --text-lh-ultra-tight: 1;
+    --text-lh-ratio-tight: 1.2;
+    --text-lh-ratio-ultra-tight: 1;
+
+    // Deprecated: ag-charts and ag-studio still use these names. Remove once both have migrated.
+    --text-lh-tight: var(--text-lh-ratio-tight);
+    --text-lh-ultra-tight: var(--text-lh-ratio-ultra-tight);
 
     --text-fs-2xs: 10px;
     --text-lh-2xs: 1.2;

--- a/external/ag-website-shared/src/design-system/components/_containers.scss
+++ b/external/ag-website-shared/src/design-system/components/_containers.scss
@@ -66,7 +66,7 @@
     position: relative;
     display: inline-block;
     padding: ($spacing-size-2 + $spacing-size-1) $spacing-size-1;
-    line-height: var(--text-lh-tight);
+    line-height: var(--text-lh-ratio-tight);
     color: var(--color-fg-tertiary);
     transition: color $transition-default-timing;
     cursor: pointer;

--- a/external/ag-website-shared/src/design-system/core/_mixins.scss
+++ b/external/ag-website-shared/src/design-system/core/_mixins.scss
@@ -28,7 +28,7 @@
 
     td {
         padding: 0;
-        line-height: var(--text-lh-tight);
+        line-height: var(--text-lh-ratio-tight);
         font-weight: var(--text-bold);
 
         &:not(:last-child) {

--- a/external/ag-website-shared/src/design-system/elements/_form-elements.scss
+++ b/external/ag-website-shared/src/design-system/elements/_form-elements.scss
@@ -64,7 +64,7 @@ input[type='number'],
 textarea {
     &#{$selector-exclude-grid} {
         padding: math.div(6em, 16) math.div(12em, 16);
-        line-height: var(--text-lh-base);
+        line-height: var(--text-lh-ratio-base);
         border-radius: var(--radius-sm);
         border: 1px solid var(--color-input-border);
         background-color: var(--color-bg-primary);
@@ -234,7 +234,7 @@ select#{$selector-exclude-grid} {
     appearance: none;
     padding: math.div(6em, 16) math.div(36em, 16) math.div(6em, 16) math.div(12em, 16);
     font-size: var(--text-fs-base);
-    line-height: var(--text-lh-base);
+    line-height: var(--text-lh-ratio-base);
     border-radius: var(--radius-sm);
     background-color: var(--color-bg-primary);
     background-image: var(--svg-chevron-down);


### PR DESCRIPTION
Groundwork for [AG-15299](https://ag-grid.atlassian.net/browse/AG-15299). **The token values are not changed yet** — this makes that change safe to do.

Two problems block a straight swap of the eight `--text-lh-*` tokens to px:

1. Only 19 of the 65 `line-height: var(--text-lh-*)` call sites in this repo pair a line-height token with its matching `--text-fs-*`. The rest reference a token belonging to a different step, so changing the token values would silently rewrite them.
2. `_base.scss` sets `html { line-height: var(--text-lh-base) }`. A unitless line-height re-multiplies against each descendant's font-size; an absolute px one does not, so every element inheriting from `html` would collapse onto one fixed length.

So this PR (a) points each mismatched site at the `--text-lh-*` belonging to its own `--text-fs-*`, keeping the scale as the single source of truth, (b) splits `--text-lh-ratio-base` out for the consumers that genuinely need a ratio — the `html` default, and form elements whose font-size comes from the user agent — and (c) renames the remaining size-agnostic ratios to match, so the naming itself says which tokens are safe to inherit.

### This changes rendering — deliberately

Honouring the pairing moves those sites onto the correct step's ratio. Computed font-size and line-height measured for every text element across 20 pages; **62 of 11,478 elements move**:

| where | font-size | line box | shift |
|---|---|---|---|
| campaign eyebrows, hero body, quote blockquote, docs intro paragraph (21 els) | 20px | 28px → 24px | −4px |
| three campaign headings (10 els) | 32px | 35.2px → 48px | +12.8px, largest element +25.6px |
| homepage and pricing quotes (5 els) | 16px | 24px → 22.4px | −1.6px |

The remainder is reflow around those changes plus known homepage animation jitter. Worth a design eye on the campaign headings in particular.

### Why the ratio split matters

With the px tokens applied on top of this branch, 419 of 9,637 elements change. Without the ratio split it is 6,957 — 40px headings drop from a 48px to a 24px line box, and the largest shift is 167px.

### Naming: `--text-lh-ratio-*` vs `--text-lh-<step>`

`--text-lh-tight` and `--text-lh-ultra-tight` are size-agnostic by design and can never become px: `--text-lh-ultra-tight` is applied at both `font-size: 46px` and `font-size: 30px`, and 17 of `--text-lh-tight`'s uses sit on rules with no `font-size` at all (`td`, `.tabs-nav-link`, a bare `p`), where the author cannot know the size to pin. They are renamed to `--text-lh-ratio-tight` / `--text-lh-ratio-ultra-tight`, which leaves one rule:

- `--text-lh-ratio-*` — unitless; use where the font-size is inherited, fluid or unknown.
- `--text-lh-<step>` — paired; valid only alongside its own `--text-fs-<step>`.

The eight scale tokens deliberately keep their names — they are the ones becoming px, so a `ratio` prefix on them would be wrong the moment the values change.

### Notes for review

- Four sites keep a literal value because no token applies: `BryntumCampaign .heroHeading` is `clamp(48px, 5.5vw, 72px)` so its line box must be a ratio; `LicenseSetup .licencePlaceholder` (15px), `ContactResultPage .heroHeading` (36px/48px) and `license-pricing .price` (46px) declare raw font sizes that are not on the scale.
- The docs intro `code` was `font-size: 0.8em` of a 20px parent, i.e. exactly `--text-fs-base` — stated explicitly so the pairing survives the token change.
- The old `--text-lh-tight` / `--text-lh-ultra-tight` names are kept as aliases of the new ones. ag-charts and ag-studio each have 5 files of their own referencing the old names, and would silently fall back to `line-height: normal` when this shared change lands there ahead of their migration. Remove the aliases once both repos are done.
- The token table in `ag-eng/skills/website-css/design-tokens.md` (ag-dev-prompts) also lists the old names.
- The rename is value-preserving by construction; verified by confirming every referenced `--text-lh-*` still resolves to a definition, rather than by re-measuring.
- Commit 1 pinned these sites to px to keep them pixel-identical; commit 3 supersedes that with the token pairing and commit 4 does the rename. Worth reading the commits in order.

### What ag-charts and ag-studio inherit on sync

16 of the changed files are in `external/ag-website-shared/`, so they land in both other products on the next subrepo sync. Eleven are pure renames with identical values; three change a computed line box:

| where | applies to | font-size | line box | shift |
|---|---|---|---|---|
| docs intro paragraph (`article > p:first-child`) | every docs page, both products | 20px | 28px → 24px | −4px |
| pricing page `.quote` (`SocialProof`) | both products | 16px | 24px → 22.4px | −1.6px |
| theme-builder param docs (`ItemDocs`) | ag-studio only | 12px | 14.4px → 20px | +5.6px (+39%) |
| `ContactResultPage .heroHeading` | both products | 36px / 48px | 43.2 → 43px, 57.6 → 58px | sub-pixel, de-fractioning |
| `license-pricing .price` | both products | 46px | 55.2px → 55px | −0.2px |

The docs intro is the widest-reaching, since it is on every documentation page in both products. The theme-builder one is the largest single jump and is studio-only.

Neither repo needs a code change to keep working — the deprecated aliases cover their old-name references. The follow-up work there is: migrate their 5 files each off the old names so the aliases can be deleted, and audit their own line-height call sites for step mismatch (ag-charts has 12, ag-studio 16) before the token values flip to px.

### Still to do on the ticket

Sign-off on the px token values, decisions on two phantom tokens (`--text-lh-relaxed`, `--text-lh-1xl`, both currently rendering as `line-height: normal`), and 13 residual rule patterns where a scale token sits on a re-sized element.

Separately found, not fixed here:

- `CodeHighlight.module.scss` sets `line-height: 0.1em` on code-block lines, computing to 1.5px — the likely cause of the code-block spacing bug reported on the ticket.
- `homepage.module.scss:346` is `list-style: var(--text-lh-ratio-tight)`, a line-height token assigned to `list-style`. Invalid, and dropped by the parser.
