### PR TITLE
AG-3390 Add staging and report-only configurations to the docs preview:csp target

### DIFF
--- a/documentation/ag-grid-docs/project.json
+++ b/documentation/ag-grid-docs/project.json
@@ -109,6 +109,12 @@
       "command": "tsx scripts/csp/preview-csp.ts --port=${PORT}",
       "options": {
         "cwd": "{projectRoot}"
+      },
+      "configurations": {
+        "staging": { "args": "--env staging" },
+        "production": { "args": "--env production" },
+        "report-only": { "args": "--mode report-only" },
+        "staging-report-only": { "args": "--env staging --mode report-only" }
       }
     },
     "lint": {

--- a/documentation/ag-grid-docs/scripts/csp/preview-csp.ts
+++ b/documentation/ag-grid-docs/scripts/csp/preview-csp.ts
@@ -35,7 +35,26 @@ import {
  *
  * Usage (run after a build; defaults to the enforced production policy):
  *   nx run ag-grid-docs:preview:csp
+ *   nx run ag-grid-docs:preview:csp:staging              (staging policy, enforced)
+ *   nx run ag-grid-docs:preview:csp:report-only          (production policy, report-only)
+ *   nx run ag-grid-docs:preview:csp:staging-report-only
  *   tsx documentation/ag-grid-docs/scripts/csp/preview-csp.ts [--env=...] [--mode=...] [--port=...] [--no-https]
+ *
+ * These configurations select the POLICY only (which CspEnv getCspValue is built for —
+ * staging and production differ in the payment/auth/form origins). They deliberately do
+ * NOT change which build is served: `dependsOn` builds the default (localhost) config, so
+ * PUBLIC_SITE_URL stays https://localhost:4611 and the example runner keeps working.
+ *
+ * A staging/production BUILD is a separate axis and cannot be served faithfully from
+ * localhost — those configurations bake their remote origin into the output (see
+ * .env.build.staging / .env.preview.production), so absolute-URL fetches go to the remote
+ * host and the examples-scope connect-src 'self' blocks them. If you specifically need a
+ * remote-origin build — e.g. to load the *staging* GTM environment, which only happens when
+ * getIsStaging() is true (see GoogleTagManager.astro) — build it explicitly and then invoke
+ * this script directly rather than through the target, so `dependsOn` does not rebuild the
+ * localhost variant over it:
+ *   nx build ag-grid-docs --configuration=staging
+ *   cd documentation/ag-grid-docs && tsx scripts/csp/preview-csp.ts --env staging
  *
  * Port: defaults to 4611 to match PUBLIC_SITE_URL baked into a local build
  * (.env.build → https://localhost:4611). The example runner fetches its modules


### PR DESCRIPTION
## What

`preview:csp` only ever served the **enforced production** policy, so validating the staging policy — or serving either policy in report-only form — locally meant invoking the script by hand.

`preview-csp.ts` already parsed `--env` and `--mode`; this just exposes them as nx configurations, following the same `{"args": ...}` shape `generate-csp` already uses in the same file.

```bash
yarn nx run ag-grid-docs:preview:csp                      # production, enforce (unchanged default)
yarn nx run ag-grid-docs:preview:csp:staging              # staging policy, enforced
yarn nx run ag-grid-docs:preview:csp:report-only          # production policy, report-only
yarn nx run ag-grid-docs:preview:csp:staging-report-only
```

Worth having because the environments genuinely differ: staging resolves to `pay.sandbox.realexpayments.com`, `test.salesforce.com` and `stripe-testing-19784.firebaseapp.com`, production to the live equivalents. The `report-only` variants enumerate violations without breaking the page, and match the header form a future report-only window would use (`PRODUCTION_CSP_PHASE`) — note production and staging both currently *enforce*.

## Policy only, not the build

The configurations select the **policy**, deliberately not the build. `dependsOn` still builds the default localhost config, so `PUBLIC_SITE_URL` stays `https://localhost:4611` and the example runner keeps working.

A staging/production *build* served from localhost would be self-defeating: those configurations bake their remote origin into the output, so absolute-URL fetches leave localhost and the examples-scope `connect-src 'self'` blocks them — violations that are artefacts of the origin mismatch rather than of the policy. That stays an explicit two-step, documented in the usage comment for the case where a remote-origin build genuinely is needed (loading the staging GTM environment, which requires `getIsStaging()`).

## Testing

- `yarn nx run ag-grid-docs:generate-csp --configuration=staging|production` confirms the two envs emit different origins, so `--env` is meaningful.
- `preview-csp.ts` validates and rejects bad `--env`/`--mode` values.
- Both invocation forms verified equivalent against a throwaway probe target, hyphenated configuration names included.
- `yarn nx lint ag-grid-docs` passes; no behaviour change to the default target.