### PR TITLE
Cover React variant tests in docs e2e CI and local runs

### DIFF
--- a/docs-e2e.sh
+++ b/docs-e2e.sh
@@ -7,7 +7,8 @@
 #   ./docs-e2e.sh "file-pattern"                    # Run tests matching pattern
 #   ./docs-e2e.sh "file-pattern" --grep "name"      # Run specific test by name
 #   ./docs-e2e.sh --all-browsers                    # Run all browsers
-#   ./docs-e2e.sh --framework reactFunctionalTs      # Run with specific framework
+#   ./docs-e2e.sh --framework reactFunctionalTs     # Run with specific framework
+#   ./docs-e2e.sh --framework reactFunctionalTs_Dev # Only the React development-build tests
 #   ./docs-e2e.sh --url https://localhost:4610      # Run against specific URL
 #   ./docs-e2e.sh --headed                          # Run in headed mode
 #   ./docs-e2e.sh --ui                              # Open Playwright UI mode
@@ -34,8 +35,10 @@ Options:
   --framework <name>      Set FRAMEWORK env var. Valid: typescript, vanilla,
                           reactFunctionalTs, reactFunctionalTs_Dev, angular, vue3
   --url <url>             Set BASE_URL env var (default: https://localhost:4610)
-  --all-variants          Also run the production React variant (or ALL_FRAMEWORK_VARIANTS=true).
-                          CI runs both; locally only the development one runs.
+  --all-variants          Sweep every example with the production React variant too (or
+                          ALL_FRAMEWORK_VARIANTS=true). The sweep covers one React build:
+                          development locally, production in CI. Tests naming a variant
+                          outright always run and are unaffected by this.
   --help                  Show this help message
 
 Playwright options (forwarded as-is):

--- a/docs-e2e.sh
+++ b/docs-e2e.sh
@@ -35,14 +35,14 @@ Options:
   --framework <name>      Set FRAMEWORK env var. Valid: typescript, vanilla,
                           reactFunctionalTs, reactFunctionalTs_Dev, angular, vue3.
                           Mirrors a CI shard, so reactFunctionalTs covers both React
-                          builds: the sweep on the production one, plus the tests
+                          builds: every example on the production one, plus the tests
                           naming reactFunctionalTs_Dev outright. Pin that instead to
                           run only those.
   --url <url>             Set BASE_URL env var (default: https://localhost:4610)
-  --all-variants          Sweep every example with the production React variant too (or
-                          ALL_FRAMEWORK_VARIANTS=true). The sweep covers one React build:
-                          development locally, production in CI. Tests naming a variant
-                          outright always run and are unaffected by this.
+  --all-variants          Run every example against the production React variant too (or
+                          ALL_FRAMEWORK_VARIANTS=true). By default examples run on one
+                          React build: development locally, production in CI. Tests
+                          naming a framework outright always run and are unaffected.
   --help                  Show this help message
 
 Playwright options (forwarded as-is):

--- a/docs-e2e.sh
+++ b/docs-e2e.sh
@@ -33,7 +33,11 @@ Any unrecognised arguments are forwarded directly to playwright test.
 Options:
   --all-browsers          Run all browsers (chromium, firefox, webkit)
   --framework <name>      Set FRAMEWORK env var. Valid: typescript, vanilla,
-                          reactFunctionalTs, reactFunctionalTs_Dev, angular, vue3
+                          reactFunctionalTs, reactFunctionalTs_Dev, angular, vue3.
+                          Mirrors a CI shard, so reactFunctionalTs covers both React
+                          builds: the sweep on the production one, plus the tests
+                          naming reactFunctionalTs_Dev outright. Pin that instead to
+                          run only those.
   --url <url>             Set BASE_URL env var (default: https://localhost:4610)
   --all-variants          Sweep every example with the production React variant too (or
                           ALL_FRAMEWORK_VARIANTS=true). The sweep covers one React build:

--- a/documentation/ag-grid-docs/src/utils/grid/test-utils.ts
+++ b/documentation/ag-grid-docs/src/utils/grid/test-utils.ts
@@ -63,27 +63,62 @@ const ALL_FRAMEWORKS = [
 ] as const;
 type AgFramework = (typeof ALL_FRAMEWORKS)[number];
 
+const PROD_VARIANT_FRAMEWORK = 'reactFunctionalTs';
+
+/**
+ * The framework this run is pinned to, or null for a run that covers them all. CI shards the suite by
+ * framework, one job per value, so a pinned run must declare nothing outside its own shard.
+ */
+function getPinnedFramework(): AgFramework | null {
+    const frameworkFilter = process.env.FRAMEWORK;
+    if (!frameworkFilter) {
+        return null;
+    }
+    const requestedFramework = frameworkFilter as AgFramework;
+    if (!ALL_FRAMEWORKS.includes(requestedFramework)) {
+        throw new Error(
+            `Invalid framework specified in FRAMEWORK environment variable: ${frameworkFilter}. Valid options are: ${ALL_FRAMEWORKS.join(', ')}`
+        );
+    }
+    return requestedFramework;
+}
+
+const PINNED_FRAMEWORK = getPinnedFramework();
+
 /**
  * React is the only framework declared twice - once on the production build, once forcing the development
- * one - so this only ever drops a React variant. That is a sixth of the suite, and locally the development
- * build is the one worth the wall clock, so CI runs both and a local run does not.
+ * one - so running both across every example doubles a sixth of the suite for little return. Only one of
+ * the two is swept: the development build locally, where its warnings are worth the wall clock, and the
+ * production build in CI. `ALL_FRAMEWORK_VARIANTS=true` (or `--all-variants`) sweeps both.
+ *
+ * This is an economy applied to the *sweep*. A spec that names a variant outright - `test.reactFunctionalTs`
+ * or `test.reactFunctionalTs_Dev` - is asserting that this example behaves differently on that build, so it
+ * is always declared and never subject to this. See isFrameworkDeclared.
  */
 const runAllFrameworkVariants = !!process.env.CI || process.env.ALL_FRAMEWORK_VARIANTS === 'true';
 
-const PROD_VARIANT_FRAMEWORK = 'reactFunctionalTs';
+/**
+ * Frameworks a pinned run covers by explicit tests alone, sweeping nothing. Pinning to one is therefore
+ * cheap - it yields only the handful of specs that ask for it by name - so `--framework
+ * reactFunctionalTs_Dev` is a quick way to run just those.
+ */
+const EXPLICIT_ONLY_FRAMEWORKS: readonly AgFramework[] = [reactFunctionalTsDev];
 
-// Filter frameworks based on FRAMEWORK environment variable
-function getFilteredFrameworks(): readonly AgFramework[] {
-    const frameworkFilter = process.env.FRAMEWORK;
-    if (frameworkFilter) {
-        const requestedFramework = frameworkFilter as AgFramework;
-        if (ALL_FRAMEWORKS.includes(requestedFramework)) {
-            return [requestedFramework] as const;
-        } else {
-            throw new Error(
-                `Invalid framework specified in FRAMEWORK environment variable: ${frameworkFilter}. Valid options are: ${ALL_FRAMEWORKS.join(', ')}`
-            );
-        }
+/**
+ * Variants a pinned run declares alongside the framework itself. A CI job is a shard per *framework*, and
+ * the two React builds are variants within one framework rather than two of them - so the React shard owns
+ * the development-build tests too, and CI needs no second job to cover them. Only tests naming the variant
+ * outright are picked up; the sweep stays on the production build (see getSweptFrameworks), which is what
+ * keeps this from doubling a sixth of the suite.
+ */
+const PINNED_FRAMEWORK_VARIANTS: Partial<Record<AgFramework, readonly AgFramework[]>> = {
+    [PROD_VARIANT_FRAMEWORK]: [reactFunctionalTsDev],
+};
+
+/** The frameworks `eachFramework` sweeps. Single-framework tests are governed by isFrameworkDeclared. */
+function getSweptFrameworks(): readonly AgFramework[] {
+    if (PINNED_FRAMEWORK) {
+        return EXPLICIT_ONLY_FRAMEWORKS.includes(PINNED_FRAMEWORK) ? [] : [PINNED_FRAMEWORK];
     }
     if (!runAllFrameworkVariants) {
         return ALL_FRAMEWORKS.filter((framework) => framework !== PROD_VARIANT_FRAMEWORK);
@@ -91,15 +126,26 @@ function getFilteredFrameworks(): readonly AgFramework[] {
     return ALL_FRAMEWORKS;
 }
 
-const FILTERED_FRAMEWORKS = getFilteredFrameworks();
+const SWEPT_FRAMEWORKS = getSweptFrameworks();
+
+/**
+ * Whether a test naming this framework outright should be declared. Only the CI shard pinning applies -
+ * declaring a test just to skip it produces a fake "skipped" result and still spins up a browser fixture.
+ */
+function isFrameworkDeclared(agFramework: AgFramework): boolean {
+    if (PINNED_FRAMEWORK === null || agFramework === PINNED_FRAMEWORK) {
+        return true;
+    }
+    return PINNED_FRAMEWORK_VARIANTS[PINNED_FRAMEWORK]?.includes(agFramework) ?? false;
+}
 
 // One worker, so a run says once what it is doing rather than once per worker.
-if (process.env.TEST_WORKER_INDEX === '0' && !process.env.FRAMEWORK) {
+if (process.env.TEST_WORKER_INDEX === '0' && !PINNED_FRAMEWORK) {
     // eslint-disable-next-line no-console
     console.log(
         runAllFrameworkVariants
-            ? `Running all framework variants: ${FILTERED_FRAMEWORKS.join(', ')}`
-            : `Skipping the ${PROD_VARIANT_FRAMEWORK} variant - set ALL_FRAMEWORK_VARIANTS=true to include it`
+            ? `Sweeping all framework variants: ${SWEPT_FRAMEWORKS.join(', ')}`
+            : `Sweeping with the ${reactFunctionalTsDev} React variant - set ALL_FRAMEWORK_VARIANTS=true to sweep ${PROD_VARIANT_FRAMEWORK} too. Tests naming a variant outright always run.`
     );
 }
 
@@ -356,11 +402,11 @@ const frameworkTest =
         testBody: (fixtures: TestFixtures) => Promise<void>,
         opts?: { allowedConsoleMessages?: string[] }
     ): void => {
-        // A single-framework test (test.typescript(...), etc.) hardcodes its framework, bypassing the
-        // FRAMEWORK filter that eachFramework applies via FILTERED_FRAMEWORKS. Declaring a test only to
-        // skip it at runtime when the CI job targets another framework produces a fake "skipped" result
-        // and still spins up a browser fixture, so don't declare it at all for a filtered-out framework.
-        if (!FILTERED_FRAMEWORKS.includes(agFramework)) {
+        // A single-framework test (test.typescript(...), etc.) names its framework outright, so only the
+        // CI shard pinning applies - not the React variant economy eachFramework is subject to. Declaring
+        // a test only to skip it at runtime when the job targets another framework produces a fake
+        // "skipped" result and still spins up a browser fixture, so don't declare it at all.
+        if (!isFrameworkDeclared(agFramework)) {
             return;
         }
 
@@ -444,7 +490,7 @@ const eachFramework = (
     opts?: { allowedConsoleMessages?: string[] }
 ) => {
     describeWithTeardown(testName, opts, () => {
-        FILTERED_FRAMEWORKS.forEach((framework) => frameworkTest(framework)(undefined, testBody));
+        SWEPT_FRAMEWORKS.forEach((framework) => frameworkTest(framework)(undefined, testBody));
     });
 };
 

--- a/documentation/ag-grid-docs/src/utils/grid/test-utils.ts
+++ b/documentation/ag-grid-docs/src/utils/grid/test-utils.ts
@@ -87,38 +87,37 @@ const PINNED_FRAMEWORK = getPinnedFramework();
 
 /**
  * React is the only framework declared twice - once on the production build, once forcing the development
- * one - so running both across every example doubles a sixth of the suite for little return. Only one of
- * the two is swept: the development build locally, where its warnings are worth the wall clock, and the
- * production build in CI. `ALL_FRAMEWORK_VARIANTS=true` (or `--all-variants`) sweeps both.
+ * one - so running `eachFramework` on both doubles a sixth of the suite for little return. Only one of the
+ * two is used: the development build locally, where its warnings are worth the wall clock, and the
+ * production build in CI. `ALL_FRAMEWORK_VARIANTS=true` (or `--all-variants`) uses both.
  *
- * This is an economy applied to the *sweep*. A spec that names a variant outright - `test.reactFunctionalTs`
- * or `test.reactFunctionalTs_Dev` - is asserting that this example behaves differently on that build, so it
- * is always declared and never subject to this. See isFrameworkDeclared.
+ * This is an economy applied to `eachFramework`. A spec that names a variant outright -
+ * `test.reactFunctionalTs` or `test.reactFunctionalTs_Dev` - is asserting that this example behaves
+ * differently on that build, so it is always declared and never subject to this. See isFrameworkDeclared.
  */
 const runAllFrameworkVariants = !!process.env.CI || process.env.ALL_FRAMEWORK_VARIANTS === 'true';
 
 /**
- * Frameworks a pinned run covers by explicit tests alone, sweeping nothing. Pinning to one is therefore
- * cheap - it yields only the handful of specs that ask for it by name - so `--framework
- * reactFunctionalTs_Dev` is a quick way to run just those.
+ * Frameworks that `eachFramework` never runs, so pinning to one leaves only the handful of specs that name
+ * it outright. That makes `--framework reactFunctionalTs_Dev` a quick way to run just those.
  */
-const EXPLICIT_ONLY_FRAMEWORKS: readonly AgFramework[] = [reactFunctionalTsDev];
+const EACH_FRAMEWORK_EXCLUDES: readonly AgFramework[] = [reactFunctionalTsDev];
 
 /**
  * Variants a pinned run declares alongside the framework itself. A CI job is a shard per *framework*, and
  * the two React builds are variants within one framework rather than two of them - so the React shard owns
  * the development-build tests too, and CI needs no second job to cover them. Only tests naming the variant
- * outright are picked up; the sweep stays on the production build (see getSweptFrameworks), which is what
- * keeps this from doubling a sixth of the suite.
+ * outright are picked up; `eachFramework` stays on the production build (see getEachFrameworkList), which
+ * is what keeps this from doubling a sixth of the suite.
  */
 const PINNED_FRAMEWORK_VARIANTS: Partial<Record<AgFramework, readonly AgFramework[]>> = {
     [PROD_VARIANT_FRAMEWORK]: [reactFunctionalTsDev],
 };
 
-/** The frameworks `eachFramework` sweeps. Single-framework tests are governed by isFrameworkDeclared. */
-function getSweptFrameworks(): readonly AgFramework[] {
+/** The frameworks `eachFramework` runs. Tests naming a framework outright use isFrameworkDeclared. */
+function getEachFrameworkList(): readonly AgFramework[] {
     if (PINNED_FRAMEWORK) {
-        return EXPLICIT_ONLY_FRAMEWORKS.includes(PINNED_FRAMEWORK) ? [] : [PINNED_FRAMEWORK];
+        return EACH_FRAMEWORK_EXCLUDES.includes(PINNED_FRAMEWORK) ? [] : [PINNED_FRAMEWORK];
     }
     if (!runAllFrameworkVariants) {
         return ALL_FRAMEWORKS.filter((framework) => framework !== PROD_VARIANT_FRAMEWORK);
@@ -126,7 +125,7 @@ function getSweptFrameworks(): readonly AgFramework[] {
     return ALL_FRAMEWORKS;
 }
 
-const SWEPT_FRAMEWORKS = getSweptFrameworks();
+const EACH_FRAMEWORK_LIST = getEachFrameworkList();
 
 /**
  * Whether a test naming this framework outright should be declared. Only the CI shard pinning applies -
@@ -144,8 +143,8 @@ if (process.env.TEST_WORKER_INDEX === '0' && !PINNED_FRAMEWORK) {
     // eslint-disable-next-line no-console
     console.log(
         runAllFrameworkVariants
-            ? `Sweeping all framework variants: ${SWEPT_FRAMEWORKS.join(', ')}`
-            : `Sweeping with the ${reactFunctionalTsDev} React variant - set ALL_FRAMEWORK_VARIANTS=true to sweep ${PROD_VARIANT_FRAMEWORK} too. Tests naming a variant outright always run.`
+            ? `Running eachFramework tests on: ${EACH_FRAMEWORK_LIST.join(', ')}`
+            : `Running eachFramework tests on: ${EACH_FRAMEWORK_LIST.join(', ')} - set ALL_FRAMEWORK_VARIANTS=true to add ${PROD_VARIANT_FRAMEWORK}. Tests naming a framework outright always run.`
     );
 }
 
@@ -490,7 +489,7 @@ const eachFramework = (
     opts?: { allowedConsoleMessages?: string[] }
 ) => {
     describeWithTeardown(testName, opts, () => {
-        SWEPT_FRAMEWORKS.forEach((framework) => frameworkTest(framework)(undefined, testBody));
+        EACH_FRAMEWORK_LIST.forEach((framework) => frameworkTest(framework)(undefined, testBody));
     });
 };
 


### PR DESCRIPTION
Splits the two jobs `FRAMEWORK` was doing — partitioning CI into per-framework shards, and choosing which React build the sweep runs on — so the sweep economy no longer drops specs that name a variant outright.

Collected tests, chromium:

| Pin | Before | After | |
| --- | --- | --- | --- |
| `reactFunctionalTs` | 1801 | **1805** | the four `test.reactFunctionalTs_Dev` tests, which no CI job selected before |
| local unpinned | 8948 | **8966** | tests naming `reactFunctionalTs`, including all six `reorder-grids` configurations |
| `angular` | 1784 | 1784 | unchanged, as for the other shards |

Nothing is dropped in either direction. The sweep on the React development build stays CI-excluded by design.

Context, not fixed here: https://ag-grid.atlassian.net/browse/AG-18154 — `reorder-grids` reaches the development build through that ticket's `version`/`prod` `loadPageOptions` rather than through the framework variant, so it always ran in CI and the gap there was local only.