### PR TITLE
fix(docs-examples): load example-runner client in the vanilla template

### DIFF
--- a/documentation/ag-grid-docs/public/example-runner/example-runner.js
+++ b/documentation/ag-grid-docs/public/example-runner/example-runner.js
@@ -1,3 +1,17 @@
+/*
+ * Browser-side runtime for documentation examples, exposed as `window.agExampleRunner`.
+ *
+ * Each generated example page calls into it to:
+ *  - set up the page shell (fake `process.env`, global error logging)
+ *  - inject an import map, resolving the `?version=` / `?prod=` query params
+ *  - seed deterministic randomness for screenshot-stable examples
+ *  - notify the parent frame once the example has rendered
+ *  - transpile the example's TypeScript modules with the in-page TypeScript
+ *    compiler, rewriting relative and CSS imports, and run the entry module
+ *
+ * No build step is involved: modules are fetched, transpiled and served to the
+ * browser as blob URLs at load time.
+ */
 /* global ts */
 (function () {
     const VERSION_PARAM = 'version';

--- a/documentation/ag-grid-docs/src/components/example-runner/framework-templates/JavascriptTemplate.astro
+++ b/documentation/ag-grid-docs/src/components/example-runner/framework-templates/JavascriptTemplate.astro
@@ -50,6 +50,7 @@ import {
     getChartsEnterpriseScriptPath,
     getGridLocaleScriptPath,
 } from '@utils/gridLibraryPaths';
+import { ExampleRunnerClient } from './lib/ExampleRunnerClient';
 import { SeedRandom } from './lib/SeedRandom';
 
 const siteUrl = Astro.site ? pathJoin(Astro.site, SITE_BASE_URL) : '/';
@@ -87,7 +88,12 @@ const gridScriptLocalePath = getCacheBustingUrl(getGridLocaleScriptPath(siteUrl)
         >
             window.__basePath = appLocation;
         </script>
-        {usesMathRandom && <SeedRandom nonce={nonce} />}
+        {usesMathRandom && (
+            <>
+                <ExampleRunnerClient nonce={nonce} />
+                <SeedRandom nonce={nonce} />
+            </>
+        )}
         {isIntegratedCharts && <script nonce={nonce} src={chartsScriptEnterprisePath} crossorigin="anonymous" />}
         <script nonce={nonce} src={isEnterprise ? gridScriptEnterprisePath : gridScriptPath} crossorigin="anonymous"
         ></script>

--- a/documentation/ag-grid-docs/src/components/example-runner/framework-templates/JavascriptTemplate.astro
+++ b/documentation/ag-grid-docs/src/components/example-runner/framework-templates/JavascriptTemplate.astro
@@ -88,12 +88,14 @@ const gridScriptLocalePath = getCacheBustingUrl(getGridLocaleScriptPath(siteUrl)
         >
             window.__basePath = appLocation;
         </script>
-        {usesMathRandom && (
-            <>
-                <ExampleRunnerClient nonce={nonce} />
-                <SeedRandom nonce={nonce} />
-            </>
-        )}
+        {
+            usesMathRandom && (
+                <>
+                    <ExampleRunnerClient nonce={nonce} />
+                    <SeedRandom nonce={nonce} />
+                </>
+            )
+        }
         {isIntegratedCharts && <script nonce={nonce} src={chartsScriptEnterprisePath} crossorigin="anonymous" />}
         <script nonce={nonce} src={isEnterprise ? gridScriptEnterprisePath : gridScriptPath} crossorigin="anonymous"
         ></script>


### PR DESCRIPTION
Vanilla (JavaScript) examples that use `Math.random()` rendered the `agExampleRunner.seedRandom(...)` inline call without ever loading `example-runner.js`, so the page threw `agExampleRunner is not defined` and then `window.agRandom is not a function`. Other frameworks get the client via `ExampleModules`; the vanilla template did not.

Repro: https://grid-staging.ag-grid.com/javascript-data-grid/provided-cell-editors-text/