### PR TITLE
AG-3390 Fix the contact form captcha across client-side navigation

### DIFF
--- a/documentation/ag-grid-docs/src/stores/darkmodeStore.ts
+++ b/documentation/ag-grid-docs/src/stores/darkmodeStore.ts
@@ -34,8 +34,9 @@ const updateHtml = (darkmode: boolean | undefined) => {
         iframe.contentWindow?.postMessage(darkModeEvent);
     });
 
-    // Send on event on page for charts that are embeded on the page
-    window.dispatchEvent(new CustomEvent('message', { detail: darkModeEvent }));
+    // No `message` CustomEvent on `window` here. A CustomEvent has no `origin`, so a third-party
+    // `message` listener that expects a real postMessage throws on it: reCAPTCHA's api.js parses
+    // `event.origin` as a URL, which breaks the captcha on any page carrying the contact form.
 };
 
 $darkmode.listen(updateHtml);

--- a/external/ag-website-shared/src/components/contact-form/ContactForm.tsx
+++ b/external/ag-website-shared/src/components/contact-form/ContactForm.tsx
@@ -59,20 +59,28 @@ interface Props {
 }
 
 const RECAPTCHA_READY_CALLBACK = 'agOnRecaptchaReady';
-
-let recaptchaReady: Promise<void> | undefined;
+const RECAPTCHA_READY_PROMISE = 'agRecaptchaReady';
 
 /**
- * Loads reCAPTCHA once per page session, in explicit-render mode.
+ * Loads reCAPTCHA once per page, in explicit-render mode.
  *
  * `api.js` auto-renders every `.g-recaptcha` container exactly once, when it first executes.
  * The Astro client router swaps pages without a reload, so `window.grecaptcha` outlives the
  * container it rendered into and a later visit to this page is left with a fresh, empty one.
  * Explicit mode hands rendering to the caller, which renders on each mount instead.
+ *
+ * The in-flight promise lives on `window` rather than in a module variable because what it
+ * guards is global: the injected script tag and the `grecaptcha` it defines. A second module
+ * instance has to join the load already under way instead of appending a duplicate script.
  */
 function loadRecaptcha(): Promise<void> {
-    recaptchaReady ??= new Promise<void>((resolve, reject) => {
-        (window as any)[RECAPTCHA_READY_CALLBACK] = resolve;
+    const globals = window as any;
+    globals[RECAPTCHA_READY_PROMISE] ??= new Promise<void>((resolve, reject) => {
+        if (globals.grecaptcha?.render != null) {
+            resolve();
+            return;
+        }
+        globals[RECAPTCHA_READY_CALLBACK] = resolve;
         const script = document.createElement('script');
         script.id = 'grecaptcha-script';
         script.src = `${RECAPTCHA_URL}?render=explicit&onload=${RECAPTCHA_READY_CALLBACK}`;
@@ -80,12 +88,12 @@ function loadRecaptcha(): Promise<void> {
         script.defer = true;
         script.onerror = (error) => {
             // Drop the cached promise so a later mount retries the load.
-            recaptchaReady = undefined;
+            globals[RECAPTCHA_READY_PROMISE] = undefined;
             reject(error);
         };
         document.head.appendChild(script);
     });
-    return recaptchaReady;
+    return globals[RECAPTCHA_READY_PROMISE];
 }
 
 export const ContactForm: FunctionComponent<Props> = ({

--- a/external/ag-website-shared/src/components/contact-form/ContactForm.tsx
+++ b/external/ag-website-shared/src/components/contact-form/ContactForm.tsx
@@ -3,6 +3,7 @@ import {
     CONSENT_LABELS,
     DATA_PROCESSING_CONSENT_REQUIRED,
 } from '@ag-website-shared/components/consent-fields/consentMessages';
+import type { CaptchaTicker } from '@ag-website-shared/components/contact-form/initCaptcha';
 import { initCaptcha } from '@ag-website-shared/components/contact-form/initCaptcha';
 import { Icon } from '@ag-website-shared/components/icon/Icon';
 import { CONSENT_FIELD_IDS, CONTACT_FORM_DATA, RECAPTCHA_URL, STUDIO_FORM_DATA } from '@ag-website-shared/constants';
@@ -57,27 +58,34 @@ interface Props {
     submitLabel?: string;
 }
 
-function loadRecaptchaScript(): Promise<void> {
-    return new Promise((resolve, reject) => {
-        if ((window as any).grecaptcha) {
-            return resolve();
-        }
-        const id = 'grecaptcha-script';
-        const existing = document.getElementById(id) as HTMLScriptElement | null;
-        if (existing) {
-            existing.addEventListener('load', () => resolve(), { once: true });
-            existing.addEventListener('error', reject, { once: true });
-            return;
-        }
-        const s = document.createElement('script');
-        s.id = id;
-        s.src = RECAPTCHA_URL;
-        s.async = true;
-        s.defer = true;
-        s.onload = () => resolve();
-        s.onerror = reject;
-        document.head.appendChild(s);
+const RECAPTCHA_READY_CALLBACK = 'agOnRecaptchaReady';
+
+let recaptchaReady: Promise<void> | undefined;
+
+/**
+ * Loads reCAPTCHA once per page session, in explicit-render mode.
+ *
+ * `api.js` auto-renders every `.g-recaptcha` container exactly once, when it first executes.
+ * The Astro client router swaps pages without a reload, so `window.grecaptcha` outlives the
+ * container it rendered into and a later visit to this page is left with a fresh, empty one.
+ * Explicit mode hands rendering to the caller, which renders on each mount instead.
+ */
+function loadRecaptcha(): Promise<void> {
+    recaptchaReady ??= new Promise<void>((resolve, reject) => {
+        (window as any)[RECAPTCHA_READY_CALLBACK] = resolve;
+        const script = document.createElement('script');
+        script.id = 'grecaptcha-script';
+        script.src = `${RECAPTCHA_URL}?render=explicit&onload=${RECAPTCHA_READY_CALLBACK}`;
+        script.async = true;
+        script.defer = true;
+        script.onerror = (error) => {
+            // Drop the cached promise so a later mount retries the load.
+            recaptchaReady = undefined;
+            reject(error);
+        };
+        document.head.appendChild(script);
     });
+    return recaptchaReady;
 }
 
 export const ContactForm: FunctionComponent<Props> = ({
@@ -86,6 +94,8 @@ export const ContactForm: FunctionComponent<Props> = ({
     submitLabel,
 }: Props) => {
     const formRef = useRef<HTMLFormElement>(null);
+    const captchaRef = useRef<HTMLDivElement>(null);
+    const captchaWidgetId = useRef<number | null>(null);
     const captchaTimestamp = useRef('');
     const reapplyCaptchaTimestamp = useRef<(() => void) | null>(null);
     const [isDebug, setIsDebug] = useState(isDev);
@@ -140,18 +150,37 @@ export const ContactForm: FunctionComponent<Props> = ({
             setReturnUrl(urlWithCurrentPath.toString());
         }
 
-        loadRecaptchaScript().then(() => {
-            reapplyCaptchaTimestamp.current = initCaptcha((ts) => {
+        let unmounted = false;
+        let captcha: CaptchaTicker | undefined;
+
+        loadRecaptcha().then(() => {
+            const container = captchaRef.current;
+            if (unmounted || container == null) {
+                return;
+            }
+            captchaWidgetId.current = (globalThis as any).grecaptcha.render(container, {
+                sitekey: captchaSiteKey,
+            });
+            captcha = initCaptcha(container, (ts) => {
                 captchaTimestamp.current = ts;
             });
+            reapplyCaptchaTimestamp.current = captcha.reapply;
         });
+
+        return () => {
+            unmounted = true;
+            captcha?.stop();
+        };
     }, []);
 
     const onValidSubmit = useCallback(() => {
         setIsDisabled(true);
         setCaptchaError(false);
 
-        const captchaPassed = (globalThis as any).grecaptcha.getResponse();
+        // Widget ids increment across client-side navigations, and a bare `getResponse()` reads
+        // widget 0, which belongs to a container an earlier page swap already destroyed.
+        const widgetId = captchaWidgetId.current;
+        const captchaPassed = widgetId != null && (globalThis as any).grecaptcha.getResponse(widgetId);
         if (captchaPassed) {
             reapplyCaptchaTimestamp.current?.();
             formRef.current?.submit();
@@ -318,7 +347,7 @@ export const ContactForm: FunctionComponent<Props> = ({
             </div>
 
             <div className={classnames('input-field', { 'input-error': captchaError })}>
-                <div className="g-recaptcha" data-sitekey={captchaSiteKey} />
+                <div ref={captchaRef} className="g-recaptcha" />
                 <div className={styles.errorContainer}>
                     {captchaError && <p className="error">Please click on the reCAPTCHA checkbox</p>}
                 </div>

--- a/external/ag-website-shared/src/components/contact-form/initCaptcha.ts
+++ b/external/ag-website-shared/src/components/contact-form/initCaptcha.ts
@@ -1,5 +1,12 @@
+export interface CaptchaTicker {
+    /** Writes the frozen timestamp back into the hidden input, just before submitting. */
+    reapply: () => void;
+    /** Stops the ticker. Call on unmount, or it keeps running for the life of the page. */
+    stop: () => void;
+}
+
 /**
- * Starts Salesforce's captcha timestamp ticker.
+ * Starts Salesforce's captcha timestamp ticker for one rendered reCAPTCHA widget.
  *
  * `onTimestamp` receives every value written, so the caller can render it back into the
  * hidden input: React resets a controlled input on re-render, and `form.submit()` only
@@ -10,7 +17,7 @@
  * The ticker stops once the captcha is solved, freezing `ts` at solve time, which is the
  * elapsed-time signal Salesforce validates.
  */
-export function initCaptcha(onTimestamp?: (ts: string) => void): () => void {
+export function initCaptcha(container: HTMLElement, onTimestamp?: (ts: string) => void): CaptchaTicker {
     let latest = '';
 
     function write(ts: string) {
@@ -24,14 +31,21 @@ export function initCaptcha(onTimestamp?: (ts: string) => void): () => void {
     }
 
     function timestamp() {
-        const response = document.getElementById('g-recaptcha-response') as HTMLInputElement;
-        if (response == null || response.value.trim() == '') {
+        // Scoped to this widget's own container: reCAPTCHA only names the first widget's field
+        // `g-recaptcha-response`, and suffixes every later one (`g-recaptcha-response-1` and so
+        // on), so a lookup by bare id silently misses any widget rendered after the first.
+        const response = container.querySelector<HTMLTextAreaElement>('textarea[name="g-recaptcha-response"]');
+        if (response == null || response.value.trim() === '') {
             latest = JSON.stringify(new Date().getTime());
             write(latest);
             onTimestamp?.(latest);
         }
     }
-    setInterval(timestamp, 500);
 
-    return () => write(latest);
+    const ticker = setInterval(timestamp, 500);
+
+    return {
+        reapply: () => write(latest),
+        stop: () => clearInterval(ticker),
+    };
 }


### PR DESCRIPTION
Ports ag-grid/ag-studio#2446 to grid. Both contact-form files were byte-identical to studio's pre-fix copies, so they carry over verbatim; only the `darkmodeStore` half needed a repo-specific decision.

## The bug

After any Astro client-side navigation, the contact page's captcha vanished and the console threw `Cannot read properties of undefined (reading 'match')`. Two independent defects:

**1. A fake `message` event.** `darkmodeStore` dispatched `new CustomEvent('message', …)` on `window`, re-fired on every `astro:after-swap`. reCAPTCHA's `api.js` installs a global `message` listener that parses `event.origin` as a URL, and a `CustomEvent` has no `origin`.

**Removed here rather than renamed**, because nothing in this repo consumes it. Integrated-charts dark mode runs off a separate channel: `ExampleIFrame.tsx` dispatches `color-scheme-change` on `document`, and the generated example code listens for it on `document` (`parser-utils.ts`). That channel is untouched. (ag-charts *does* consume the window event, so its port renames the event instead.)

**2. No re-render of the widget.** `ContactForm` relied on `api.js`'s one-shot auto-render. `window.grecaptcha` survives a page swap, so `loadRecaptchaScript()` short-circuited and nothing ever rendered into the fresh container.

This was worse than a missing widget: submitting after a navigation threw `No reCAPTCHA clients exist.` and showed the user nothing, because a bare `getResponse()` reads widget 0, whose container the swap destroyed.

## The fix

- `darkmodeStore` no longer dispatches the `message` CustomEvent.
- `ContactForm` loads reCAPTCHA with `render=explicit&onload=…` and renders on each mount, keeping the widget id for `getResponse`.
- `initCaptcha` takes the container so it reads that widget's own response field, and returns `{ reapply, stop }` so the effect clears the ticker on unmount.

## Verification

`nx format`, `nx lint ag-grid-docs` (0 errors), `nx build ag-grid-docs` (1056 tasks) and `nx test ag-grid-docs` (899 tests, 45 files, all passing) all pass.

Playwright against a local production build, `/contact/`:

| | result |
|---|---|
| Hard load | widget renders (2 children, 2 iframes, 1 response field) |
| Nav away | no console errors |
| Nav back | widget renders again, no errors |
| Second round trip | widget renders again, no errors |
| Dark-mode toggle | still drives `data-dark-mode` and `data-ag-theme-mode` |

The same mechanism was verified in more depth on studio, where the shared code is identical: the ticker is cleaned up per mount (created N, cleared N-1), the response field resolves correctly for widgets after the first, and the timestamp still freezes at solve time.