### PR TITLE
AG-18153 Record the StrictMode decision for React docs examples

### DIFF
--- a/plugins/ag-grid-generate-example-files/src/executors/generate/generator/transformation-scripts/grid-vanilla-to-react-functional-ts.ts
+++ b/plugins/ag-grid-generate-example-files/src/executors/generate/generator/transformation-scripts/grid-vanilla-to-react-functional-ts.ts
@@ -149,6 +149,16 @@ function extractComponentInformation(properties, componentFilenames: string[]): 
     return components;
 }
 
+/**
+ * Generates the React entry point for an example.
+ *
+ * The entry point deliberately mounts the example in `<StrictMode>` (AG-18153): it is React's
+ * recommended default, and these examples are copy-paste starting points, so they should mount
+ * the way a user's own app would. This is the only React entry point generated - the JS variant
+ * is this output passed through `convertTsxToJsx`, so it inherits the choice - and the website
+ * runner, Plunker and CodeSandbox are all shipped these same generated files, so the one choice
+ * applies to all three surfaces.
+ */
 export function vanillaToReactFunctionalTs(
     bindings: ParsedBindings,
     exampleConfig: ExampleConfig,


### PR DESCRIPTION
Decision: React docs examples keep rendering inside `<StrictMode>`. It is React's recommended default and these examples are copy-paste starting points, so they should mount the way a user's own app would. The repo already assumes this — the generated `useFetchJson` helper explicitly drops the superseded response when StrictMode runs its effect twice. This PR records the decision as a doc comment on `vanillaToReactFunctionalTs`, the single React entry-point generator; it is the only change, so generated output is unaffected.

AC2 already held on the base branch, so nothing needed changing to make the three surfaces agree. There is one React entry-point generator, the JS variant is its output passed through `convertTsxToJsx`, and all 126 hand-authored `provided/reactFunctionalTs/index.tsx` files use StrictMode (none omit it). The website runner is served those generated files via the `[fileName].ts` route, and Plunker and CodeSandbox get the same set via `contents.json.ts`, which reads the same `getGeneratedContents`.

AC3 cannot be verified yet, and is deferred rather than claimed. `getImportMap.ts` resolves react/react-dom to esm.sh's default build, which is the production one (`https://esm.sh/react@19.2.1` serves minified `react.mjs`; `?dev` serves `react.development.mjs`). StrictMode only double-invokes renders and effects in a development build, so it is currently inert on the website runner and on Plunker. CodeSandbox does run development React via CRA's dev server, so that surface is the one where double invocation is live — and the one we cannot currently test.

The cause is a regression from the SystemJS removal, reported so AG-18154 can fix it alongside its `?version` work: the `?prod=false` query parameter is dead under the ES-module loader, because nothing in `ExampleModules.tsx` or `getImportMap.ts` reads query parameters, whereas the old `grid-react-boilerplate/systemjs.config.js` read it and swapped in `react.development.js`. Consequently the e2e `reactFunctionalTs_Dev` variant currently exercises nothing beyond the production build, and the two `test.skip(agFramework === 'reactFunctionalTs_Dev', 'Example has React Dev errors in it.')` skips (`row-height-complex`, `two-grids-with-multiple-records`) are vacuous and will need revisiting once the development build loads again. This PR deliberately does not touch `getImportMap.ts` or `ExampleModules.tsx` to avoid colliding with that work.

Verified with `nx run-many -t test lint -p ag-grid-generate-example-files` (71 tests pass, lint clean), `yarn nx format --sort-root-tsconfig-paths=false`, and `./checks.sh`. `checks.sh` reports one failure, `ag-behavioural-testing:build:test`, with `TS2307: Cannot find module '@testing-library/react'`. That is an artefact of the worktree this branch was developed in, not a repo problem and not caused by this change: `@testing-library/react` is declared in `testing/behavioural/package.json` and present in `yarn.lock`, and a normally-installed checkout has it at `testing/behavioural/node_modules/@testing-library/react`. The worktree was provisioned by copying the root `node_modules` without the per-workspace nested ones, so that project's dependencies are absent there. That target should be taken as unverified by me rather than as passing; CI on this PR covers it.
