### PR TITLE
AG-3390 Self-host the docs fonts from @fontsource

### DIFF
--- a/documentation/ag-grid-docs/astro.config.mjs
+++ b/documentation/ag-grid-docs/astro.config.mjs
@@ -182,20 +182,55 @@ const httpsEnabled = !['0', 'false'].includes(PUBLIC_HTTPS_SERVER);
 
 // https://astro.build/config
 export default defineConfig({
+    /**
+     * Site fonts, resolved from the installed `@fontsource-variable` packages rather than
+     * `fontProviders.google()`.
+     *
+     * The Google provider resolves a `fonts.gstatic.com` URL at build time and downloads it
+     * with no retry. Google periodically re-cuts those files without bumping the version in
+     * the URL, and stale CSS lingering on some edge nodes then hands out filenames gstatic
+     * has already deleted - a 404 that fails the whole docs build. Resolving from
+     * node_modules removes the build-time network call entirely and pins the files to the
+     * lockfile.
+     *
+     * Each family ships as one variable woff2, declared at the SAME discrete weights the
+     * Google provider declared (sans 400/500/700, mono 400/700) rather than at the file's
+     * full variable range. That is deliberate: CSS matches a requested weight to the nearest
+     * declared one, so the ~58 `font-weight: 600` call sites in the docs currently resolve to
+     * 700. Exposing the continuous range would let them resolve to a true 600 and lighten
+     * text across the site - a typography change, which does not belong in a build fix.
+     * Widening these to a range is a deliberate follow-up, not a free win.
+     *
+     * No `unicodeRange` here, unlike the faces the Google provider emitted. That descriptor
+     * exists to let a browser skip downloading a subset it has no characters for, which needs
+     * more than one subset to mean anything - there is a single latin file per family, it is
+     * preloaded from Layout.astro regardless, and its coverage is exactly the range fontsource
+     * declares for it. Anything outside that range falls back per glyph either way.
+     */
     fonts: [
         {
-            provider: fontProviders.google(),
+            provider: fontProviders.local(),
             name: 'IBM Plex Sans',
             cssVariable: '--font-ibm-plex-sans',
-            weights: ['400', '500', '700'],
-            styles: ['normal'],
+            options: {
+                variants: [400, 500, 700].map((weight) => ({
+                    weight,
+                    style: 'normal',
+                    src: ['@fontsource-variable/ibm-plex-sans/files/ibm-plex-sans-latin-wght-normal.woff2'],
+                })),
+            },
         },
         {
-            provider: fontProviders.google(),
+            provider: fontProviders.local(),
             name: 'JetBrains Mono',
             cssVariable: '--font-jetbrains-mono',
-            weights: ['400', '700'],
-            styles: ['normal'],
+            options: {
+                variants: [400, 700].map((weight) => ({
+                    weight,
+                    style: 'normal',
+                    src: ['@fontsource-variable/jetbrains-mono/files/jetbrains-mono-latin-wght-normal.woff2'],
+                })),
+            },
         },
     ],
     site: PUBLIC_SITE_URL,

--- a/documentation/ag-grid-docs/package.json
+++ b/documentation/ag-grid-docs/package.json
@@ -95,6 +95,8 @@
     "vue": "^3.5.13"
   },
   "devDependencies": {
+    "@fontsource-variable/ibm-plex-sans": "^5.3.0",
+    "@fontsource-variable/jetbrains-mono": "^5.3.0",
     "@fontsource/ibm-plex-sans": "^5.3.0",
     "@playwright/test": "^1.59.1",
     "@trivago/prettier-plugin-sort-imports": "^6.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3256,6 +3256,16 @@
   resolved "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz#a269e055e40e2f45873bae9d1a2fdccbd314ea3f"
   integrity sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==
 
+"@fontsource-variable/ibm-plex-sans@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@fontsource-variable/ibm-plex-sans/-/ibm-plex-sans-5.3.0.tgz#61ed443b8f904720fb28049370dc201e152f3ed5"
+  integrity sha512-agG8tXFEo0hD9+J7npa4vbbWult52eMLVaQ6WQRlhs/iCAojrMAoejru85W9HTVXHfyUj96KM7gp/KGAS87XaQ==
+
+"@fontsource-variable/jetbrains-mono@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@fontsource-variable/jetbrains-mono/-/jetbrains-mono-5.3.0.tgz#5738dedd3af40606b0d9b7626f4ba7c4586cb39b"
+  integrity sha512-F32xpS2NsGYoQi2ADSkKTgpJj7ozajsGgDJ8woTnqjmIB+dxDIqImjl4pXZVEExu8UFZ2ndhmX18EBS/hdz3Lw==
+
 "@fontsource/ibm-plex-sans@^5.3.0":
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/@fontsource/ibm-plex-sans/-/ibm-plex-sans-5.3.0.tgz#8099950b404e625f65e7bd833bcb84ffe6bcd40c"
@@ -22148,16 +22158,7 @@ string-split-by@^1.0.0:
   dependencies:
     parenthesis "^3.1.5"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -22270,7 +22271,7 @@ stringify-entities@^4.0.0:
     character-entities-html4 "^2.0.0"
     character-entities-legacy "^3.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -22283,13 +22284,6 @@ strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1, strip-ansi@^7.1.0:
   version "7.1.2"
@@ -24591,7 +24585,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -24613,15 +24607,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
Port of https://github.com/ag-grid/ag-studio/pull/2411 (AS-1169) to grid, after confirming grid hits the same fault.

## The failure

`fontProviders.google()` resolves a `fonts.gstatic.com` URL at build time and downloads it with no retry. Google periodically re-cuts those files without bumping the version in the URL, and stale CSS lingering on some edge nodes then hands out filenames gstatic has already deleted — a 404 that fails the whole docs build:

```
[CannotFetchFontFile] [astro:fonts] An error occurred while fetching the font file
from https://fonts.gstatic.com/s/ibmplexsans/v23/zYXZ…
  Hint: This is often caused by connectivity issues.
```

It has already hit **both** families the site uses:

| Run | Date | Family |
| --- | --- | --- |
| [31507101912](https://github.com/ag-grid/ag-grid/actions/runs/31507101912) | 2026-08-11 | JetBrains Mono |
| [32036811141](https://github.com/ag-grid/ag-grid/actions/runs/32036811141) | 2026-08-17 | IBM Plex Sans |

Both failed the **Docs Build & Link Checker** job, which runs on any non-draft PR touching code or docs — so the exposure is broad, not a niche path. Found by scanning all 56 failed `CI` / `Documentation Tests` runs since 2026-08-04; the same scan against ag-studio (where the fault is known) returned 8 of 28, which is how I checked the search wasn't producing false negatives.

## The change

Resolve both families from the installed `@fontsource-variable` packages, which removes the build-time network call entirely and pins the files to the lockfile.

**Rendering is unchanged, deliberately.** Each family ships as one variable woff2 but is declared at the same discrete weights the Google provider declares — sans 400/500/700, mono 400/700.

That matters: CSS matches a requested weight to the nearest *declared* one, so declaring the file's full variable range would not be a simplification but a typography change. The docs request weights the current config never ships:

```
 58  font-weight: 600     ← resolves to 700 today
  1  font-weight: 300     ← resolves to 400 today
  1  font-weight: 800
142  font-weight: bold    (= 700)
137  font-weight: 400
 74  font-weight: 500
```

Under a continuous range those 58 call sites would start resolving to a true, lighter 600 — a site-wide shift that does not belong in a build fix. Widening the ranges is worth doing as its own PR with a visual pass, since those call sites have never actually rendered at 600.

## One intentional difference from the old output

The faces do **not** carry the `unicode-range` the Google provider emitted. That descriptor exists to let a browser skip downloading a subset it has no characters for, which requires more than one subset to mean anything:

- there is a single latin file per family, so there is no second subset to skip;
- it is preloaded from `Layout.astro:226-227` regardless, so nothing is saved;
- its coverage is exactly the range fontsource declares for it, so anything outside falls back per glyph either way.

Carrying it would have meant ~24 lines of config for an inert descriptor.

## Verification

Diffed the built output against what staging serves today, normalising the per-build family and file hashes:

```
as-is           : differ
ignoring u-range: identical
faces: deployed=10 new=10
blocks differing as-is: 5   (exactly the 5 real faces that carried unicode-range)
```

So: same weights, same two woff2 files shared across weights, same fallback metric overrides (`size-adjust`, `ascent-override`, …) — identical descriptor for descriptor apart from the deliberately-dropped `unicode-range`, and the blocks that differ are precisely the ones that carried it.

Plus:
- **Full docs build: exit 0.** No `gstatic` or `CannotFetchFontFile` anywhere in the log.
- Two woff2 emitted to `dist/_astro/fonts/` at 48K and 40K, byte-matching the source packages.
- `grep -c fonts.gstatic.com dist/index.html` → **0**.
- Prettier clean.

## Deliberately out of scope

**The CSP is untouched.** `fonts.googleapis.com` in `style-src` and `fonts.gstatic.com` in `font-src` remain load-bearing — the example runner (`ExampleStyle.astro`), the docs-e2e font mirror (`localFonts.ts`) and two campaign pages still request Google Fonts. Only ordinary site pages stop reaching for them, so tightening the policy needs those three dealt with first.

`@fontsource/ibm-plex-sans` (the static package) stays too: it feeds `localFonts.ts`, which inlines faces into intercepted Google Fonts stylesheets so example grids don't auto-size columns against fallback metrics. Unrelated to the build-time provider.

## Note on the lockfile

Alongside the two pinned additions, the `yarn.lock` diff collapses the `string-width-cjs` / `strip-ansi-cjs` / `wrap-ansi-cjs` alias entries into their plain keys. That's yarn v1 normalisation from running an install — the entries are merged with identical resolutions, nothing added or dropped. Happy to revert that hunk if you'd rather keep the diff to two lines.

## Separately worth a look

While scanning I found a different, genuine font flakiness in the e2e suite: 20–22 instances across two failing `Documentation Tests` runs of

```
Not mirrored, so these went to the network:
 - https://fonts.gstatic.com/s/ibmplexsans/v23/…woff2
   requested by .../examples/row-pagination/custom-controls/angular/
```

`localFonts.ts` didn't cover those requests, so they hit the real network — a font race that can change measured column widths. Not addressed here.