### PR TITLE
AG-18203 Shorten the injectImportMap comment

### DIFF
--- a/documentation/ag-grid-docs/src/components/example-runner/framework-templates/lib/injectImportMap.ts
+++ b/documentation/ag-grid-docs/src/components/example-runner/framework-templates/lib/injectImportMap.ts
@@ -42,11 +42,7 @@ export interface InjectImportMapOptions {
 /**
  * Registers the example page's import map, substituting the framework version and build that
  * `?version=` and `?prod=` ask for -- neither is known when the page is statically generated.
- * Emitted as a classic inline script, so the parser registers the map before it reaches the
- * example's module script, as the import-map spec requires.
  *
- * A version that is not a plausible version string aborts the load visibly rather than quietly
- * falling back to the pinned default; a well-formed but non-existent one is left to 404.
  *
  * Serialised into the page with `toString()`, so it must reference nothing outside its own
  * parameters.

--- a/documentation/ag-grid-docs/src/components/example-runner/framework-templates/lib/injectImportMap.ts
+++ b/documentation/ag-grid-docs/src/components/example-runner/framework-templates/lib/injectImportMap.ts
@@ -40,19 +40,13 @@ export interface InjectImportMapOptions {
 }
 
 /**
- * Registers the example page's import map, resolving the framework version and whether to
- * run against its development build from the `?version=` and `?prod=` URL parameters.
+ * Registers the example page's import map, substituting the framework version and build that
+ * `?version=` and `?prod=` ask for -- neither is known when the page is statically generated.
+ * Emitted as a classic inline script, so the parser registers the map before it reaches the
+ * example's module script, as the import-map spec requires.
  *
- * Example pages are statically generated, so neither is known when the page is built: the
- * maps are rendered with a placeholder where the framework version goes, and this picks one,
- * substitutes the version and registers it in the browser. It is emitted as a classic inline
- * script, which the parser runs synchronously -- so the map is in place before the parser
- * reaches the example's module script, which is what the import-map spec requires.
- *
- * A version that is not a plausible version string aborts the load with a visible message,
- * rather than quietly running the example against the pinned default. A well-formed but
- * non-existent version is left to fail on its own: the CDN 404s and the example does not
- * start.
+ * A version that is not a plausible version string aborts the load visibly rather than quietly
+ * falling back to the pinned default; a well-formed but non-existent one is left to 404.
  *
  * Serialised into the page with `toString()`, so it must reference nothing outside its own
  * parameters.
@@ -68,7 +62,7 @@ export function injectImportMap({
 }: InjectImportMapOptions): void {
     const urlParams = new URLSearchParams(window.location.search);
     const requestedVersion = urlParams.get(versionParam);
-    // Production unless the URL says otherwise, as under SystemJS
+    // Production unless the URL says otherwise
     const isProd = urlParams.get(prodParam) !== 'false';
     let version = defaultVersion;
 


### PR DESCRIPTION
Cut the `?version=`/`?prod=` block comment down to what a reader needs, and dropped the stale "as under SystemJS" aside.

On the paired half of the sub-task — boilerplate not visible on the website: the example runner lists `generatedContents.files`, and the only `index.html` in there is the fragment the example itself authors. The page scaffolding lives in the Astro templates and never enters that map, so there was nothing to hide. Plunker and CodeSandbox get the full page by design — that is what makes the export runnable standalone.

Sub-task of AG-17103, stacked on #14841 (chain against #14784).