### PR TITLE
AG-18233 + AG-14491 advanced filters fixes

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/filter-advanced/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/filter-advanced/index.mdoc
@@ -144,6 +144,7 @@ For `text` and `object` Cell Data Types, `caseSensitive = true` can be set to en
 For `number`, `date`, `dateString`, `dateTime` and `dateTimeString` Cell Data Types, the following properties can be set to include blank values for the relevant options:
 
 - `includeBlanksInEquals = true`
+- `includeBlanksInNotEqual = true`
 - `includeBlanksInLessThan = true`
 - `includeBlanksInGreaterThan = true`
 

--- a/packages/ag-grid-enterprise/src/advancedFilter/advancedFilterExpressionService.ts
+++ b/packages/ag-grid-enterprise/src/advancedFilter/advancedFilterExpressionService.ts
@@ -1,4 +1,11 @@
-import { _exists, _parseBigIntOrNull, _parseDateTimeFromString, _serialiseDate, _toStringOrNull } from 'ag-stack';
+import {
+    _exists,
+    _hasOwn,
+    _parseBigIntOrNull,
+    _parseDateTimeFromString,
+    _serialiseDate,
+    _toStringOrNull,
+} from 'ag-stack';
 
 import type {
     AgColumn,
@@ -30,6 +37,15 @@ import {
     TextFilterExpressionOperators,
 } from './filterExpressionOperators';
 import { getBigIntParser } from './filterExpressionUtils';
+
+/** The `filterParams` an Advanced Filter evaluator honours; the rest are column-filter UI concerns. */
+const COPIED_FILTER_PARAMS: (keyof FilterExpressionEvaluatorParams<any>)[] = [
+    'caseSensitive',
+    'includeBlanksInEquals',
+    'includeBlanksInNotEqual',
+    'includeBlanksInLessThan',
+    'includeBlanksInGreaterThan',
+];
 
 export class AdvancedFilterExpressionService extends BeanStub implements NamedBean {
     beanName = 'advFilterExpSvc' as const;
@@ -269,9 +285,16 @@ export class AdvancedFilterExpressionService extends BeanStub implements NamedBe
         return entries;
     }
 
-    public getOperatorAutocompleteEntries(column: AgColumn, baseCellDataType: BaseCellDataType): AutocompleteEntry[] {
-        const activeOperators = this.getActiveOperators(column);
-        return this.getDataTypeExpressionOperator(baseCellDataType)!.getEntries(activeOperators);
+    /** The options the column offers: those of the data type that `filterParams.filterOptions` names, or all. */
+    public getOperatorAutocompleteEntries(
+        column: AgColumn | null | undefined,
+        baseCellDataType?: BaseCellDataType
+    ): AutocompleteEntry[] {
+        const operatorForType = this.getDataTypeExpressionOperator(baseCellDataType);
+        if (!operatorForType) {
+            return [];
+        }
+        return operatorForType.getEntries(column ? this.getActiveOperators(column) : undefined);
     }
 
     public getJoinOperatorAutocompleteEntries(): AutocompleteEntry[] {
@@ -293,7 +316,9 @@ export class AdvancedFilterExpressionService extends BeanStub implements NamedBe
         baseCellDataType?: BaseCellDataType,
         operator?: string
     ): FilterExpressionOperator<any> | undefined {
-        return this.getDataTypeExpressionOperator(baseCellDataType)?.operators?.[operator!];
+        const operators = this.getDataTypeExpressionOperator(baseCellDataType)?.operators;
+        // A model `type` such as `toString` must not resolve to an inherited member.
+        return operators && _hasOwn(operators, operator!) ? operators[operator!] : undefined;
     }
 
     public getExpressionJoinOperators(): { AND: string; OR: string } {
@@ -364,14 +389,13 @@ export class AdvancedFilterExpressionService extends BeanStub implements NamedBe
         }
         const { filterParams } = column.colDef;
         if (filterParams) {
-            ['caseSensitive', 'includeBlanksInEquals', 'includeBlanksInLessThan', 'includeBlanksInGreaterThan'].forEach(
-                (param: keyof FilterExpressionEvaluatorParams<ConvertedTValue, TValue>) => {
-                    const paramValue = filterParams[param];
-                    if (paramValue) {
-                        params[param] = paramValue;
-                    }
+            for (let i = 0, len = COPIED_FILTER_PARAMS.length; i < len; ++i) {
+                const param = COPIED_FILTER_PARAMS[i];
+                const paramValue = filterParams[param];
+                if (paramValue) {
+                    params[param] = paramValue;
                 }
-            );
+            }
         }
         this.expressionEvaluatorParams[colId] = params;
 

--- a/packages/ag-grid-enterprise/src/advancedFilter/colFilterExpressionParser.ts
+++ b/packages/ag-grid-enterprise/src/advancedFilter/colFilterExpressionParser.ts
@@ -116,29 +116,32 @@ class OperatorParser implements Parser {
     public expectedNumOperands: number = 0;
     private operator: string = '';
     private parsedOperator: string;
+    /** Last character of the resolved name; set once the region is settled. */
+    private matchEndPosition: number | undefined;
 
     constructor(
         private readonly params: FilterExpressionParserParams,
         public readonly startPosition: number,
-        private readonly baseCellDataType: BaseCellDataType
+        private readonly baseCellDataType: BaseCellDataType,
+        private readonly column: AgColumn | null | undefined
     ) {}
 
     public parse(char: string, position: number): boolean | undefined {
-        if (char === ' ' || char === ')') {
-            const isMatch = this.parseOperator(false, position - 1);
-            if (isMatch) {
-                return true;
-            } else {
+        if (this.matchEndPosition == null) {
+            const isTerminator = char === ' ' || char === ')';
+            if (!isTerminator || !this.parseOperator(false, position - 1)) {
                 this.operator += char;
+                return undefined;
             }
-        } else {
-            this.operator += char;
         }
-        return undefined;
+        // A resolved name may run past the terminator that settled it, so the rest of it is consumed as read.
+        return position <= this.matchEndPosition! ? undefined : true;
     }
 
     public complete(position: number): void {
-        this.parseOperator(true, position);
+        if (this.matchEndPosition == null) {
+            this.parseOperator(true, position);
+        }
     }
 
     public getValidationError(): FilterExpressionValidationError | null {
@@ -159,25 +162,69 @@ class OperatorParser implements Parser {
         return this.parsedOperator;
     }
 
+    /**
+     * Greedy, over the options the column offers: the longest name spelled here wins, so one that another name
+     * starts with - or one containing a terminator - resolves.
+     */
     private parseOperator(fromComplete: boolean, endPosition: number): boolean {
-        const operatorForType = this.params.advFilterExpSvc.getDataTypeExpressionOperator(this.baseCellDataType)!;
-        const parsedOperator = operatorForType.findOperator(this.operator);
+        const { params, startPosition } = this;
+        const expression = params.expression;
+        const advFilterExpSvc = params.advFilterExpSvc;
+        const entries = advFilterExpSvc.getOperatorAutocompleteEntries(this.column, this.baseCellDataType);
         this.endPosition = endPosition;
-        if (parsedOperator) {
-            this.parsedOperator = parsedOperator;
-            const operator = operatorForType.operators[parsedOperator];
+
+        const minLength = endPosition - startPosition + 1;
+        const partialSearchValue = expression.slice(startPosition, endPosition + 1).toLocaleLowerCase() + ' ';
+        let matchedOperator: string | undefined;
+        let matchedLength = 0;
+        let isPartialMatch = false;
+        for (let i = 0, len = entries.length; i < len; ++i) {
+            const entry = entries[i];
+            const displayValue = (entry.displayValue ?? '').toLocaleLowerCase();
+            if (
+                displayValue.length > matchedLength &&
+                displayValue.length >= minLength &&
+                isNameAt(expression, startPosition, displayValue)
+            ) {
+                matchedOperator = entry.key;
+                matchedLength = displayValue.length;
+            }
+            if (displayValue.startsWith(partialSearchValue)) {
+                isPartialMatch = true;
+            }
+        }
+
+        if (matchedOperator) {
+            const matchEndPosition = startPosition + matchedLength - 1;
+            this.parsedOperator = matchedOperator;
+            this.endPosition = matchEndPosition;
+            this.matchEndPosition = matchEndPosition;
+            const operator = advFilterExpSvc.getExpressionOperator(this.baseCellDataType, matchedOperator)!;
             this.expectedNumOperands = operator.numOperands;
             const operatorDisplayValue = operator.displayValue;
-            checkAndUpdateExpression(this.params, this.operator, operatorDisplayValue, endPosition);
+            const userValue = expression.slice(startPosition, matchEndPosition + 1);
+            checkAndUpdateExpression(params, userValue, operatorDisplayValue, matchEndPosition);
             this.operator = operatorDisplayValue;
             return true;
         }
-        const isPartialMatch = parsedOperator === null;
         if (fromComplete || !isPartialMatch) {
             this.valid = false;
         }
         return false;
     }
+}
+
+/**
+ * A name only resolves where a terminator or the expression end follows it: were it allowed to run into the
+ * next character, the caller would drop that character and the text would name an option it does not spell.
+ */
+function isNameAt(expression: string, startPosition: number, lowerCaseDisplayValue: string): boolean {
+    const endPosition = startPosition + lowerCaseDisplayValue.length;
+    const nextChar = expression[endPosition];
+    return (
+        (nextChar === undefined || nextChar === ' ' || nextChar === ')') &&
+        expression.slice(startPosition, endPosition).toLocaleLowerCase() === lowerCaseDisplayValue
+    );
 }
 
 class OperandParser implements Parser {
@@ -360,7 +407,12 @@ export class ColFilterExpressionParser {
                         this.columnParser = new ColumnParser(this.params, i);
                         parser = this.columnParser;
                     } else if (!this.operatorParser) {
-                        this.operatorParser = new OperatorParser(this.params, i, this.columnParser.baseCellDataType);
+                        this.operatorParser = new OperatorParser(
+                            this.params,
+                            i,
+                            this.columnParser.baseCellDataType,
+                            this.columnParser.column
+                        );
                         parser = this.operatorParser;
                     } else {
                         this.operandParser = new OperandParser(

--- a/packages/ag-grid-enterprise/src/advancedFilter/colFilterExpressionParser.ts
+++ b/packages/ag-grid-enterprise/src/advancedFilter/colFilterExpressionParser.ts
@@ -180,16 +180,18 @@ class OperatorParser implements Parser {
         let isPartialMatch = false;
         for (let i = 0, len = entries.length; i < len; ++i) {
             const entry = entries[i];
-            const displayValue = (entry.displayValue ?? '').toLocaleLowerCase();
+            const displayValue = entry.displayValue ?? '';
+            // Lengths come from the name as written: lower-casing can change them, `İ` becoming two units.
+            const lowerCaseDisplayValue = displayValue.toLocaleLowerCase();
             if (
                 displayValue.length > matchedLength &&
                 displayValue.length >= minLength &&
-                isNameAt(expression, startPosition, displayValue)
+                isNameAt(expression, startPosition, displayValue, lowerCaseDisplayValue)
             ) {
                 matchedOperator = entry.key;
                 matchedLength = displayValue.length;
             }
-            if (displayValue.startsWith(partialSearchValue)) {
+            if (lowerCaseDisplayValue.startsWith(partialSearchValue)) {
                 isPartialMatch = true;
             }
         }
@@ -218,8 +220,13 @@ class OperatorParser implements Parser {
  * A name only resolves where a terminator or the expression end follows it: were it allowed to run into the
  * next character, the caller would drop that character and the text would name an option it does not spell.
  */
-function isNameAt(expression: string, startPosition: number, lowerCaseDisplayValue: string): boolean {
-    const endPosition = startPosition + lowerCaseDisplayValue.length;
+function isNameAt(
+    expression: string,
+    startPosition: number,
+    displayValue: string,
+    lowerCaseDisplayValue: string
+): boolean {
+    const endPosition = startPosition + displayValue.length;
     const nextChar = expression[endPosition];
     return (
         (nextChar === undefined || nextChar === ' ' || nextChar === ')') &&

--- a/packages/ag-grid-enterprise/src/advancedFilter/filterExpressionOperators.ts
+++ b/packages/ag-grid-enterprise/src/advancedFilter/filterExpressionOperators.ts
@@ -8,6 +8,7 @@ import type { AutocompleteEntry } from './autocomplete/autocompleteParams';
 export interface FilterExpressionEvaluatorParams<ConvertedTValue, TValue = ConvertedTValue> {
     caseSensitive?: boolean;
     includeBlanksInEquals?: boolean;
+    includeBlanksInNotEqual?: boolean;
     includeBlanksInLessThan?: boolean;
     includeBlanksInGreaterThan?: boolean;
     valueConverter: (value: TValue, node: IRowNode) => ConvertedTValue;
@@ -32,7 +33,6 @@ export interface DataTypeFilterExpressionOperators<ConvertedTValue, TValue = Con
         [operator: string]: FilterExpressionOperator<ConvertedTValue, TValue>;
     };
     getEntries(activeOperators?: string[]): AutocompleteEntry[];
-    findOperator(displayValue: string): string | null | undefined;
 }
 
 export abstract class FilterExpressionOperators implements Record<
@@ -113,10 +113,6 @@ export class TextFilterExpressionOperators<TValue = string> implements DataTypeF
 
     public getEntries(activeOperators?: string[]): AutocompleteEntry[] {
         return getEntries(this.operators, activeOperators);
-    }
-
-    public findOperator(displayValue: string): string | null | undefined {
-        return findMatch(displayValue, this.operators, ({ displayValue }) => displayValue);
     }
 
     private initOperators(): void {
@@ -206,10 +202,6 @@ export class ScalarFilterExpressionOperators<
         return getEntries(this.operators, activeOperators);
     }
 
-    public findOperator(displayValue: string): string | null | undefined {
-        return findMatch(displayValue, this.operators, ({ displayValue }) => displayValue);
-    }
-
     private initOperators(): void {
         const { translate, equals } = this.params;
         this.operators = {
@@ -234,8 +226,9 @@ export class ScalarFilterExpressionOperators<
                         node,
                         params,
                         operand1!,
-                        !!params.includeBlanksInEquals,
-                        (v, o) => !equals(v, o)
+                        !!params.includeBlanksInNotEqual,
+                        (v, o) => !equals(v, o),
+                        true
                     ),
                 numOperands: 1,
             },
@@ -310,12 +303,19 @@ export class ScalarFilterExpressionOperators<
         params: FilterExpressionEvaluatorParams<ConvertedTValue, TValue>,
         operand: ConvertedTValue,
         nullsMatch: boolean,
-        expression: (value: ConvertedTValue, operand: ConvertedTValue) => boolean
+        expression: (value: ConvertedTValue, operand: ConvertedTValue) => boolean,
+        isNegated?: boolean
     ): boolean {
         if (value == null) {
             return nullsMatch;
         }
-        return expression(params.valueConverter(value, node), operand);
+        const convertedValue = params.valueConverter(value, node);
+        // A value the data type cannot read is nothing to compare against, as the column filter's own validity
+        // gate decides: it matches no comparison, and so matches every negation of one.
+        if (convertedValue == null) {
+            return !!isNegated;
+        }
+        return expression(convertedValue, operand);
     }
 }
 
@@ -328,10 +328,6 @@ export class BooleanFilterExpressionOperators implements DataTypeFilterExpressio
 
     public getEntries(activeOperators?: string[]): AutocompleteEntry[] {
         return getEntries(this.operators, activeOperators);
-    }
-
-    public findOperator(displayValue: string): string | null | undefined {
-        return findMatch(displayValue, this.operators, ({ displayValue }) => displayValue);
     }
 
     private initOperators(): void {

--- a/testing/ag-test-utils/src/filters/advancedFilterBuilderHarness.ts
+++ b/testing/ag-test-utils/src/filters/advancedFilterBuilderHarness.ts
@@ -303,9 +303,10 @@ export class AdvancedFilterBuilderHarness {
         this.api.onFilterChanged();
         // Recreating the rows is the whole point of this helper, so poll until the rendered rows are
         // new element instances — the only signal that can distinguish a rebuild from the original render.
-        await waitFor(() => {
+        await waitFor(async () => {
             nudgeVirtualList('.ag-advanced-filter-builder-virtual-list-viewport');
             nudgeVirtualList('.ag-rich-select-virtual-list-viewport');
+            await asyncSetTimeout(0);
             const rowsNow = Array.from(document.querySelectorAll<HTMLElement>(ITEM_WRAPPER));
             if (rowsNow.length === 0 || rowsNow.some((row) => rowsBefore.includes(row))) {
                 throw new Error('builder item rows were not recreated');

--- a/testing/ag-test-utils/src/widgets/dropdowns.ts
+++ b/testing/ag-test-utils/src/widgets/dropdowns.ts
@@ -11,7 +11,11 @@ import { firePointerLikeClick } from '../test-utils-events';
 
 const RICH_SELECT_VIEWPORT = '.ag-rich-select-virtual-list-viewport';
 
-/** Nudges a VirtualList viewport so the grid re-runs drawVirtualRows against its (mocked) height. */
+/**
+ * Nudges a VirtualList viewport so the grid re-runs drawVirtualRows against its (mocked) height.
+ * A `waitFor` callback around a nudge that rebuilds rows must `await asyncSetTimeout(0)`, or it re-polls on
+ * that mutation as a microtask and starves its own deadline timer; a stable list re-renders nothing.
+ */
 export function nudgeVirtualList(selector: string, root: ParentNode = document): void {
     const el = root.querySelector<HTMLElement>(selector);
     if (el) {
@@ -66,10 +70,10 @@ export async function selectRichSelectRow(label: string, root: ParentNode = docu
     let rows: HTMLElement[] = [];
     let index = -1;
     // Polled on a time budget, not a tick count: the list mounts a macrotask after the click and a fixed
-    // number of ticks flakes under load. Nudging inside the callback is safe - `waitFor` arms an independent
-    // `setTimeout` for its deadline, so the mutations it observes only add polls.
-    await waitFor(() => {
+    // number of ticks flakes under load.
+    await waitFor(async () => {
         nudgeVirtualList(RICH_SELECT_VIEWPORT, root);
+        await asyncSetTimeout(0);
         rows = Array.from(root.querySelectorAll<HTMLElement>('.ag-rich-select-row'));
         index = rows.findIndex((r) => r.textContent?.trim() === label);
         if (index < 0) {

--- a/testing/behavioural/src/filters/advanced-filter-regression/af-options.test.ts
+++ b/testing/behavioural/src/filters/advanced-filter-regression/af-options.test.ts
@@ -11,6 +11,7 @@ import type { GridApi, GridOptions, IFilterOptionDef } from 'ag-grid-community';
 import {
     ClientSideRowModelModule,
     DateFilterModule,
+    LocaleModule,
     NumberFilterModule,
     TextFilterModule,
     enableDevValidations,
@@ -306,6 +307,22 @@ describe('Advanced Filter — currently-unsupported operators (baseline)', () =>
                 └── LEAF id:1 date:"2024-06-15"
             `);
         });
+
+        // A preset key names no AF option, so it can make none available: the list leaves only `equals`.
+        test('an operator absent from the preset list is not offered', async () => {
+            const api: GridApi = await gridsManager.createGridAndWait('grid1', OPTS);
+
+            await AdvancedFilterHarness.get(api).applyExpression('[Date] > "2024-03-01"');
+            await asyncSetTimeout(0);
+
+            await new FilterDom(api, 'preset column greaterThan not offered').checkFilterDom(`
+                ADVANCED FILTER
+                input: "[Date] > "2024-03-01""
+                valid: false — Expression has an error. Option not found - > "2024-03-01".
+                buttons: Apply ⊘ | Builder
+                model: null
+            `);
+        });
     });
 
     describe('inRange is not offered today', () => {
@@ -382,42 +399,122 @@ describe('Advanced Filter — currently-unsupported operators (baseline)', () =>
             `);
         });
     });
+});
 
-    describe('string filterOptions restrict autocomplete suggestions only, not the parser', () => {
-        const OPTS: GridOptions = {
+/** The docs promise `filterOptions` sets the options available to the Advanced Filter, not only its autocomplete. */
+describe('Advanced Filter — string filterOptions restrict the options', () => {
+    const gridsManager = new TestGridsManager({
+        modules: [
+            TextFilterModule,
+            NumberFilterModule,
+            DateFilterModule,
+            LocaleModule,
+            AdvancedFilterModule,
+            ClientSideRowModelModule,
+        ],
+    });
+
+    afterEach(() => gridsManager.reset());
+
+    function optionsWithNotContainsNamed(notContainsName?: string): GridOptions {
+        return {
             columnDefs: [{ field: 'name', filter: 'agTextColumnFilter', filterParams: { filterOptions: ['equals'] } }],
             rowData: [{ name: 'Bolt' }, { name: 'Ng' }],
             enableAdvancedFilter: true,
+            localeText: notContainsName ? { advancedFilterNotContains: notContainsName } : undefined,
         };
+    }
 
-        test('an operator outside the restricted list is still accepted by the parser', async () => {
-            const api: GridApi = await gridsManager.createGridAndWait('grid1', OPTS);
+    test('an option the list names parses', async () => {
+        const api: GridApi = await gridsManager.createGridAndWait('grid1', optionsWithNotContainsNamed());
 
-            // `contains` is a valid text operator but NOT in the column's restricted `filterOptions`.
-            // The restriction only trims the autocomplete suggestions — the parser still accepts it,
-            // so the expression applies. (Baseline for AG-10819: the operator set is not enforced.)
-            await AdvancedFilterHarness.get(api).applyExpression('[Name] contains "o"');
-            await asyncSetTimeout(0);
-            expect(api.getAdvancedFilterModel()).toEqual({
-                filterType: 'text',
-                colId: 'name',
-                type: 'contains',
-                filter: 'o',
-            });
-            await new GridRows(api, 'restricted-but-parsed operator applied').check(`
-                ROOT id:ROOT_NODE_ID
-                └── LEAF id:0 name:"Bolt"
-            `);
+        await AdvancedFilterHarness.get(api).applyExpression('[Name] equals "Bolt"');
+        await asyncSetTimeout(0);
 
-            await AdvancedFilterHarness.get(api).applyExpression('[Name] equals "Bolt"');
-            await asyncSetTimeout(0);
-            expect(api.getAdvancedFilterModel()).toEqual({
-                filterType: 'text',
-                colId: 'name',
-                type: 'equals',
-                filter: 'Bolt',
-            });
+        expect(api.getAdvancedFilterModel()).toEqual({
+            filterType: 'text',
+            colId: 'name',
+            type: 'equals',
+            filter: 'Bolt',
         });
+        await new GridRows(api, 'a named option').check(`
+            ROOT id:ROOT_NODE_ID
+            └── LEAF id:0 name:"Bolt"
+        `);
+    });
+
+    test('an option the list omits is not a known option', async () => {
+        const api: GridApi = await gridsManager.createGridAndWait('grid1', optionsWithNotContainsNamed());
+
+        await AdvancedFilterHarness.get(api).applyExpression('[Name] contains "o"');
+        await asyncSetTimeout(0);
+
+        await new FilterDom(api, 'an omitted option').checkFilterDom(`
+            ADVANCED FILTER
+            input: "[Name] contains "o""
+            valid: false — Expression has an error. Option not found - contains "o".
+            buttons: Apply ⊘ | Builder
+            model: null
+        `);
+    });
+
+    test('a model naming an option the list omits does not apply', async () => {
+        const api: GridApi = await gridsManager.createGridAndWait('grid1', optionsWithNotContainsNamed());
+
+        api.setAdvancedFilterModel({ filterType: 'text', colId: 'name', type: 'contains', filter: 'o' });
+        await asyncSetTimeout(0);
+
+        await new FilterDom(api, 'a model naming an omitted option').checkFilterDom(`
+            ADVANCED FILTER
+            input: "[Name] contains "o""
+            valid: false — Expression has an error. Option not found - contains "o".
+            buttons: Apply ⊘ | Builder
+            model: null
+        `);
+    });
+
+    test('an omitted longer name does not beat the shorter one it starts with', async () => {
+        const api: GridApi = await gridsManager.createGridAndWait('grid1', optionsWithNotContainsNamed('equals not'));
+
+        // `equals not` names the omitted `notContains`, so only `equals` is in the running: `not` becomes its
+        // operand and `"Bolt"` is left where a join operator belongs.
+        await AdvancedFilterHarness.get(api).applyExpression('[Name] equals not "Bolt"');
+        await asyncSetTimeout(0);
+
+        await new FilterDom(api, 'an omitted longer name').checkFilterDom(`
+            ADVANCED FILTER
+            input: "[Name] equals not "Bolt""
+            valid: false — Expression has an error. Join operator not found - "Bolt".
+            buttons: Apply ⊘ | Builder
+            model: null
+        `);
+    });
+
+    // Presets have no expression form yet, so a list of only presets names nothing the parser can offer.
+    test('a list naming no Advanced Filter option leaves the column unfilterable', async () => {
+        const api: GridApi = await gridsManager.createGridAndWait('grid1', {
+            columnDefs: [
+                {
+                    field: 'date',
+                    cellDataType: 'dateString',
+                    filter: 'agDateColumnFilter',
+                    filterParams: { filterOptions: ['today', 'yesterday'] },
+                },
+            ],
+            rowData: [{ date: '2024-01-01' }],
+            enableAdvancedFilter: true,
+        });
+
+        await AdvancedFilterHarness.get(api).applyExpression('[Date] = "2024-01-01"');
+        await asyncSetTimeout(0);
+
+        await new FilterDom(api, 'a list naming no AF option').checkFilterDom(`
+            ADVANCED FILTER
+            input: "[Date] = "2024-01-01""
+            valid: false — Expression has an error. Option not found - = "2024-01-01".
+            buttons: Apply ⊘ | Builder
+            model: null
+        `);
     });
 });
 

--- a/testing/behavioural/src/filters/advanced-filter-regression/af-parser.test.ts
+++ b/testing/behavioural/src/filters/advanced-filter-regression/af-parser.test.ts
@@ -589,6 +589,44 @@ describe('Advanced Filter — parser edge cases', () => {
         });
     });
 
+    describe('an operator name whose lowercase is longer than the name', () => {
+        const localeGridsManager = new TestGridsManager({
+            modules: [
+                TextFilterModule,
+                NumberFilterModule,
+                LocaleModule,
+                AdvancedFilterModule,
+                ClientSideRowModelModule,
+            ],
+        });
+
+        afterEach(() => localeGridsManager.reset());
+
+        // `İ` lowercases to two UTF-16 units, so the name is longer lowercased than as typed: a boundary
+        // taken from the lowercased form overruns the name and never matches what the text spells.
+        test('a name containing a dotted capital I parses', async () => {
+            const api = await localeGridsManager.createGridAndWait('grid1', {
+                ...OPTS,
+                localeText: { advancedFilterContains: 'İçerir' },
+            });
+            const af = AdvancedFilterHarness.get(api);
+
+            await af.applyExpression('[Athlete] İçerir "e"');
+            await asyncSetTimeout(0);
+
+            expect(api.getAdvancedFilterModel()).toEqual({
+                filterType: 'text',
+                colId: 'athlete',
+                type: 'contains',
+                filter: 'e',
+            });
+            await new GridRows(api, 'a dotted capital I in the name').check(`
+                ROOT id:ROOT_NODE_ID
+                └── LEAF id:2 athlete:"Wei" age:28 big:"10000000000000000001n"
+            `);
+        });
+    });
+
     describe('bigint operand', () => {
         test('a bigint literal beyond Number.MAX_SAFE_INTEGER filters exactly', async () => {
             const api = await gridsManager.createGridAndWait('grid1', OPTS);

--- a/testing/behavioural/src/filters/advanced-filter-regression/af-parser.test.ts
+++ b/testing/behavioural/src/filters/advanced-filter-regression/af-parser.test.ts
@@ -1,7 +1,13 @@
 import { AdvancedFilterHarness, FilterDom, GridRows, TestGridsManager, asyncSetTimeout } from 'ag-test-utils';
 
 import type { GridApi, GridOptions } from 'ag-grid-community';
-import { ClientSideRowModelModule, DateFilterModule, NumberFilterModule, TextFilterModule } from 'ag-grid-community';
+import {
+    ClientSideRowModelModule,
+    DateFilterModule,
+    LocaleModule,
+    NumberFilterModule,
+    TextFilterModule,
+} from 'ag-grid-community';
 import { AdvancedFilterModule } from 'ag-grid-enterprise';
 
 /**
@@ -405,6 +411,180 @@ describe('Advanced Filter — parser edge cases', () => {
                 ├── LEAF id:0 athlete:"Bolt" age:25 big:"10000000000000000001n"
                 ├── LEAF id:1 athlete:"Ng" age:40 big:"20000000000000000002n"
                 └── LEAF id:2 athlete:"Wei" age:28 big:"10000000000000000001n"
+            `);
+        });
+    });
+
+    describe('an operator name another one starts with', () => {
+        // Its own manager: `localeText` needs LocaleModule, and the names under test only exist through it.
+        const localeGridsManager = new TestGridsManager({
+            modules: [
+                TextFilterModule,
+                NumberFilterModule,
+                LocaleModule,
+                AdvancedFilterModule,
+                ClientSideRowModelModule,
+            ],
+        });
+
+        afterEach(() => localeGridsManager.reset());
+
+        function optionsWithNotContainsNamed(name: string): GridOptions<Row> {
+            return { ...OPTS, localeText: { advancedFilterNotContains: name } };
+        }
+
+        test('the longer name parses rather than the shorter one it starts with', async () => {
+            const api = await localeGridsManager.createGridAndWait(
+                'grid1',
+                optionsWithNotContainsNamed('contains not')
+            );
+            const af = AdvancedFilterHarness.get(api);
+
+            await af.applyExpression('[Athlete] contains not "e"');
+            await asyncSetTimeout(0);
+
+            expect(af.value).toBe('[Athlete] contains not "e"');
+            expect(api.getAdvancedFilterModel()).toEqual({
+                filterType: 'text',
+                colId: 'athlete',
+                type: 'notContains',
+                filter: 'e',
+            });
+            await new GridRows(api, 'the longer operator name').check(`
+                ROOT id:ROOT_NODE_ID
+                ├── LEAF id:0 athlete:"Bolt" age:25 big:"10000000000000000001n"
+                └── LEAF id:1 athlete:"Ng" age:40 big:"20000000000000000002n"
+            `);
+        });
+
+        test('the shorter name still parses on its own', async () => {
+            const api = await localeGridsManager.createGridAndWait(
+                'grid1',
+                optionsWithNotContainsNamed('contains not')
+            );
+            const af = AdvancedFilterHarness.get(api);
+
+            await af.applyExpression('[Athlete] contains "e"');
+            await asyncSetTimeout(0);
+
+            expect(af.value).toBe('[Athlete] contains "e"');
+            expect(api.getAdvancedFilterModel()).toEqual({
+                filterType: 'text',
+                colId: 'athlete',
+                type: 'contains',
+                filter: 'e',
+            });
+            await new GridRows(api, 'the shorter operator name').check(`
+                ROOT id:ROOT_NODE_ID
+                └── LEAF id:2 athlete:"Wei" age:28 big:"10000000000000000001n"
+            `);
+        });
+
+        test('a model naming the longer option round-trips through the expression', async () => {
+            const api = await localeGridsManager.createGridAndWait(
+                'grid1',
+                optionsWithNotContainsNamed('contains not')
+            );
+
+            api.setAdvancedFilterModel({ filterType: 'text', colId: 'athlete', type: 'notContains', filter: 'e' });
+            await asyncSetTimeout(0);
+
+            expect(AdvancedFilterHarness.get(api).value).toBe('[Athlete] contains not "e"');
+            await new GridRows(api, 'a model naming the longer option').check(`
+                ROOT id:ROOT_NODE_ID
+                ├── LEAF id:0 athlete:"Bolt" age:25 big:"10000000000000000001n"
+                └── LEAF id:1 athlete:"Ng" age:40 big:"20000000000000000002n"
+            `);
+        });
+
+        test('a longer name left incomplete falls back to the shorter match, and the rest is rejected', async () => {
+            const api = await localeGridsManager.createGridAndWait(
+                'grid1',
+                optionsWithNotContainsNamed('contains not really')
+            );
+
+            // Greedy but not destructive: only `contains` resolves, so `not` is its operand and `"e"` is left
+            // where a join operator belongs - the text is reported rather than silently swallowed by the scan.
+            await AdvancedFilterHarness.get(api).applyExpression('[Athlete] contains not "e"');
+            await asyncSetTimeout(0);
+
+            await new FilterDom(api, 'an incomplete longer name').checkFilterDom(`
+                ADVANCED FILTER
+                input: "[Athlete] contains not "e""
+                valid: false — Expression has an error. Join operator not found - "e".
+                buttons: Apply ⊘ | Builder
+                model: null
+            `);
+        });
+
+        test('an operand continuing the longer name falls back to the shorter one rather than failing', async () => {
+            const api = await localeGridsManager.createGridAndWait(
+                'grid1',
+                optionsWithNotContainsNamed('contains not')
+            );
+            const af = AdvancedFilterHarness.get(api);
+
+            // `notes` spells `not` and then keeps going, so the longer name is not what the text says.
+            await af.applyExpression('[Athlete] contains notes');
+            await asyncSetTimeout(0);
+
+            expect(api.getAdvancedFilterModel()).toEqual({
+                filterType: 'text',
+                colId: 'athlete',
+                type: 'contains',
+                filter: 'notes',
+            });
+            await new GridRows(api, 'an operand continuing the longer name').check(`
+                ROOT id:ROOT_NODE_ID
+            `);
+        });
+
+        test('a name containing a closing bracket parses', async () => {
+            const api = await localeGridsManager.createGridAndWait(
+                'grid1',
+                optionsWithNotContainsNamed('not (contains)')
+            );
+            const af = AdvancedFilterHarness.get(api);
+
+            await af.applyExpression('[Athlete] not (contains) "e"');
+            await asyncSetTimeout(0);
+
+            expect(af.value).toBe('[Athlete] not (contains) "e"');
+            expect(api.getAdvancedFilterModel()).toEqual({
+                filterType: 'text',
+                colId: 'athlete',
+                type: 'notContains',
+                filter: 'e',
+            });
+            await new GridRows(api, 'a bracketed operator name').check(`
+                ROOT id:ROOT_NODE_ID
+                ├── LEAF id:0 athlete:"Bolt" age:25 big:"10000000000000000001n"
+                └── LEAF id:1 athlete:"Ng" age:40 big:"20000000000000000002n"
+            `);
+        });
+
+        test('a bracket closing the enclosing group is not taken as part of the name', async () => {
+            const api = await localeGridsManager.createGridAndWait(
+                'grid1',
+                optionsWithNotContainsNamed('not (contains)')
+            );
+            const af = AdvancedFilterHarness.get(api);
+
+            await af.applyExpression('([Athlete] not (contains) "e") OR [Age] = 40');
+            await asyncSetTimeout(0);
+
+            expect(api.getAdvancedFilterModel()).toEqual({
+                filterType: 'join',
+                type: 'OR',
+                conditions: [
+                    { filterType: 'text', colId: 'athlete', type: 'notContains', filter: 'e' },
+                    { filterType: 'number', colId: 'age', type: 'equals', filter: 40 },
+                ],
+            });
+            await new GridRows(api, 'a bracketed name inside a group').check(`
+                ROOT id:ROOT_NODE_ID
+                ├── LEAF id:0 athlete:"Bolt" age:25 big:"10000000000000000001n"
+                └── LEAF id:1 athlete:"Ng" age:40 big:"20000000000000000002n"
             `);
         });
     });

--- a/testing/behavioural/src/filters/advanced-filter/advanced-filter-column-filter-parity.test.ts
+++ b/testing/behavioural/src/filters/advanced-filter/advanced-filter-column-filter-parity.test.ts
@@ -89,12 +89,10 @@ describe('Advanced Filter matches the column filter', () => {
         { colId: 'athlete', filterType: 'text' as const, filter: 'alpha' },
         { colId: 'age', filterType: 'number' as const, filter: 2 },
     ])('$colId', ({ colId, filterType, filter }) => {
-        // A number column's `notEqual` is not at parity: the Advanced Filter admits blanks to it by
-        // `includeBlanksInEquals`, where the column filter reads `includeBlanksInNotEqual`.
         const valuedOptions =
             filterType === 'text'
                 ? ['contains', 'notContains', 'equals', 'notEqual', 'startsWith', 'endsWith']
-                : ['equals', 'greaterThan', 'greaterThanOrEqual', 'lessThan', 'lessThanOrEqual'];
+                : ['equals', 'notEqual', 'greaterThan', 'greaterThanOrEqual', 'lessThan', 'lessThanOrEqual'];
 
         test.each(valuedOptions)('`%s` filters the same rows', async (type) => {
             const columnFilterIds = await withColumnFilter(colId, { filterType, type, filter });
@@ -120,6 +118,52 @@ describe('Advanced Filter matches the column filter', () => {
             expectFiltered(columnFilterIds);
             expect(advancedFilterIds).toEqual(columnFilterIds);
         });
+    });
+
+    test('`includeBlanksInNotEqual` admits a blank to `notEqual` in both', async () => {
+        const columnFilterIds = await withColumnFilter('age', { filterType: 'number', type: 'notEqual', filter: 2 });
+
+        expect(columnFilterIds).toContain(3); // the row with a null age
+        expect(await withAdvancedFilter({ filterType: 'number', colId: 'age', type: 'notEqual', filter: 2 })).toEqual(
+            columnFilterIds
+        );
+    });
+
+    // The column filter's `isValid(cellValue)` gate keeps an unreadable date out of the comparison; the
+    // Advanced Filter has no equivalent and converts before it compares.
+    test('an unreadable date compares rather than throwing, in both', async () => {
+        expect(await withColumnFilter('date', { filterType: 'date', type: 'equals', dateFrom: '2008-08-24' })).toEqual([
+            0,
+        ]);
+        expect(
+            await withAdvancedFilter({
+                filterType: 'dateString',
+                colId: 'date',
+                type: 'equals',
+                filter: '2008-08-24',
+            })
+        ).toEqual([0]);
+    });
+
+    // The negated half of the same gate, and the only case in which an unreadable value is a match.
+    test('an unreadable date is admitted to `notEqual`, in both', async () => {
+        const columnFilterIds = await withColumnFilter('date', {
+            filterType: 'date',
+            type: 'notEqual',
+            dateFrom: '2008-08-24',
+        });
+
+        expect(columnFilterIds).toContain(1); // whitespace
+        expect(columnFilterIds).toContain(4); // 'not a date'
+        expect(columnFilterIds).not.toContain(2); // null is blank, not unreadable
+        expect(
+            await withAdvancedFilter({
+                filterType: 'dateString',
+                colId: 'date',
+                type: 'notEqual',
+                filter: '2008-08-24',
+            })
+        ).toEqual(columnFilterIds);
     });
 
     // A whitespace date is rejected as an invalid date before either filter asks whether it is blank, so


### PR DESCRIPTION
<!-- base: latest -->

# AG-14491: Advanced Filter option names and evaluation are not at parity with the column filter

FIX [AG-14491](https://ag-grid.atlassian.net/browse/AG-14491)
FIX [AG-18233](https://ag-grid.atlassian.net/browse/AG-18233)

Six defects stopping an option the column filter offers from being used through the Advanced Filter. Each needs a
non-default option, a renamed locale string or unreadable data to reach, so a default grid is unaffected.

## Option name resolution (AG-14491)

`OperatorParser` took the first name that matched at a space, so a name another name starts with never resolved
(`contains not` settled on `contains`) and a name containing `)` ended at the bracket, losing the enclosing group
with it. It now takes the longest name spelled at the operator's start that a terminator or the expression end
follows.

`filterOptions` now restricts the parser, which the Advanced Filter docs already promise, rather than only its
autocomplete. A column naming just relative-date presets is therefore left with no option until AG-10029 gives
presets an expression form.

`getExpressionOperator` indexes the operator map with an own-key check, so a model `type` cannot resolve to an
inherited member. No reachable consequence today.

## Evaluation (AG-18233)

`notEqual` read `includeBlanksInEquals`, and `includeBlanksInNotEqual` never reached the evaluator params, so a
column setting it had it ignored. Both fixed, and the option is now documented.

A cell value the column's data type cannot read threw `TypeError: Cannot read properties of undefined (reading
'getTime')` and lost the whole filter pass. It now matches no comparison, and so every negation of one, which is
what `ScalarFilterHandler` gives behind its `isValid` gate.

## Size

| scope  | net lines |  lines changed | hunks | files changed |
| ------ | --------: | -------------: | ----: | ------------: |
| source |       +72 | 166 (+119 -47) |    28 |      3 edited |
| tests  |      +326 | 398 (+362 -36) |    20 |      5 edited |
| docs   |        +1 |        1 added |     1 |      1 edited |

## Test harness

`selectRichSelectRow` and `AdvancedFilterBuilderHarness.forceReRender` nudge a VirtualList inside a `waitFor`
callback, which starved its deadline timer: a condition that never held spun at full CPU instead of failing.
Both yield a macrotask per poll.
