### PR TITLE
fix(github-triage-pipeline): resolve-channel 404s on the classic Jira host, pin is a no-op

### DIFF
--- a/.github/workflows/github-triage-pipeline.yml
+++ b/.github/workflows/github-triage-pipeline.yml
@@ -153,10 +153,23 @@ jobs:
                       exit 0
                   fi
 
+                  # A scoped Jira API token is rejected on the classic <site>.atlassian.net
+                  # host and only authenticates via the api.atlassian.com/ex/jira/{cloudId}
+                  # gateway (see the github-triage-pipeline action's executors/jira.ts) — so
+                  # resolve the cloudId first via the unauthenticated tenant_info lookup,
+                  # matching the pipeline's own resolveCloudId(). Hitting the site host
+                  # directly 404s here even with valid credentials.
+                  if ! cloud_id=$(curl -sS --fail --max-time 20 "$JIRA_SITE_URL/_edge/tenant_info" \
+                        | jq -r '.cloudId // empty') || [ -z "$cloud_id" ]; then
+                      echo "::warning title=channel-pin::could not resolve cloudId for $JIRA_SITE_URL — falling back to latest"
+                      emit latest "cloudId lookup failed"
+                      exit 0
+                  fi
+
                   if ! labels=$(curl -sS --fail --max-time 20 \
                         -u "$JIRA_EMAIL:$JIRA_API_TOKEN" \
                         -H 'Accept: application/json' \
-                        "$JIRA_SITE_URL/rest/api/3/issue/$ISSUE_KEY?fields=labels" \
+                        "https://api.atlassian.com/ex/jira/$cloud_id/rest/api/3/issue/$ISSUE_KEY?fields=labels" \
                         | jq -r '.fields.labels[]? // empty'); then
                       # FAIL-SAFE to production. An unreadable ticket must not silently
                       # route a production drag to canary; a dry run losing its pin is


### PR DESCRIPTION
## Summary

`resolve-channel` (added by ag-dev-prompts#815, the channel-pin feature) reads
the `channel-canary` label off the AITGH ticket by hitting
`$JIRA_SITE_URL/rest/api/3/issue/...` directly with Basic auth. A scoped Jira
API token is rejected on that classic site host and only authenticates
through the `api.atlassian.com/ex/jira/{cloudId}` gateway — the pipeline's own
`executors/jira.ts` already documents and avoids exactly this. The result:
every real drag since the JIRA rule stopped sending an explicit `channel`
gets a 404 on the label read and silently falls back to `latest`, regardless
of whether the ticket actually carries `channel-canary`.

Confirmed live in the job logs — same 404 on both AITGH-28's resume
(2026-08-14T11:11:49Z) and AITGH-29's resume (2026-08-17T09:45:01Z):

```
curl: (22) The requested URL returned error: 404
::warning::could not read labels for AITGH-29 — falling back to latest
```

The fail-safe made this silent rather than harmful (falling back to
`latest` is the safe direction for real production tickets), but the pin
itself has been a no-op since go-live — every canary-pinned dry-run ticket
would resolve to `latest` on a drag instead of the channel it was actually
triaged under.

## Fix

Resolve the cloudId first via the unauthenticated `_edge/tenant_info`
lookup — the same call the pipeline's own `resolveCloudId()` (in
`_shared.ts`) already makes — then hit the gateway host instead of the site
host for the label read. Verified the tenant_info call directly:

```
$ curl -sS "https://ag-grid.atlassian.net/_edge/tenant_info"
{"cloudId":"1565837d-d6d1-4228-bcb2-4cb74df700f2"}
```

## Test plan

- [ ] Re-run `stage=resume` (or wait for the next real drag) and confirm the
      `resolve-channel` job log shows `resolved channel: canary
      (channel-canary pin present)` for a ticket carrying the label, instead
      of the 404 fallback.
