### PR TITLE
Speed up integrated-chart behavioural tests

### DIFF
--- a/testing/behavioural/src/charts/format-panel-options.test.ts
+++ b/testing/behavioural/src/charts/format-panel-options.test.ts
@@ -455,7 +455,9 @@ describe('chart tool panel options', () => {
               ]
             `);
         },
-        20 * 60 * 1000
+        // ~17s locally for the full 37-chart-type matrix; the allowance is for slower CI, not for the
+        // matrix growing. If this starts timing out, something is sleeping rather than doing work.
+        2 * 60 * 1000
     );
 });
 

--- a/testing/behavioural/src/test-utils/polyfills/mockGridLayout.ts
+++ b/testing/behavioural/src/test-utils/polyfills/mockGridLayout.ts
@@ -26,6 +26,12 @@ export const mockGridLayout = {
      * clientY, so a mismatch drifts row selection past the first couple of rows. */
     listItemHeight: 24,
 
+    /** Size reported for an Integrated Charts canvas wrapper - the element AG Charts observes as its
+     * container. A container that never reports a size leaves the chart waiting out a 500ms
+     * first-auto-size timeout on every layout-level update. */
+    chartWidth: 600,
+    chartHeight: 400,
+
     /** When true, `offset*`/`client*` dimensions come from `getBoundingClientRect()`. Default
      * `false` returns jsdom's 0, matching most captured snapshots; opt in for viewport-aware code
      * such as page-key navigation. */
@@ -51,6 +57,13 @@ function inPopupOrDialog(el: HTMLElement): boolean {
 
 function inVirtualList(el: HTMLElement): boolean {
     return !!el.closest(VIRTUAL_LIST_SELECTOR);
+}
+
+/** `gridChartComp`'s `eChart`, which is the element handed to AG Charts as its container. */
+const CHART_CONTAINER_CLASS = 'ag-chart-canvas-wrapper';
+
+function isChartContainer(el: HTMLElement): boolean {
+    return el.classList.contains(CHART_CONTAINER_CLASS);
 }
 
 const getElementType = (el: HTMLElement) => {
@@ -93,6 +106,9 @@ const getElementType = (el: HTMLElement) => {
     }
     if (classList.contains('ag-rich-select-row')) {
         return 'rich-select-row';
+    }
+    if (classList.contains(CHART_CONTAINER_CLASS)) {
+        return 'chart-container';
     }
     return 'default';
 };
@@ -176,6 +192,12 @@ function getBoundingClientRect(this: HTMLElement): DOMRect {
 
         case 'rich-select-row': {
             height = listItemHeight;
+            break;
+        }
+
+        case 'chart-container': {
+            width = mockGridLayout.chartWidth;
+            height = mockGridLayout.chartHeight;
             break;
         }
 
@@ -305,6 +327,11 @@ function init(): boolean {
                     return this.getBoundingClientRect()[axis];
                 }
                 if (isHeightProp && inVirtualList(this)) {
+                    return this.getBoundingClientRect()[axis];
+                }
+                // AG Charts sizes itself off its container's `client*`, and skips its 500ms
+                // first-auto-size wait once it has seen a non-zero size.
+                if (isChartContainer(this)) {
                     return this.getBoundingClientRect()[axis];
                 }
                 return original?.get?.call(this) ?? 0;


### PR DESCRIPTION
AG Charts waits out a 500ms first-auto-size timeout on every layout-level update until it has seen a non-zero container size. jsdom reports `0` for `client*`, so `_lastAutoSize` was never set and every integrated-chart behavioural test paid that 500ms on each update.

`mockGridLayout` now reports a size (600x400, configurable) for `gridChartComp`'s chart canvas wrapper — the element AG Charts observes as its container — so the first synchronous size read succeeds and the wait never arms.

`format-panel-options.test.ts`: 136s -> 16.5s. Its timeout drops from 20 minutes to 2. The other chart suites also speed up. Full `./behave.sh` is green (10,408 tests), and the mock is gated on a class that appears nowhere outside integrated charts.

Reported by Salvatore Previti.