### PR TITLE
AG-16738-filter-options-validation-and-typing-follow-up

### DIFF
--- a/packages/ag-grid-community/src/filter/filterLocaleText.ts
+++ b/packages/ag-grid-community/src/filter/filterLocaleText.ts
@@ -1,5 +1,5 @@
 import type { LocaleTextFunc } from 'ag-stack';
-import { _translate } from 'ag-stack';
+import { _hasOwn, _translate } from 'ag-stack';
 
 const FILTER_LOCALE_TEXT = {
     applyFilter: 'Apply',
@@ -83,10 +83,34 @@ const FILTER_LOCALE_TEXT = {
 
 export type FilterLocaleTextKey = keyof typeof FILTER_LOCALE_TEXT;
 
+/**
+ * An option key is a locale key only when the grid itself defines text for it, so an own-property test: `toString`
+ * and friends are legal option keys and reach `_translate` as a function, which throws.
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
+ */
+export function isFilterLocaleTextKey(key: string): key is FilterLocaleTextKey {
+    return _hasOwn(FILTER_LOCALE_TEXT, key);
+}
+
+/**
+ * A filter option key the grid does not define is its own default, so `getLocaleText` is never handed the
+ * `undefined` its `defaultValue: string` contract forbids.
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
+ */
+export function translateFilterOptionKey(
+    bean: { getLocaleTextFunc(): LocaleTextFunc },
+    key: string | null | undefined
+): string {
+    if (key == null) {
+        return ''; // no option, so nothing to localise
+    }
+    return isFilterLocaleTextKey(key) ? translateForFilter(bean, key) : bean.getLocaleTextFunc()(key, key);
+}
+
 /** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function translateForFilter(
     bean: { getLocaleTextFunc(): LocaleTextFunc },
-    key: keyof typeof FILTER_LOCALE_TEXT,
+    key: FilterLocaleTextKey,
     variableValues?: string[]
 ): string {
     return _translate(bean, FILTER_LOCALE_TEXT, key, variableValues);

--- a/packages/ag-grid-community/src/filter/floating/provided/simpleFloatingFilter.ts
+++ b/packages/ag-grid-community/src/filter/floating/provided/simpleFloatingFilter.ts
@@ -36,10 +36,11 @@ export abstract class SimpleFloatingFilter<TParams extends IFloatingFilterParams
 
     protected abstract readonly filterType: 'text' | 'number' | 'bigint' | 'date';
 
-    protected abstract readonly FilterModelFormatterClass: new (
+    /** Subclasses narrow `filterParams` to their own filter's params type. */
+    protected abstract createModelFormatter(
         optionsFactory: OptionsFactory,
         filterParams: ISimpleFilterParams
-    ) => SimpleFilterModelFormatter<ISimpleFilterParams>;
+    ): SimpleFilterModelFormatter<ISimpleFilterParams>;
 
     protected setLastTypeFromModel(model: ProvidedFilterModel): void {
         // if no model provided by the parent filter use default
@@ -99,7 +100,7 @@ export abstract class SimpleFloatingFilter<TParams extends IFloatingFilterParams
         optionsFactory.init(this.beans.log, params.filterParams as ISimpleFilterParams, this.defaultOptions);
 
         this.filterModelFormatter = this.createManagedBean(
-            new this.FilterModelFormatterClass(optionsFactory, params.filterParams as ISimpleFilterParams)
+            this.createModelFormatter(optionsFactory, params.filterParams as ISimpleFilterParams)
         );
 
         this.setSimpleParams(params, false);

--- a/packages/ag-grid-community/src/filter/provided/bigInt/bigIntFilterHandler.ts
+++ b/packages/ag-grid-community/src/filter/provided/bigInt/bigIntFilterHandler.ts
@@ -1,6 +1,7 @@
 import { _parseBigIntOrNull } from 'ag-stack';
 
 import type { Comparator } from '../iScalarFilter';
+import type { OptionsFactory } from '../optionsFactory';
 import { ScalarFilterHandler } from '../scalarFilterHandler';
 import { DEFAULT_BIGINT_FILTER_OPTIONS } from './bigIntFilterConstants';
 import { BigIntFilterModelFormatter } from './bigIntFilterModelFormatter';
@@ -9,10 +10,15 @@ import type { BigIntFilterModel, IBigIntFilterParams } from './iBigIntFilter';
 
 export class BigIntFilterHandler extends ScalarFilterHandler<BigIntFilterModel, bigint, IBigIntFilterParams> {
     public readonly filterType = 'bigint' as const;
-    protected readonly FilterModelFormatterClass = BigIntFilterModelFormatter;
-
     constructor() {
         super(mapValuesFromBigIntFilterModel, DEFAULT_BIGINT_FILTER_OPTIONS);
+    }
+
+    protected createModelFormatter(
+        optionsFactory: OptionsFactory,
+        filterParams: IBigIntFilterParams
+    ): BigIntFilterModelFormatter {
+        return new BigIntFilterModelFormatter(optionsFactory, filterParams);
     }
 
     protected override comparator(): Comparator<bigint> {

--- a/packages/ag-grid-community/src/filter/provided/bigInt/bigIntFloatingFilter.ts
+++ b/packages/ag-grid-community/src/filter/provided/bigInt/bigIntFloatingFilter.ts
@@ -3,17 +3,29 @@ import { _parseBigIntOrNull } from 'ag-stack';
 import { FloatingFilterTextInputService } from '../../floating/provided/floatingFilterTextInputService';
 import type { FloatingFilterInputService } from '../../floating/provided/iFloatingFilterInputService';
 import { TextInputFloatingFilter } from '../../floating/provided/textInputFloatingFilter';
+import type { OptionsFactory } from '../optionsFactory';
 import { DEFAULT_BIGINT_FILTER_OPTIONS } from './bigIntFilterConstants';
 import { BigIntFilterModelFormatter } from './bigIntFilterModelFormatter';
 import { getAllowedCharPattern } from './bigIntFilterUtils';
-import type { BigIntFilterModel, BigIntFilterParams, IBigIntFloatingFilterParams } from './iBigIntFilter';
+import type {
+    BigIntFilterModel,
+    BigIntFilterParams,
+    IBigIntFilterParams,
+    IBigIntFloatingFilterParams,
+} from './iBigIntFilter';
 
 export class BigIntFloatingFilter extends TextInputFloatingFilter<IBigIntFloatingFilterParams, BigIntFilterModel> {
-    protected readonly FilterModelFormatterClass = BigIntFilterModelFormatter;
     private allowedCharPattern: string | null;
     private bigintParser: BigIntFilterParams['bigintParser'] | undefined;
     protected readonly filterType = 'bigint';
     protected readonly defaultOptions = DEFAULT_BIGINT_FILTER_OPTIONS;
+
+    protected createModelFormatter(
+        optionsFactory: OptionsFactory,
+        filterParams: IBigIntFilterParams
+    ): BigIntFilterModelFormatter {
+        return new BigIntFilterModelFormatter(optionsFactory, filterParams);
+    }
 
     protected override updateParams(params: IBigIntFloatingFilterParams): void {
         const filterParams = params.filterParams as BigIntFilterParams;

--- a/packages/ag-grid-community/src/filter/provided/bigInt/iBigIntFilter.ts
+++ b/packages/ag-grid-community/src/filter/provided/bigInt/iBigIntFilter.ts
@@ -35,8 +35,8 @@ export type BigIntFilterParams<TData = any> = IBigIntFilterParams & IFilterParam
  * Parameters used in `colDef.filterParams` to configure a BigInt Filter (`agBigIntColumnFilter`).
  */
 export interface IBigIntFilterParams extends IScalarFilterParams {
-    /** Array of filter options to present to the user. A key the filter cannot evaluate is reported when used. */
-    filterOptions?: (IFilterOptionDef | ScalarFilterOptionKey | CustomFilterOptionKey)[];
+    /** Array of filter options to present to the user. */
+    filterOptions?: (IFilterOptionDef | ScalarFilterOptionKey)[];
     /** The default filter option to be selected. Must be one of the offered options. */
     defaultOption?: ScalarFilterOptionKey | CustomFilterOptionKey;
     /**

--- a/packages/ag-grid-community/src/filter/provided/date/dateFilterHandler.ts
+++ b/packages/ag-grid-community/src/filter/provided/date/dateFilterHandler.ts
@@ -1,5 +1,6 @@
 import type { Comparator } from '../iScalarFilter';
 import type { ISimpleFilterModelPresetType, Tuple } from '../iSimpleFilter';
+import type { OptionsFactory } from '../optionsFactory';
 import { ScalarFilterHandler } from '../scalarFilterHandler';
 import { DEFAULT_DATE_FILTER_OPTIONS } from './dateFilterConstants';
 import { DateFilterModelFormatter } from './dateFilterModelFormatter';
@@ -28,11 +29,17 @@ interface RangeCacheItem extends Range {
 
 export class DateFilterHandler extends ScalarFilterHandler<DateFilterModel, Date, IDateFilterParams> {
     public readonly filterType = 'date' as const;
-    protected readonly FilterModelFormatterClass = DateFilterModelFormatter;
     private readonly filterTypeToRangeCache = new Map<ISimpleFilterModelPresetType, RangeCacheItem>();
 
     constructor() {
         super(mapValuesFromDateFilterModel, DEFAULT_DATE_FILTER_OPTIONS);
+    }
+
+    protected createModelFormatter(
+        optionsFactory: OptionsFactory,
+        filterParams: IDateFilterParams
+    ): DateFilterModelFormatter {
+        return new DateFilterModelFormatter(optionsFactory, filterParams);
     }
 
     getOrRefreshRangeCacheItem(key: ISimpleFilterModelPresetType, rangeFn: (s: Date, e: Date) => [Date, Date]): Range {

--- a/packages/ag-grid-community/src/filter/provided/date/dateFilterModelFormatter.ts
+++ b/packages/ag-grid-community/src/filter/provided/date/dateFilterModelFormatter.ts
@@ -2,8 +2,7 @@ import { _dateToFormattedString, _parseDateTimeFromString } from 'ag-stack';
 
 import type { AgColumn } from '../../../entities/agColumn';
 import type { SharedFilterParams } from '../../../interfaces/iFilter';
-import type { FilterLocaleTextKey } from '../../filterLocaleText';
-import { translateForFilter } from '../../filterLocaleText';
+import { translateFilterOptionKey } from '../../filterLocaleText';
 import type { OptionsFactory } from '../optionsFactory';
 import { SCALAR_FILTER_TYPE_KEYS, SimpleFilterModelFormatter } from '../simpleFilterModelFormatter';
 import type { DateFilterModel, IDateFilterParams } from './iDateFilter';
@@ -48,7 +47,7 @@ export class DateFilterModelFormatter extends SimpleFilterModelFormatter<
         const formattedTo = () => (dateTo !== null ? formatDate(dateTo) : 'null');
 
         if (dateFrom == null && dateTo == null) {
-            return translateForFilter(this, type as FilterLocaleTextKey);
+            return translateFilterOptionKey(this, type);
         }
 
         if (forToolPanel) {

--- a/packages/ag-grid-community/src/filter/provided/date/dateFloatingFilter.ts
+++ b/packages/ag-grid-community/src/filter/provided/date/dateFloatingFilter.ts
@@ -9,12 +9,13 @@ import type { GridInputTextField } from '../../../widgets/gridWidgetTypes';
 import type { FloatingFilterDisplayParams, IFloatingFilterParams } from '../../floating/floatingFilter';
 import { SimpleFloatingFilter } from '../../floating/provided/simpleFloatingFilter';
 import type { ISimpleFilterModel } from '../iSimpleFilter';
+import type { OptionsFactory } from '../optionsFactory';
 import { getDebounceMs } from '../providedFilterUtils';
 import { DateCompWrapper } from './dateCompWrapper';
 import type { DateFilter } from './dateFilter';
 import { DEFAULT_DATE_FILTER_OPTIONS } from './dateFilterConstants';
 import { DateFilterModelFormatter } from './dateFilterModelFormatter';
-import type { DateFilterModel, DateFilterParams } from './iDateFilter';
+import type { DateFilterModel, DateFilterParams, IDateFilterParams } from './iDateFilter';
 
 const DateFloatingFilterElement: ElementParams = {
     tag: 'div',
@@ -33,13 +34,19 @@ export class DateFloatingFilter extends SimpleFloatingFilter<IFloatingFilterPara
     private readonly eReadOnlyText: GridInputTextField = RefPlaceholder;
     private readonly eDateWrapper: HTMLInputElement = RefPlaceholder;
 
-    protected readonly FilterModelFormatterClass = DateFilterModelFormatter;
     private dateComp: DateCompWrapper;
     protected readonly filterType = 'date';
     protected readonly defaultOptions = DEFAULT_DATE_FILTER_OPTIONS;
 
     constructor() {
         super(DateFloatingFilterElement, [AgInputTextFieldSelector]);
+    }
+
+    protected createModelFormatter(
+        optionsFactory: OptionsFactory,
+        filterParams: IDateFilterParams
+    ): DateFilterModelFormatter {
+        return new DateFilterModelFormatter(optionsFactory, filterParams);
     }
 
     protected override setParams(params: IFloatingFilterParams<DateFilter>): void {

--- a/packages/ag-grid-community/src/filter/provided/date/iDateFilter.ts
+++ b/packages/ag-grid-community/src/filter/provided/date/iDateFilter.ts
@@ -60,8 +60,8 @@ export type DateFilterParams<TData = any> = IDateFilterParams & IFilterParams<TD
  */
 
 export interface IDateFilterParams extends IScalarFilterParams {
-    /** Array of filter options to present to the user. A key the filter cannot evaluate is reported when used. */
-    filterOptions?: (IFilterOptionDef | DateFilterOptionKey | CustomFilterOptionKey)[];
+    /** Array of filter options to present to the user. */
+    filterOptions?: (IFilterOptionDef | DateFilterOptionKey)[];
     /** The default filter option to be selected. Must be one of the offered options. */
     defaultOption?: DateFilterOptionKey | CustomFilterOptionKey;
     /**

--- a/packages/ag-grid-community/src/filter/provided/iSimpleFilter.ts
+++ b/packages/ag-grid-community/src/filter/provided/iSimpleFilter.ts
@@ -51,7 +51,7 @@ export interface ISimpleFilterParams extends IProvidedFilterParams {
      * Array of filter options to present to the user.
      * A key the filter cannot evaluate is reported when a value is tested against it under the built-in matching.
      */
-    filterOptions?: (IFilterOptionDef | ISimpleFilterModelType | CustomFilterOptionKey)[];
+    filterOptions?: (IFilterOptionDef | ISimpleFilterModelType)[];
     /** The default filter option to be selected. Must be one of the offered options. */
     defaultOption?: ISimpleFilterModelType | CustomFilterOptionKey;
     /**

--- a/packages/ag-grid-community/src/filter/provided/number/iNumberFilter.ts
+++ b/packages/ag-grid-community/src/filter/provided/number/iNumberFilter.ts
@@ -35,8 +35,8 @@ export type NumberFilterParams<TData = any> = INumberFilterParams & IFilterParam
  */
 
 export interface INumberFilterParams extends IScalarFilterParams {
-    /** Array of filter options to present to the user. A key the filter cannot evaluate is reported when used. */
-    filterOptions?: (IFilterOptionDef | ScalarFilterOptionKey | CustomFilterOptionKey)[];
+    /** Array of filter options to present to the user. */
+    filterOptions?: (IFilterOptionDef | ScalarFilterOptionKey)[];
     /** The default filter option to be selected. Must be one of the offered options. */
     defaultOption?: ScalarFilterOptionKey | CustomFilterOptionKey;
     /**

--- a/packages/ag-grid-community/src/filter/provided/number/numberFilterHandler.ts
+++ b/packages/ag-grid-community/src/filter/provided/number/numberFilterHandler.ts
@@ -1,4 +1,5 @@
 import type { Comparator } from '../iScalarFilter';
+import type { OptionsFactory } from '../optionsFactory';
 import { ScalarFilterHandler } from '../scalarFilterHandler';
 import type { INumberFilterParams, NumberFilterModel } from './iNumberFilter';
 import { DEFAULT_NUMBER_FILTER_OPTIONS } from './numberFilterConstants';
@@ -7,10 +8,15 @@ import { mapValuesFromNumberFilterModel } from './numberFilterUtils';
 
 export class NumberFilterHandler extends ScalarFilterHandler<NumberFilterModel, number, INumberFilterParams> {
     public readonly filterType = 'number' as const;
-    protected readonly FilterModelFormatterClass = NumberFilterModelFormatter;
-
     constructor() {
         super(mapValuesFromNumberFilterModel, DEFAULT_NUMBER_FILTER_OPTIONS);
+    }
+
+    protected createModelFormatter(
+        optionsFactory: OptionsFactory,
+        filterParams: INumberFilterParams
+    ): NumberFilterModelFormatter {
+        return new NumberFilterModelFormatter(optionsFactory, filterParams);
     }
 
     protected override comparator(): Comparator<number> {

--- a/packages/ag-grid-community/src/filter/provided/number/numberFloatingFilter.ts
+++ b/packages/ag-grid-community/src/filter/provided/number/numberFloatingFilter.ts
@@ -7,7 +7,13 @@ import type { GridInputNumberField, GridInputTextField } from '../../../widgets/
 import { FloatingFilterTextInputService } from '../../floating/provided/floatingFilterTextInputService';
 import type { FloatingFilterInputService } from '../../floating/provided/iFloatingFilterInputService';
 import { TextInputFloatingFilter } from '../../floating/provided/textInputFloatingFilter';
-import type { INumberFloatingFilterParams, NumberFilterModel, NumberFilterParams } from './iNumberFilter';
+import type { OptionsFactory } from '../optionsFactory';
+import type {
+    INumberFilterParams,
+    INumberFloatingFilterParams,
+    NumberFilterModel,
+    NumberFilterParams,
+} from './iNumberFilter';
 import { DEFAULT_NUMBER_FILTER_OPTIONS } from './numberFilterConstants';
 import { NumberFilterModelFormatter } from './numberFilterModelFormatter';
 import { getAllowedCharPattern } from './numberFilterUtils';
@@ -104,10 +110,16 @@ class FloatingFilterNumberInputService extends BeanStub implements FloatingFilte
 }
 
 export class NumberFloatingFilter extends TextInputFloatingFilter<INumberFloatingFilterParams, NumberFilterModel> {
-    protected readonly FilterModelFormatterClass = NumberFilterModelFormatter;
     private allowedCharPattern: string | null;
     protected readonly filterType = 'number';
     protected readonly defaultOptions = DEFAULT_NUMBER_FILTER_OPTIONS;
+
+    protected createModelFormatter(
+        optionsFactory: OptionsFactory,
+        filterParams: INumberFilterParams
+    ): NumberFilterModelFormatter {
+        return new NumberFilterModelFormatter(optionsFactory, filterParams);
+    }
 
     protected override updateParams(params: INumberFloatingFilterParams): void {
         const allowedCharPattern = getAllowedCharPattern(params.filterParams as NumberFilterParams);

--- a/packages/ag-grid-community/src/filter/provided/providedFilterUtils.ts
+++ b/packages/ag-grid-community/src/filter/provided/providedFilterUtils.ts
@@ -3,7 +3,7 @@ import type { LocaleTextFunc } from 'ag-stack';
 import type { FilterWrapperParams } from '../../interfaces/iFilter';
 import type { LogService } from '../../validation/logService';
 import type { FilterLocaleTextKey } from '../filterLocaleText';
-import { translateForFilter } from '../filterLocaleText';
+import { translateFilterOptionKey, translateForFilter } from '../filterLocaleText';
 import type { IProvidedFilterParams } from './iProvidedFilter';
 import type { FilterOptionKey, FilterPlaceholderFunction } from './iSimpleFilter';
 import type { OptionsFactory } from './optionsFactory';
@@ -35,7 +35,7 @@ export function translateFilterOption(
     const customOption = optionsFactory.getCustomOption(filterOptionKey);
     return customOption
         ? bean.getLocaleTextFunc()(customOption.displayKey, customOption.displayName)
-        : translateForFilter(bean, filterOptionKey as FilterLocaleTextKey);
+        : translateFilterOptionKey(bean, filterOptionKey);
 }
 
 export function getPlaceholderText(

--- a/packages/ag-grid-community/src/filter/provided/simpleFilter.ts
+++ b/packages/ag-grid-community/src/filter/provided/simpleFilter.ts
@@ -19,6 +19,7 @@ import { _createElement } from '../../utils/element';
 import type { Component, ComponentSelector } from '../../widgets/component';
 import type { GridInputTextField, GridRadioButton, GridSelect } from '../../widgets/gridWidgetTypes';
 import type { FilterLocaleTextKey } from '../filterLocaleText';
+import { isFilterLocaleTextKey } from '../filterLocaleText';
 import type {
     FilterOptionKey,
     ICombinedSimpleModel,
@@ -375,9 +376,10 @@ export abstract class SimpleFilter<
         eType.setDisabled(filterListOptions.length <= 1);
     }
 
-    /** `translate` is overridden per filter, so a built-in key must go through it rather than the shared lookup. */
+    /** `translate` is overridden per filter, so a key the grid defines goes through it; any other is its own label. */
     private createBoilerplateListOption(option: string): ListOption {
-        return { value: option, text: this.translate(option as FilterLocaleTextKey) };
+        const text = isFilterLocaleTextKey(option) ? this.translate(option) : this.getLocaleTextFunc()(option, option);
+        return { value: option, text };
     }
 
     private createCustomListOption(option: IFilterOptionDef): ListOption {

--- a/packages/ag-grid-community/src/filter/provided/simpleFilterHandler.ts
+++ b/packages/ag-grid-community/src/filter/provided/simpleFilterHandler.ts
@@ -29,10 +29,11 @@ export abstract class SimpleFilterHandler<
     /** Used to get the filter type for filter models. */
     public abstract readonly filterType: 'text' | 'number' | 'bigint' | 'date';
 
-    protected abstract readonly FilterModelFormatterClass: new (
+    /** Subclasses narrow `filterParams` to their own filter's params type. */
+    protected abstract createModelFormatter(
         optionsFactory: OptionsFactory,
         filterParams: ISimpleFilterParams
-    ) => SimpleFilterModelFormatter<ISimpleFilterParams>;
+    ): SimpleFilterModelFormatter<ISimpleFilterParams>;
 
     protected params: FilterHandlerParams<any, any, TModel | ICombinedSimpleModel<TModel>, TParams>;
     private optionsFactory: OptionsFactory;
@@ -73,9 +74,7 @@ export abstract class SimpleFilterHandler<
         this.optionsFactory = optionsFactory;
         optionsFactory.init(this.beans.log, filterParams, this.defaultOptions);
 
-        this.filterModelFormatter = this.createManagedBean(
-            new this.FilterModelFormatterClass(optionsFactory, filterParams)
-        );
+        this.filterModelFormatter = this.createManagedBean(this.createModelFormatter(optionsFactory, filterParams));
 
         this.updateParams(params);
 

--- a/packages/ag-grid-community/src/filter/provided/text/iTextFilter.ts
+++ b/packages/ag-grid-community/src/filter/provided/text/iTextFilter.ts
@@ -66,8 +66,8 @@ export type TextFilterParams<TData = any> = ITextFilterParams & IFilterParams<TD
  */
 
 export interface ITextFilterParams extends ISimpleFilterParams {
-    /** Array of filter options to present to the user. A key the filter cannot evaluate is reported when used. */
-    filterOptions?: (IFilterOptionDef | TextFilterOptionKey | CustomFilterOptionKey)[];
+    /** Array of filter options to present to the user. */
+    filterOptions?: (IFilterOptionDef | TextFilterOptionKey)[];
     /** The default filter option to be selected. Must be one of the offered options. */
     defaultOption?: TextFilterOptionKey | CustomFilterOptionKey;
     /**

--- a/packages/ag-grid-community/src/filter/provided/text/textFilterHandler.ts
+++ b/packages/ag-grid-community/src/filter/provided/text/textFilterHandler.ts
@@ -1,6 +1,7 @@
 import type { FilterHandlerParams, IDoesFilterPassParams } from '../../../interfaces/iFilter';
 import type { FilterOptionKey, ICombinedSimpleModel, TextFilterOptionKey, Tuple } from '../iSimpleFilter';
 import { isCombinedFilterModel } from '../iSimpleFilter';
+import type { OptionsFactory } from '../optionsFactory';
 import { SimpleFilterHandler } from '../simpleFilterHandler';
 import { isBlank } from '../simpleFilterUtils';
 import type { ITextFilterParams, TextFilterModel, TextFormatter, TextMatcher } from './iTextFilter';
@@ -50,12 +51,18 @@ const defaultLowercaseFormatter: TextFormatter = (from: string) =>
 
 export class TextFilterHandler extends SimpleFilterHandler<TextFilterModel, string, ITextFilterParams> {
     public readonly filterType = 'text' as const;
-    protected readonly FilterModelFormatterClass = TextFilterModelFormatter;
     private matcher: TextMatcher;
     private formatter: TextFormatter;
 
     constructor() {
         super(mapValuesFromTextFilterModel, DEFAULT_TEXT_FILTER_OPTIONS);
+    }
+
+    protected createModelFormatter(
+        optionsFactory: OptionsFactory,
+        filterParams: ITextFilterParams
+    ): TextFilterModelFormatter {
+        return new TextFilterModelFormatter(optionsFactory, filterParams);
     }
 
     protected override updateParams(

--- a/packages/ag-grid-community/src/filter/provided/text/textFloatingFilter.ts
+++ b/packages/ag-grid-community/src/filter/provided/text/textFloatingFilter.ts
@@ -1,14 +1,21 @@
 import { FloatingFilterTextInputService } from '../../floating/provided/floatingFilterTextInputService';
 import type { FloatingFilterInputService } from '../../floating/provided/iFloatingFilterInputService';
 import { TextInputFloatingFilter } from '../../floating/provided/textInputFloatingFilter';
-import type { ITextFloatingFilterParams, TextFilterModel } from './iTextFilter';
+import type { OptionsFactory } from '../optionsFactory';
+import type { ITextFilterParams, ITextFloatingFilterParams, TextFilterModel } from './iTextFilter';
 import { DEFAULT_TEXT_FILTER_OPTIONS } from './textFilterConstants';
 import { TextFilterModelFormatter } from './textFilterModelFormatter';
 
 export class TextFloatingFilter extends TextInputFloatingFilter<ITextFloatingFilterParams, TextFilterModel> {
-    protected readonly FilterModelFormatterClass = TextFilterModelFormatter;
     protected readonly filterType = 'text';
     protected readonly defaultOptions = DEFAULT_TEXT_FILTER_OPTIONS;
+
+    protected createModelFormatter(
+        optionsFactory: OptionsFactory,
+        filterParams: ITextFilterParams
+    ): TextFilterModelFormatter {
+        return new TextFilterModelFormatter(optionsFactory, filterParams);
+    }
 
     protected createFloatingFilterInputService(): FloatingFilterInputService {
         return this.createManagedBean(new FloatingFilterTextInputService());

--- a/packages/ag-grid-community/src/misc/state/stateService.ts
+++ b/packages/ag-grid-community/src/misc/state/stateService.ts
@@ -1,4 +1,4 @@
-import { _debounce, _jsonEquals } from 'ag-stack';
+import { _debounce, _hasOwn, _jsonEquals } from 'ag-stack';
 
 import { _getColGroupState, _setColGroupState } from '../../columns/columnGroups/columnGroupState';
 import type { ColumnState, ColumnStateParams } from '../../columns/columnStateUtils';
@@ -661,10 +661,7 @@ export class StateService extends BeanStub implements NamedBean {
         source: 'gridInitializing' | 'api',
         ignoreSet?: Set<GridStateKey>
     ): void {
-        if (
-            ignoreSet?.has('columnGroup') ||
-            (source !== 'api' && !Object.prototype.hasOwnProperty.call(state, 'columnGroup'))
-        ) {
+        if (ignoreSet?.has('columnGroup') || (source !== 'api' && !_hasOwn(state, 'columnGroup'))) {
             return;
         }
 

--- a/packages/ag-grid-enterprise/src/advancedFilter/filterExpressionOperators.ts
+++ b/packages/ag-grid-enterprise/src/advancedFilter/filterExpressionOperators.ts
@@ -1,3 +1,5 @@
+import { _hasOwn } from 'ag-stack';
+
 import type { BaseCellDataType, IRowNode } from 'ag-grid-community';
 
 import type { ADVANCED_FILTER_LOCALE_TEXT } from './advancedFilterLocaleText';
@@ -82,10 +84,9 @@ function getEntries<ConvertedTValue, TValue = ConvertedTValue>(
     const len = keys.length;
     const entries: AutocompleteEntry[] = new Array(len);
     let count = 0;
-    const hasOwnProperty = Object.prototype.hasOwnProperty;
     for (let i = 0; i < len; ++i) {
         const key = keys[i];
-        const operator = hasOwnProperty.call(operators, key) ? operators[key] : undefined;
+        const operator = _hasOwn(operators, key) ? operators[key] : undefined;
         if (operator) {
             entries[count++] = { key, displayValue: operator.displayValue };
         }

--- a/packages/ag-grid-enterprise/src/charts/chartComp/datasource/chartDatasource.ts
+++ b/packages/ag-grid-enterprise/src/charts/chartComp/datasource/chartDatasource.ts
@@ -1,4 +1,4 @@
-import { _last } from 'ag-stack';
+import { _hasOwn, _last } from 'ag-stack';
 
 import type {
     AgColumn,
@@ -260,7 +260,7 @@ export class ChartDatasource extends BeanStub {
                     }
 
                     // aggregated value
-                    if (value && Object.prototype.hasOwnProperty.call(value, 'toString')) {
+                    if (value && _hasOwn(value, 'toString')) {
                         value = parseFloat(value.toString());
                     }
 

--- a/packages/ag-grid-enterprise/src/pdfExport/utils/document/fontMetrics.ts
+++ b/packages/ag-grid-enterprise/src/pdfExport/utils/document/fontMetrics.ts
@@ -1,3 +1,5 @@
+import { _hasOwn } from 'ag-stack';
+
 import type { PdfBuiltInFontFamily, PdfFontFamily } from 'ag-grid-community';
 
 const FIRST_PRINTABLE_ASCII = 32;
@@ -158,9 +160,7 @@ function getFontWidths(fontFamily: PdfBuiltInFontFamily): number[] {
 }
 
 function resolveBase14FontFamily(fontFamily: PdfFontFamily): PdfBuiltInFontFamily {
-    return Object.prototype.hasOwnProperty.call(FONT_VERTICAL_METRICS, fontFamily)
-        ? (fontFamily as PdfBuiltInFontFamily)
-        : 'Helvetica';
+    return _hasOwn(FONT_VERTICAL_METRICS, fontFamily) ? (fontFamily as PdfBuiltInFontFamily) : 'Helvetica';
 }
 
 function resolveBaseCharacter(char: string): string {

--- a/packages/ag-stack/src/main-internal.ts
+++ b/packages/ag-stack/src/main-internal.ts
@@ -246,7 +246,15 @@ export {
 } from './utils/focus';
 export { _batchCall, _debounce, _doOnce, _throttle, _waitUntil } from './utils/function';
 export { _fuzzySuggestions } from './utils/fuzzyMatch';
-export { _defaultComparator, _exists, _jsonEquals, _makeNull, _missing, _toStringOrNull } from './utils/generic';
+export {
+    _defaultComparator,
+    _exists,
+    _hasOwn,
+    _jsonEquals,
+    _makeNull,
+    _missing,
+    _toStringOrNull,
+} from './utils/generic';
 export { _isEventFromPrintableCharacter } from './utils/keyboard';
 export { _getLocaleTextFromFunc, _getLocaleTextFromMap, _getLocaleTextFunc, _translate } from './utils/locale';
 export { _isPromise } from './utils/promise';

--- a/packages/ag-stack/src/utils/generic.ts
+++ b/packages/ag-stack/src/utils/generic.ts
@@ -1,3 +1,14 @@
+const hasOwnProperty = Object.prototype.hasOwnProperty;
+
+/**
+ * Own properties only: a lookup table keyed by a user-supplied string otherwise resolves `toString` and friends
+ * off `Object.prototype` and hands back a function where a value was expected.
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
+ */
+export function _hasOwn(obj: object, key: PropertyKey): boolean {
+    return hasOwnProperty.call(obj, key);
+}
+
 /**
  * If value is undefined, null or blank, returns null, otherwise returns the value
  * @param {T} value

--- a/testing/behavioural/src/filters/filter-options-validation.test.ts
+++ b/testing/behavioural/src/filters/filter-options-validation.test.ts
@@ -5,6 +5,7 @@ import {
     BigIntFilterModule,
     ClientSideRowModelModule,
     DateFilterModule,
+    LocaleModule,
     NumberFilterModule,
     TextFilterModule,
     enableDevValidations,
@@ -565,13 +566,51 @@ describe('Column filter — a built-in option the filter cannot evaluate', () =>
         `);
     });
 
-    test('a `textMatcher` answering the key is what makes it usable, and nothing is reported', async () => {
+    test('a `textMatcher` decides for a built-in option too, and nothing is reported', async () => {
         const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
         const filterParams: ITextFilterParams = {
-            filterOptions: ['contains', 'lessThan'],
+            filterOptions: ['contains', 'startsWith'],
+            // Deliberately not what `startsWith` means: only the matcher running can produce this result.
             textMatcher: ({ filterOption, value, filterText }) =>
-                filterOption === 'lessThan' ? value < filterText! : value.includes(filterText!),
+                filterOption === 'startsWith' ? value.endsWith(filterText!) : value.includes(filterText!),
+            debounceMs: 0,
+            maxNumConditions: 1,
+        };
+        const api: GridApi = await gridsManager.createGridAndWait('grid1', {
+            columnDefs: [{ field: 'athlete', filter: 'agTextColumnFilter', filterParams }],
+            rowData: [{ athlete: 'Bolt' }, { athlete: 'Ng' }],
+        } as GridOptions);
+
+        const filter = await ColumnFilterHarness.open(api, 'athlete');
+        await filter.selectOperator('Begins with');
+        await filter.setText('g', 0);
+        await asyncSetTimeout(0);
+
+        await new GridRows(api, 'the matcher decides, not the built-in `startsWith`').check(`
+            ROOT id:ROOT_NODE_ID
+            └── LEAF id:1 athlete:"Ng"
+        `);
+        expect(warnSpy).not.toHaveBeenCalled();
+        await new FilterDom(api, 'the matcher decides for a built-in option', { colId: 'athlete' }).checkFilterDom(`
+            COLUMN FILTER
+            operator: "Begins with"
+            input: "g"
+            model:
+              filterType: "text"
+              type: "startsWith"
+              filter: "g"
+        `);
+    });
+
+    test('a `textMatcher` answering a key the text filter cannot evaluate suppresses the report', async () => {
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+        // A JavaScript config: `ITextFilterParams` rejects `'lessThan'`, but the grid still offers what it is given.
+        const filterParams = {
+            filterOptions: ['contains', 'lessThan'],
+            textMatcher: ({ filterOption, value, filterText }: any) =>
+                filterOption === 'lessThan' ? value < filterText : value.includes(filterText),
             debounceMs: 0,
             maxNumConditions: 1,
         };
@@ -608,6 +647,57 @@ describe('Column filter — a built-in option the filter cannot evaluate', () =>
         expect(warnSpy).not.toHaveBeenCalled();
         const filter = await ColumnFilterHarness.open(api, 'athlete');
         expect(await filter.operatorOptions()).toEqual(['Contains', 'Between']);
+        await new FilterDom(api, 'a custom option supplying a built-in key', { colId: 'athlete' }).checkFilterDom(`
+            COLUMN FILTER
+            operator: "Contains"
+            input: "" ⟨Filter...⟩
+            model: null
+        `);
+    });
+});
+
+describe('Column filter — localising the option keys', () => {
+    const gridsManager = new TestGridsManager({
+        modules: [TextFilterModule, LocaleModule, ColumnMenuModule, ClientSideRowModelModule],
+    });
+
+    beforeAll(() => {
+        setupAgTestIds();
+        installFilterLayoutMock();
+    });
+    afterAll(() => uninstallFilterLayoutMock());
+    afterEach(() => gridsManager.reset());
+
+    test('`getLocaleText` is given a real default for every offered option', async () => {
+        const calls: { key: string; defaultValue: unknown }[] = [];
+        // A JavaScript config: `ITextFilterParams` rejects `'soundsLike'`, but the grid still offers what it is given.
+        const filterParams = {
+            filterOptions: [
+                'contains',
+                'soundsLike',
+                { displayKey: 'multipleOf', displayName: 'Multiple of', predicate: () => true },
+            ],
+            debounceMs: 0,
+            maxNumConditions: 1,
+        };
+        const api: GridApi = await gridsManager.createGridAndWait('grid1', {
+            getLocaleText: ({ key, defaultValue }) => {
+                if (key === 'contains' || key === 'soundsLike' || key === 'multipleOf') {
+                    calls.push({ key, defaultValue });
+                }
+                return key === 'soundsLike' ? 'Sounds like' : defaultValue;
+            },
+            columnDefs: [{ field: 'athlete', filter: 'agTextColumnFilter', filterParams }],
+            rowData: [{ athlete: 'Bolt' }],
+        } as GridOptions);
+
+        const filter = await ColumnFilterHarness.open(api, 'athlete');
+        expect(await filter.operatorOptions()).toEqual(['Contains', 'Sounds like', 'Multiple of']);
+        expect(calls).toEqual([
+            { key: 'contains', defaultValue: 'Contains' },
+            { key: 'soundsLike', defaultValue: 'soundsLike' },
+            { key: 'multipleOf', defaultValue: 'Multiple of' },
+        ]);
     });
 });
 
@@ -661,6 +751,12 @@ describe('Column filter — a custom option whose `displayKey` is a built-in key
 
         const filter = await ColumnFilterHarness.open(api, 'age');
         expect(await filter.operatorOptions()).toEqual(['Equals', 'Greater than']);
+        await new FilterDom(api, 'a built-in key listed twice', { colId: 'age' }).checkFilterDom(`
+            COLUMN FILTER
+            operator: "Equals"
+            input: "" ⟨Filter...⟩
+            model: null
+        `);
     });
 
     test('keeps the place the key was first listed in, whichever form declared it', async () => {
@@ -922,6 +1018,37 @@ describe('Column filter — a malformed `filterOptions` list', () => {
 
         // A custom option has no built-in locale text, so its `displayName` is what the callback must see.
         expect(seen).toContainEqual({ filterOptionKey: 'withinOf', filterOption: 'Within Of' });
+        await new FilterDom(api, '`filterPlaceholder` is given the custom option', { colId: 'age' }).checkFilterDom(`
+            COLUMN FILTER
+            operator: "Within Of"
+            input [0]: "" ⟨From⟩
+            input [1]: "" ⟨To⟩
+            model: null
+        `);
+    });
+
+    test('`filterPlaceholder` is given a bare key the grid does not define, not an empty string', async () => {
+        const seen: { filterOptionKey: string; filterOption: string }[] = [];
+        // A JavaScript config: `INumberFilterParams` rejects `'withinOf'`, but the grid still offers what it is given.
+        const filterParams = {
+            filterOptions: ['equals', 'withinOf'],
+            filterPlaceholder: ({ filterOptionKey, filterOption, placeholder }: any) => {
+                seen.push({ filterOptionKey, filterOption });
+                return placeholder;
+            },
+            debounceMs: 0,
+            maxNumConditions: 1,
+        };
+        const api = await gridsManager.createGridAndWait('grid1', {
+            columnDefs: [{ field: 'age', filter: 'agNumberColumnFilter', filterParams }],
+            rowData: [{ age: 25 }, { age: 40 }],
+        });
+
+        const harness = await ColumnFilterHarness.open(api, 'age');
+        await harness.selectOperator('withinOf');
+
+        // With no built-in locale text and no custom option to name it, the key stands in as its own display name.
+        expect(seen).toContainEqual({ filterOptionKey: 'withinOf', filterOption: 'withinOf' });
     });
 
     test('a custom option declared with only the removed `test` is rejected rather than offered', async () => {
@@ -974,9 +1101,9 @@ describe('Column filter — a malformed `filterOptions` list', () => {
     });
 });
 
-describe('Custom filter option — a `displayKey` shadowing `Object.prototype`', () => {
+describe('Column filter — an option key shadowing `Object.prototype`', () => {
     const gridsManager = new TestGridsManager({
-        modules: [NumberFilterModule, ColumnMenuModule, ClientSideRowModelModule],
+        modules: [NumberFilterModule, LocaleModule, ColumnMenuModule, ClientSideRowModelModule],
     });
 
     beforeAll(() => {
@@ -988,6 +1115,29 @@ describe('Custom filter option — a `displayKey` shadowing `Object.prototype`',
         gridsManager.reset();
         vi.restoreAllMocks();
         enableDevValidations({ throwOn: ALL_SEVERITIES });
+    });
+
+    test('a bare key is offered under its own name rather than resolving on the locale table', async () => {
+        const calls: { key: string; defaultValue: unknown }[] = [];
+        // A JavaScript config: `INumberFilterParams` rejects these, but the grid still offers what it is given.
+        const filterParams = { filterOptions: ['equals', 'toString', 'valueOf'], debounceMs: 0, maxNumConditions: 1 };
+        const api: GridApi<AgeRow> = await gridsManager.createGridAndWait('grid1', {
+            getLocaleText: ({ key, defaultValue }) => {
+                if (key === 'toString' || key === 'valueOf') {
+                    calls.push({ key, defaultValue });
+                }
+                return defaultValue;
+            },
+            columnDefs: [{ field: 'age', filter: 'agNumberColumnFilter', filterParams }],
+            rowData: EDGE_KEY_ROWS,
+        } as GridOptions);
+
+        const filter = await ColumnFilterHarness.open(api, 'age');
+        expect(await filter.operatorOptions()).toEqual(['Equals', 'toString', 'valueOf']);
+        expect(calls).toEqual([
+            { key: 'toString', defaultValue: 'toString' },
+            { key: 'valueOf', defaultValue: 'valueOf' },
+        ]);
     });
 
     test('the column filter offers it and filters with it', async () => {
@@ -1206,6 +1356,10 @@ describe('Column filter — a combined model naming an option the column does no
             ├── LEAF id:1 age:40
             └── LEAF id:2 age:28
         `);
+        await new FilterDom(api, 'a combined model with an unoffered condition', { colId: 'age' }).checkFilterDom(`
+            FLOATING FILTER age: (not present)
+            model: null
+        `);
     });
 });
 
@@ -1325,6 +1479,85 @@ describe('Column filter — `filterPlaceholder` on the floating filter', () => {
             input: "" ⟨Filter...⟩
             active: false
             model: null
+        `);
+    });
+});
+
+describe('Column filter — the date summary for an option the grid does not define', () => {
+    const gridsManager = new TestGridsManager({
+        modules: [DateFilterModule, ColumnMenuModule, ClientSideRowModelModule],
+    });
+
+    beforeAll(() => setupAgTestIds());
+    afterEach(() => {
+        gridsManager.reset();
+        vi.restoreAllMocks();
+        enableDevValidations({ throwOn: ALL_SEVERITIES });
+    });
+
+    // A read-only floating filter shows `getModelAsString`, which is where a valueless date condition is named.
+    test('names the key itself rather than resolving to nothing', async () => {
+        // Deliberate: the date filter cannot evaluate the key, which triggers warning #76.
+        enableDevValidations({ throwOn: ALL_SEVERITIES, suppress: [76] });
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+        // A JavaScript config: `IDateFilterParams` rejects `'soundsLike'`, but the grid still offers what it is given.
+        const filterParams = { filterOptions: ['equals', 'soundsLike'], readOnly: true, debounceMs: 0 };
+        const api: GridApi = await gridsManager.createGridAndWait('grid1', {
+            columnDefs: [{ field: 'date', filter: 'agDateColumnFilter', floatingFilter: true, filterParams }],
+            rowData: [{ date: '2024-01-01' }],
+        } as GridOptions);
+
+        await api.setColumnFilterModel('date', {
+            filterType: 'date',
+            type: 'soundsLike',
+            dateFrom: null,
+            dateTo: null,
+        });
+        await api.onFilterChanged();
+        await asyncSetTimeout(0);
+
+        expect(warnSpy.mock.calls.flat().join(' ')).toContain('warning #76');
+        await new FilterDom(api, 'a valueless condition the grid does not define', { colId: 'date' }).checkFilterDom(`
+            FLOATING FILTER date
+            input: "soundsLike" ⊘
+            active: true
+            model:
+              filterType: "date"
+              type: "soundsLike"
+              dateFrom: null
+              dateTo: null
+        `);
+    });
+
+    // Settles whether a zero-input custom option reaches the key-based path: it is resolved before that.
+    test('a zero-input custom option is named by its `displayName`, not its key', async () => {
+        const filterParams = {
+            filterOptions: [
+                'equals',
+                { displayKey: 'isWeekend', displayName: 'Is weekend', numberOfInputs: 0, predicate: () => true },
+            ],
+            readOnly: true,
+            debounceMs: 0,
+        };
+        const api: GridApi = await gridsManager.createGridAndWait('grid1', {
+            columnDefs: [{ field: 'date', filter: 'agDateColumnFilter', floatingFilter: true, filterParams }],
+            rowData: [{ date: '2024-01-01' }],
+        } as GridOptions);
+
+        await api.setColumnFilterModel('date', { filterType: 'date', type: 'isWeekend', dateFrom: null, dateTo: null });
+        await api.onFilterChanged();
+        await asyncSetTimeout(0);
+
+        await new FilterDom(api, 'a zero-input custom option', { colId: 'date' }).checkFilterDom(`
+            FLOATING FILTER date
+            input: "Is weekend" ⊘
+            active: true
+            model:
+              filterType: "date"
+              type: "isWeekend"
+              dateFrom: null
+              dateTo: null
         `);
     });
 });


### PR DESCRIPTION
<!-- base: latest -->

# Filter options: `filterOptions` accepts only that filter's options, and an unknown option key localises

<!-- Needs the follow-up ticket key here as `FIX AG-XXXXX` on its own line for CI to move it to QA. -->

| scope  | net lines | lines changed | hunks | files changed |
| ------ | --------: | ------------: | ----: | ------------: |
| source |       +42 | 104 (+73 -31) |    26 |     15 edited |
| tests  |      +202 | 212 (+207 -5) |    12 |      1 edited |

## `filterOptions` rejects a key the filter cannot use

AG-16738 (#14800) narrowed `filterOptions` per filter type, then added `CustomFilterOptionKey` (`string & Record<never, never>`) to each narrowed union. Since that accepts any string, the narrowing checked nothing and `filterOptions: ['contians']` compiled. Removing it leaves the narrowing to do its job. It stays on `defaultOption` and the model's `type`, which do take a custom option's `displayKey`.

Such a key was never usable anyway: it is offered in the dropdown, then reported with warning `#76` when a value is tested against it.

No breaking change. That member arrived in #14800 and never shipped, so this restores `ISimpleFilterParams.filterOptions` to its last-released type. The narrowing a consumer can observe, `ITextFilterParams` no longer taking a date preset, is #14800's and ships in the same version.

## `getLocaleText` no longer receives `undefined`

`defaultValue` is declared `string`, but three call sites cast an option key into `FilterLocaleTextKey`; for a key with no built-in text the lookup missed, the callback was handed `undefined`, and `defaultValue.toUpperCase()` threw. `isFilterLocaleTextKey` and `translateFilterOptionKey` replace the casts, so such a key stands in as its own `defaultValue`. Reachable only from a JavaScript config, which is what the new tests use.

## Own-property lookups: `_hasOwn`

`table[key] !== undefined` on a plain object literal resolves `toString`, `valueOf` and the rest off `Object.prototype`: a filter option key of `valueOf` reached `_translate`, which called the inherited function and threw `TypeError: Cannot convert undefined or null to object`, leaving the column filter unable to open. `_hasOwn` is added to `ag-stack`, and the five existing `Object.prototype.hasOwnProperty.call` sites now use it.

_hasOwn can be replaced with Object.hasOwn in the future when we switch to ES2023