### PR TITLE
github-triage: drop the unused issues:write from the browser chain jobs

### DIFF
--- a/.github/workflows/github-triage-pipeline.yml
+++ b/.github/workflows/github-triage-pipeline.yml
@@ -301,7 +301,19 @@ jobs:
         runs-on: ubuntu-latest
         permissions:
             contents: read
-            issues: write
+            # NO `issues: write` — deliberately narrower than the `run` job.
+            #
+            # These two stages navigate UNTRUSTED, reporter-authored repro pages, and
+            # they perform ZERO GitHub writes: every write they cause is the pipeline's
+            # own Jira write, authenticated by JIRA_API_TOKEN. Inheriting `issues: write`
+            # therefore handed an injectable agent a credential it never uses — and
+            # "the agent has no write tool" does not mean the token is out of reach,
+            # since it can read the environment and call the GitHub API directly.
+            # Raised twice as a P0 on ag-dev-prompts#840; the full browser-stage
+            # hardening stays deferred for the pilot, but an UNUSED permission is not
+            # hardening work, it is a mistake. See ag-dev-prompts
+            # docs/github-triage-deferred-hardening.md section 1.
+            issues: read
             packages: read
         outputs:
             reproduces: ${{ steps.pipeline.outputs.reproduces }}
@@ -339,7 +351,19 @@ jobs:
         runs-on: ubuntu-latest
         permissions:
             contents: read
-            issues: write
+            # NO `issues: write` — deliberately narrower than the `run` job.
+            #
+            # These two stages navigate UNTRUSTED, reporter-authored repro pages, and
+            # they perform ZERO GitHub writes: every write they cause is the pipeline's
+            # own Jira write, authenticated by JIRA_API_TOKEN. Inheriting `issues: write`
+            # therefore handed an injectable agent a credential it never uses — and
+            # "the agent has no write tool" does not mean the token is out of reach,
+            # since it can read the environment and call the GitHub API directly.
+            # Raised twice as a P0 on ag-dev-prompts#840; the full browser-stage
+            # hardening stays deferred for the pilot, but an UNUSED permission is not
+            # hardening work, it is a mistake. See ag-dev-prompts
+            # docs/github-triage-deferred-hardening.md section 1.
+            issues: read
             packages: read
         steps:
             - uses: actions/checkout@v4


### PR DESCRIPTION
## Why

`browser-verify-chain` and `repro-rebuild-chain` navigate **untrusted, reporter-authored** repro pages, and they perform **zero GitHub writes** — every write they cause is the pipeline's own Jira write, authenticated by `JIRA_API_TOKEN`. They were inheriting the `run` job's `issues: write`, which handed an injectable agent a credential it never uses.

The reason this matters more than it looks: *"the agent has no write tool"* means no write tool is wired into its toolset. It does **not** mean the token is out of reach — the agent has Bash and WebFetch and can read the environment, so it could call the GitHub API directly. On this one path the human approve-drag is therefore **not** the last line of defence, which is exactly the assumption the rest of the pilot's safety story rests on.

Raised twice as a **P0** by review on ag-grid/ag-dev-prompts#840.

## Why now, when browser hardening is deliberately deferred

The full browser-stage hardening — a dedicated minimal-permission job, no action-supplied token, tool and egress confinement — **stays deferred** for the pilot, by an explicit standing decision (security is not the current priority; a control needs a demonstrated risk; no hostile issue has ever been observed). That decision is not being reopened here.

But an **unused** permission is not hardening work — it is a mistake, and it costs nothing to stop making it. So it should not queue behind a programme it isn't part of.

## What changed

Both chain jobs go from `issues: write` → `issues: read`.

- **Reduced, not removed**, so issue reads keep working.
- **The `run` job is untouched** — `execute` genuinely needs `issues: write` to post the reply, apply the label and close the issue.
- The reasoning is left as a comment at both sites, so nobody "restores consistency" with `run` later without reading why they differ.

## Verification

YAML parses; permissions confirmed per job:

| job | permissions |
|---|---|
| `run` | `contents: read`, **`issues: write`**, `packages: read` |
| `browser-verify-chain` | `contents: read`, **`issues: read`**, `packages: read` |
| `repro-rebuild-chain` | `contents: read`, **`issues: read`**, `packages: read` |

Worth watching on the next auto-triaged confirmed bug: if either browser stage turns out to need an issue write nobody has identified, it will fail visibly on that stage rather than silently — and the stage is advisory, so a failure cannot block or corrupt a verdict.

Context: ag-dev-prompts `docs/github-triage-deferred-hardening.md` § 1, first row.
