### PR TITLE
Send an identifying User-Agent on build-time fetches to the live sites

### DIFF
--- a/documentation/ag-grid-docs/src/utils/robotsTxt.test.ts
+++ b/documentation/ag-grid-docs/src/utils/robotsTxt.test.ts
@@ -1,4 +1,7 @@
-import { AI_CRAWLERS, productionRobotsTxt } from './robotsTxt';
+import { BUILD_USER_AGENT } from '@ag-website-shared/constants';
+import { vi } from 'vitest';
+
+import { AI_CRAWLERS, fetchRobotsDisallow, productionRobotsTxt } from './robotsTxt';
 
 // Representative Allow/Disallow paths, mirroring what the route feeds in production.
 const ALLOW_PATHS = ['/campaigns/bryntum-gantt/'];
@@ -91,5 +94,49 @@ describe('productionRobotsTxt — AI-crawler position (SE-78)', () => {
         expect(userAgentGroups).toHaveLength(2);
         expect(txt).toContain('Sitemap: ');
         expect(txt).toContain('sitemap-index.xml');
+    });
+});
+
+describe('fetchRobotsDisallow', () => {
+    const CHARTS_URL = 'https://www.ag-grid.com/charts/robots-disallow.json';
+    const STUDIO_URL = 'https://www.ag-grid.com/studio/robots-disallow.json';
+
+    const okResponse = (paths: string[]) => ({ ok: true, json: async () => paths });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        vi.unstubAllGlobals();
+    });
+
+    test('identifies the build in the User-Agent', async () => {
+        const fetchMock = vi.fn().mockResolvedValue(okResponse([]));
+        vi.stubGlobal('fetch', fetchMock);
+
+        await fetchRobotsDisallow([CHARTS_URL]);
+
+        expect(fetchMock).toHaveBeenCalledWith(CHARTS_URL, { headers: { 'User-Agent': BUILD_USER_AGENT } });
+    });
+
+    test('flattens the disallow paths of every url into one list', async () => {
+        vi.stubGlobal(
+            'fetch',
+            vi.fn(async (url: string) =>
+                url === CHARTS_URL ? okResponse(['/charts/debug/']) : okResponse(['/studio/examples/'])
+            )
+        );
+
+        await expect(fetchRobotsDisallow([CHARTS_URL, STUDIO_URL])).resolves.toEqual([
+            '/charts/debug/',
+            '/studio/examples/',
+        ]);
+    });
+
+    test('rejects on a failed request rather than silently dropping its disallow paths', async () => {
+        vi.spyOn(console, 'error').mockImplementation(() => {});
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, statusText: 'Service Unavailable' }));
+
+        await expect(fetchRobotsDisallow([CHARTS_URL])).rejects.toThrow(
+            `Failed to fetch ${CHARTS_URL}: Service Unavailable`
+        );
     });
 });

--- a/documentation/ag-grid-docs/src/utils/robotsTxt.ts
+++ b/documentation/ag-grid-docs/src/utils/robotsTxt.ts
@@ -1,3 +1,4 @@
+import { BUILD_USER_AGENT } from '@ag-website-shared/constants';
 import { SITE_URL } from '@constants';
 
 import { pathJoin } from './pathJoin';
@@ -82,7 +83,7 @@ Sitemap: ${pathJoin(SITE_URL, urlWithBaseUrl('/sitemap-index.xml'))}
 
 export const fetchRobotsDisallow = async (urls: string[]) => {
     const fetches = urls.map((url) =>
-        fetch(url)
+        fetch(url, { headers: { 'User-Agent': BUILD_USER_AGENT } })
             .then((response) => {
                 if (!response.ok) {
                     throw new Error(`Failed to fetch ${url}: ${response.statusText}`);

--- a/external/ag-website-shared/src/constants.ts
+++ b/external/ag-website-shared/src/constants.ts
@@ -78,6 +78,12 @@ export const STUDIO_FORM_DATA = {
 // Relative to website folder
 export const SITEMAP_CACHE_DIR = '.astro/cache/sitemap';
 
+/**
+ * `User-Agent` identifying build-time fetches against the live AG sites (sitemaps, robots disallow
+ * lists), which are not served to the default agent.
+ */
+export const BUILD_USER_AGENT = 'Mozilla/5.0 (compatible; ag-website-build)';
+
 export const PRIVACY_POLICY_URL = 'https://www.ag-grid.com/privacy';
 
 // Figma

--- a/external/ag-website-shared/src/utils/getSitemapXml.test.ts
+++ b/external/ag-website-shared/src/utils/getSitemapXml.test.ts
@@ -1,0 +1,44 @@
+import { vi } from 'vitest';
+
+import { BUILD_USER_AGENT } from '../constants';
+import { getSitemapXml } from './getSitemapXml';
+
+const SITEMAP_URL = 'https://www.ag-grid.com/sitemap-0.xml';
+const SITEMAP_XML = '<urlset><url><loc>https://www.ag-grid.com/</loc></url></urlset>';
+// A cache folder that does not exist, so every case here takes the "fetch from the live site" path
+// — the one a production build hits after `--clean-cache=true`.
+const MISSING_CACHE_DIR = '.astro/cache/sitemap-does-not-exist';
+
+const logger = { info: vi.fn(), warn: vi.fn(), log: vi.fn() };
+
+const fetchSitemap = () =>
+    getSitemapXml({ cacheDir: MISSING_CACHE_DIR, sitemapUrl: SITEMAP_URL, logger, gitHash: 'test-hash' });
+
+describe('getSitemapXml', () => {
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    test('identifies the build in the User-Agent', async () => {
+        const fetchMock = vi.fn().mockResolvedValue({ ok: true, text: async () => SITEMAP_XML });
+        vi.stubGlobal('fetch', fetchMock);
+
+        await expect(fetchSitemap()).resolves.toBe(SITEMAP_XML);
+
+        expect(fetchMock).toHaveBeenCalledWith(SITEMAP_URL, { headers: { 'User-Agent': BUILD_USER_AGENT } });
+    });
+
+    test('throws on a failed request rather than using the error page as the sitemap', async () => {
+        vi.stubGlobal(
+            'fetch',
+            vi.fn().mockResolvedValue({
+                ok: false,
+                status: 503,
+                statusText: 'Service Unavailable',
+                text: async () => '<html><h1>ERROR</h1></html>',
+            })
+        );
+
+        await expect(fetchSitemap()).rejects.toThrow(`Failed to fetch sitemap ${SITEMAP_URL}: 503 Service Unavailable`);
+    });
+});

--- a/external/ag-website-shared/src/utils/getSitemapXml.ts
+++ b/external/ag-website-shared/src/utils/getSitemapXml.ts
@@ -1,6 +1,7 @@
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 
+import { BUILD_USER_AGENT } from '../constants';
 import { getGitHash } from './gitUtils';
 
 type Logger = Pick<Console, 'info' | 'warn' | 'log'>;
@@ -55,7 +56,12 @@ export const getSitemapXml = async ({
     }
 
     if (xmlSitemap == null) {
-        const response = await fetch(sitemapUrl);
+        const response = await fetch(sitemapUrl, { headers: { 'User-Agent': BUILD_USER_AGENT } });
+        if (!response.ok) {
+            // Without this the error response body is used as the sitemap, silently producing a
+            // broken `/sitemap` page instead of failing the build.
+            throw new Error(`Failed to fetch sitemap ${sitemapUrl}: ${response.status} ${response.statusText}`);
+        }
         xmlSitemap = await response.text();
         logger.log(`⚠️ No cached sitemap found, fetched from live site: ${sitemapUrl}`);
     }


### PR DESCRIPTION
## Problem

`nx run ag-grid-docs:preview:production` (and `nx build ag-grid-docs -c production`) fails during the build while generating `robots.txt`: the requests for the charts/studio disallow lists go out with Node's default agent and are not served.

Production builds are the only ones that take this path — `src/pages/robots.txt.ts` only fetches those lists when `getIsProduction()` is true, and staging builds fall into `disallowAll`.

## Changes

- **`BUILD_USER_AGENT`** added to `@ag-website-shared/constants` — it lives in the shared subrepo because both affected fetches do the same thing from different packages.
- **`fetchRobotsDisallow`** (`robotsTxt.ts`) sends it — this is the reported failure.
- **`getSitemapXml`** (`ag-website-shared`) sends it too, and now **throws on a non-ok response**. It fetches `LIVE_SITEMAP_URL` (`https://www.ag-grid.com/sitemap-0.xml` in production) on a cold cache with no `ok` check, so an error response body was being used as the sitemap and written into the `/sitemap` page. `-c production` passes `--clean-cache=true --run-second-build=true`, so the first build always hit this and only the second build's cache hid it. It failed silently where `robots.txt` failed loudly.

## Testing

- `robotsTxt.test.ts` — extended with a `fetchRobotsDisallow` suite: the header is sent, disallow lists from multiple URLs are flattened, and a failed request rejects rather than silently dropping that site's disallow paths.
- `getSitemapXml.test.ts` — new suite covering the cache-miss path: the header is sent, and a failed response throws instead of returning the error page as the sitemap.
- Both suites confirmed red against the unpatched source before the fix.
- Verified against the real endpoints: `/charts/robots-disallow.json`, `/studio/robots-disallow.json` and `/sitemap-0.xml` all fetch successfully with the change and fail without it.
- `./checks.sh` passes.

## Notes

- `yarn nx dev` takes the same fetch path (`getIsDev()` is also true in `robots.txt.ts`), so this fixes `/robots.txt` locally as well — it just failed per-request there instead of failing the build.
- Pointing the URLs at staging is not an option: `charts-staging`/`studio-staging` return 404 for `robots-disallow.json`; only the localhost charts/studio dev servers serve them (the commented-out lines in `.env.dev`).
- Failing soft on the fetch was rejected — it would risk silently shipping a production `robots.txt` missing the charts/studio disallow entries.
- `getSitemapXml.ts` and `constants.ts` are in `external/ag-website-shared`, shared with the charts and studio repos.
