### PR TITLE
[Clipboard] - Code Improvements

### DIFF
--- a/packages/ag-grid-enterprise/src/clipboard/clipboardService.ts
+++ b/packages/ag-grid-enterprise/src/clipboard/clipboardService.ts
@@ -357,8 +357,24 @@ export class ClipboardService extends BeanStub implements NamedBean, IClipboardS
         const rangeRowCount = rangeSvc.getRangeRowCount(cellRange);
         const isRowMultiple = rangeRowCount >= clipboardRowCount && rangeRowCount % clipboardRowCount === 0;
 
-        const clipboardColCount = clipboardData[0].length;
-        const rangeColCount = cellRange.columns.length;
+        // clipboard data can be ragged (e.g. from processDataFromClipboard), so the widest
+        // row determines how many columns the range must provide
+        let clipboardColCount = 0;
+        for (const clipboardDataRow of clipboardData) {
+            const rowLength = clipboardDataRow.length;
+            if (rowLength > clipboardColCount) {
+                clipboardColCount = rowLength;
+            }
+        }
+
+        // the selection column cannot be pasted into, so it does not count towards the range size
+        const rangeColumns = cellRange.columns;
+        let rangeColCount = 0;
+        for (const column of rangeColumns) {
+            if (!isColumnSelectionCol(column)) {
+                rangeColCount++;
+            }
+        }
         const isColMultiple = rangeColCount >= clipboardColCount && rangeColCount % clipboardColCount === 0;
 
         return {
@@ -373,8 +389,18 @@ export class ClipboardService extends BeanStub implements NamedBean, IClipboardS
         updatedRowNodes: RowNode[],
         changedPath: ChangedPath | undefined
     ) {
+        const { gos } = this.beans;
+        const processCellFromClipboardFunc = gos.getCallback('processCellFromClipboard');
+
+        // If doing CSRM and NOT tree data, group rows are aggregates and read-only by default.
+        const skipGroupRows = this.clientSideRowModel != null && !gos.get('enableGroupEdit') && !gos.get('treeData');
+
         let indexOffset = 0;
         let dataRowIndex = 0;
+
+        // pasting into the selection column is not supported, so it is excluded from the
+        // paste operation while remaining part of the range itself
+        let pasteColumns: AgColumn[] = [];
 
         const rowCallback: RowCallback = (
             currentRow: RowPosition,
@@ -382,6 +408,13 @@ export class ClipboardService extends BeanStub implements NamedBean, IClipboardS
             range: CellRange,
             rangeIndex: number
         ) => {
+            if (rangeIndex === 0) {
+                // each range repeats the clipboard data from its first row
+                indexOffset = 0;
+                dataRowIndex = 0;
+                pasteColumns = (range.columns as AgColumn[]).filter((column) => !isColumnSelectionCol(column));
+            }
+
             const atEndOfClipboardData = rangeIndex - indexOffset >= clipboardData.length;
 
             if (atEndOfClipboardData) {
@@ -396,27 +429,22 @@ export class ClipboardService extends BeanStub implements NamedBean, IClipboardS
 
             const currentRowData = clipboardData[rangeIndex - indexOffset];
 
-            // otherwise we are not the first row, so copy
-            updatedRowNodes.push(rowNode);
+            // a skipped row still consumes its position, so the paste stays aligned with the range
+            dataRowIndex++;
 
-            const processCellFromClipboardFunc = this.gos.getCallback('processCellFromClipboard');
-            const columns = range.columns as AgColumn[];
-
-            // remove the selection column (paste into selection is not supported)
-            // this columns should be removed from the paste operation but not
-            // from the range itself.
-            const selectionColIdx = columns.findIndex(isColumnSelectionCol);
-            if (selectionColIdx !== -1) {
-                columns.splice(selectionColIdx, 1);
+            if (currentRowData.length === 0 || this.shouldSkipPasteRow(rowNode, pasteColumns, skipGroupRows)) {
+                return;
             }
 
-            for (let idx = 0; idx < columns.length; idx++) {
-                const column = columns[idx];
+            updatedRowNodes.push(rowNode);
+
+            for (let idx = 0, len = pasteColumns.length; idx < len; idx++) {
+                const column = pasteColumns[idx];
                 if (!column.isCellEditable(rowNode) || column.isSuppressPaste(rowNode)) {
                     continue;
                 }
 
-                // repeat data for columns we don't have data for - happens when to range is bigger than copied data range
+                // repeat data for columns we don't have data for - happens when the range is bigger than copied data range
                 let calculatedIdx = idx;
                 if (idx >= currentRowData.length) {
                     calculatedIdx = idx % currentRowData.length;
@@ -426,7 +454,7 @@ export class ClipboardService extends BeanStub implements NamedBean, IClipboardS
                     rowNode,
                     column,
                     currentRowData[calculatedIdx],
-                    EXPORT_TYPE_DRAG_COPY,
+                    EXPORT_TYPE_CLIPBOARD,
                     processCellFromClipboardFunc,
                     true
                 );
@@ -438,8 +466,6 @@ export class ClipboardService extends BeanStub implements NamedBean, IClipboardS
                 const cellId = _createCellId({ rowIndex, column, rowPinned });
                 cellsToFlash[cellId] = true;
             }
-
-            dataRowIndex++;
         };
 
         this.iterateActiveRanges(rowCallback, false, this.getPreProcessRangeCallback(clipboardData));

--- a/testing/behavioural/src/cell-editing/clipboard/clipboard-paste-range.test.ts
+++ b/testing/behavioural/src/cell-editing/clipboard/clipboard-paste-range.test.ts
@@ -1,7 +1,13 @@
 import { waitFor } from '@testing-library/dom';
 import { EditEventTracker, GridColumns, GridRows, TestGridsManager, clipboardUtils, waitForEvent } from 'ag-test-utils';
 
-import { RowSelectionModule, SELECTION_COLUMN_ID, TextEditorModule, UndoRedoEditModule, setupAgTestIds } from 'ag-grid-community';
+import {
+    RowSelectionModule,
+    SELECTION_COLUMN_ID,
+    TextEditorModule,
+    UndoRedoEditModule,
+    setupAgTestIds,
+} from 'ag-grid-community';
 import {
     BatchEditModule,
     CellSelectionModule,

--- a/testing/behavioural/src/cell-editing/clipboard/clipboard-paste-range.test.ts
+++ b/testing/behavioural/src/cell-editing/clipboard/clipboard-paste-range.test.ts
@@ -1,12 +1,27 @@
 import { waitFor } from '@testing-library/dom';
 import { EditEventTracker, GridColumns, GridRows, TestGridsManager, clipboardUtils, waitForEvent } from 'ag-test-utils';
 
-import { TextEditorModule, UndoRedoEditModule, setupAgTestIds } from 'ag-grid-community';
-import { BatchEditModule, CellSelectionModule, ClipboardModule } from 'ag-grid-enterprise';
+import { RowSelectionModule, SELECTION_COLUMN_ID, TextEditorModule, UndoRedoEditModule, setupAgTestIds } from 'ag-grid-community';
+import {
+    BatchEditModule,
+    CellSelectionModule,
+    ClipboardModule,
+    RowGroupingEditModule,
+    RowGroupingModule,
+} from 'ag-grid-enterprise';
 
 describe('Clipboard Paste Behaviour: paste into range / multi-range', () => {
     const gridMgr = new TestGridsManager({
-        modules: [ClipboardModule, CellSelectionModule, BatchEditModule, UndoRedoEditModule, TextEditorModule],
+        modules: [
+            ClipboardModule,
+            CellSelectionModule,
+            BatchEditModule,
+            UndoRedoEditModule,
+            TextEditorModule,
+            RowSelectionModule,
+            RowGroupingModule,
+            RowGroupingEditModule,
+        ],
     });
 
     beforeAll(() => {
@@ -194,6 +209,201 @@ describe('Clipboard Paste Behaviour: paste into range / multi-range', () => {
             ├── LEAF id:ROW_1 a:"P1" b:"b1"
             ├── LEAF id:ROW_2 a:"P0" b:"b2"
             └── LEAF id:ROW_3 a:"P1" b:"b3"
+        `);
+    });
+
+    test('paste into range containing the selection column skips it and keeps it in the range', async () => {
+        const api = await gridMgr.createGridAndWait('pasteRangeSelectionCol', {
+            ...gridOptions,
+            rowSelection: { mode: 'multiRow' },
+            rowData: makeRowData(),
+            getRowId: (p) => p.data.id,
+        });
+
+        // 1×2 clipboard, range covers the selection column plus column "a"
+        clipboardUtils.setText('X\tY');
+        setRange(api, { rowStartIndex: 1, rowEndIndex: 1, columns: [SELECTION_COLUMN_ID, 'a'] });
+        api.setFocusedCell(1, 'a');
+
+        const pasteEnd = waitForEvent('pasteEnd', api);
+        api.pasteFromClipboard();
+        await pasteEnd;
+
+        // the selection column provides no paste target, so the range extends to fit both values
+        await new GridRows(api, 'after paste over selection column').check(`
+            ROOT id:ROOT_NODE_ID
+            ├── LEAF id:ROW_0 a:"a0" b:"b0"
+            ├── LEAF id:ROW_1 a:"X" b:"Y"
+            ├── LEAF id:ROW_2 a:"a2" b:"b2"
+            └── LEAF id:ROW_3 a:"a3" b:"b3"
+        `);
+
+        // the range itself keeps the selection column
+        const rangeColumnIds = api.getCellRanges()![0].columns.map((c) => c.getColId());
+        expect(rangeColumnIds).toEqual([SELECTION_COLUMN_ID, 'a', 'b']);
+    });
+
+    test('range paste reports type "clipboard" to processCellFromClipboard', async () => {
+        const types: string[] = [];
+        const api = await gridMgr.createGridAndWait('pasteRangeCallbackType', {
+            ...gridOptions,
+            rowData: makeRowData(),
+            getRowId: (p) => p.data.id,
+            processCellFromClipboard: (params) => {
+                types.push(params.type);
+                return params.value;
+            },
+        });
+
+        clipboardUtils.setText('X0\tY0\nX1\tY1');
+        setRange(api, { rowStartIndex: 1, rowEndIndex: 2, columns: ['a', 'b'] });
+        api.setFocusedCell(1, 'a');
+
+        const pasteEnd = waitForEvent('pasteEnd', api);
+        api.pasteFromClipboard();
+        await pasteEnd;
+
+        expect(types).toEqual(['clipboard', 'clipboard', 'clipboard', 'clipboard']);
+    });
+
+    test('ragged clipboard rows widen the range to the widest row', async () => {
+        const api = await gridMgr.createGridAndWait('pasteRangeRagged', {
+            ...gridOptions,
+            rowData: makeRowData(),
+            getRowId: (p) => p.data.id,
+        });
+
+        // first clipboard row has 1 value, second has 2
+        clipboardUtils.setText('X0\nX1\tY1');
+        setRange(api, { rowStartIndex: 1, rowEndIndex: 2, columns: ['a'] });
+        api.setFocusedCell(1, 'a');
+
+        const pasteEnd = waitForEvent('pasteEnd', api);
+        api.pasteFromClipboard();
+        await pasteEnd;
+
+        // the range widens to the widest clipboard row; short rows repeat to fill it
+        await new GridRows(api, 'after ragged paste').check(`
+            ROOT id:ROOT_NODE_ID
+            ├── LEAF id:ROW_0 a:"a0" b:"b0"
+            ├── LEAF id:ROW_1 a:"X0" b:"X0"
+            ├── LEAF id:ROW_2 a:"X1" b:"Y1"
+            └── LEAF id:ROW_3 a:"a3" b:"b3"
+        `);
+    });
+
+    test('empty clipboard row from processDataFromClipboard is skipped without writing', async () => {
+        const api = await gridMgr.createGridAndWait('pasteRangeEmptyRow', {
+            ...gridOptions,
+            rowData: makeRowData(),
+            getRowId: (p) => p.data.id,
+            processDataFromClipboard: () => [['X0'], []],
+        });
+
+        clipboardUtils.setText('ignored');
+        setRange(api, { rowStartIndex: 1, rowEndIndex: 2, columns: ['a'] });
+        api.setFocusedCell(1, 'a');
+
+        const pasteEnd = waitForEvent('pasteEnd', api);
+        api.pasteFromClipboard();
+        await pasteEnd;
+
+        await new GridRows(api, 'after paste with empty row').check(`
+            ROOT id:ROOT_NODE_ID
+            ├── LEAF id:ROW_0 a:"a0" b:"b0"
+            ├── LEAF id:ROW_1 a:"X0" b:"b1"
+            ├── LEAF id:ROW_2 a:"a2" b:"b2"
+            └── LEAF id:ROW_3 a:"a3" b:"b3"
+        `);
+    });
+
+    test('range paste skips footer rows and keeps values positionally aligned', async () => {
+        const api = await gridMgr.createGridAndWait('pasteRangeFooter', {
+            cellSelection: true,
+            defaultColDef: { editable: true },
+            columnDefs: [{ field: 'g', rowGroup: true, hide: true }, { field: 'a' }],
+            enableGroupEdit: true,
+            groupTotalRow: 'bottom',
+            groupDefaultExpanded: -1,
+            rowData: [
+                { id: 'ROW_0', g: 'G', a: 'a0' },
+                { id: 'ROW_1', g: 'G', a: 'a1' },
+            ],
+            getRowId: (p) => p.data.id,
+        });
+
+        // displayed rows: 0 group, 1-2 leaves, 3 footer
+        const footerNode = api.getDisplayedRowAtIndex(3)!;
+        expect(footerNode.footer).toBe(true);
+
+        const eventTracker = new EditEventTracker(api);
+
+        clipboardUtils.setText('V0\nV1\nV2');
+        setRange(api, { rowStartIndex: 1, rowEndIndex: 3, columns: ['a'] });
+        api.setFocusedCell(1, 'a');
+
+        const pasteEnd = waitForEvent('pasteEnd', api);
+        api.pasteFromClipboard();
+        await pasteEnd;
+
+        // leaves receive their positional values; the footer row is skipped, its value dropped
+        expect(api.getRowNode('ROW_0')!.data.a).toBe('V0');
+        expect(api.getRowNode('ROW_1')!.data.a).toBe('V1');
+        expect(footerNode.data?.a).toBeUndefined();
+        expect(eventTracker.counts.cellValueChanged).toBe(2);
+    });
+
+    test('group row inside range is skipped without shifting values', async () => {
+        const api = await gridMgr.createGridAndWait('pasteRangeGroupRow', {
+            cellSelection: true,
+            defaultColDef: { editable: true },
+            columnDefs: [{ field: 'g', rowGroup: true, hide: true }, { field: 'a' }],
+            groupDefaultExpanded: -1,
+            rowData: [
+                { id: 'ROW_0', g: 'G', a: 'a0' },
+                { id: 'ROW_1', g: 'G', a: 'a1' },
+            ],
+            getRowId: (p) => p.data.id,
+        });
+
+        // displayed rows: 0 group, 1-2 leaves
+        clipboardUtils.setText('V0\nV1\nV2');
+        setRange(api, { rowStartIndex: 0, rowEndIndex: 2, columns: ['a'] });
+        api.setFocusedCell(0, 'a');
+
+        const pasteEnd = waitForEvent('pasteEnd', api);
+        api.pasteFromClipboard();
+        await pasteEnd;
+
+        // the group row consumes clipboard row V0 without writing; leaves stay positionally aligned
+        expect(api.getRowNode('ROW_0')!.data.a).toBe('V1');
+        expect(api.getRowNode('ROW_1')!.data.a).toBe('V2');
+    });
+
+    test('clipboard tiling restarts for each range', async () => {
+        const api = await gridMgr.createGridAndWait('pasteMultiTiling', {
+            ...gridOptions,
+            rowData: makeRowData(),
+            getRowId: (p) => p.data.id,
+        });
+
+        // first range tiles the 2-row clipboard twice; second range restarts from the first clipboard row
+        clipboardUtils.setText('P0\nP1');
+        api.clearCellSelection();
+        api.addCellRange({ rowStartIndex: 0, rowEndIndex: 3, columns: ['a'] });
+        api.addCellRange({ rowStartIndex: 2, rowEndIndex: 3, columns: ['b'] });
+        api.setFocusedCell(0, 'a');
+
+        const pasteEnd = waitForEvent('pasteEnd', api);
+        api.pasteFromClipboard();
+        await pasteEnd;
+
+        await new GridRows(api, 'after multi-range tiled paste').check(`
+            ROOT id:ROOT_NODE_ID
+            ├── LEAF id:ROW_0 a:"P0" b:"b0"
+            ├── LEAF id:ROW_1 a:"P1" b:"b1"
+            ├── LEAF id:ROW_2 a:"P0" b:"P0"
+            └── LEAF id:ROW_3 a:"P1" b:"P1"
         `);
     });
 


### PR DESCRIPTION
This PR fixes 5 issues found in the Clipboard range paste

- Fix 1 -  selection column no longer mutates the range. pasteIntoActiveRange now builds a filtered pasteColumns copy (recomputed at each range's first row, after the pre-process resize) instead of splicing range.columns in place. The dimension math in getAdjustedRangeDimensionForPaste also stops counting the selection column, so a range of [selection, a] with a 2-value clipboard row now extends to provide 2 real paste targets instead of concluding it already fits.

- Fix 2 - processCellFromClipboard now receives type: 'clipboard' in the range paste path (was 'dragCopy'). copyRangeDown (Ctrl+D) keeps 'dragCopy', that one genuinely is a copy down.

- Fix 3 - ragged clipboard data. The column count now comes from the widest clipboard row rather than clipboardData[0].length, and a zero-length row is skipped instead of feeding idx % 0 (NaN) into the value lookup.

- Fix 4 - position-based row skipping. The range paste now runs the same shouldSkipPasteRow guard as the focused-cell path, but positionally: a footer/detail/read-only-group row inside the range consumes its clipboard row without being written to, and data never shifts to other rows. This closes the real hazard, setDataValue on footer/detail nodes, which the per-column isCellEditable check does not block (footer cells report editable with plain editable: true + enableGroupEdit).

- FIx 5 - while moving the tiling state I found that indexOffset/dataRowIndex leaked across ranges, with two ranges where the first tiles (e.g. 4 rows from a 2-row clipboard), the second range indexed clipboardData[negative] and threw. The per-range reset at rangeIndex === 0 fixes it, and each range now restarts the clipboard block, matching the documented "each range is pasted independently" semantics. It's one line inside the function I was already rewriting; happy to split it out if you'd rather.