### PR TITLE
AG-18184 Restore production mode for Angular docs examples

### DIFF
--- a/documentation/ag-grid-docs/public/example-runner/grid-angular-boilerplate/main.ts
+++ b/documentation/ag-grid-docs/public/example-runner/grid-angular-boilerplate/main.ts
@@ -5,7 +5,16 @@ import { bootstrapApplication } from '@angular/platform-browser';
 
 import { AppComponent } from './app.component';
 
-if ((window as any).ENABLE_PROD_MODE) {
+// `?prod` picks the framework build an example runs against - the same parameter the import map
+// reads to choose React's development bundle (PROD_PARAM in getImportMap.ts). Production is the
+// default and only an explicit `prod=false` opts out, matching both that injector and the SystemJS
+// config this replaced.
+//
+// Read straight from the URL rather than through a `window` flag: the flag was only ever set by the
+// two deleted systemjs configs, and this file is copied verbatim into each generated example, so
+// nothing else is around to set it. Plunker and CodeSandbox exports carry no query string and so
+// get production mode, as they did under SystemJS.
+if (new URLSearchParams(window.location.search).get('prod') !== 'false') {
     enableProdMode();
 }
 


### PR DESCRIPTION
Removing SystemJS deleted the only two files that set `window.ENABLE_PROD_MODE`, so `enableProdMode()` stopped running for every Angular example. This reads `?prod` from the URL instead — production by default, `?prod=false` opts out — matching `latest` and the React import map's `PROD_PARAM`.

Verified via Angular's dev-mode console banner: absent with no parameter and with `?prod=true`, present with `?prod=false`, no console errors in any case. Angular docs e2e shard: 1777 passed.