### PR TITLE
Load the example runner script in the vanilla JS template

### DIFF
--- a/documentation/ag-grid-docs/src/components/example-runner/components/FrameworkTemplate.astro
+++ b/documentation/ag-grid-docs/src/components/example-runner/components/FrameworkTemplate.astro
@@ -108,6 +108,7 @@ const shouldShowTemplate = (framework: InternalFramework) => {
             extras={extras}
             headFragment={headFragment}
             usesMathRandom={usesMathRandom}
+            transpileInBrowser={transpileInBrowser}
             nonce={nonce}
         >
             {addInitMessageScript && (

--- a/documentation/ag-grid-docs/src/components/example-runner/framework-templates/JavascriptTemplate.astro
+++ b/documentation/ag-grid-docs/src/components/example-runner/framework-templates/JavascriptTemplate.astro
@@ -15,6 +15,7 @@ interface Props {
     extraStyles?: string;
     extras?: string[];
     usesMathRandom?: boolean;
+    transpileInBrowser?: boolean;
     nonce?: string;
 }
 
@@ -33,6 +34,7 @@ const {
     extraStyles,
     extras,
     usesMathRandom,
+    transpileInBrowser,
     nonce,
 } = Astro.props as Props;
 
@@ -88,7 +90,7 @@ const gridScriptLocalePath = getCacheBustingUrl(getGridLocaleScriptPath(siteUrl)
         >
             window.__basePath = appLocation;
         </script>
-        <ExampleRunnerClient nonce={nonce} />
+        <ExampleRunnerClient isExported={transpileInBrowser} nonce={nonce} />
         {usesMathRandom && <SeedRandom nonce={nonce} />}
         {isIntegratedCharts && <script nonce={nonce} src={chartsScriptEnterprisePath} crossorigin="anonymous" />}
         <script nonce={nonce} src={isEnterprise ? gridScriptEnterprisePath : gridScriptPath} crossorigin="anonymous"

--- a/documentation/ag-grid-docs/src/components/example-runner/framework-templates/JavascriptTemplate.astro
+++ b/documentation/ag-grid-docs/src/components/example-runner/framework-templates/JavascriptTemplate.astro
@@ -88,14 +88,8 @@ const gridScriptLocalePath = getCacheBustingUrl(getGridLocaleScriptPath(siteUrl)
         >
             window.__basePath = appLocation;
         </script>
-        {
-            usesMathRandom && (
-                <>
-                    <ExampleRunnerClient nonce={nonce} />
-                    <SeedRandom nonce={nonce} />
-                </>
-            )
-        }
+        <ExampleRunnerClient nonce={nonce} />
+        {usesMathRandom && <SeedRandom nonce={nonce} />}
         {isIntegratedCharts && <script nonce={nonce} src={chartsScriptEnterprisePath} crossorigin="anonymous" />}
         <script nonce={nonce} src={isEnterprise ? gridScriptEnterprisePath : gridScriptPath} crossorigin="anonymous"
         ></script>

--- a/documentation/ag-grid-docs/src/components/example-runner/framework-templates/JavascriptTemplate.astro
+++ b/documentation/ag-grid-docs/src/components/example-runner/framework-templates/JavascriptTemplate.astro
@@ -52,7 +52,7 @@ import {
     getChartsEnterpriseScriptPath,
     getGridLocaleScriptPath,
 } from '@utils/gridLibraryPaths';
-import { ExampleRunnerClient } from './lib/ExampleRunnerClient';
+import { ExampleRunnerCall, ExampleRunnerClient } from './lib/ExampleRunnerClient';
 import { SeedRandom } from './lib/SeedRandom';
 
 const siteUrl = Astro.site ? pathJoin(Astro.site, SITE_BASE_URL) : '/';
@@ -91,6 +91,7 @@ const gridScriptLocalePath = getCacheBustingUrl(getGridLocaleScriptPath(siteUrl)
             window.__basePath = appLocation;
         </script>
         <ExampleRunnerClient isExported={transpileInBrowser} nonce={nonce} />
+        <ExampleRunnerCall fn="setUpPage" nonce={nonce} />
         {usesMathRandom && <SeedRandom nonce={nonce} />}
         {isIntegratedCharts && <script nonce={nonce} src={chartsScriptEnterprisePath} crossorigin="anonymous" />}
         <script nonce={nonce} src={isEnterprise ? gridScriptEnterprisePath : gridScriptPath} crossorigin="anonymous"


### PR DESCRIPTION
`JavascriptTemplate.astro` only loaded `example-runner.js` when the example used `Math.random`, so vanilla-JS examples without it threw `ReferenceError: agExampleRunner is not defined` from the postInitMessage inline script (e.g. javascript-data-grid/master-detail). Load the client unconditionally, as the other framework templates do via `ExampleModules`.