### PR TITLE
AG-18204 Import enterprise on demand in the injected test-id block

### DIFF
--- a/documentation/ag-grid-docs/src/utils/exampleModules/getImportMap.ts
+++ b/documentation/ag-grid-docs/src/utils/exampleModules/getImportMap.ts
@@ -185,7 +185,7 @@ export const getImportMap = ({
         'ag-grid-community': esmEntryPoint('ag-grid-community'),
         'ag-grid-community/styles/': stylesPrefix('ag-grid-community'),
         // Every example resolves enterprise, not just the enterprise ones: the generator's
-        // test-id block imports it to look up module names given by `?modules=`
+        // test-id block imports it on demand to look up module names given by `?modules=`
         'ag-grid-enterprise': esmEntryPoint('ag-grid-enterprise'),
         'ag-grid-enterprise/styles/': stylesPrefix('ag-grid-enterprise'),
         '@ag-grid-community/locale': esmEntryPoint('@ag-grid-community/locale'),

--- a/plugins/ag-grid-generate-example-files/src/executors/generate/generator/transformation-scripts/parser-utils.ts
+++ b/plugins/ag-grid-generate-example-files/src/executors/generate/generator/transformation-scripts/parser-utils.ts
@@ -822,13 +822,16 @@ export function getEnableAGTestIdLogic(isUmd: boolean = false): string {
 
     // Support dynamically adding modules during integration testing
     const agGridCommunityImport = isUmd ? '' : `import * as ${community} from 'ag-grid-community';`;
-    const agGridEnterpriseImport = isUmd ? '' : `import * as ${enterprise} from 'ag-grid-enterprise';`;
 
+    // Enterprise is imported on demand: only `?modules=` resolves names against it, and a static
+    // import would have every community example load and parse the enterprise bundle for nothing.
+    // A genuinely enterprise example imports it itself and is unaffected.
     const extraModules = isUmd
         ? ''
         : `
     const modulesCSV = url.get('modules');
     if (modulesCSV) {
+        const ${enterprise} = await import('ag-grid-enterprise');
         ${community}.ModuleRegistry.registerModules(
             modulesCSV.split(',').map(name => ${community}[name] || ${enterprise}[name])
         );
@@ -842,7 +845,6 @@ export function getEnableAGTestIdLogic(isUmd: boolean = false): string {
 
     const method = `
 ${agGridCommunityImport}
-${agGridEnterpriseImport}
 const url = new URLSearchParams(window.location.search);
 const enableTestIds = url.get('enableTestIds');
 if (enableTestIds) {


### PR DESCRIPTION
Audit of #14756's improvements against this branch. Seven of the eight survive unchanged — inlined fonts, `prod=true` for `reactFunctionalTs`, the single React variant locally, the teardown destruction check, local-only `ignoreHTTPSErrors`, `useFetchJson` cancellation, and the behavioural output hygiene. The Node-side transpilation and the ESM bundle conversion were rightly deleted with SystemJS: examples are transpiled server-side and `typescript.min.js` is never requested at all.

One did not survive. #14756 stripped the generator's injected `import * as agGridEnterprise from 'ag-grid-enterprise'` at the Playwright route level, because only `?modules=` resolves names against it and every other example was parsing the enterprise bundle for a dead branch. That route handler went with `localTranspile.ts`, and the static import came back — this time for real users too, not just the e2e run.

Fixed at the source instead of in the test harness: the block imports enterprise dynamically, inside the `?modules=` branch. Native ESM makes that straightforward, and the import map already carries the entry.

Sub-task of AG-17103, against #14784.