### PR TITLE
AG-18154 Restore the ?version= and ?prod= example URL parameters

### DIFF
--- a/documentation/ag-grid-docs/README.md
+++ b/documentation/ag-grid-docs/README.md
@@ -4,3 +4,19 @@
 
 1. Install dependencies: `npm i`
 2. Start the dev server: `npm run dev`
+
+## Running an example against a different framework version
+
+A standalone example page accepts a `version` URL parameter, which overrides the framework version its
+import map resolves — React, Angular or Vue, depending on the example's framework:
+
+```
+https://localhost:4610/examples/column-sizing/column-flex/reactFunctionalTs/?version=18.3.1
+```
+
+Without the parameter the example resolves the version the docs pin (see
+`src/utils/exampleModules/getImportMap.ts`). A value that is not a version aborts the load with a message
+on the page instead of quietly falling back to the pinned version; a well-formed version that does not
+exist fails when the CDN 404s.
+
+Docs e2e specs select a version with the `version` field of the `loadPageOptions` fixture.

--- a/documentation/ag-grid-docs/README.md
+++ b/documentation/ag-grid-docs/README.md
@@ -5,18 +5,21 @@
 1. Install dependencies: `npm i`
 2. Start the dev server: `npm run dev`
 
-## Running an example against a different framework version
+## Running an example against a different framework version or build
 
-A standalone example page accepts a `version` URL parameter, which overrides the framework version its
-import map resolves — React, Angular or Vue, depending on the example's framework:
+A standalone example page accepts two URL parameters, both of which change what its import map resolves:
+
+- `version` — the framework version: React, Angular or Vue, depending on the example's framework.
+- `prod` — `prod=false` resolves the framework's development build, with its warnings and dev-only
+  validations. Only React has a separate one; examples otherwise run against the production build.
 
 ```
-https://localhost:4610/examples/column-sizing/column-flex/reactFunctionalTs/?version=18.3.1
+https://localhost:4610/examples/column-sizing/column-flex/reactFunctionalTs/?version=18.3.1&prod=false
 ```
 
-Without the parameter the example resolves the version the docs pin (see
-`src/utils/exampleModules/getImportMap.ts`). A value that is not a version aborts the load with a message
-on the page instead of quietly falling back to the pinned version; a well-formed version that does not
-exist fails when the CDN 404s.
+Without the parameters an example resolves the version the docs pin and the production build, as it did
+under SystemJS (see `src/utils/exampleModules/getImportMap.ts`). A `version` that is not a version aborts
+the load with a message on the page instead of quietly falling back to the pinned version; a well-formed
+version that does not exist fails when the CDN 404s.
 
-Docs e2e specs select a version with the `version` field of the `loadPageOptions` fixture.
+Docs e2e specs select both with the `version` and `prod` fields of the `loadPageOptions` fixture.

--- a/documentation/ag-grid-docs/src/components/example-runner/framework-templates/lib/ExampleModules.test.tsx
+++ b/documentation/ag-grid-docs/src/components/example-runner/framework-templates/lib/ExampleModules.test.tsx
@@ -3,6 +3,8 @@ import { NPM_CDN } from '@constants';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { afterEach, describe, expect, test, vi } from 'vitest';
 
+import { IMPORT_MAP_OPTIONS_ID } from './injectImportMap';
+
 const FRAMEWORKS: InternalFramework[] = ['typescript', 'reactFunctionalTs', 'angular', 'vue3'];
 
 /**
@@ -37,12 +39,44 @@ const renderImportMap = async ({
         />
     );
 
-    const importMap = html.match(/<script type="importmap">([\s\S]*?)<\/script>/);
-    if (!importMap) {
+    const served = html.match(/<script type="importmap">([\s\S]*?)<\/script>/);
+    if (served) {
+        return JSON.parse(served[1].replace(/&quot;/g, '"')).imports as Record<string, string>;
+    }
+
+    // Framework examples register the map in the browser instead, so that the framework version
+    // and build can come from the URL -- so run the injector over the options the page carries
+    const options = html.match(new RegExp(`<script[^>]*id="${IMPORT_MAP_OPTIONS_ID}"[^>]*>([\\s\\S]*?)</script>`));
+    if (!options) {
         throw new Error(`No import map rendered in:\n${html}`);
     }
 
-    return JSON.parse(importMap[1].replace(/&quot;/g, '"')).imports as Record<string, string>;
+    return await registerImportMap(options[1].replace(/&quot;/g, '"'));
+};
+
+/**
+ * Runs the page's own injector over its serialised options, rather than substituting the tokens
+ * here, so that what this asserts on is what a browser would resolve. No URL parameters, so it
+ * gives the pinned version and the production build -- what a plain example load resolves.
+ */
+const registerImportMap = async (optionsJson: string) => {
+    const registered: any[] = [];
+
+    vi.stubGlobal('window', { location: { search: '' } });
+    vi.stubGlobal('document', {
+        createElement: () => ({}) as any,
+        head: { appendChild: (element: any) => registered.push(element) },
+        body: { appendChild: () => undefined },
+    });
+
+    try {
+        const { injectImportMap } = await import('./injectImportMap');
+        injectImportMap(JSON.parse(optionsJson));
+    } finally {
+        vi.unstubAllGlobals();
+    }
+
+    return JSON.parse(registered[0].textContent).imports as Record<string, string>;
 };
 
 describe('ExampleModules', () => {

--- a/documentation/ag-grid-docs/src/components/example-runner/framework-templates/lib/ExampleModules.tsx
+++ b/documentation/ag-grid-docs/src/components/example-runner/framework-templates/lib/ExampleModules.tsx
@@ -2,6 +2,7 @@ import type { InternalFramework } from '@ag-grid-types';
 import {
     FRAMEWORK_VERSION_PARAM,
     FRAMEWORK_VERSION_PATTERN,
+    PROD_PARAM,
     getDefaultFrameworkVersion,
     getImportMap,
 } from '@utils/exampleModules/getImportMap';
@@ -34,7 +35,8 @@ interface Props {
  * The exception is Plunker, which is handed the sources as authored -- see `transpileInBrowser`.
  *
  * For framework examples the map is registered in the browser rather than served as markup, so
- * that `?version=` can pick the framework version to run against -- see `injectImportMap`.
+ * that `?version=` and `?prod=` can pick the framework version and build an example runs
+ * against -- see `injectImportMap`.
  */
 export const ExampleModules = ({
     appLocation,
@@ -47,23 +49,32 @@ export const ExampleModules = ({
     nonce,
 }: Props) => {
     const defaultVersion = getDefaultFrameworkVersion(internalFramework);
-    const importMap = getImportMap({
-        internalFramework,
-        isEnterprise,
-        isIntegratedCharts,
-        // Substituted in the browser, so the version can come from the URL (see injectImportMap)
-        frameworkVersion: defaultVersion ? FRAMEWORK_VERSION_PLACEHOLDER : undefined,
-    });
-    const template = JSON.stringify({ imports: importMap }, null, 4);
+    // Substituted in the browser, so the version can come from the URL (see injectImportMap)
+    const frameworkVersion = defaultVersion ? FRAMEWORK_VERSION_PLACEHOLDER : undefined;
+    const renderMap = (isProd: boolean) => {
+        const imports = getImportMap({
+            internalFramework,
+            isEnterprise,
+            isIntegratedCharts,
+            frameworkVersion,
+            isProd,
+        });
+        return JSON.stringify({ imports }, null, 4);
+    };
+
+    const production = renderMap(true);
+    const development = renderMap(false);
     const startFile = pathJoin(appLocation, toModuleFileName(entryFileName));
 
     const injectOptions: InjectImportMapOptions | undefined = defaultVersion
         ? {
-              template,
+              // Only React has a separate development build, so for the others there is one map
+              templates: { production, development: development === production ? undefined : development },
               defaultVersion,
               placeholder: FRAMEWORK_VERSION_PLACEHOLDER,
               versionParam: FRAMEWORK_VERSION_PARAM,
               versionPattern: FRAMEWORK_VERSION_PATTERN.source,
+              prodParam: PROD_PARAM,
           }
         : undefined;
 
@@ -76,7 +87,7 @@ export const ExampleModules = ({
                 />
             ) : (
                 // Nothing to resolve from the URL, so the map is served as rendered
-                <script nonce={nonce} type="importmap" dangerouslySetInnerHTML={{ __html: template }} />
+                <script nonce={nonce} type="importmap" dangerouslySetInnerHTML={{ __html: production }} />
             )}
             {usesMathRandom && <SeedRandom nonce={nonce} />}
 

--- a/documentation/ag-grid-docs/src/components/example-runner/framework-templates/lib/ExampleModules.tsx
+++ b/documentation/ag-grid-docs/src/components/example-runner/framework-templates/lib/ExampleModules.tsx
@@ -1,7 +1,9 @@
 import type { InternalFramework } from '@ag-grid-types';
 import {
+    DEVELOPMENT_FLAGS,
     FRAMEWORK_VERSION_PARAM,
     FRAMEWORK_VERSION_PATTERN,
+    PRODUCTION_FLAGS,
     PROD_PARAM,
     getDefaultFrameworkVersion,
     getImportMap,
@@ -11,7 +13,13 @@ import { pathJoin } from '@utils/pathJoin';
 
 import { BrowserTranspiler } from './BrowserTranspiler';
 import { SeedRandom } from './SeedRandom';
-import { FRAMEWORK_VERSION_PLACEHOLDER, type InjectImportMapOptions, injectImportMap } from './injectImportMap';
+import {
+    DEV_FLAG_PLACEHOLDERS,
+    FRAMEWORK_VERSION_PLACEHOLDER,
+    IMPORT_MAP_OPTIONS_ID,
+    type InjectImportMapOptions,
+    injectImportMap,
+} from './injectImportMap';
 
 interface Props {
     appLocation: string;
@@ -49,27 +57,31 @@ export const ExampleModules = ({
     nonce,
 }: Props) => {
     const defaultVersion = getDefaultFrameworkVersion(internalFramework);
-    // Substituted in the browser, so the version can come from the URL (see injectImportMap)
-    const frameworkVersion = defaultVersion ? FRAMEWORK_VERSION_PLACEHOLDER : undefined;
-    const renderMap = (isProd: boolean) => {
-        const imports = getImportMap({
-            internalFramework,
-            isEnterprise,
-            isIntegratedCharts,
-            frameworkVersion,
-            isProd,
-        });
-        return JSON.stringify({ imports }, null, 4);
-    };
-
-    const production = renderMap(true);
-    const development = renderMap(false);
+    // The framework version and build are substituted in the browser, so that they can come
+    // from the URL: the map is rendered once, with a token everywhere either one appears
+    const imports = getImportMap({
+        internalFramework,
+        isEnterprise,
+        isIntegratedCharts,
+        frameworkVersion: defaultVersion && FRAMEWORK_VERSION_PLACEHOLDER,
+        dev: defaultVersion ? DEV_FLAG_PLACEHOLDERS : PRODUCTION_FLAGS,
+    });
+    const importMap = JSON.stringify({ imports }, null, 4);
     const startFile = pathJoin(appLocation, toModuleFileName(entryFileName));
 
     const injectOptions: InjectImportMapOptions | undefined = defaultVersion
         ? {
-              // Only React has a separate development build, so for the others there is one map
-              templates: { production, development: development === production ? undefined : development },
+              template: importMap,
+              buildTokens: {
+                  production: {
+                      [DEV_FLAG_PLACEHOLDERS.query]: PRODUCTION_FLAGS.query,
+                      [DEV_FLAG_PLACEHOLDERS.appended]: PRODUCTION_FLAGS.appended,
+                  },
+                  development: {
+                      [DEV_FLAG_PLACEHOLDERS.query]: DEVELOPMENT_FLAGS.query,
+                      [DEV_FLAG_PLACEHOLDERS.appended]: DEVELOPMENT_FLAGS.appended,
+                  },
+              },
               defaultVersion,
               placeholder: FRAMEWORK_VERSION_PLACEHOLDER,
               versionParam: FRAMEWORK_VERSION_PARAM,
@@ -81,13 +93,25 @@ export const ExampleModules = ({
     return (
         <>
             {injectOptions ? (
-                <script
-                    nonce={nonce}
-                    dangerouslySetInnerHTML={{ __html: `(${injectImportMap})(${JSON.stringify(injectOptions)});` }}
-                />
+                <>
+                    <script
+                        nonce={nonce}
+                        type="application/json"
+                        id={IMPORT_MAP_OPTIONS_ID}
+                        dangerouslySetInnerHTML={{ __html: JSON.stringify(injectOptions) }}
+                    />
+                    <script
+                        nonce={nonce}
+                        dangerouslySetInnerHTML={{
+                            __html:
+                                `(${injectImportMap})(JSON.parse(` +
+                                `document.getElementById(${JSON.stringify(IMPORT_MAP_OPTIONS_ID)}).textContent));`,
+                        }}
+                    />
+                </>
             ) : (
                 // Nothing to resolve from the URL, so the map is served as rendered
-                <script nonce={nonce} type="importmap" dangerouslySetInnerHTML={{ __html: production }} />
+                <script nonce={nonce} type="importmap" dangerouslySetInnerHTML={{ __html: importMap }} />
             )}
             {usesMathRandom && <SeedRandom nonce={nonce} />}
 

--- a/documentation/ag-grid-docs/src/components/example-runner/framework-templates/lib/ExampleModules.tsx
+++ b/documentation/ag-grid-docs/src/components/example-runner/framework-templates/lib/ExampleModules.tsx
@@ -1,10 +1,16 @@
 import type { InternalFramework } from '@ag-grid-types';
-import { getImportMap } from '@utils/exampleModules/getImportMap';
+import {
+    FRAMEWORK_VERSION_PARAM,
+    FRAMEWORK_VERSION_PATTERN,
+    getDefaultFrameworkVersion,
+    getImportMap,
+} from '@utils/exampleModules/getImportMap';
 import { toModuleFileName } from '@utils/exampleModules/transformExampleModule';
 import { pathJoin } from '@utils/pathJoin';
 
 import { BrowserTranspiler } from './BrowserTranspiler';
 import { SeedRandom } from './SeedRandom';
+import { FRAMEWORK_VERSION_PLACEHOLDER, type InjectImportMapOptions, injectImportMap } from './injectImportMap';
 
 interface Props {
     appLocation: string;
@@ -26,6 +32,9 @@ interface Props {
  * package specifiers, and the entry file is loaded as a module. TypeScript and JSX sources
  * are transpiled server-side and served as `.js`, so the entry point is requested as such.
  * The exception is Plunker, which is handed the sources as authored -- see `transpileInBrowser`.
+ *
+ * For framework examples the map is registered in the browser rather than served as markup, so
+ * that `?version=` can pick the framework version to run against -- see `injectImportMap`.
  */
 export const ExampleModules = ({
     appLocation,
@@ -37,16 +46,38 @@ export const ExampleModules = ({
     transpileInBrowser,
     nonce,
 }: Props) => {
-    const importMap = getImportMap({ internalFramework, isEnterprise, isIntegratedCharts });
+    const defaultVersion = getDefaultFrameworkVersion(internalFramework);
+    const importMap = getImportMap({
+        internalFramework,
+        isEnterprise,
+        isIntegratedCharts,
+        // Substituted in the browser, so the version can come from the URL (see injectImportMap)
+        frameworkVersion: defaultVersion ? FRAMEWORK_VERSION_PLACEHOLDER : undefined,
+    });
+    const template = JSON.stringify({ imports: importMap }, null, 4);
     const startFile = pathJoin(appLocation, toModuleFileName(entryFileName));
+
+    const injectOptions: InjectImportMapOptions | undefined = defaultVersion
+        ? {
+              template,
+              defaultVersion,
+              placeholder: FRAMEWORK_VERSION_PLACEHOLDER,
+              versionParam: FRAMEWORK_VERSION_PARAM,
+              versionPattern: FRAMEWORK_VERSION_PATTERN.source,
+          }
+        : undefined;
 
     return (
         <>
-            <script
-                nonce={nonce}
-                type="importmap"
-                dangerouslySetInnerHTML={{ __html: JSON.stringify({ imports: importMap }, null, 4) }}
-            />
+            {injectOptions ? (
+                <script
+                    nonce={nonce}
+                    dangerouslySetInnerHTML={{ __html: `(${injectImportMap})(${JSON.stringify(injectOptions)});` }}
+                />
+            ) : (
+                // Nothing to resolve from the URL, so the map is served as rendered
+                <script nonce={nonce} type="importmap" dangerouslySetInnerHTML={{ __html: template }} />
+            )}
             {usesMathRandom && <SeedRandom nonce={nonce} />}
 
             {/* Examples read `process.env.NODE_ENV` to guard dev-only validations, and nothing

--- a/documentation/ag-grid-docs/src/components/example-runner/framework-templates/lib/injectImportMap.test.ts
+++ b/documentation/ag-grid-docs/src/components/example-runner/framework-templates/lib/injectImportMap.test.ts
@@ -1,10 +1,15 @@
-import { FRAMEWORK_VERSION_PLACEHOLDER, injectImportMap } from './injectImportMap';
-
-const importMap = (query: string) =>
-    JSON.stringify({ imports: { react: `https://esm.sh/react@${FRAMEWORK_VERSION_PLACEHOLDER}${query}` } });
+import { DEV_FLAG_PLACEHOLDERS, FRAMEWORK_VERSION_PLACEHOLDER, injectImportMap } from './injectImportMap';
 
 const OPTIONS = {
-    templates: { production: importMap(''), development: importMap('?dev') },
+    template: JSON.stringify({
+        imports: {
+            react: `https://esm.sh/react@${FRAMEWORK_VERSION_PLACEHOLDER}${DEV_FLAG_PLACEHOLDERS.query}`,
+        },
+    }),
+    buildTokens: {
+        production: { [DEV_FLAG_PLACEHOLDERS.query]: '', [DEV_FLAG_PLACEHOLDERS.appended]: '' },
+        development: { [DEV_FLAG_PLACEHOLDERS.query]: '?dev', [DEV_FLAG_PLACEHOLDERS.appended]: '&dev' },
+    },
     defaultVersion: '19.2.1',
     placeholder: FRAMEWORK_VERSION_PLACEHOLDER,
     versionParam: 'version',
@@ -73,12 +78,16 @@ describe('injectImportMap', () => {
         expect(JSON.parse(head[0].textContent).imports.react).toBe('https://esm.sh/react@18.3.1?dev');
     });
 
-    test('falls back to the one map for frameworks with no separate development build', () => {
+    test('leaves a map with no build-dependent entries alone when asked for the development build', () => {
         const { head } = stubPage('?prod=false');
 
-        injectImportMap({ ...OPTIONS, templates: { production: OPTIONS.templates.production } });
+        // Every framework but React: no build token appears, so both builds give the same map
+        injectImportMap({
+            ...OPTIONS,
+            template: JSON.stringify({ imports: { vue: `https://cdn/vue@${FRAMEWORK_VERSION_PLACEHOLDER}/vue.js` } }),
+        });
 
-        expect(JSON.parse(head[0].textContent).imports.react).toBe('https://esm.sh/react@19.2.1');
+        expect(JSON.parse(head[0].textContent).imports.vue).toBe('https://cdn/vue@19.2.1/vue.js');
     });
 
     test('fails visibly rather than falling back when the version is not a version', () => {

--- a/documentation/ag-grid-docs/src/components/example-runner/framework-templates/lib/injectImportMap.test.ts
+++ b/documentation/ag-grid-docs/src/components/example-runner/framework-templates/lib/injectImportMap.test.ts
@@ -21,13 +21,14 @@ const OPTIONS = {
  * The function runs in the example page, so the test supplies the pieces of the page it
  * touches: the URL it reads the version from and the elements it appends.
  */
-const stubPage = (search: string) => {
+const stubPage = (search: string, nonce?: string) => {
     const elements: any[] = [];
     const head: any[] = [];
     const body: any[] = [];
 
     vi.stubGlobal('window', { location: { search } });
     vi.stubGlobal('document', {
+        currentScript: nonce === undefined ? null : { nonce },
         createElement: (tagName: string) => {
             const element = { tagName, attributes: {} as Record<string, string>, setAttribute: undefined as any };
             element.setAttribute = (name: string, value: string) => (element.attributes[name] = value);
@@ -90,6 +91,22 @@ describe('injectImportMap', () => {
         expect(JSON.parse(head[0].textContent).imports.vue).toBe('https://cdn/vue@19.2.1/vue.js');
     });
 
+    test('takes the nonce of the script running it, for a page whose CSP allows only nonces', () => {
+        const { head } = stubPage('', 'test-nonce');
+
+        injectImportMap(OPTIONS);
+
+        expect(head[0].nonce).toBe('test-nonce');
+    });
+
+    test('registers no nonce when the page has none', () => {
+        const { head } = stubPage('');
+
+        injectImportMap(OPTIONS);
+
+        expect(head[0].nonce).toBeUndefined();
+    });
+
     test('fails visibly rather than falling back when the version is not a version', () => {
         const { head, body } = stubPage('?version=latest');
 
@@ -98,5 +115,13 @@ describe('injectImportMap', () => {
         // No map registered, so the example cannot quietly run against the pinned default
         expect(head).toHaveLength(0);
         expect(body[0].textContent).toContain('latest');
+    });
+
+    test('fails the same way for an empty version, rather than taking it as absent', () => {
+        const { head } = stubPage('?version=');
+
+        expect(() => injectImportMap(OPTIONS)).toThrowError(/not a valid \?version= value/);
+
+        expect(head).toHaveLength(0);
     });
 });

--- a/documentation/ag-grid-docs/src/components/example-runner/framework-templates/lib/injectImportMap.test.ts
+++ b/documentation/ag-grid-docs/src/components/example-runner/framework-templates/lib/injectImportMap.test.ts
@@ -1,0 +1,65 @@
+import { FRAMEWORK_VERSION_PLACEHOLDER, injectImportMap } from './injectImportMap';
+
+const OPTIONS = {
+    template: JSON.stringify({ imports: { react: `https://esm.sh/react@${FRAMEWORK_VERSION_PLACEHOLDER}` } }),
+    defaultVersion: '19.2.1',
+    placeholder: FRAMEWORK_VERSION_PLACEHOLDER,
+    versionParam: 'version',
+    versionPattern: /^\d+\.\d+\.\d+(?:[-+][\w.-]+)*$/.source,
+};
+
+/**
+ * The function runs in the example page, so the test supplies the pieces of the page it
+ * touches: the URL it reads the version from and the elements it appends.
+ */
+const stubPage = (search: string) => {
+    const elements: any[] = [];
+    const head: any[] = [];
+    const body: any[] = [];
+
+    vi.stubGlobal('window', { location: { search } });
+    vi.stubGlobal('document', {
+        createElement: (tagName: string) => {
+            const element = { tagName, attributes: {} as Record<string, string>, setAttribute: undefined as any };
+            element.setAttribute = (name: string, value: string) => (element.attributes[name] = value);
+            elements.push(element);
+            return element;
+        },
+        head: { appendChild: (element: any) => head.push(element) },
+        body: { appendChild: (element: any) => body.push(element) },
+    });
+
+    return { head, body };
+};
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe('injectImportMap', () => {
+    test('registers the pinned version when the URL requests none', () => {
+        const { head } = stubPage('?enableTestIds=true');
+
+        injectImportMap(OPTIONS);
+
+        expect(head).toHaveLength(1);
+        expect(head[0].type).toBe('importmap');
+        expect(JSON.parse(head[0].textContent).imports.react).toBe('https://esm.sh/react@19.2.1');
+    });
+
+    test('registers the version the URL requests', () => {
+        const { head } = stubPage('?version=18.3.1');
+
+        injectImportMap(OPTIONS);
+
+        expect(JSON.parse(head[0].textContent).imports.react).toBe('https://esm.sh/react@18.3.1');
+    });
+
+    test('fails visibly rather than falling back when the version is not a version', () => {
+        const { head, body } = stubPage('?version=latest');
+
+        expect(() => injectImportMap(OPTIONS)).toThrowError(/not a valid \?version= value/);
+
+        // No map registered, so the example cannot quietly run against the pinned default
+        expect(head).toHaveLength(0);
+        expect(body[0].textContent).toContain('latest');
+    });
+});

--- a/documentation/ag-grid-docs/src/components/example-runner/framework-templates/lib/injectImportMap.test.ts
+++ b/documentation/ag-grid-docs/src/components/example-runner/framework-templates/lib/injectImportMap.test.ts
@@ -1,11 +1,15 @@
 import { FRAMEWORK_VERSION_PLACEHOLDER, injectImportMap } from './injectImportMap';
 
+const importMap = (query: string) =>
+    JSON.stringify({ imports: { react: `https://esm.sh/react@${FRAMEWORK_VERSION_PLACEHOLDER}${query}` } });
+
 const OPTIONS = {
-    template: JSON.stringify({ imports: { react: `https://esm.sh/react@${FRAMEWORK_VERSION_PLACEHOLDER}` } }),
+    templates: { production: importMap(''), development: importMap('?dev') },
     defaultVersion: '19.2.1',
     placeholder: FRAMEWORK_VERSION_PLACEHOLDER,
     versionParam: 'version',
     versionPattern: /^\d+\.\d+\.\d+(?:[-+][\w.-]+)*$/.source,
+    prodParam: 'prod',
 };
 
 /**
@@ -51,6 +55,30 @@ describe('injectImportMap', () => {
         injectImportMap(OPTIONS);
 
         expect(JSON.parse(head[0].textContent).imports.react).toBe('https://esm.sh/react@18.3.1');
+    });
+
+    test('registers the production build unless the URL asks for the development one', () => {
+        const { head } = stubPage('?prod=true');
+
+        injectImportMap(OPTIONS);
+
+        expect(JSON.parse(head[0].textContent).imports.react).toBe('https://esm.sh/react@19.2.1');
+    });
+
+    test('registers the development build for prod=false', () => {
+        const { head } = stubPage('?prod=false&version=18.3.1');
+
+        injectImportMap(OPTIONS);
+
+        expect(JSON.parse(head[0].textContent).imports.react).toBe('https://esm.sh/react@18.3.1?dev');
+    });
+
+    test('falls back to the one map for frameworks with no separate development build', () => {
+        const { head } = stubPage('?prod=false');
+
+        injectImportMap({ ...OPTIONS, templates: { production: OPTIONS.templates.production } });
+
+        expect(JSON.parse(head[0].textContent).imports.react).toBe('https://esm.sh/react@19.2.1');
     });
 
     test('fails visibly rather than falling back when the version is not a version', () => {

--- a/documentation/ag-grid-docs/src/components/example-runner/framework-templates/lib/injectImportMap.ts
+++ b/documentation/ag-grid-docs/src/components/example-runner/framework-templates/lib/injectImportMap.ts
@@ -72,7 +72,9 @@ export function injectImportMap({
     const isProd = urlParams.get(prodParam) !== 'false';
     let version = defaultVersion;
 
-    if (requestedVersion) {
+    // An empty `?version=` is a version that is not a version, not an absent one, so it fails
+    // below rather than quietly loading the default
+    if (requestedVersion !== null) {
         if (!new RegExp(versionPattern).test(requestedVersion)) {
             const message =
                 `Example not loaded: "${requestedVersion}" is not a valid ?${versionParam}= value. ` +
@@ -100,5 +102,14 @@ export function injectImportMap({
     const importMap = document.createElement('script');
     importMap.type = 'importmap';
     importMap.textContent = importMapJson;
+
+    // An example may carry a CSP that allows inline scripts only by nonce -- the security-test
+    // examples do -- and a script created here has none, so it takes the nonce of the script
+    // running this. Read from the IDL attribute, which keeps the value after the parser hides it.
+    const nonce = (document.currentScript as HTMLScriptElement | null)?.nonce;
+    if (nonce) {
+        importMap.nonce = nonce;
+    }
+
     document.head.appendChild(importMap);
 }

--- a/documentation/ag-grid-docs/src/components/example-runner/framework-templates/lib/injectImportMap.ts
+++ b/documentation/ag-grid-docs/src/components/example-runner/framework-templates/lib/injectImportMap.ts
@@ -1,0 +1,69 @@
+/**
+ * Stands in for the framework version in the rendered import map until the browser
+ * substitutes the version being run against. Shaped like a version so the entries stay
+ * recognisable as URLs.
+ */
+export const FRAMEWORK_VERSION_PLACEHOLDER = '0.0.0-ag-framework-version';
+
+export interface InjectImportMapOptions {
+    /** The import map, serialised, with `placeholder` wherever the framework version goes */
+    template: string;
+    /** Substituted for `placeholder` when the URL does not request a version */
+    defaultVersion: string;
+    placeholder: string;
+    /** URL parameter naming the framework version to run against */
+    versionParam: string;
+    /** Source of the pattern a requested version must match */
+    versionPattern: string;
+}
+
+/**
+ * Registers the example page's import map, resolving the framework version from the
+ * `?version=` URL parameter when one is given.
+ *
+ * Example pages are statically generated, so the requested version is not known when the
+ * page is built: the map is rendered with a placeholder where the framework version goes,
+ * and this substitutes the version and registers the map in the browser. It is emitted as a
+ * classic inline script, which the parser runs synchronously -- so the map is in place
+ * before the parser reaches the example's module script, which is what the import-map spec
+ * requires.
+ *
+ * A version that is not a plausible version string aborts the load with a visible message,
+ * rather than quietly running the example against the pinned default. A well-formed but
+ * non-existent version is left to fail on its own: the CDN 404s and the example does not
+ * start.
+ *
+ * Serialised into the page with `toString()`, so it must reference nothing outside its own
+ * parameters.
+ */
+export function injectImportMap({
+    template,
+    defaultVersion,
+    placeholder,
+    versionParam,
+    versionPattern,
+}: InjectImportMapOptions): void {
+    const requestedVersion = new URLSearchParams(window.location.search).get(versionParam);
+    let version = defaultVersion;
+
+    if (requestedVersion) {
+        if (!new RegExp(versionPattern).test(requestedVersion)) {
+            const message =
+                `Example not loaded: "${requestedVersion}" is not a valid ?${versionParam}= value. ` +
+                `Expected a framework version such as ${defaultVersion}.`;
+
+            const banner = document.createElement('div');
+            banner.textContent = message;
+            banner.setAttribute('style', 'padding: 1rem; font-family: monospace; color: #b00020;');
+            document.body.appendChild(banner);
+
+            throw new Error(message);
+        }
+        version = requestedVersion;
+    }
+
+    const importMap = document.createElement('script');
+    importMap.type = 'importmap';
+    importMap.textContent = template.split(placeholder).join(version);
+    document.head.appendChild(importMap);
+}

--- a/documentation/ag-grid-docs/src/components/example-runner/framework-templates/lib/injectImportMap.ts
+++ b/documentation/ag-grid-docs/src/components/example-runner/framework-templates/lib/injectImportMap.ts
@@ -5,13 +5,29 @@
  */
 export const FRAMEWORK_VERSION_PLACEHOLDER = '0.0.0-ag-framework-version';
 
+/**
+ * Stand in for the two forms the development-build flag takes in a URL (see `DevFlags`), so
+ * that one rendered map can serve either build.
+ */
+export const DEV_FLAG_PLACEHOLDERS = {
+    query: '?ag-dev-query',
+    appended: '&ag-dev-appended',
+};
+
+/** Identifies the JSON block the page carries this function's options in */
+export const IMPORT_MAP_OPTIONS_ID = 'ag-import-map-options';
+
 export interface InjectImportMapOptions {
     /**
-     * The import map, serialised, with `placeholder` wherever the framework version goes.
-     * `development` is the map resolving the framework's development build, present only
-     * where it differs from the production one.
+     * The import map, serialised, with `placeholder` wherever the framework version goes and
+     * the build tokens wherever the build is selected.
      */
-    templates: { production: string; development?: string };
+    template: string;
+    /**
+     * What the build tokens in `template` stand for in each build, applied whole -- a map with
+     * no build-dependent entries, which is every framework but React, substitutes nothing.
+     */
+    buildTokens: { production: Record<string, string>; development: Record<string, string> };
     /** Substituted for `placeholder` when the URL does not request a version */
     defaultVersion: string;
     placeholder: string;
@@ -42,7 +58,8 @@ export interface InjectImportMapOptions {
  * parameters.
  */
 export function injectImportMap({
-    templates,
+    template,
+    buildTokens,
     defaultVersion,
     placeholder,
     versionParam,
@@ -71,10 +88,17 @@ export function injectImportMap({
         version = requestedVersion;
     }
 
-    const template = (isProd ? templates.production : templates.development) ?? templates.production;
+    const substitutions: Record<string, string> = {
+        [placeholder]: version,
+        ...(isProd ? buildTokens.production : buildTokens.development),
+    };
+    let importMapJson = template;
+    for (const token of Object.keys(substitutions)) {
+        importMapJson = importMapJson.split(token).join(substitutions[token]);
+    }
 
     const importMap = document.createElement('script');
     importMap.type = 'importmap';
-    importMap.textContent = template.split(placeholder).join(version);
+    importMap.textContent = importMapJson;
     document.head.appendChild(importMap);
 }

--- a/documentation/ag-grid-docs/src/components/example-runner/framework-templates/lib/injectImportMap.ts
+++ b/documentation/ag-grid-docs/src/components/example-runner/framework-templates/lib/injectImportMap.ts
@@ -6,8 +6,12 @@
 export const FRAMEWORK_VERSION_PLACEHOLDER = '0.0.0-ag-framework-version';
 
 export interface InjectImportMapOptions {
-    /** The import map, serialised, with `placeholder` wherever the framework version goes */
-    template: string;
+    /**
+     * The import map, serialised, with `placeholder` wherever the framework version goes.
+     * `development` is the map resolving the framework's development build, present only
+     * where it differs from the production one.
+     */
+    templates: { production: string; development?: string };
     /** Substituted for `placeholder` when the URL does not request a version */
     defaultVersion: string;
     placeholder: string;
@@ -15,18 +19,19 @@ export interface InjectImportMapOptions {
     versionParam: string;
     /** Source of the pattern a requested version must match */
     versionPattern: string;
+    /** URL parameter asking for the development build, with `prod=false` */
+    prodParam: string;
 }
 
 /**
- * Registers the example page's import map, resolving the framework version from the
- * `?version=` URL parameter when one is given.
+ * Registers the example page's import map, resolving the framework version and whether to
+ * run against its development build from the `?version=` and `?prod=` URL parameters.
  *
- * Example pages are statically generated, so the requested version is not known when the
- * page is built: the map is rendered with a placeholder where the framework version goes,
- * and this substitutes the version and registers the map in the browser. It is emitted as a
- * classic inline script, which the parser runs synchronously -- so the map is in place
- * before the parser reaches the example's module script, which is what the import-map spec
- * requires.
+ * Example pages are statically generated, so neither is known when the page is built: the
+ * maps are rendered with a placeholder where the framework version goes, and this picks one,
+ * substitutes the version and registers it in the browser. It is emitted as a classic inline
+ * script, which the parser runs synchronously -- so the map is in place before the parser
+ * reaches the example's module script, which is what the import-map spec requires.
  *
  * A version that is not a plausible version string aborts the load with a visible message,
  * rather than quietly running the example against the pinned default. A well-formed but
@@ -37,13 +42,17 @@ export interface InjectImportMapOptions {
  * parameters.
  */
 export function injectImportMap({
-    template,
+    templates,
     defaultVersion,
     placeholder,
     versionParam,
     versionPattern,
+    prodParam,
 }: InjectImportMapOptions): void {
-    const requestedVersion = new URLSearchParams(window.location.search).get(versionParam);
+    const urlParams = new URLSearchParams(window.location.search);
+    const requestedVersion = urlParams.get(versionParam);
+    // Production unless the URL says otherwise, as under SystemJS
+    const isProd = urlParams.get(prodParam) !== 'false';
     let version = defaultVersion;
 
     if (requestedVersion) {
@@ -61,6 +70,8 @@ export function injectImportMap({
         }
         version = requestedVersion;
     }
+
+    const template = (isProd ? templates.production : templates.development) ?? templates.production;
 
     const importMap = document.createElement('script');
     importMap.type = 'importmap';

--- a/documentation/ag-grid-docs/src/utils/exampleModules/getImportMap.test.ts
+++ b/documentation/ag-grid-docs/src/utils/exampleModules/getImportMap.test.ts
@@ -1,7 +1,7 @@
 import type { InternalFramework } from '@ag-grid-types';
 import { NPM_CDN } from '@constants';
 
-import { FRAMEWORK_VERSION_PATTERN, getDefaultFrameworkVersion, getImportMap } from './getImportMap';
+import { DEVELOPMENT_FLAGS, FRAMEWORK_VERSION_PATTERN, getDefaultFrameworkVersion, getImportMap } from './getImportMap';
 
 const FRAMEWORKS: InternalFramework[] = ['typescript', 'reactFunctional', 'reactFunctionalTs', 'angular', 'vue3'];
 
@@ -184,7 +184,7 @@ describe('getImportMap', () => {
             const development = getImportMap({
                 internalFramework: 'reactFunctionalTs',
                 isEnterprise: false,
-                isProd: false,
+                dev: DEVELOPMENT_FLAGS,
             });
 
             // esm.sh serves the production build unless asked for `dev`
@@ -202,7 +202,7 @@ describe('getImportMap', () => {
         test.each(['angular', 'vue3'] as InternalFramework[])(
             '%s resolves the same entries either way, having no separate development build',
             (internalFramework) => {
-                expect(getImportMap({ internalFramework, isEnterprise: false, isProd: false })).toEqual(
+                expect(getImportMap({ internalFramework, isEnterprise: false, dev: DEVELOPMENT_FLAGS })).toEqual(
                     getImportMap({ internalFramework, isEnterprise: false })
                 );
             }

--- a/documentation/ag-grid-docs/src/utils/exampleModules/getImportMap.test.ts
+++ b/documentation/ag-grid-docs/src/utils/exampleModules/getImportMap.test.ts
@@ -1,7 +1,7 @@
 import type { InternalFramework } from '@ag-grid-types';
 import { NPM_CDN } from '@constants';
 
-import { getImportMap } from './getImportMap';
+import { FRAMEWORK_VERSION_PATTERN, getDefaultFrameworkVersion, getImportMap } from './getImportMap';
 
 const FRAMEWORKS: InternalFramework[] = ['typescript', 'reactFunctional', 'reactFunctionalTs', 'angular', 'vue3'];
 
@@ -122,5 +122,59 @@ describe('getImportMap', () => {
 
             expect(local['ag-grid-community']).not.toContain(NPM_CDN);
         });
+    });
+
+    describe('framework version', () => {
+        const frameworkEntry: Partial<Record<InternalFramework, string>> = {
+            reactFunctionalTs: 'react',
+            angular: '@angular/core',
+            vue3: 'vue',
+        };
+
+        test.each(Object.entries(frameworkEntry))('%s resolves the pinned version by default', (framework, entry) => {
+            const importMap = getImportMap({
+                internalFramework: framework as InternalFramework,
+                isEnterprise: false,
+            });
+
+            expect(importMap[entry]).toContain(`@${getDefaultFrameworkVersion(framework as InternalFramework)}`);
+        });
+
+        test.each(Object.entries(frameworkEntry))('%s resolves the requested version', (framework, entry) => {
+            const importMap = getImportMap({
+                internalFramework: framework as InternalFramework,
+                isEnterprise: false,
+                frameworkVersion: '1.2.3',
+            });
+
+            expect(importMap[entry]).toContain('@1.2.3');
+        });
+
+        test('overriding the version leaves the companion packages pinned', () => {
+            const importMap = getImportMap({
+                internalFramework: 'angular',
+                isEnterprise: false,
+                frameworkVersion: '1.2.3',
+            });
+
+            expect(importMap['rxjs']).not.toContain('@1.2.3');
+            expect(importMap['tslib']).not.toContain('@1.2.3');
+        });
+
+        test('the frameworkless examples have no framework version', () => {
+            expect(getDefaultFrameworkVersion('typescript')).toBeUndefined();
+            expect(getDefaultFrameworkVersion('vanilla')).toBeUndefined();
+        });
+
+        test.each(['19.2.1', '18.3.1', '20.0.0-next.7', '3.5.17+build.1'])('%s is a valid version', (version) => {
+            expect(FRAMEWORK_VERSION_PATTERN.test(version)).toBe(true);
+        });
+
+        test.each(['19', '19.2', 'latest', '../evil', '19.2.1/../evil', 'https://example.com'])(
+            '%s is not a valid version',
+            (version) => {
+                expect(FRAMEWORK_VERSION_PATTERN.test(version)).toBe(false);
+            }
+        );
     });
 });

--- a/documentation/ag-grid-docs/src/utils/exampleModules/getImportMap.test.ts
+++ b/documentation/ag-grid-docs/src/utils/exampleModules/getImportMap.test.ts
@@ -166,8 +166,21 @@ describe('getImportMap', () => {
             expect(getDefaultFrameworkVersion('vanilla')).toBeUndefined();
         });
 
-        test.each(['19.2.1', '18.3.1', '20.0.0-next.7', '3.5.17+build.1'])('%s is a valid version', (version) => {
-            expect(FRAMEWORK_VERSION_PATTERN.test(version)).toBe(true);
+        test.each(['19.2.1', '18.3.1', '20.0.0-next.7', '3.5.17+build.1', '1.2.3-rc.1+build.2'])(
+            '%s is a valid version',
+            (version) => {
+                expect(FRAMEWORK_VERSION_PATTERN.test(version)).toBe(true);
+            }
+        );
+
+        test('rejects a long near-miss without the match itself becoming expensive', () => {
+            // The suffixes are matched once each, so a value engineered to make a repeated group
+            // backtrack cannot: this settles immediately rather than hanging the example page
+            const start = performance.now();
+
+            expect(FRAMEWORK_VERSION_PATTERN.test(`1.2.3-${'a-'.repeat(2000)}!`)).toBe(false);
+
+            expect(performance.now() - start).toBeLessThan(100);
         });
 
         test.each(['19', '19.2', 'latest', '../evil', '19.2.1/../evil', 'https://example.com'])(

--- a/documentation/ag-grid-docs/src/utils/exampleModules/getImportMap.test.ts
+++ b/documentation/ag-grid-docs/src/utils/exampleModules/getImportMap.test.ts
@@ -177,4 +177,35 @@ describe('getImportMap', () => {
             }
         );
     });
+
+    describe('framework build', () => {
+        test('React resolves its production build by default and its development build on request', () => {
+            const production = getImportMap({ internalFramework: 'reactFunctionalTs', isEnterprise: false });
+            const development = getImportMap({
+                internalFramework: 'reactFunctionalTs',
+                isEnterprise: false,
+                isProd: false,
+            });
+
+            // esm.sh serves the production build unless asked for `dev`
+            expect(production['react']).not.toContain('dev');
+            expect(production['react-dom']).not.toContain('dev');
+
+            expect(development['react']).toBe(
+                `https://esm.sh/react@${getDefaultFrameworkVersion('reactFunctionalTs')}?dev`
+            );
+            expect(development['react/']).toContain('&dev/');
+            expect(development['react-dom']).toContain('?external=react&dev');
+            expect(development['react-dom/']).toContain('&external=react&dev/');
+        });
+
+        test.each(['angular', 'vue3'] as InternalFramework[])(
+            '%s resolves the same entries either way, having no separate development build',
+            (internalFramework) => {
+                expect(getImportMap({ internalFramework, isEnterprise: false, isProd: false })).toEqual(
+                    getImportMap({ internalFramework, isEnterprise: false })
+                );
+            }
+        );
+    });
 });

--- a/documentation/ag-grid-docs/src/utils/exampleModules/getImportMap.ts
+++ b/documentation/ag-grid-docs/src/utils/exampleModules/getImportMap.ts
@@ -15,65 +15,97 @@ import { pathJoin } from '@utils/pathJoin';
 export type ImportMap = Record<string, string>;
 
 /**
- * The framework versions examples run against, deliberately independent of the versions the
- * docs site itself is built with.
+ * The framework versions examples run against by default, deliberately independent of the
+ * versions the docs site itself is built with. Overridable per page load with the
+ * `?version=` URL parameter (see `injectImportMap`).
  */
-const ANGULAR_VERSION = '20.0.0';
-const REACT_VERSION = '19.2.1';
+const DEFAULT_ANGULAR_VERSION = '20.0.0';
+const DEFAULT_REACT_VERSION = '19.2.1';
+const DEFAULT_VUE_VERSION = '3.5.17';
+
+/**
+ * Companion packages, pinned rather than overridable: they are not the framework whose
+ * version an example is being tried against.
+ */
 const RXJS_VERSION = '7.8.1';
 const TSLIB_VERSION = '2.3.1';
-const VUE_VERSION = '3.5.17';
+
+/** The URL parameter that overrides the framework version an example runs against */
+export const FRAMEWORK_VERSION_PARAM = 'version';
+
+/** `major.minor.patch`, optionally with a pre-release or build suffix */
+export const FRAMEWORK_VERSION_PATTERN = /^\d+\.\d+\.\d+(?:[-+][\w.-]+)*$/;
 
 /**
  * React and React DOM have no ES module build on npm, so they resolve through esm.sh.
  * `external=react` keeps React DOM from bundling a second copy of React, which would give
  * the page two renderers and break hooks.
  */
-const REACT_IMPORTS: ImportMap = {
-    react: `https://esm.sh/react@${REACT_VERSION}`,
-    'react/': `https://esm.sh/react@${REACT_VERSION}/`,
-    'react-dom': `https://esm.sh/react-dom@${REACT_VERSION}?external=react`,
-    'react-dom/': `https://esm.sh/react-dom@${REACT_VERSION}&external=react/`,
-};
+const reactImports = (version: string): ImportMap => ({
+    react: `https://esm.sh/react@${version}`,
+    'react/': `https://esm.sh/react@${version}/`,
+    'react-dom': `https://esm.sh/react-dom@${version}?external=react`,
+    'react-dom/': `https://esm.sh/react-dom@${version}&external=react/`,
+});
 
 /** `esm-browser` is the build that ships Vue's runtime template compiler */
-const VUE_IMPORTS: ImportMap = {
-    vue: `${NPM_CDN}/vue@${VUE_VERSION}/dist/vue.esm-browser.js`,
+const vueImports = (version: string): ImportMap => ({
+    vue: `${NPM_CDN}/vue@${version}/dist/vue.esm-browser.js`,
+});
+
+const angularImports = (version: string): ImportMap => {
+    const angularPackage = (name: string, entryPoint = name) =>
+        `${NPM_CDN}/@angular/${name}@${version}/fesm2022/${entryPoint}.mjs`;
+
+    return {
+        '@angular/animations': angularPackage('animations'),
+        '@angular/animations/browser': angularPackage('animations', 'browser'),
+        '@angular/common': angularPackage('common'),
+        '@angular/common/http': angularPackage('common', 'http'),
+        '@angular/compiler': angularPackage('compiler'),
+        '@angular/core': angularPackage('core'),
+        '@angular/core/primitives/di': angularPackage('core', 'primitives/di'),
+        '@angular/core/primitives/event-dispatch': angularPackage('core', 'primitives/event-dispatch'),
+        '@angular/core/primitives/signals': angularPackage('core', 'primitives/signals'),
+        '@angular/forms': angularPackage('forms'),
+        '@angular/platform-browser': angularPackage('platform-browser'),
+        '@angular/platform-browser/animations': angularPackage('platform-browser', 'animations'),
+        '@angular/platform-browser-dynamic': angularPackage('platform-browser-dynamic'),
+        // rxjs' own ESM build imports its internals without file extensions, which native
+        // resolution cannot follow, so it comes from esm.sh with those specifiers resolved
+        rxjs: `https://esm.sh/rxjs@${RXJS_VERSION}`,
+        'rxjs/': `https://esm.sh/rxjs@${RXJS_VERSION}&external=rxjs/`,
+        tslib: `${NPM_CDN}/tslib@${TSLIB_VERSION}/tslib.es6.js`,
+    };
 };
 
-const angularPackage = (name: string, entryPoint = name) =>
-    `${NPM_CDN}/@angular/${name}@${ANGULAR_VERSION}/fesm2022/${entryPoint}.mjs`;
-
-const ANGULAR_IMPORTS: ImportMap = {
-    '@angular/animations': angularPackage('animations'),
-    '@angular/animations/browser': angularPackage('animations', 'browser'),
-    '@angular/common': angularPackage('common'),
-    '@angular/common/http': angularPackage('common', 'http'),
-    '@angular/compiler': angularPackage('compiler'),
-    '@angular/core': angularPackage('core'),
-    '@angular/core/primitives/di': angularPackage('core', 'primitives/di'),
-    '@angular/core/primitives/event-dispatch': angularPackage('core', 'primitives/event-dispatch'),
-    '@angular/core/primitives/signals': angularPackage('core', 'primitives/signals'),
-    '@angular/forms': angularPackage('forms'),
-    '@angular/platform-browser': angularPackage('platform-browser'),
-    '@angular/platform-browser/animations': angularPackage('platform-browser', 'animations'),
-    '@angular/platform-browser-dynamic': angularPackage('platform-browser-dynamic'),
-    // rxjs' own ESM build imports its internals without file extensions, which native
-    // resolution cannot follow, so it comes from esm.sh with those specifiers resolved
-    rxjs: `https://esm.sh/rxjs@${RXJS_VERSION}`,
-    'rxjs/': `https://esm.sh/rxjs@${RXJS_VERSION}&external=rxjs/`,
-    tslib: `${NPM_CDN}/tslib@${TSLIB_VERSION}/tslib.es6.js`,
-};
-
-const getFrameworkImports = (internalFramework: InternalFramework): ImportMap => {
+/** The pinned version an example runs against, or undefined for the frameworkless examples */
+export const getDefaultFrameworkVersion = (internalFramework: InternalFramework): string | undefined => {
     if (isReactInternalFramework(internalFramework)) {
-        return REACT_IMPORTS;
+        return DEFAULT_REACT_VERSION;
     }
     if (internalFramework === 'angular') {
-        return ANGULAR_IMPORTS;
+        return DEFAULT_ANGULAR_VERSION;
     }
     if (internalFramework === 'vue3') {
-        return VUE_IMPORTS;
+        return DEFAULT_VUE_VERSION;
+    }
+    return undefined;
+};
+
+const getFrameworkImports = (internalFramework: InternalFramework, frameworkVersion?: string): ImportMap => {
+    const version = frameworkVersion ?? getDefaultFrameworkVersion(internalFramework);
+    if (!version) {
+        return {};
+    }
+    if (isReactInternalFramework(internalFramework)) {
+        return reactImports(version);
+    }
+    if (internalFramework === 'angular') {
+        return angularImports(version);
+    }
+    if (internalFramework === 'vue3') {
+        return vueImports(version);
     }
     return {};
 };
@@ -105,10 +137,13 @@ export const getImportMap = ({
     internalFramework,
     isEnterprise,
     isIntegratedCharts,
+    frameworkVersion,
 }: {
     internalFramework: InternalFramework;
     isEnterprise: boolean;
     isIntegratedCharts?: boolean;
+    /** Framework version to resolve against; the pinned default when omitted */
+    frameworkVersion?: string;
 }): ImportMap => {
     const imports: ImportMap = {
         'ag-stack': esmEntryPoint('ag-stack'),
@@ -119,7 +154,7 @@ export const getImportMap = ({
         'ag-grid-enterprise': esmEntryPoint('ag-grid-enterprise'),
         'ag-grid-enterprise/styles/': stylesPrefix('ag-grid-enterprise'),
         '@ag-grid-community/locale': esmEntryPoint('@ag-grid-community/locale'),
-        ...getFrameworkImports(internalFramework),
+        ...getFrameworkImports(internalFramework, frameworkVersion),
     };
 
     if (isEnterprise || isIntegratedCharts) {

--- a/documentation/ag-grid-docs/src/utils/exampleModules/getImportMap.ts
+++ b/documentation/ag-grid-docs/src/utils/exampleModules/getImportMap.ts
@@ -33,8 +33,13 @@ const TSLIB_VERSION = '2.3.1';
 /** The URL parameter that overrides the framework version an example runs against */
 export const FRAMEWORK_VERSION_PARAM = 'version';
 
-/** `major.minor.patch`, optionally with a pre-release or build suffix */
-export const FRAMEWORK_VERSION_PATTERN = /^\d+\.\d+\.\d+(?:[-+][\w.-]+)*$/;
+/**
+ * `major.minor.patch`, optionally with a pre-release suffix and a build suffix. Each suffix is
+ * matched once rather than as one repeated group, so that no quantifier nests inside another over
+ * the same characters -- a version arriving from the URL would otherwise be able to make matching
+ * it cost far more than reading it.
+ */
+export const FRAMEWORK_VERSION_PATTERN = /^\d+\.\d+\.\d+(?:-[\w.-]+)?(?:\+[\w.-]+)?$/;
 
 /**
  * The URL parameter that picks the framework's development build. As under SystemJS, examples

--- a/documentation/ag-grid-docs/src/utils/exampleModules/getImportMap.ts
+++ b/documentation/ag-grid-docs/src/utils/exampleModules/getImportMap.ts
@@ -37,16 +37,27 @@ export const FRAMEWORK_VERSION_PARAM = 'version';
 export const FRAMEWORK_VERSION_PATTERN = /^\d+\.\d+\.\d+(?:[-+][\w.-]+)*$/;
 
 /**
+ * The URL parameter that picks the framework's development build. As under SystemJS, examples
+ * run against the production build unless the URL says `prod=false`.
+ */
+export const PROD_PARAM = 'prod';
+
+/**
  * React and React DOM have no ES module build on npm, so they resolve through esm.sh.
  * `external=react` keeps React DOM from bundling a second copy of React, which would give
- * the page two renderers and break hooks.
+ * the page two renderers and break hooks. esm.sh serves the production build by default and
+ * the development one -- React's warnings and its dev-only validations -- given `dev`.
  */
-const reactImports = (version: string): ImportMap => ({
-    react: `https://esm.sh/react@${version}`,
-    'react/': `https://esm.sh/react@${version}/`,
-    'react-dom': `https://esm.sh/react-dom@${version}?external=react`,
-    'react-dom/': `https://esm.sh/react-dom@${version}&external=react/`,
-});
+const reactImports = (version: string, isProd: boolean): ImportMap => {
+    const dev = isProd ? '' : '&dev';
+
+    return {
+        react: `https://esm.sh/react@${version}${isProd ? '' : '?dev'}`,
+        'react/': `https://esm.sh/react@${version}${dev}/`,
+        'react-dom': `https://esm.sh/react-dom@${version}?external=react${dev}`,
+        'react-dom/': `https://esm.sh/react-dom@${version}&external=react${dev}/`,
+    };
+};
 
 /** `esm-browser` is the build that ships Vue's runtime template compiler */
 const vueImports = (version: string): ImportMap => ({
@@ -93,13 +104,17 @@ export const getDefaultFrameworkVersion = (internalFramework: InternalFramework)
     return undefined;
 };
 
-const getFrameworkImports = (internalFramework: InternalFramework, frameworkVersion?: string): ImportMap => {
+const getFrameworkImports = (
+    internalFramework: InternalFramework,
+    frameworkVersion?: string,
+    isProd = true
+): ImportMap => {
     const version = frameworkVersion ?? getDefaultFrameworkVersion(internalFramework);
     if (!version) {
         return {};
     }
     if (isReactInternalFramework(internalFramework)) {
-        return reactImports(version);
+        return reactImports(version, isProd);
     }
     if (internalFramework === 'angular') {
         return angularImports(version);
@@ -138,12 +153,15 @@ export const getImportMap = ({
     isEnterprise,
     isIntegratedCharts,
     frameworkVersion,
+    isProd = true,
 }: {
     internalFramework: InternalFramework;
     isEnterprise: boolean;
     isIntegratedCharts?: boolean;
     /** Framework version to resolve against; the pinned default when omitted */
     frameworkVersion?: string;
+    /** Whether to resolve the framework's production build, as examples do by default */
+    isProd?: boolean;
 }): ImportMap => {
     const imports: ImportMap = {
         'ag-stack': esmEntryPoint('ag-stack'),
@@ -154,7 +172,7 @@ export const getImportMap = ({
         'ag-grid-enterprise': esmEntryPoint('ag-grid-enterprise'),
         'ag-grid-enterprise/styles/': stylesPrefix('ag-grid-enterprise'),
         '@ag-grid-community/locale': esmEntryPoint('@ag-grid-community/locale'),
-        ...getFrameworkImports(internalFramework, frameworkVersion),
+        ...getFrameworkImports(internalFramework, frameworkVersion, isProd),
     };
 
     if (isEnterprise || isIntegratedCharts) {

--- a/documentation/ag-grid-docs/src/utils/exampleModules/getImportMap.ts
+++ b/documentation/ag-grid-docs/src/utils/exampleModules/getImportMap.ts
@@ -43,21 +43,33 @@ export const FRAMEWORK_VERSION_PATTERN = /^\d+\.\d+\.\d+(?:[-+][\w.-]+)*$/;
 export const PROD_PARAM = 'prod';
 
 /**
+ * How esm.sh is asked for the framework's development build -- React's warnings and its
+ * dev-only validations -- which it serves given the `dev` flag, the production build being its
+ * default. The flag reaches a URL either as its query or appended to flags already there, so
+ * both forms travel together. `ExampleModules` passes placeholders instead of these, so that
+ * the browser can pick a build from the URL after the page is built.
+ */
+export interface DevFlags {
+    /** Opens the query string of a URL that has none, as `?dev` */
+    query: string;
+    /** Appends to a query already present, as `&dev` */
+    appended: string;
+}
+
+export const PRODUCTION_FLAGS: DevFlags = { query: '', appended: '' };
+export const DEVELOPMENT_FLAGS: DevFlags = { query: '?dev', appended: '&dev' };
+
+/**
  * React and React DOM have no ES module build on npm, so they resolve through esm.sh.
  * `external=react` keeps React DOM from bundling a second copy of React, which would give
- * the page two renderers and break hooks. esm.sh serves the production build by default and
- * the development one -- React's warnings and its dev-only validations -- given `dev`.
+ * the page two renderers and break hooks.
  */
-const reactImports = (version: string, isProd: boolean): ImportMap => {
-    const dev = isProd ? '' : '&dev';
-
-    return {
-        react: `https://esm.sh/react@${version}${isProd ? '' : '?dev'}`,
-        'react/': `https://esm.sh/react@${version}${dev}/`,
-        'react-dom': `https://esm.sh/react-dom@${version}?external=react${dev}`,
-        'react-dom/': `https://esm.sh/react-dom@${version}&external=react${dev}/`,
-    };
-};
+const reactImports = (version: string, { query, appended }: DevFlags): ImportMap => ({
+    react: `https://esm.sh/react@${version}${query}`,
+    'react/': `https://esm.sh/react@${version}${appended}/`,
+    'react-dom': `https://esm.sh/react-dom@${version}?external=react${appended}`,
+    'react-dom/': `https://esm.sh/react-dom@${version}&external=react${appended}/`,
+});
 
 /** `esm-browser` is the build that ships Vue's runtime template compiler */
 const vueImports = (version: string): ImportMap => ({
@@ -107,14 +119,14 @@ export const getDefaultFrameworkVersion = (internalFramework: InternalFramework)
 const getFrameworkImports = (
     internalFramework: InternalFramework,
     frameworkVersion?: string,
-    isProd = true
+    dev: DevFlags = PRODUCTION_FLAGS
 ): ImportMap => {
     const version = frameworkVersion ?? getDefaultFrameworkVersion(internalFramework);
     if (!version) {
         return {};
     }
     if (isReactInternalFramework(internalFramework)) {
-        return reactImports(version, isProd);
+        return reactImports(version, dev);
     }
     if (internalFramework === 'angular') {
         return angularImports(version);
@@ -153,15 +165,15 @@ export const getImportMap = ({
     isEnterprise,
     isIntegratedCharts,
     frameworkVersion,
-    isProd = true,
+    dev = PRODUCTION_FLAGS,
 }: {
     internalFramework: InternalFramework;
     isEnterprise: boolean;
     isIntegratedCharts?: boolean;
     /** Framework version to resolve against; the pinned default when omitted */
     frameworkVersion?: string;
-    /** Whether to resolve the framework's production build, as examples do by default */
-    isProd?: boolean;
+    /** How to ask for the framework's development build; the production build by default */
+    dev?: DevFlags;
 }): ImportMap => {
     const imports: ImportMap = {
         'ag-stack': esmEntryPoint('ag-stack'),
@@ -172,7 +184,7 @@ export const getImportMap = ({
         'ag-grid-enterprise': esmEntryPoint('ag-grid-enterprise'),
         'ag-grid-enterprise/styles/': stylesPrefix('ag-grid-enterprise'),
         '@ag-grid-community/locale': esmEntryPoint('@ag-grid-community/locale'),
-        ...getFrameworkImports(internalFramework, frameworkVersion, isProd),
+        ...getFrameworkImports(internalFramework, frameworkVersion, dev),
     };
 
     if (isEnterprise || isIntegratedCharts) {

--- a/documentation/ag-grid-docs/src/utils/grid/test-utils.ts
+++ b/documentation/ag-grid-docs/src/utils/grid/test-utils.ts
@@ -24,6 +24,10 @@ type PlaywrightFixtures = ExtractFixtures<typeof base>;
 
 type AgIdFor = ReturnType<typeof wrapAgTestIdFor<Locator>>;
 type LoadPageOptions = {
+    /**
+     * Whether the example runs against the framework's production build. False picks the
+     * development build, with its warnings and dev-only validations -- React only.
+     */
     prod: boolean;
     /**
      * Framework version the example runs against, e.g. '18.3.1' for React. Omitted, the

--- a/documentation/ag-grid-docs/src/utils/grid/test-utils.ts
+++ b/documentation/ag-grid-docs/src/utils/grid/test-utils.ts
@@ -25,6 +25,10 @@ type PlaywrightFixtures = ExtractFixtures<typeof base>;
 type AgIdFor = ReturnType<typeof wrapAgTestIdFor<Locator>>;
 type LoadPageOptions = {
     prod: boolean;
+    /**
+     * Framework version the example runs against, e.g. '18.3.1' for React. Omitted, the
+     * example resolves the version the docs pin (see getImportMap).
+     */
     version: string;
 };
 


### PR DESCRIPTION
Restores the two example URL parameters the SystemJS boilerplate used to honour and the ES-modules change left dead. Nothing under `src/components/example-runner/` or `src/utils/exampleModules/` read query params any more:

- `?version=` — the framework version (AG-18154). Honoured on `latest` for React, Angular and Vue.
- `?prod=false` — the framework's development build. React only, as esm.sh serves the production build by default and the development one given `dev`. The docs e2e `reactFunctionalTs_Dev` variant sends this, so until now it exercised nothing different from the production variant.

The framework version and build become parameters of `getImportMap` rather than build-time constants. Example pages are statically generated, so neither can be resolved server-side: the map is rendered once with a token where the version goes and another where the development-build flag goes, and a classic inline script (`injectImportMap`) substitutes both and registers the map. It runs before the parser reaches the example's module script, which is what the import-map spec requires. Frameworkless examples have nothing to resolve from the URL, so their map is still served as markup.

    https://localhost:4610/examples/column-sizing/column-flex/reactFunctionalTs/?version=18.3.1&prod=false

Defaults are unchanged: the pinned versions and the production build, matching the old `systemjs.config.js` semantics (production unless `prod=false`). A `version` that is not a version aborts the load with a message on the page instead of falling back to the default; a well-formed but non-existent version fails on the CDN 404. Companion packages (rxjs, tslib) stay pinned.

Trade-off worth naming: framework example pages no longer carry a declarative import map, including on the great majority of loads that pass no parameters, so module fetching begins only once the inline script has run. Static generation leaves no way to resolve a URL parameter server-side, so this is the cost of the parameters existing at all.

Stacked on #14819, whose production-CDN guard asserted on the served `<script type="importmap">` that framework pages no longer emit. The guard now runs this PR's own injector over the options the page carries, so it keeps covering React, Angular and Vue and checks what a browser would actually resolve.

Verified: the docs unit suite (`./behave.sh --project ag-grid-docs`) — 801 passing, including the override, the pinned default, the invalid-version path, the dev/prod maps and the extended CDN guard; `nx lint ag-grid-docs` clean. The esm.sh `?dev` / `&dev` URL shapes were checked against the CDN for React 18 and 19, and the classic-script-then-module-script ordering in Chromium against a minimal page. One pre-existing failure, `getErrorText.test.ts` (`Failed to resolve entry for package "ag-stack"`), is unrelated and reproduces on a clean tree.

No full `docs-e2e.sh` run: the React dev variant now really loads the development build, so any console errors it surfaces are expected fallout for the follow-up ticket, along with the two `test.skip(agFramework === 'reactFunctionalTs_Dev', ...)` guards that have been vacuous since the SystemJS removal.

Not included: Angular's `window.ENABLE_PROD_MODE`, which `public/example-runner/grid-angular-boilerplate/main.ts` still reads and nothing sets, so Angular examples run without `enableProdMode()`. The two SystemJS configs that set it were deleted by #14784, so this is a pre-existing regression on that branch rather than something this PR changes; restoring it would flip every Angular example into production mode by default, so it wants its own ticket.
