### PR TITLE
github-triage: go live on new issues, gate the labeled trigger, resolve channel from the ticket pin

### DIFF
--- a/.github/workflows/github-triage-pipeline.yml
+++ b/.github/workflows/github-triage-pipeline.yml
@@ -43,11 +43,20 @@ name: GitHub issue AI triage
 # ============================================================================
 
 on:
-    # Auto-triage of new triage-labelled issues — DISABLED for the initial manual
-    # dogfood (run via workflow_dispatch first). Uncomment to go live once the
-    # dispatch + drag paths are validated.
-    # issues:
-    #     types: [opened, labeled]
+    # Auto-triage of new `triage`-labelled issues — LIVE (this is the go-live switch;
+    # it was commented out for the manual dogfood phase).
+    #
+    # `labeled` is needed as well as `opened` because the `triage` label is
+    # very often added a moment after the issue is filed, not at creation.
+    #
+    # ⚠️ The `labeled` half fires on ANY label being added, so the `run` job's gate
+    # additionally requires the ADDED label to be `triage` specifically. Without
+    # that, stamping any other label (`AG-NNNNN`, `waiting-for-repro`, `invalid`)
+    # on one of the ~64 pre-existing open `triage` issues would fire a full triage
+    # on it — bypassing the batch-selection rule, and re-triaging an issue that may
+    # already carry a reviewed verdict (which the pipeline would overwrite).
+    issues:
+        types: [opened, labeled]
     repository_dispatch:
         types: [gh-triage-resume, gh-triage-manual-resume, gh-triage-manual-browser-verify, gh-triage-manual-repro-rebuild]
     workflow_dispatch:
@@ -83,20 +92,98 @@ concurrency:
     cancel-in-progress: false
 
 env:
-    # Defaults to `latest`. A repository_dispatch (the JIRA `→ In Progress` drag)
-    # overrides via client_payload.channel; a workflow_dispatch via inputs.channel.
-    # During rollout/dogfood the JIRA rule sends "channel":"canary" so the drag runs
-    # the unpromoted action (canary dist-tag → `latest` only on promotion); drop the
-    # payload channel at activation so production drags run the promoted `latest`.
+    # Defaults to `latest`; a workflow_dispatch overrides via inputs.channel.
+    #
+    # For a repository_dispatch (the JIRA drag + the manual buttons) treat this as a
+    # FALLBACK only — the effective value comes from the `resolve-channel` job below,
+    # which reads the mapping ticket's own `channel-canary` pin so a ticket triaged on
+    # canary keeps resuming/executing on canary while production traffic runs latest.
+    # A workflow-level `env:` cannot reference a job output, which is why the jobs
+    # below read `needs.resolve-channel.outputs.channel` and fall back to this.
     DEV_PROMPTS_CHANNEL: ${{ github.event.client_payload.channel || inputs.channel || 'latest' }}
 
 jobs:
+    # -------------------------------------------------- resolve-channel
+    # Which @ag-grid/dev-prompts dist-tag should this dispatch run?
+    #
+    # The drag's payload comes from ONE Jira Automation rule, so it cannot carry a
+    # per-ticket channel — which meant production and canary dry-run traffic could
+    # not coexist on the board. Instead the pipeline stamps the channel it ran from
+    # onto the mapping ticket as a `channel-canary` label, and this job reads it back.
+    # Present ⇒ canary, absent ⇒ latest. See the github-triage-pipeline action's
+    # `core/channel-label.ts`.
+    #
+    # The guarantee is release-channel continuity, NOT build immutability: dist-tags
+    # move (canary on every publish, latest nightly), so a later drag runs newer code
+    # from the SAME channel. That is deliberate — a version pin would freeze a ticket
+    # triaged before a fix onto the broken code.
+    #
+    # Deliberately a raw REST GET rather than the pipeline bundle: this has to decide
+    # WHICH channel to install, so it cannot itself depend on an installed package.
+    # `labels` is a system field, so no field-id resolution is needed.
+    #
+    # MIGRATION: while the Jira rule still sends "channel":"canary" that payload wins,
+    # so behaviour is unchanged and the pin is inert. Removing the `channel` field from
+    # the rule body is the switch that hands control to the pin.
+    resolve-channel:
+        if: github.event_name == 'repository_dispatch' && github.event.client_payload.issue_key != ''
+        runs-on: ubuntu-latest
+        timeout-minutes: 5
+        permissions: {}
+        outputs:
+            channel: ${{ steps.r.outputs.channel }}
+        steps:
+            - id: r
+              shell: bash
+              env:
+                  # Via env, never string-interpolated into the script body.
+                  ISSUE_KEY: ${{ github.event.client_payload.issue_key }}
+                  PAYLOAD_CHANNEL: ${{ github.event.client_payload.channel }}
+                  JIRA_EMAIL: ${{ secrets.JIRA_AI_BOT_EMAIL }}
+                  JIRA_API_TOKEN: ${{ secrets.JIRA_AI_BOT_API_TOKEN }}
+                  JIRA_SITE_URL: ${{ vars.JIRA_SITE_URL }}
+              run: |
+                  set -uo pipefail
+
+                  emit() { echo "channel=$1" >> "$GITHUB_OUTPUT"; echo "resolved channel: $1 ($2)"; }
+
+                  # An explicit payload channel is an intentional override and wins.
+                  if [ -n "${PAYLOAD_CHANNEL:-}" ]; then
+                      emit "$PAYLOAD_CHANNEL" "explicit client_payload.channel"
+                      exit 0
+                  fi
+
+                  if ! labels=$(curl -sS --fail --max-time 20 \
+                        -u "$JIRA_EMAIL:$JIRA_API_TOKEN" \
+                        -H 'Accept: application/json' \
+                        "$JIRA_SITE_URL/rest/api/3/issue/$ISSUE_KEY?fields=labels" \
+                        | jq -r '.fields.labels[]? // empty'); then
+                      # FAIL-SAFE to production. An unreadable ticket must not silently
+                      # route a production drag to canary; a dry run losing its pin is
+                      # the cheaper, visible failure.
+                      echo "::warning title=channel-pin::could not read labels for $ISSUE_KEY — falling back to latest"
+                      emit latest "label read failed"
+                      exit 0
+                  fi
+
+                  if printf '%s\n' "$labels" | grep -qx 'channel-canary'; then
+                      emit canary "channel-canary pin present"
+                  else
+                      emit latest "no pin"
+                  fi
+
     # -------------------------------------------------- preflight
     # Only on the JIRA `→ In Progress` drag. Mechanical (no agent): reads the
     # AITGH ticket's SUGGESTED-ACTION-READY marker + comments + bot-actor and
     # emits `stage` (execute | resume | '' for suppress).
     preflight:
-        if: github.event_name == 'repository_dispatch' && github.event.action == 'gh-triage-resume'
+        needs: [resolve-channel]
+        # `!cancelled()` because resolve-channel is SKIPPED for every non-dispatch
+        # event, and a skipped dependency would otherwise skip this job regardless of
+        # the condition below (which is already false in exactly those cases).
+        if: |
+            !cancelled() &&
+            github.event_name == 'repository_dispatch' && github.event.action == 'gh-triage-resume'
         runs-on: ubuntu-latest
         timeout-minutes: 5
         permissions:
@@ -112,7 +199,7 @@ jobs:
             - name: Install @ag-grid/dev-prompts
               uses: ./external/ag-shared/github/actions/install-ag-dev-prompts
               with:
-                  channel: ${{ env.DEV_PROMPTS_CHANNEL }}
+                  channel: ${{ needs.resolve-channel.outputs.channel || env.DEV_PROMPTS_CHANNEL }}
             - id: pf
               uses: ./.ag-dev-prompts/node_modules/@ag-grid/dev-prompts/.github/actions/github-triage-resume-preflight
               with:
@@ -130,11 +217,11 @@ jobs:
     # stage directly, no preflight/routing involved: the PM's button click IS
     # the unambiguous intent signal).
     run:
-        needs: [preflight]
+        needs: [preflight, resolve-channel]
         if: |
             !cancelled() &&
             (
-              (github.event_name == 'issues' && contains(github.event.issue.labels.*.name, 'triage') && github.event.issue.state == 'open')
+              (github.event_name == 'issues' && contains(github.event.issue.labels.*.name, 'triage') && github.event.issue.state == 'open' && (github.event.action == 'opened' || github.event.label.name == 'triage'))
               || github.event_name == 'workflow_dispatch'
               || (github.event_name == 'repository_dispatch' && needs.preflight.outputs.stage != '')
               || (github.event_name == 'repository_dispatch' && github.event.action == 'gh-triage-manual-resume')
@@ -159,7 +246,7 @@ jobs:
             - name: Install @ag-grid/dev-prompts
               uses: ./external/ag-shared/github/actions/install-ag-dev-prompts
               with:
-                  channel: ${{ env.DEV_PROMPTS_CHANNEL }}
+                  channel: ${{ needs.resolve-channel.outputs.channel || env.DEV_PROMPTS_CHANNEL }}
             - id: pipeline
               uses: ./.ag-dev-prompts/node_modules/@ag-grid/dev-prompts/.github/actions/github-triage-pipeline
               with:
@@ -176,6 +263,10 @@ jobs:
                   # regardless of preflight's own behaviour.
                   stage: ${{ (github.event.action == 'gh-triage-manual-resume' && 'resume') || (github.event.action == 'gh-triage-manual-browser-verify' && 'browser-verify') || (github.event.action == 'gh-triage-manual-repro-rebuild' && 'repro-rebuild') || needs.preflight.outputs.stage || inputs.stage || 'triage' }}
                   product: grid
+                  # Provenance for the pin: `post` stamps this channel onto the
+                  # mapping ticket so `resolve-channel` can route the NEXT drag to the
+                  # same channel. Must match the channel actually installed above.
+                  channel: ${{ needs.resolve-channel.outputs.channel || env.DEV_PROMPTS_CHANNEL }}
                   gh_issue: ${{ github.event.issue.number || github.event.client_payload.gh_issue || inputs.gh_issue }}
                   issue_key: ${{ needs.preflight.outputs.issue_key || github.event.client_payload.issue_key || inputs.issue_key }}
                   anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## Why

Three changes to the GitHub-issue triage stub. One is the go-live switch; the other two are what makes it safe to flip.

**Blast radius of going live is small and read-only.** Triage creates an AITGH mapping ticket and hands back — it makes **no customer-facing write**. Nothing reaches the GitHub issue without a human dragging the ticket `Needs Review → In Progress` on the AITGH board. New-issue volume is also low (1–2/week measured over the last two weeks).

## What

### 1. `issues:` uncommented — the go-live switch

Auto-triage of newly-filed `triage`-labelled issues. Note this is **not retroactive**: GitHub Actions triggers are event-driven, so the ~64 pre-existing open `triage` issues are untouched. Working through those stays a deliberate batch activity.

### 2. The `labeled` trigger is gated on the ADDED label

`labeled` fires on **any** label being added, and the previous condition only checked that the issue *has* `triage`. So stamping `AG-NNNNN`, `waiting-for-repro` or `invalid` on one of those 64 backlog issues would have fired a full triage on it — bypassing the batch-selection rule, and re-triaging issues that already carry a reviewed verdict, which the pipeline overwrites. Now the `labeled` half requires `github.event.label.name == 'triage'`; `opened` is unchanged.

### 3. `resolve-channel` — production and dry-run traffic coexist

The drag's payload comes from a **single** Jira Automation rule, so it cannot carry a per-ticket channel — one globally-configured channel for the whole board. During the pilot that rule sends `canary` unconditionally, so pointing it at `latest` for production would have removed the canary board drag that dry runs use.

Instead the pipeline stamps the channel it ran from onto the mapping ticket as a `channel-canary` label (ag-grid/ag-dev-prompts#815), and this job reads it back: present ⇒ `canary`, absent ⇒ `latest`.

- A **raw REST GET**, not the pipeline bundle — it has to decide *which* channel to install, so it cannot depend on an installed package. `labels` is a system field, so no field-id resolution is needed.
- **Fails SAFE to `latest`.** An unreadable ticket must not silently route a production drag to canary; a dry run losing its pin is the cheaper and more visible failure.
- The issue key goes in via `env:`, never string-interpolated into the script body.
- The job holds `permissions: {}` — it needs no GitHub token at all.

The guarantee is **release-channel continuity, not build immutability**: dist-tags move, so a later drag runs newer code from the same channel. That is deliberate — a version pin would freeze a ticket triaged before a fix onto the broken build.

## Migration — zero-gap, and the Jira rule is the switch

While the Jira rule still sends `"channel":"canary"`, that payload **wins** and behaviour is unchanged; the pin sits inert. Deleting the `channel` field from the rule body (AITGH → Project settings → Automation → *transitioned → In Progress* → Send web request) is what hands routing to the pin. So merging this changes nothing about which channel runs until that edit is made.

## Dependency

Needs `@ag-grid/dev-prompts >= 1.6.229` for the stamping half — already live on `canary` (`1.6.229-20260813120808.054f159f`), promoting to `latest` at 04:00 UTC. The action's `channel` input is **optional**, so this is safe to land before that promotion: until then nothing stamps, every ticket reads as unpinned, and drags resolve exactly as they do today.

## Verification

YAML validated (parses; `resolve-channel` correctly wired into both `preflight` and `run`, which use `needs.resolve-channel.outputs.channel || env.DEV_PROMPTS_CHANNEL`). `preflight` gained `!cancelled()` because `resolve-channel` is skipped on every non-dispatch event, and a skipped dependency would otherwise skip it regardless of its own condition.

Design reference: ag-dev-prompts → `docs/github-triage-pipeline.md`.