### PR TITLE
AG-18201 Name the example's framework version where a reader can edit it

### DIFF
--- a/documentation/ag-grid-docs/public/example-runner/inject-import-map.js
+++ b/documentation/ag-grid-docs/public/example-runner/inject-import-map.js
@@ -8,12 +8,15 @@
  * deferred, and an import map added after module loading has started is an error.
  *
  * The page supplies only what varies per example, in `#ag-import-map`: the rendered map, with
- * a token wherever the version or the build appears, and the version and build to use by default.
- * Everything below is fixed, and is checked against its TypeScript counterpart by
- * `injectImportMap.test.ts` so the two cannot drift.
+ * a token wherever the version or the build appears, and the build to use by default. The
+ * version it runs against is a variable of its own, `window.agFrameworkVersion`, so that a
+ * reader of the page can point the example at another version by editing it. Everything below
+ * is fixed, and is checked against its TypeScript counterpart by `injectImportMap.test.ts` so
+ * the two cannot drift.
  */
 (function () {
     var OPTIONS_ID = 'ag-import-map';
+    var VERSION_GLOBAL = 'agFrameworkVersion';
     var VERSION_PARAM = 'version';
     var PROD_PARAM = 'prod';
     var VERSION_PLACEHOLDER = '0.0.0-ag-framework-version';
@@ -33,30 +36,30 @@
     // export taken before this script asked for one -- gets the production build, since this is
     // served from a mutable URL and so has to keep reading pages older than itself.
     var isProd = requestedProd === null ? options.defaultProd !== false : requestedProd !== 'false';
-    var version = options.defaultVersion;
+    // The version the page names unless the URL asks for another, so that editing the page runs
+    // the example against a version of the reader's choosing. `defaultVersion` is read for a page
+    // from before the version became a variable of its own -- an export taken then.
+    var pageVersion = window[VERSION_GLOBAL] || options.defaultVersion;
+    var version = requestedVersion === null ? pageVersion : requestedVersion;
 
     // An empty `?version=` is a version that is not a version, not an absent one, so it fails
     // here rather than quietly loading the default. A well-formed but non-existent one is left
     // to 404 on its own.
-    if (requestedVersion !== null) {
-        if (!new RegExp(VERSION_PATTERN).test(requestedVersion)) {
-            var message =
-                'Example not loaded: "' +
-                requestedVersion +
-                '" is not a valid ?' +
-                VERSION_PARAM +
-                '= value. Expected a framework version such as ' +
-                options.defaultVersion +
-                '.';
+    if (!new RegExp(VERSION_PATTERN).test(version)) {
+        var source = requestedVersion === null ? 'window.' + VERSION_GLOBAL : '?' + VERSION_PARAM + '=';
+        var message =
+            'Example not loaded: "' +
+            version +
+            '" is not a valid ' +
+            source +
+            ' value. Expected a framework version such as 19.2.1.';
 
-            var banner = document.createElement('div');
-            banner.textContent = message;
-            banner.setAttribute('style', 'padding: 1rem; font-family: monospace; color: #b00020;');
-            document.body.appendChild(banner);
+        var banner = document.createElement('div');
+        banner.textContent = message;
+        banner.setAttribute('style', 'padding: 1rem; font-family: monospace; color: #b00020;');
+        document.body.appendChild(banner);
 
-            throw new Error(message);
-        }
-        version = requestedVersion;
+        throw new Error(message);
     }
 
     var substitutions = Object.assign({}, isProd ? BUILD_TOKENS.production : BUILD_TOKENS.development);

--- a/documentation/ag-grid-docs/src/components/example-runner/framework-templates/lib/ExampleImportMap.tsx
+++ b/documentation/ag-grid-docs/src/components/example-runner/framework-templates/lib/ExampleImportMap.tsx
@@ -3,12 +3,14 @@ import { getIsDev } from '@utils/env';
 import { exampleRunnerAsset } from '@utils/exampleModules/exampleRunnerAsset';
 import {
     DEV_FLAG_PLACEHOLDERS,
+    FRAMEWORK_VERSION_GLOBAL,
     FRAMEWORK_VERSION_PLACEHOLDER,
     IMPORT_MAP_OPTIONS_ID,
     PRODUCTION_FLAGS,
     getDefaultFrameworkVersion,
     getImportMap,
 } from '@utils/exampleModules/getImportMap';
+import { getFrameworkDisplayText, getFrameworkFromInternalFramework } from '@utils/framework';
 
 interface Props {
     internalFramework: InternalFramework;
@@ -42,12 +44,14 @@ const renderImportMap = ({ internalFramework, isEnterprise, isIntegratedCharts }
  * For framework examples it is registered in the browser rather than served as markup, so that
  * `?version=` and `?prod=` can pick the framework version and build. Which build the page falls
  * back to is fixed when it is generated: the development one under the dev server, so that local
- * examples run against React's development build as they did under SystemJS. The page carries the
- * rendered map and nothing else; what substitutes and registers it is served -- see
+ * examples run against React's development build as they did under SystemJS. The version is the
+ * page's own, written where a reader of `index.html` can change it; the map it is substituted
+ * into travels as data, and what registers it is served -- see
  * `public/example-runner/inject-import-map.js`.
  */
 export const ExampleImportMap = ({ internalFramework, isEnterprise, isIntegratedCharts, nonce }: Props) => {
     const { template, defaultVersion } = renderImportMap({ internalFramework, isEnterprise, isIntegratedCharts });
+    const frameworkName = getFrameworkDisplayText(getFrameworkFromInternalFramework(internalFramework));
 
     if (!defaultVersion) {
         // Nothing to resolve from the URL, so the map is served as rendered
@@ -58,11 +62,15 @@ export const ExampleImportMap = ({ internalFramework, isEnterprise, isIntegrated
         <>
             <script
                 nonce={nonce}
+                dangerouslySetInnerHTML={{
+                    __html: `\n// The ${frameworkName} version this example runs against -- edit to try another\nwindow.${FRAMEWORK_VERSION_GLOBAL} = '${defaultVersion}';\n`,
+                }}
+            />
+            <script
+                nonce={nonce}
                 type="application/json"
                 id={IMPORT_MAP_OPTIONS_ID}
-                dangerouslySetInnerHTML={{
-                    __html: JSON.stringify({ template, defaultVersion, defaultProd: !getIsDev() }),
-                }}
+                dangerouslySetInnerHTML={{ __html: JSON.stringify({ template, defaultProd: !getIsDev() }) }}
             />
             <script nonce={nonce} src={exampleRunnerAsset('inject-import-map.js')} />
         </>

--- a/documentation/ag-grid-docs/src/components/example-runner/framework-templates/lib/ExampleModules.test.tsx
+++ b/documentation/ag-grid-docs/src/components/example-runner/framework-templates/lib/ExampleModules.test.tsx
@@ -1,6 +1,6 @@
 import type { InternalFramework } from '@ag-grid-types';
 import { NPM_CDN } from '@constants';
-import { IMPORT_MAP_OPTIONS_ID } from '@utils/exampleModules/getImportMap';
+import { FRAMEWORK_VERSION_GLOBAL, IMPORT_MAP_OPTIONS_ID } from '@utils/exampleModules/getImportMap';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { renderToStaticMarkup } from 'react-dom/server';
@@ -64,18 +64,23 @@ const renderImportMap = async (props: { internalFramework: InternalFramework; tr
         throw new Error(`No import map rendered in:\n${html}`);
     }
 
-    return await registerImportMap(options[1].replace(/&quot;/g, '"'));
+    const version = html.match(new RegExp(`window\\.${FRAMEWORK_VERSION_GLOBAL} = '([^']+)';`));
+    if (!version) {
+        throw new Error(`No framework version named in:\n${html}`);
+    }
+
+    return await registerImportMap(options[1].replace(/&quot;/g, '"'), version[1]);
 };
 
 /**
  * Runs the page's own injector over its serialised options, rather than substituting the tokens
  * here, so that what this asserts on is what a browser would resolve. No URL parameters, so it
- * gives the pinned version and the production build -- what a plain example load resolves.
+ * gives the version the page names and the production build -- what a plain example load resolves.
  */
-const registerImportMap = async (optionsJson: string) => {
+const registerImportMap = async (optionsJson: string, version: string) => {
     const registered: any[] = [];
 
-    vi.stubGlobal('window', { location: { search: '' } });
+    vi.stubGlobal('window', { location: { search: '' }, [FRAMEWORK_VERSION_GLOBAL]: version });
     vi.stubGlobal('document', {
         currentScript: null,
         getElementById: (id: string) => (id === IMPORT_MAP_OPTIONS_ID ? { textContent: optionsJson } : null),
@@ -153,17 +158,35 @@ describe('ExampleModules', () => {
         test('carries no script body of its own beyond the data the served scripts read', async () => {
             const html = await renderMarkup({ internalFramework, usesMathRandom: true });
 
-            // Every inline script is either the base-path assignment the templates emit or a
-            // JSON block; anything else is machinery that belongs in a served file
+            // Every inline script is a JSON block, the base-path assignment the templates emit or
+            // the framework version the page is meant to be edited on; anything else is machinery
+            // that belongs in a served file
             const inline = [...html.matchAll(/<script(?![^>]*\bsrc=)([^>]*)>([\s\S]*?)<\/script>/g)];
             const machinery = inline.filter(
                 ([, attributes, body]) =>
                     !attributes.includes('application/json') &&
                     !attributes.includes('importmap') &&
-                    !body.includes('__basePath')
+                    !body.includes('__basePath') &&
+                    !body.includes(`window.${FRAMEWORK_VERSION_GLOBAL}`)
             );
 
             expect(machinery.map(([, , body]) => body)).toEqual([]);
+        });
+
+        test('names the framework version where a reader of the page can change it', async () => {
+            const html = await renderMarkup({ internalFramework });
+
+            // Frameworkless examples have no framework version to run against
+            if (internalFramework === 'typescript') {
+                expect(html).not.toContain(FRAMEWORK_VERSION_GLOBAL);
+                return;
+            }
+
+            const assignment = html.match(new RegExp(`window\\.${FRAMEWORK_VERSION_GLOBAL} = '([^']+)';`));
+
+            expect(assignment?.[1]).toMatch(/^\d+\.\d+\.\d+/);
+            // Ahead of the injector that reads it, which the parser runs as it reaches it
+            expect(html.indexOf(assignment![0])).toBeLessThan(html.indexOf('inject-import-map.js'));
         });
     });
 });

--- a/documentation/ag-grid-docs/src/components/example-runner/framework-templates/lib/injectImportMap.test.ts
+++ b/documentation/ag-grid-docs/src/components/example-runner/framework-templates/lib/injectImportMap.test.ts
@@ -1,6 +1,7 @@
 import {
     DEVELOPMENT_FLAGS,
     DEV_FLAG_PLACEHOLDERS,
+    FRAMEWORK_VERSION_GLOBAL,
     FRAMEWORK_VERSION_PARAM,
     FRAMEWORK_VERSION_PATTERN,
     FRAMEWORK_VERSION_PLACEHOLDER,
@@ -27,23 +28,39 @@ const TEMPLATE = JSON.stringify({
 
 /**
  * The injector runs in the example page, so the test supplies the pieces of the page it touches:
- * the URL it reads the version from, the block it reads the map from, and what it appends.
+ * the version and URL it resolves the version from, the block it reads the map from, and what it
+ * appends.
  */
 const stubPage = (
     search: string,
-    { nonce, template = TEMPLATE, defaultProd }: { nonce?: string; template?: string; defaultProd?: boolean } = {}
+    {
+        nonce,
+        template = TEMPLATE,
+        defaultProd,
+        pageVersion = '19.2.1',
+        defaultVersion,
+    }: {
+        nonce?: string;
+        template?: string;
+        defaultProd?: boolean;
+        pageVersion?: string | null;
+        defaultVersion?: string;
+    } = {}
 ) => {
     const head: any[] = [];
     const body: any[] = [];
-    // Omitted rather than defaulted when the test names no default, so that a page from before
-    // the script read one can be stubbed
+    // Each omitted rather than defaulted when the test names none, so that a page from before the
+    // script read it can be stubbed
     const options = JSON.stringify({
         template,
-        defaultVersion: '19.2.1',
+        ...(defaultVersion === undefined ? {} : { defaultVersion }),
         ...(defaultProd === undefined ? {} : { defaultProd }),
     });
 
-    vi.stubGlobal('window', { location: { search } });
+    vi.stubGlobal('window', {
+        location: { search },
+        ...(pageVersion === null ? {} : { [FRAMEWORK_VERSION_GLOBAL]: pageVersion }),
+    });
     vi.stubGlobal('document', {
         currentScript: nonce === undefined ? null : { nonce },
         getElementById: (id: string) => (id === IMPORT_MAP_OPTIONS_ID ? { textContent: options } : null),
@@ -66,7 +83,7 @@ const registeredImports = (head: any[]) => JSON.parse(head[0].textContent).impor
 afterEach(() => vi.unstubAllGlobals());
 
 describe('inject-import-map.js', () => {
-    test('registers the pinned version when the URL requests none', () => {
+    test('registers the version the page names when the URL requests none', () => {
         const { head } = stubPage('?enableTestIds=true', { defaultProd: true });
 
         injectImportMap();
@@ -171,6 +188,42 @@ describe('inject-import-map.js', () => {
         expect(head).toHaveLength(0);
     });
 
+    test('registers the version the page has been edited to name', () => {
+        const { head } = stubPage('', { pageVersion: '18.3.1' });
+
+        injectImportMap();
+
+        expect(registeredImports(head).react).toBe('https://esm.sh/react@18.3.1');
+    });
+
+    test('lets the URL override the version the page names', () => {
+        const { head } = stubPage('?version=17.0.2', { pageVersion: '18.3.1' });
+
+        injectImportMap();
+
+        expect(registeredImports(head).react).toBe('https://esm.sh/react@17.0.2');
+    });
+
+    test('fails visibly when the page has been edited to a version that is not a version', () => {
+        const { head, body } = stubPage('', { pageVersion: 'latest' });
+
+        expect(() => injectImportMap()).toThrowError(
+            new RegExp(`not a valid window.${FRAMEWORK_VERSION_GLOBAL} value`)
+        );
+
+        expect(head).toHaveLength(0);
+        expect(body[0].textContent).toContain('latest');
+    });
+
+    test('reads the version from the map options for a page that names none of its own', () => {
+        // The script is served from a mutable URL, so it outlives the pages that carry it
+        const { head } = stubPage('', { pageVersion: null, defaultVersion: '18.3.1' });
+
+        injectImportMap();
+
+        expect(registeredImports(head).react).toBe('https://esm.sh/react@18.3.1');
+    });
+
     /**
      * The served file cannot import the constants the map is rendered with, so it carries its own
      * copies. A page whose tokens the injector does not recognise would register a map still
@@ -188,6 +241,7 @@ describe('inject-import-map.js', () => {
 
         test.each([
             ['OPTIONS_ID', IMPORT_MAP_OPTIONS_ID],
+            ['VERSION_GLOBAL', FRAMEWORK_VERSION_GLOBAL],
             ['VERSION_PARAM', FRAMEWORK_VERSION_PARAM],
             ['PROD_PARAM', PROD_PARAM],
             ['VERSION_PLACEHOLDER', FRAMEWORK_VERSION_PLACEHOLDER],

--- a/documentation/ag-grid-docs/src/utils/exampleModules/getImportMap.ts
+++ b/documentation/ag-grid-docs/src/utils/exampleModules/getImportMap.ts
@@ -16,8 +16,9 @@ export type ImportMap = Record<string, string>;
 
 /**
  * The framework versions examples run against by default, deliberately independent of the
- * versions the docs site itself is built with. Overridable per page load with the
- * `?version=` URL parameter (see `injectImportMap`).
+ * versions the docs site itself is built with. Rendered into the page as the version it names,
+ * which a reader can edit, and overridable per page load with the `?version=` URL parameter
+ * (see `public/example-runner/inject-import-map.js`).
  */
 const DEFAULT_ANGULAR_VERSION = '20.0.0';
 const DEFAULT_REACT_VERSION = '19.2.1';
@@ -87,6 +88,13 @@ export const DEV_FLAG_PLACEHOLDERS: DevFlags = {
  * `public/example-runner/inject-import-map.js` to register.
  */
 export const IMPORT_MAP_OPTIONS_ID = 'ag-import-map';
+
+/**
+ * The global the page names its framework version in, which the injector reads. A variable of
+ * its own rather than a field of the map's JSON, so that a reader of `index.html` -- of an
+ * exported example above all -- can run it against another version by editing one legible line.
+ */
+export const FRAMEWORK_VERSION_GLOBAL = 'agFrameworkVersion';
 
 /**
  * React and React DOM have no ES module build on npm, so they resolve through esm.sh.


### PR DESCRIPTION
The version an example runs against reached the page only as a field of the import map's serialised options, where it is neither legible nor editable. It is now `window.agFrameworkVersion`, written above the injector that reads it, so a reader of an example's `index.html` — a Plunker or CodeSandbox export above all — can point it at another version by editing one line.

`?version=` still overrides it, and a page from before the variable existed still resolves the version from its options.