### PR TITLE
AG-18202 Emit the example import map as compact JSON

### DIFF
--- a/documentation/ag-grid-docs/src/components/example-runner/framework-templates/lib/ExampleModules.tsx
+++ b/documentation/ag-grid-docs/src/components/example-runner/framework-templates/lib/ExampleModules.tsx
@@ -66,7 +66,8 @@ export const ExampleModules = ({
         frameworkVersion: defaultVersion && FRAMEWORK_VERSION_PLACEHOLDER,
         dev: defaultVersion ? DEV_FLAG_PLACEHOLDERS : PRODUCTION_FLAGS,
     });
-    const importMap = JSON.stringify({ imports }, null, 4);
+    // Not pretty-printed: nothing reads this in the page, and the indentation is only weight
+    const importMap = JSON.stringify({ imports });
     const startFile = pathJoin(appLocation, toModuleFileName(entryFileName));
 
     const injectOptions: InjectImportMapOptions | undefined = defaultVersion


### PR DESCRIPTION
Pretty-printing the import map bought nothing — nothing reads it in the page, and for framework examples the map is embedded a second time inside the injector's options JSON, where the indentation showed up as a wall of `\n` escapes.

Serialised compact instead. Substitution is token-based, so the injector is unaffected.

Sub-task of AG-17103, against #14784.