### PR TITLE
AG-18156 Guard that production example import maps resolve AG packages from the CDN

### DIFF
--- a/documentation/ag-grid-docs/src/components/example-runner/framework-templates/lib/BrowserTranspiler.tsx
+++ b/documentation/ag-grid-docs/src/components/example-runner/framework-templates/lib/BrowserTranspiler.tsx
@@ -38,7 +38,7 @@ const MODULE_EXTENSION_REGEX = /\.(tsx?|jsx?|mjs|cjs)$/i;
  */
 export const BrowserTranspiler = ({ entryFileName, nonce }: Props) => (
     <>
-        <script nonce={nonce} src={TYPESCRIPT_URL} crossorigin="anonymous" />
+        <script nonce={nonce} src={TYPESCRIPT_URL} crossOrigin="anonymous" />
         <script
             nonce={nonce}
             type="module"

--- a/documentation/ag-grid-docs/src/components/example-runner/framework-templates/lib/ExampleModules.test.tsx
+++ b/documentation/ag-grid-docs/src/components/example-runner/framework-templates/lib/ExampleModules.test.tsx
@@ -1,0 +1,74 @@
+import type { InternalFramework } from '@ag-grid-types';
+import { NPM_CDN } from '@constants';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+const FRAMEWORKS: InternalFramework[] = ['typescript', 'reactFunctionalTs', 'angular', 'vue3'];
+
+/**
+ * The example runner, the Plunker page and the static CodeSandbox page all render this component,
+ * so the import map it emits is what each of them ships. `transpileInBrowser` is the only thing
+ * that differs between them: Plunker and the static CodeSandbox template are handed the sources as
+ * authored, the runner is served them transpiled.
+ */
+const renderImportMap = async ({
+    internalFramework,
+    transpileInBrowser,
+}: {
+    internalFramework: InternalFramework;
+    transpileInBrowser?: boolean;
+}) => {
+    // `.env.build.production` sets `PUBLIC_USE_PUBLISHED_PACKAGES`, which `@constants` reads at
+    // module scope, so the modules have to be re-evaluated with it in place
+    vi.stubEnv('PUBLIC_USE_PUBLISHED_PACKAGES', 'true');
+    vi.stubEnv('PUBLIC_BASE_URL', '/AG-17103/');
+    vi.stubEnv('PUBLIC_SITE_URL', 'https://testing.ag-grid.com');
+    vi.resetModules();
+
+    const { ExampleModules } = await import('./ExampleModules');
+    const html = renderToStaticMarkup(
+        <ExampleModules
+            appLocation="/examples/column-groups/basic-grouping/typescript/"
+            entryFileName="main.ts"
+            internalFramework={internalFramework}
+            isEnterprise
+            isIntegratedCharts
+            transpileInBrowser={transpileInBrowser}
+        />
+    );
+
+    const importMap = html.match(/<script type="importmap">([\s\S]*?)<\/script>/);
+    if (!importMap) {
+        throw new Error(`No import map rendered in:\n${html}`);
+    }
+
+    return JSON.parse(importMap[1].replace(/&quot;/g, '"')).imports as Record<string, string>;
+};
+
+describe('ExampleModules', () => {
+    afterEach(() => {
+        vi.unstubAllEnvs();
+        vi.resetModules();
+    });
+
+    describe.each(FRAMEWORKS)('%s', (internalFramework) => {
+        test('emits an import map resolving AG packages from the npm CDN when built against published packages', async () => {
+            const imports = await renderImportMap({ internalFramework });
+            const agEntries = Object.entries(imports).filter(
+                ([specifier]) => specifier.startsWith('ag-') || specifier.startsWith('@ag-grid-community/')
+            );
+
+            expect(agEntries.length).toBeGreaterThan(0);
+            for (const [specifier, url] of agEntries) {
+                expect(url.startsWith(`${NPM_CDN}/`), `${specifier} -> ${url}`).toBe(true);
+            }
+        });
+
+        test('emits the same import map for the Plunker and CodeSandbox exports as for the runner', async () => {
+            const runner = await renderImportMap({ internalFramework });
+            const exported = await renderImportMap({ internalFramework, transpileInBrowser: true });
+
+            expect(exported).toEqual(runner);
+        });
+    });
+});

--- a/documentation/ag-grid-docs/src/utils/exampleModules/getImportMap.test.ts
+++ b/documentation/ag-grid-docs/src/utils/exampleModules/getImportMap.test.ts
@@ -1,8 +1,45 @@
 import type { InternalFramework } from '@ag-grid-types';
+import { NPM_CDN } from '@constants';
 
 import { getImportMap } from './getImportMap';
 
 const FRAMEWORKS: InternalFramework[] = ['typescript', 'reactFunctional', 'reactFunctionalTs', 'angular', 'vue3'];
+
+const EXAMPLE_VARIANTS = [
+    { isEnterprise: false, isIntegratedCharts: false },
+    { isEnterprise: true, isIntegratedCharts: false },
+    { isEnterprise: false, isIntegratedCharts: true },
+];
+
+/** AG packages, as opposed to the third-party framework entries, which have their own CDNs */
+const isAgPackage = (specifier: string) => specifier.startsWith('ag-') || specifier.startsWith('@ag-grid-community/');
+
+/** Strips any subpath, so that `ag-grid-community/styles/` gives the package it belongs to */
+const getPackageName = (specifier: string) =>
+    specifier
+        .split('/')
+        .slice(0, specifier.startsWith('@') ? 2 : 1)
+        .join('/');
+
+/**
+ * `.env.build.production` sets `PUBLIC_USE_PUBLISHED_PACKAGES`, which `@constants` reads at module
+ * scope, so the modules have to be re-evaluated with it in place to see what production emits.
+ * `PUBLIC_BASE_URL` is stubbed alongside it because branch builds set it, and a path prefix must
+ * never end up in a published-packages import map.
+ */
+const getProductionImportMap = async (args: {
+    internalFramework: InternalFramework;
+    isEnterprise: boolean;
+    isIntegratedCharts: boolean;
+}) => {
+    vi.stubEnv('PUBLIC_USE_PUBLISHED_PACKAGES', 'true');
+    vi.stubEnv('PUBLIC_BASE_URL', '/AG-17103/');
+    vi.stubEnv('PUBLIC_SITE_URL', 'https://testing.ag-grid.com');
+    vi.resetModules();
+
+    const { getImportMap: getProductionMap } = await import('./getImportMap');
+    return getProductionMap(args);
+};
 
 describe('getImportMap', () => {
     describe.each(FRAMEWORKS)('%s', (internalFramework) => {
@@ -36,5 +73,54 @@ describe('getImportMap', () => {
 
         // Resolvable either way, for the generator's test-id block
         expect(community['ag-grid-enterprise']).toBeDefined();
+    });
+
+    /**
+     * The production site is built against published packages, so its examples must load AG Grid
+     * from the npm CDN and never from the site that served them -- a `localhost`, staging or
+     * branch-prefixed URL here would leave a published example unable to load, and the same import
+     * map is what the Plunker and CodeSandbox exports carry (see `ExampleModules`).
+     */
+    describe('built against published packages', () => {
+        afterEach(() => {
+            vi.unstubAllEnvs();
+            vi.resetModules();
+        });
+
+        describe.each(FRAMEWORKS)('%s', (internalFramework) => {
+            test.each(EXAMPLE_VARIANTS)('resolves every AG package from the npm CDN (%o)', async (variant) => {
+                const importMap = await getProductionImportMap({ internalFramework, ...variant });
+                const agEntries = Object.entries(importMap).filter(([specifier]) => isAgPackage(specifier));
+
+                expect(agEntries.length).toBeGreaterThan(0);
+                for (const [specifier, url] of agEntries) {
+                    // Every entry is versioned, including the trailing-slash stylesheet prefixes,
+                    // whose specifier is a subpath of the package rather than the package itself
+                    const cdnPrefix = `${NPM_CDN}/${getPackageName(specifier)}@`;
+                    expect(url.startsWith(cdnPrefix), `${specifier} -> ${url}`).toBe(true);
+                }
+            });
+
+            test.each(EXAMPLE_VARIANTS)('resolves nothing from the site serving it (%o)', async (variant) => {
+                const importMap = await getProductionImportMap({ internalFramework, ...variant });
+
+                for (const [specifier, url] of Object.entries(importMap)) {
+                    expect(url, specifier).toMatch(/^https:\/\//);
+                    // A port only ever appears on a local or preview host
+                    expect(url, specifier).not.toMatch(/^https:\/\/[^/]+:\d+/);
+                    expect(url, specifier).not.toContain('localhost');
+                    expect(url, specifier).not.toContain('ag-grid.com');
+                    // The branch path prefix stubbed above, which must not leak into the URLs
+                    expect(url, specifier).not.toContain('AG-17103');
+                }
+            });
+        });
+
+        test('is what makes the AG packages resolve to the CDN', async () => {
+            // Guards the tests above against passing because the CDN is used unconditionally
+            const local = getImportMap({ internalFramework: 'typescript', isEnterprise: true });
+
+            expect(local['ag-grid-community']).not.toContain(NPM_CDN);
+        });
     });
 });


### PR DESCRIPTION
Verified that `getImportMap` resolves every AG Grid package to `https://cdn.jsdelivr.net/npm/<package>@<version>` when the site is built against published packages (`PUBLIC_USE_PUBLISHED_PACKAGES`, set only by `.env.build.production` / `.env.preview.production`), and that no localhost, staging or branch-prefixed URL can reach a production import map. The example runner, Plunker and static CodeSandbox pages all render the same `ExampleModules` component, so they carry the identical map; the React CodeSandbox template has no import map and takes its versions from `package.json`.

New tests guard this against silent regression:

- `getImportMap.test.ts` — for every framework and community/enterprise/integrated-charts variant, every AG entry starts with the versioned jsDelivr prefix, and no entry contains a port, `localhost`, an `ag-grid.com` host or the stubbed branch path prefix. A companion test asserts the CDN is not used unconditionally, so the guard cannot pass vacuously.
- `ExampleModules.test.tsx` — the rendered import map is CDN-only, and identical for the exported (`transpileInBrowser`) and runner variants.

Also switches `BrowserTranspiler`'s `crossorigin` to React's `crossOrigin`; the emitted HTML is unchanged, it just no longer warns when rendered in the new test.

Evidence from the deployed test build: fetched `examples/column-groups/basic-grouping/{typescript,reactFunctionalTs,angular,vue3}/{example-runner,plunkr,codesandbox}` from https://testing.ag-grid.com/AG-17103/ (all 12 returned 200) and inspected each emitted import map. Every AG entry there is `https://testing.ag-grid.com/AG-17103/files/<package>/…`, and the React CodeSandbox page has no import map at all. Both are expected branch-build artefacts rather than production defects: that build does not set `PUBLIC_USE_PUBLISHED_PACKAGES`, so it deliberately serves its own path-prefixed build, and the React CodeSandbox template never emits a map. No genuine defect was found, so no fix was required. Live production could not be checked directly — `https://www.ag-grid.com/examples/...` returns 403 to a non-browser client, and the deployed production site predates this branch, so no production build using native ES modules exists yet; the published-mode evidence above therefore comes from executing the real code paths under the production environment.
