### PR TITLE
Skip JIRA mention comment for AI workflow PRs

### DIFF
--- a/.github/workflows/gh-comment-hook.yml
+++ b/.github/workflows/gh-comment-hook.yml
@@ -39,6 +39,7 @@ jobs:
           PR_ID: ${{ github.event.pull_request.number }}
           PR_URL: ${{ github.event.pull_request.html_url }}
           PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
           EVENT_ACTION: ${{ github.event.action }}
           JIRA_API_AUTH: ${{ secrets.JIRA_API_AUTH }}
           JOB_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
@@ -52,6 +53,7 @@ jobs:
             const pr_url = process.env.PR_URL;
             const pr_title = process.env.PR_TITLE;
             const eventAction = process.env.EVENT_ACTION;
+            const headRef = process.env.PR_HEAD_REF || '';
 
             // Expand bare JIRA ticket mentions (#AG-XXXX) into markdown links
             const body = old_body.replace(/#((AG|RTI)-\d{3,})/g, `[$1](https://ag-grid.atlassian.net/browse/$1)`);
@@ -64,6 +66,13 @@ jobs:
             // after opening). The per-PR sentinel dedup below prevents duplicate comments.
             if (eventAction !== 'opened' && eventAction !== 'edited') return;
             if (!process.env.JIRA_API_AUTH) return;
+
+            // AI Workflow Delivery PRs post their own JIRA comment once the run is
+            // actually ready for review, so skip the generic mention comment here.
+            if (headRef.startsWith('ghabot-ag-')) {
+                console.log(`Skipping JIRA mention comment for AI workflow PR (branch ${headRef}).`);
+                return;
+            }
 
             const { addJiraComment, getJiraIssueComments } =
                 require('./scripts/ci/_utils.mjs');


### PR DESCRIPTION
AI Workflow Delivery PRs (branches matching `ghabot-ag-*`) post their own JIRA comment when the run is actually ready for review, so the generic "This issue was mentioned in PR #N" comment posted by `gh-comment-hook` on PR open/edit is just noise on the ticket.

This skips only that comment. The `#AG-XXXX` → markdown link expansion of the PR body still runs, and the merge-time comment/transition in `update-jira-ticket.yml` is untouched.

Detection is by head-branch prefix, matching what `ci.yml` and `jira-agent-pipeline.yml` already key off, rather than by actor (the pipeline's PR author identity varies).