### PR TITLE
AG-18201 Extract example page boilerplate and split ExampleModules

### DIFF
--- a/documentation/ag-grid-docs/src/components/example-runner/framework-templates/lib/ExampleImportMap.tsx
+++ b/documentation/ag-grid-docs/src/components/example-runner/framework-templates/lib/ExampleImportMap.tsx
@@ -1,0 +1,99 @@
+import type { InternalFramework } from '@ag-grid-types';
+import {
+    DEVELOPMENT_FLAGS,
+    FRAMEWORK_VERSION_PARAM,
+    FRAMEWORK_VERSION_PATTERN,
+    PRODUCTION_FLAGS,
+    PROD_PARAM,
+    getDefaultFrameworkVersion,
+    getImportMap,
+} from '@utils/exampleModules/getImportMap';
+
+import {
+    DEV_FLAG_PLACEHOLDERS,
+    FRAMEWORK_VERSION_PLACEHOLDER,
+    IMPORT_MAP_OPTIONS_ID,
+    type InjectImportMapOptions,
+    injectImportMap,
+} from './injectImportMap';
+
+interface Props {
+    internalFramework: InternalFramework;
+    isEnterprise: boolean;
+    isIntegratedCharts?: boolean;
+    nonce?: string;
+}
+
+/**
+ * Renders the map with a token wherever the framework version or the build appears, so that one
+ * rendered map can serve every version and build the URL asks for. Frameworks with no version to
+ * resolve get their real values rendered in, since nothing is substituted for them in the browser.
+ */
+const renderImportMap = ({ internalFramework, isEnterprise, isIntegratedCharts }: Omit<Props, 'nonce'>) => {
+    const defaultVersion = getDefaultFrameworkVersion(internalFramework);
+    const imports = getImportMap({
+        internalFramework,
+        isEnterprise,
+        isIntegratedCharts,
+        frameworkVersion: defaultVersion && FRAMEWORK_VERSION_PLACEHOLDER,
+        dev: defaultVersion ? DEV_FLAG_PLACEHOLDERS : PRODUCTION_FLAGS,
+    });
+
+    // Not pretty-printed: nothing reads this in the page, and the indentation is only weight
+    return { template: JSON.stringify({ imports }), defaultVersion };
+};
+
+/** What the browser needs to turn the rendered template into the map for this page's URL */
+const getInjectOptions = (template: string, defaultVersion: string): InjectImportMapOptions => ({
+    template,
+    buildTokens: {
+        production: {
+            [DEV_FLAG_PLACEHOLDERS.query]: PRODUCTION_FLAGS.query,
+            [DEV_FLAG_PLACEHOLDERS.appended]: PRODUCTION_FLAGS.appended,
+        },
+        development: {
+            [DEV_FLAG_PLACEHOLDERS.query]: DEVELOPMENT_FLAGS.query,
+            [DEV_FLAG_PLACEHOLDERS.appended]: DEVELOPMENT_FLAGS.appended,
+        },
+    },
+    defaultVersion,
+    placeholder: FRAMEWORK_VERSION_PLACEHOLDER,
+    versionParam: FRAMEWORK_VERSION_PARAM,
+    versionPattern: FRAMEWORK_VERSION_PATTERN.source,
+    prodParam: PROD_PARAM,
+});
+
+/**
+ * The import map that resolves the example's bare package specifiers.
+ *
+ * For framework examples it is registered in the browser rather than served as markup, so that
+ * `?version=` and `?prod=` can pick the framework version and build -- see `injectImportMap`.
+ */
+export const ExampleImportMap = ({ internalFramework, isEnterprise, isIntegratedCharts, nonce }: Props) => {
+    const { template, defaultVersion } = renderImportMap({ internalFramework, isEnterprise, isIntegratedCharts });
+
+    if (!defaultVersion) {
+        // Nothing to resolve from the URL, so the map is served as rendered
+        return <script nonce={nonce} type="importmap" dangerouslySetInnerHTML={{ __html: template }} />;
+    }
+
+    const options = JSON.stringify(getInjectOptions(template, defaultVersion));
+    const optionsElement = `document.getElementById(${JSON.stringify(IMPORT_MAP_OPTIONS_ID)})`;
+
+    return (
+        <>
+            <script
+                nonce={nonce}
+                type="application/json"
+                id={IMPORT_MAP_OPTIONS_ID}
+                dangerouslySetInnerHTML={{ __html: options }}
+            />
+            <script
+                nonce={nonce}
+                dangerouslySetInnerHTML={{
+                    __html: `(${injectImportMap})(JSON.parse(${optionsElement}.textContent));`,
+                }}
+            />
+        </>
+    );
+};

--- a/documentation/ag-grid-docs/src/components/example-runner/framework-templates/lib/ExampleModules.test.tsx
+++ b/documentation/ag-grid-docs/src/components/example-runner/framework-templates/lib/ExampleModules.test.tsx
@@ -9,11 +9,11 @@ const FRAMEWORKS: InternalFramework[] = ['typescript', 'reactFunctionalTs', 'ang
 
 /**
  * The example runner, the Plunker page and the static CodeSandbox page all render this component,
- * so the import map it emits is what each of them ships. `transpileInBrowser` is the only thing
+ * so what it emits is what each of them ships. `transpileInBrowser` is the only thing
  * that differs between them: Plunker and the static CodeSandbox template are handed the sources as
  * authored, the runner is served them transpiled.
  */
-const renderImportMap = async ({
+const renderMarkup = async ({
     internalFramework,
     transpileInBrowser,
 }: {
@@ -38,6 +38,12 @@ const renderImportMap = async ({
             transpileInBrowser={transpileInBrowser}
         />
     );
+
+    return html;
+};
+
+const renderImportMap = async (props: { internalFramework: InternalFramework; transpileInBrowser?: boolean }) => {
+    const html = await renderMarkup(props);
 
     const served = html.match(/<script type="importmap">([\s\S]*?)<\/script>/);
     if (served) {
@@ -103,6 +109,17 @@ describe('ExampleModules', () => {
             const exported = await renderImportMap({ internalFramework, transpileInBrowser: true });
 
             expect(exported).toEqual(runner);
+        });
+
+        test('emits the page boilerplate once, before the example is loaded', async () => {
+            const html = await renderMarkup({ internalFramework });
+
+            const shim = html.indexOf('window.process');
+            const entryModule = html.indexOf('type="module"');
+
+            expect(html.match(/window\.process/g)).toHaveLength(1);
+            expect(shim).toBeGreaterThan(-1);
+            expect(shim).toBeLessThan(entryModule);
         });
     });
 });

--- a/documentation/ag-grid-docs/src/components/example-runner/framework-templates/lib/ExampleModules.tsx
+++ b/documentation/ag-grid-docs/src/components/example-runner/framework-templates/lib/ExampleModules.tsx
@@ -1,25 +1,11 @@
 import type { InternalFramework } from '@ag-grid-types';
-import {
-    DEVELOPMENT_FLAGS,
-    FRAMEWORK_VERSION_PARAM,
-    FRAMEWORK_VERSION_PATTERN,
-    PRODUCTION_FLAGS,
-    PROD_PARAM,
-    getDefaultFrameworkVersion,
-    getImportMap,
-} from '@utils/exampleModules/getImportMap';
 import { toModuleFileName } from '@utils/exampleModules/transformExampleModule';
 import { pathJoin } from '@utils/pathJoin';
 
 import { BrowserTranspiler } from './BrowserTranspiler';
+import { ExampleImportMap } from './ExampleImportMap';
+import { ExamplePageBoilerplate } from './ExamplePageBoilerplate';
 import { SeedRandom } from './SeedRandom';
-import {
-    DEV_FLAG_PLACEHOLDERS,
-    FRAMEWORK_VERSION_PLACEHOLDER,
-    IMPORT_MAP_OPTIONS_ID,
-    type InjectImportMapOptions,
-    injectImportMap,
-} from './injectImportMap';
 
 interface Props {
     appLocation: string;
@@ -38,13 +24,10 @@ interface Props {
 
 /**
  * Example modules are loaded natively by the browser: an import map resolves the bare
- * package specifiers, and the entry file is loaded as a module. TypeScript and JSX sources
- * are transpiled server-side and served as `.js`, so the entry point is requested as such.
- * The exception is Plunker, which is handed the sources as authored -- see `transpileInBrowser`.
- *
- * For framework examples the map is registered in the browser rather than served as markup, so
- * that `?version=` and `?prod=` can pick the framework version and build an example runs
- * against -- see `injectImportMap`.
+ * package specifiers (see `ExampleImportMap`), and the entry file is loaded as a module.
+ * TypeScript and JSX sources are transpiled server-side and served as `.js`, so the entry point
+ * is requested as such. The exception is Plunker, which is handed the sources as authored --
+ * see `transpileInBrowser`.
  */
 export const ExampleModules = ({
     appLocation,
@@ -55,82 +38,20 @@ export const ExampleModules = ({
     usesMathRandom,
     transpileInBrowser,
     nonce,
-}: Props) => {
-    const defaultVersion = getDefaultFrameworkVersion(internalFramework);
-    // The framework version and build are substituted in the browser, so that they can come
-    // from the URL: the map is rendered once, with a token everywhere either one appears
-    const imports = getImportMap({
-        internalFramework,
-        isEnterprise,
-        isIntegratedCharts,
-        frameworkVersion: defaultVersion && FRAMEWORK_VERSION_PLACEHOLDER,
-        dev: defaultVersion ? DEV_FLAG_PLACEHOLDERS : PRODUCTION_FLAGS,
-    });
-    // Not pretty-printed: nothing reads this in the page, and the indentation is only weight
-    const importMap = JSON.stringify({ imports });
-    const startFile = pathJoin(appLocation, toModuleFileName(entryFileName));
-
-    const injectOptions: InjectImportMapOptions | undefined = defaultVersion
-        ? {
-              template: importMap,
-              buildTokens: {
-                  production: {
-                      [DEV_FLAG_PLACEHOLDERS.query]: PRODUCTION_FLAGS.query,
-                      [DEV_FLAG_PLACEHOLDERS.appended]: PRODUCTION_FLAGS.appended,
-                  },
-                  development: {
-                      [DEV_FLAG_PLACEHOLDERS.query]: DEVELOPMENT_FLAGS.query,
-                      [DEV_FLAG_PLACEHOLDERS.appended]: DEVELOPMENT_FLAGS.appended,
-                  },
-              },
-              defaultVersion,
-              placeholder: FRAMEWORK_VERSION_PLACEHOLDER,
-              versionParam: FRAMEWORK_VERSION_PARAM,
-              versionPattern: FRAMEWORK_VERSION_PATTERN.source,
-              prodParam: PROD_PARAM,
-          }
-        : undefined;
-
-    return (
-        <>
-            {injectOptions ? (
-                <>
-                    <script
-                        nonce={nonce}
-                        type="application/json"
-                        id={IMPORT_MAP_OPTIONS_ID}
-                        dangerouslySetInnerHTML={{ __html: JSON.stringify(injectOptions) }}
-                    />
-                    <script
-                        nonce={nonce}
-                        dangerouslySetInnerHTML={{
-                            __html:
-                                `(${injectImportMap})(JSON.parse(` +
-                                `document.getElementById(${JSON.stringify(IMPORT_MAP_OPTIONS_ID)}).textContent));`,
-                        }}
-                    />
-                </>
-            ) : (
-                // Nothing to resolve from the URL, so the map is served as rendered
-                <script nonce={nonce} type="importmap" dangerouslySetInnerHTML={{ __html: importMap }} />
-            )}
-            {usesMathRandom && <SeedRandom nonce={nonce} />}
-
-            {/* Examples read `process.env.NODE_ENV` to guard dev-only validations, and nothing
-                in a browser defines it. Classic scripts run before deferred module scripts, so
-                this is in place by the time the example's own code does. */}
-            <script
-                nonce={nonce}
-                dangerouslySetInnerHTML={{
-                    __html: `window.process = { env: { NODE_ENV: 'development' } };
-window.addEventListener('error', function (e) { console.error('ERROR', e.message, e.filename); });`,
-                }}
-            />
-            {transpileInBrowser ? (
-                <BrowserTranspiler entryFileName={entryFileName} nonce={nonce} />
-            ) : (
-                <script nonce={nonce} type="module" src={startFile} />
-            )}
-        </>
-    );
-};
+}: Props) => (
+    <>
+        <ExampleImportMap
+            internalFramework={internalFramework}
+            isEnterprise={isEnterprise}
+            isIntegratedCharts={isIntegratedCharts}
+            nonce={nonce}
+        />
+        {usesMathRandom && <SeedRandom nonce={nonce} />}
+        <ExamplePageBoilerplate nonce={nonce} />
+        {transpileInBrowser ? (
+            <BrowserTranspiler entryFileName={entryFileName} nonce={nonce} />
+        ) : (
+            <script nonce={nonce} type="module" src={pathJoin(appLocation, toModuleFileName(entryFileName))} />
+        )}
+    </>
+);

--- a/documentation/ag-grid-docs/src/components/example-runner/framework-templates/lib/ExamplePageBoilerplate.tsx
+++ b/documentation/ag-grid-docs/src/components/example-runner/framework-templates/lib/ExamplePageBoilerplate.tsx
@@ -1,0 +1,21 @@
+interface Props {
+    nonce?: string;
+}
+
+/**
+ * Examples read `process.env.NODE_ENV` to guard dev-only validations, and nothing in a browser
+ * defines it.
+ */
+const PROCESS_ENV_SHIM = `window.process = { env: { NODE_ENV: 'development' } };`;
+
+/** Uncaught errors are reported with the file that threw, which a module stack trace does not name */
+const ERROR_REPORTER = `window.addEventListener('error', function (e) { console.error('ERROR', e.message, e.filename); });`;
+
+/**
+ * The scaffolding every example page carries, none of which is part of the example itself. It is a
+ * classic script rather than a module, so the parser runs it before it reaches the deferred module
+ * scripts the example is loaded through.
+ */
+export const ExamplePageBoilerplate = ({ nonce }: Props) => (
+    <script nonce={nonce} dangerouslySetInnerHTML={{ __html: `${PROCESS_ENV_SHIM}\n${ERROR_REPORTER}` }} />
+);

--- a/documentation/ag-grid-docs/src/components/example-runner/framework-templates/lib/injectImportMap.ts
+++ b/documentation/ag-grid-docs/src/components/example-runner/framework-templates/lib/injectImportMap.ts
@@ -40,19 +40,9 @@ export interface InjectImportMapOptions {
 }
 
 /**
- * Registers the example page's import map, resolving the framework version and whether to
- * run against its development build from the `?version=` and `?prod=` URL parameters.
+ * Registers the example page's import map, substituting the framework version and build that
+ * `?version=` and `?prod=` ask for -- neither is known when the page is statically generated.
  *
- * Example pages are statically generated, so neither is known when the page is built: the
- * maps are rendered with a placeholder where the framework version goes, and this picks one,
- * substitutes the version and registers it in the browser. It is emitted as a classic inline
- * script, which the parser runs synchronously -- so the map is in place before the parser
- * reaches the example's module script, which is what the import-map spec requires.
- *
- * A version that is not a plausible version string aborts the load with a visible message,
- * rather than quietly running the example against the pinned default. A well-formed but
- * non-existent version is left to fail on its own: the CDN 404s and the example does not
- * start.
  *
  * Serialised into the page with `toString()`, so it must reference nothing outside its own
  * parameters.
@@ -68,7 +58,7 @@ export function injectImportMap({
 }: InjectImportMapOptions): void {
     const urlParams = new URLSearchParams(window.location.search);
     const requestedVersion = urlParams.get(versionParam);
-    // Production unless the URL says otherwise, as under SystemJS
+    // Production unless the URL says otherwise
     const isProd = urlParams.get(prodParam) !== 'false';
     let version = defaultVersion;
 


### PR DESCRIPTION
`ExampleModules` had grown into one component that built the import map, decided how to register it, carried the page's `process.env` shim and error reporter, and loaded the entry module.

Split into single-responsibility units:

- `ExampleImportMap` — renders the map, and either serves it or emits the injector for it.
- `ExamplePageBoilerplate` — the page scaffolding that is not part of the example (the `process.env.NODE_ENV` shim and the uncaught-error reporter).
- `ExampleModules` — composition only.

No behavioural change; the emitted markup is the same. Covered by a new test asserting the boilerplate is emitted once and ahead of the example's module script.

Sub-task of AG-17103, stacked on #14840 (both against #14784).