### PR TITLE
github-triage: unblock auto-triage for community-reported issues

### DIFF
--- a/.github/workflows/github-triage-pipeline.yml
+++ b/.github/workflows/github-triage-pipeline.yml
@@ -263,6 +263,23 @@ jobs:
                   # regardless of preflight's own behaviour.
                   stage: ${{ (github.event.action == 'gh-triage-manual-resume' && 'resume') || (github.event.action == 'gh-triage-manual-browser-verify' && 'browser-verify') || (github.event.action == 'gh-triage-manual-repro-rebuild' && 'repro-rebuild') || needs.preflight.outputs.stage || inputs.stage || 'triage' }}
                   product: grid
+                  # claude-code-action refuses to run when the TRIGGERING ACTOR lacks
+                  # write access — and on an `issues` event that actor is the ISSUE
+                  # AUTHOR, a community reporter with `read`. Auto-triage therefore
+                  # failed for every genuine community report ("Actor does not have
+                  # write permissions to the repository") and only ever worked when a
+                  # maintainer happened to touch the issue, which is the opposite of
+                  # the feature. It looked healthy because the first live ticket was
+                  # label-triggered by a maintainer; the first real community report
+                  # (AITGH-28 / #14837) failed on both auto-fires.
+                  #
+                  # Scoped to the `issues` event ALONE: the board drag, the manual
+                  # buttons and workflow_dispatch all already carry a write-capable
+                  # actor, so the gate stays armed there at no cost — and stays armed
+                  # for any trigger added later. Setting this also makes
+                  # claude-code-action best-effort scrub secrets from subprocess
+                  # environments.
+                  allowed_non_write_users: ${{ github.event_name == 'issues' && '*' || '' }}
                   # Provenance for the pin: `post` stamps this channel onto the
                   # mapping ticket so `resolve-channel` can route the NEXT drag to the
                   # same channel. Must match the channel actually installed above.


### PR DESCRIPTION
## Why

**Auto-triage has never worked for a genuine community report, and it looked healthy.**

`claude-code-action` refuses to run when the **triggering actor** lacks write access. On an `issues` event that actor is the **issue author** — a community reporter with `read` — so the run dies immediately:

```
##[error]Action failed with error: Actor does not have write permissions to the repository
```

Which means auto-triage only ever worked when a **maintainer** touched the issue. That is the opposite of the feature.

**Why it looked fine:** the first live ticket, AITGH-27 / #14517, was label-triggered by a maintainer, so the *maintainer* was the actor and it passed. The first real community report — AITGH-28 / #14837, author permission `read` — failed on **both** auto-fires (`opened` and `labeled`). The manual resume then succeeded, because the dispatcher was the actor.

## What

Passes `allowed_non_write_users` to the pipeline action, **scoped to the `issues` event alone**:

```yaml
allowed_non_write_users: ${{ github.event_name == 'issues' && '*' || '' }}
```

The board drag, the manual `•••` buttons and `workflow_dispatch` all already carry a write-capable actor, so the gate **stays armed** on those paths at no cost — and stays armed for any trigger added later. Setting the input also makes `claude-code-action` best-effort scrub secrets from subprocess environments.

## The alternative that was researched and rejected

Relaying the `issues` event through a `repository_dispatch` sent with the existing `JIRA_AGENT` GitHub App, so the actor becomes the app (which has write) and no bypass is needed. Rejected because:

- **Identical exposure** — the agent still reads attacker-authored issue text in the same job. It makes the *actor* trusted while the *trigger* is still a stranger's action.
- **Unverifiable dependency** — needs the app installed on `ag-grid` itself with dispatch rights, which cannot be confirmed without org admin.
- **The action deliberately resists it** — `getActorsToCheck` walks the *upstream* run's actor for `workflow_run` events specifically so chaining cannot launder an untrusted actor.

Scoping the flag per-event recovers the one real advantage the relay had: the gate stays armed everywhere else.

## What this does not change

The exposure is the same either way — the agent processes untrusted content in a job holding `issues: write` (which `execute` needs). Reducing *that* is the job split, tracked in ag-dev-prompts `docs/github-triage-deferred-hardening.md` § 1 and deliberately deferred for the pilot.

Note the browser chain jobs are already narrowed to `issues: read` (#14834), so this widens nothing there.

## Dependency

Needs `@ag-grid/dev-prompts >= 1.6.239` (ag-grid/ag-dev-prompts#862) for the passthrough. The action input is **optional and defaults to empty**, so this is safe to land before that promotes — until it does, the input is simply ignored and behaviour is unchanged.
