### PR TITLE
AG-3390 - Only run the docs site's second build when the sitemap has changed

### DIFF
--- a/documentation/ag-grid-docs/project.json
+++ b/documentation/ag-grid-docs/project.json
@@ -19,7 +19,7 @@
         "!{projectRoot}/vitest.config.ts",
         "{workspaceRoot}/external/ag-website-shared/**",
         "charts",
-        "{projectRoot}/.astro/cache/sitemap/**",
+        "{projectRoot}/.astro/cache/sitemap/sitemap-0.xml",
         { "env": "PUBLIC_PACKAGE_VERSION" }
       ],
       "cache": true,

--- a/documentation/ag-grid-docs/src/pages/sitemap.astro
+++ b/documentation/ag-grid-docs/src/pages/sitemap.astro
@@ -4,13 +4,14 @@ import parseSitemap from '@ag-website-shared/components/sitemap/utils/sitemaputi
 import { getSitemapXml } from '@ag-website-shared/utils/getSitemapXml';
 import Layout from '../layouts/Layout.astro';
 import { LIVE_SITEMAP_URL, PRODUCTION_GRID_SITE_URL } from '@constants';
-import { SITEMAP_CACHE_DIR } from '@ag-website-shared/constants';
+import { SITEMAP_BUILD_DIR, SITEMAP_CACHE_DIR } from '@ag-website-shared/constants';
 import { STATIC_PAGE_CONTENT } from '@utils/markdown-pages/staticPageContent';
 
 const sitemapUrl = LIVE_SITEMAP_URL || `${PRODUCTION_GRID_SITE_URL}/sitemap-0.xml`;
 const xmlSitemap = await getSitemapXml({
     cacheDir: SITEMAP_CACHE_DIR,
     sitemapUrl,
+    recordDir: SITEMAP_BUILD_DIR,
 });
 const parsedSitemap = parseSitemap(xmlSitemap);
 

--- a/documentation/ag-grid-docs/src/pages/sitemap.md.ts
+++ b/documentation/ag-grid-docs/src/pages/sitemap.md.ts
@@ -1,5 +1,5 @@
 import parseSitemap from '@ag-website-shared/components/sitemap/utils/sitemaputils';
-import { SITEMAP_CACHE_DIR } from '@ag-website-shared/constants';
+import { SITEMAP_BUILD_DIR, SITEMAP_CACHE_DIR } from '@ag-website-shared/constants';
 import { getSitemapXml } from '@ag-website-shared/utils/getSitemapXml';
 import { DISABLE_MARKDOWN_DOCS, LIVE_SITEMAP_URL, PRODUCTION_GRID_SITE_URL } from '@constants';
 import { STATIC_PAGE_CONTENT } from '@utils/markdown-pages/staticPageContent';
@@ -13,7 +13,11 @@ export async function GET() {
     }
 
     const sitemapUrl = LIVE_SITEMAP_URL || `${PRODUCTION_GRID_SITE_URL}/sitemap-0.xml`;
-    const xmlSitemap = await getSitemapXml({ cacheDir: SITEMAP_CACHE_DIR, sitemapUrl });
+    const xmlSitemap = await getSitemapXml({
+        cacheDir: SITEMAP_CACHE_DIR,
+        sitemapUrl,
+        recordDir: SITEMAP_BUILD_DIR,
+    });
     const parsedSitemap = parseSitemap(xmlSitemap);
 
     const content = STATIC_PAGE_CONTENT.sitemap;

--- a/documentation/ag-grid-docs/src/utils/sitemap.ts
+++ b/documentation/ag-grid-docs/src/utils/sitemap.ts
@@ -73,12 +73,14 @@ const filterIgnoredPages = (page: string) => {
  *
  * There are 2 locations where the sitemap is generated:
  *
- * 1. Sitemap xml (`sitemap-0.xml`) - after a complete build, the sitemap xml file is generated in the astro `dist` folder. It is also cached in `[documentation]/.astro/cache/sitemap/sitemap-0.xml` (from the `ag-cache-sitemap` astro plugin). The cache also stores the git hash of the build, so it can be used to determine whether to cache again
+ * 1. Sitemap xml (`sitemap-0.xml`) - after a complete build, the sitemap xml file is generated in the astro `dist` folder. It is also cached in `[documentation]/.astro/cache/sitemap/sitemap-0.xml` (from the `ag-cache-sitemap` astro plugin), which refreshes the cache whenever the page list changed
  * 2. Sitemap page (`/sitemap`) - this page is generated from the sitemap xml, however since the page cannot be generated until the build is complete, it either uses what is in the cache (from a previous build), or pulls it from `LIVE_SITEMAP_URL`
+ *
+ * Because of (2), a build may need to run twice for the sitemap page to list the pages the same build generated. `buildWithSitemapCache` only does that when the page list actually moved - see that script for the comparison it makes.
  *
  * To generate the sitemap locally:
  *
- * 1. With localhost links - run `nx build ag-grid-docs --clean-cache=true --run-second-build=true` to clear out the cache and run the build twice, so the sitemap page is updated. Preview with `nx preview ag-grid-docs`
+ * 1. With localhost links - run `nx build ag-grid-docs --clean-cache=true --run-second-build=true` to clear out the cache and allow the second build, so the sitemap page is updated. Preview with `nx preview ag-grid-docs`
  * 2. With production links - run the production preview with `nx preview ag-grid-docs -c production`
  *
  * Check the sitemap locally at `http://localhost:4611/sitemap-0.xml` and `http://localhost:4611/sitemap`

--- a/external/ag-website-shared/plugins/agCacheSitemap.ts
+++ b/external/ag-website-shared/plugins/agCacheSitemap.ts
@@ -3,10 +3,22 @@ import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { getGitHash } from '../src/utils/gitUtils';
+import { diffSitemapLocs, getSitemapLocs } from '../src/utils/sitemapLocs';
 
 type Options = {
     cacheFolder: string;
+};
+
+const readFileOrNull = async (filePath: string) => {
+    try {
+        return await fs.readFile(filePath, 'utf8');
+    } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+            return null;
+        }
+
+        throw error;
+    }
 };
 
 export default function createPlugin({ cacheFolder }: Options): AstroIntegration {
@@ -14,7 +26,6 @@ export default function createPlugin({ cacheFolder }: Options): AstroIntegration
         name: 'ag-cache-sitemap',
         hooks: {
             'astro:build:done': async ({ dir, logger }) => {
-                const currentHash = getGitHash();
                 const outputDir = fileURLToPath(dir);
                 const sitemapSourcePath = path.join(outputDir, 'sitemap-0.xml');
                 const metaSourcePath = path.join(outputDir, 'debug', 'meta.json');
@@ -23,30 +34,33 @@ export default function createPlugin({ cacheFolder }: Options): AstroIntegration
                 const cacheSitemapPath = path.join(cacheRoot, 'sitemap-0.xml');
                 const cacheMetaPath = path.join(cacheRoot, 'debug', 'meta.json');
 
-                const readCachedHash = async () => {
-                    try {
-                        const raw = await fs.readFile(cacheMetaPath, 'utf8');
-                        const cachedMeta = JSON.parse(raw);
-                        return cachedMeta?.git?.hash ?? null;
-                    } catch (error) {
-                        if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
-                            return null;
-                        }
-
-                        throw error;
-                    }
-                };
-
-                const cachedHash = await readCachedHash();
-                if (cachedHash === currentHash) {
-                    logger.info(`Sitemap cache already up to date for ${currentHash}.`);
+                const generatedXml = await readFileOrNull(sitemapSourcePath);
+                if (generatedXml == null) {
+                    logger.warn('sitemap-0.xml not found — nothing to cache.');
                     return;
                 }
 
+                // Cached on the page list rather than the git hash: a commit that touches no page
+                // leaves the sitemap identical, and a rebuild at the same commit can still change it
+                // (uncommitted content edits), so the hash answers neither question. The page list is
+                // also all the sitemap page renders, so an unchanged list means an unchanged page.
+                const cachedXml = await readFileOrNull(cacheSitemapPath);
+                const sitemapUnchanged =
+                    cachedXml != null &&
+                    diffSitemapLocs(getSitemapLocs(cachedXml), getSitemapLocs(generatedXml)).matches;
+
                 await fs.mkdir(path.dirname(cacheMetaPath), { recursive: true });
+                if (sitemapUnchanged) {
+                    // Only the meta, so the recorded git hash tracks the build that last confirmed
+                    // this sitemap and `getSitemapXml` does not report the cache as stale.
+                    await fs.copyFile(metaSourcePath, cacheMetaPath);
+                    logger.info('Cached sitemap already lists the same pages — left in place.');
+                    return;
+                }
+
                 await fs.copyFile(sitemapSourcePath, cacheSitemapPath);
                 await fs.copyFile(metaSourcePath, cacheMetaPath);
-                logger.info(`Cached sitemap and meta.json for ${currentHash}.`);
+                logger.info(`Cached sitemap with ${getSitemapLocs(generatedXml).length} page(s).`);
             },
         },
     };

--- a/external/ag-website-shared/scripts/buildWithSitemapCache.ts
+++ b/external/ag-website-shared/scripts/buildWithSitemapCache.ts
@@ -1,20 +1,38 @@
 #!/usr/bin/env tsx
 /**
- * Build helper for AG Charts website.
+ * Build helper for the AG websites.
  *
- * Runs a full Astro build to generate the sitemap cache, then optionally runs a
- * second build that uses the sitemap cache to generate the sitemap page.
+ * The sitemap page is a chicken-and-egg case: it lists the pages in the sitemap, but the sitemap is
+ * only generated once every page — including this one — has been built. So the page renders from a
+ * *previous* sitemap (the on-disk cache, or the live site) and the build has to run again to catch
+ * the page up whenever the page list has actually moved.
+ *
+ * "Whenever it has actually moved" is the point: a second full build of the whole site is expensive,
+ * and most builds do not add or remove a page. So the first build records which sitemap its sitemap
+ * pages rendered from (see `consumedSitemapRecord`), and this script only builds again when that
+ * differs from the sitemap the build went on to generate. Builds that generate no sitemap at all
+ * (archives — see the `astro.config.mjs` integrations) can never need the second pass.
  *
  * Flags:
  * - --run-second-build / --no-run-second-build / --run-second-build=false
+ *   Allow a second build when the sitemap pages are out of date. Without it, they are left as-is.
  * - --clean-cache / --no-clean-cache / --clean-cache=false
+ *   Discard the cached sitemap first, so the first build renders from the live site instead.
  * - All other params are passed through to Astro
  */
 import { spawnSync } from 'node:child_process';
-import { rmSync } from 'node:fs';
+import { readFileSync, rmSync } from 'node:fs';
 import path from 'node:path';
 
-import { SITEMAP_CACHE_DIR } from '../src/constants';
+import { SITEMAP_BUILD_DIR, SITEMAP_CACHE_DIR } from '../src/constants';
+import {
+    decideSecondBuild,
+    getConsumedSitemapRecordPath,
+    readConsumedSitemapRecord,
+} from '../src/utils/consumedSitemapRecord';
+
+// Astro's default `outDir`, which none of the websites override.
+const ASTRO_OUT_DIR = 'dist';
 
 const rawArgs = process.argv.slice(2);
 const normaliseFlag = (flag: string) => flag.replace(/^--/, '');
@@ -41,16 +59,22 @@ const getFlagValue = (flag: string) => {
     return value;
 };
 const hasFlag = (flag: string) => getFlagValue(flag) ?? false;
+const OWN_FLAGS = ['--run-second-build', '--clean-cache'];
 const runSecondBuild = hasFlag('--run-second-build');
 const cleanCache = hasFlag('--clean-cache');
-const astroArgs = [
-    'build',
-    ...rawArgs.filter((arg) => !arg.startsWith('--run-second-build') && !arg.startsWith('--clean-cache')),
-];
+const astroArgs = ['build', ...rawArgs.filter((arg) => !OWN_FLAGS.some((flag) => arg.startsWith(flag)))];
 
-const cleanSitemapCache = async () => {
-    const cacheFolder = path.resolve(SITEMAP_CACHE_DIR);
-    rmSync(cacheFolder, { recursive: true, force: true });
+/** Null when this build generated no sitemap at all, as archive builds do. */
+const readGeneratedSitemap = () => {
+    try {
+        return readFileSync(path.join(ASTRO_OUT_DIR, 'sitemap-0.xml'), 'utf8');
+    } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+            return null;
+        }
+
+        throw error;
+    }
 };
 
 const runBuild = () => {
@@ -62,13 +86,24 @@ const runBuild = () => {
 
 if (cleanCache) {
     console.log('✨ Cleaning sitemap cache');
-    cleanSitemapCache();
+    rmSync(path.resolve(SITEMAP_CACHE_DIR), { recursive: true, force: true });
 }
+
+// A record left by an earlier build would otherwise be read as this build's.
+rmSync(getConsumedSitemapRecordPath(SITEMAP_BUILD_DIR), { force: true });
 
 runBuild();
 
 if (runSecondBuild) {
-    console.log('♻️ Building again to use latest sitemap');
+    const { needed, reason } = decideSecondBuild({
+        generatedXml: readGeneratedSitemap(),
+        record: readConsumedSitemapRecord(SITEMAP_BUILD_DIR),
+    });
 
-    runBuild();
+    if (needed) {
+        console.log(`♻️ Building again to update the sitemap page: ${reason}`);
+        runBuild();
+    } else {
+        console.log(`✅ Skipping the second build — ${reason}.`);
+    }
 }

--- a/external/ag-website-shared/src/constants.ts
+++ b/external/ag-website-shared/src/constants.ts
@@ -79,6 +79,16 @@ export const STUDIO_FORM_DATA = {
 export const SITEMAP_CACHE_DIR = '.astro/cache/sitemap';
 
 /**
+ * Scratch folder for the sitemap bookkeeping `buildWithSitemapCache` needs across the two builds it
+ * may run — currently the record of which sitemap the first build's sitemap pages rendered from.
+ *
+ * Deliberately outside `SITEMAP_CACHE_DIR`: the cached sitemap is a declared nx input for the docs
+ * `build` target (a change to it has to re-run the build), and this bookkeeping changes on every
+ * build without changing what the site renders, so it must not feed that hash.
+ */
+export const SITEMAP_BUILD_DIR = '.astro/cache/sitemap-build';
+
+/**
  * `User-Agent` identifying build-time fetches against the live AG sites (sitemaps, robots disallow
  * lists), which are not served to the default agent.
  */

--- a/external/ag-website-shared/src/utils/consumedSitemapRecord.test.ts
+++ b/external/ag-website-shared/src/utils/consumedSitemapRecord.test.ts
@@ -1,0 +1,61 @@
+import { type ConsumedSitemapRecord, decideSecondBuild } from './consumedSitemapRecord';
+
+const HOME = 'https://www.ag-grid.com/';
+const ABOUT = 'https://www.ag-grid.com/about/';
+const PIPELINE = 'https://www.ag-grid.com/pipeline/';
+
+const sitemapXml = (...locs: string[]) =>
+    `<?xml version="1.0" encoding="UTF-8"?><urlset>${locs
+        .map((loc) => `<url><loc>${loc}</loc><lastmod>2026-08-21T00:00:00.000Z</lastmod></url>`)
+        .join('')}</urlset>`;
+
+const cacheRecord = (...locs: string[]): ConsumedSitemapRecord => ({ source: 'cache', locs });
+const liveRecord = (...locs: string[]): ConsumedSitemapRecord => ({
+    source: 'live',
+    sitemapUrl: 'https://www.ag-grid.com/sitemap-0.xml',
+    locs,
+});
+
+describe('decideSecondBuild', () => {
+    test('skips the second build when the generated sitemap lists the pages already rendered', () => {
+        const decision = decideSecondBuild({
+            generatedXml: sitemapXml(HOME, ABOUT),
+            record: cacheRecord(HOME, ABOUT),
+        });
+
+        expect(decision).toEqual({ needed: false, reason: 'sitemap unchanged since the cached sitemap — 2 page(s)' });
+    });
+
+    test('skips the second build when the live sitemap the page rendered from is still current', () => {
+        const decision = decideSecondBuild({
+            generatedXml: sitemapXml(HOME, ABOUT),
+            record: liveRecord(HOME, ABOUT),
+        });
+
+        expect(decision.needed).toBe(false);
+        expect(decision.reason).toContain('the live sitemap (https://www.ag-grid.com/sitemap-0.xml)');
+    });
+
+    test('builds again when a page was added', () => {
+        const decision = decideSecondBuild({
+            generatedXml: sitemapXml(HOME, ABOUT, PIPELINE),
+            record: cacheRecord(HOME, ABOUT),
+        });
+
+        expect(decision).toEqual({ needed: true, reason: `1 added (${PIPELINE})` });
+    });
+
+    test('builds again when the first build had no sitemap to render from', () => {
+        const decision = decideSecondBuild({ generatedXml: sitemapXml(HOME), record: null });
+
+        expect(decision.needed).toBe(true);
+    });
+
+    test('skips the second build when this build generates no sitemap at all', () => {
+        // Archive builds: the sitemap integrations are not registered and the /sitemap page is
+        // removed from the output, so no amount of rebuilding can change it.
+        const decision = decideSecondBuild({ generatedXml: null, record: null });
+
+        expect(decision.needed).toBe(false);
+    });
+});

--- a/external/ag-website-shared/src/utils/consumedSitemapRecord.ts
+++ b/external/ag-website-shared/src/utils/consumedSitemapRecord.ts
@@ -1,0 +1,109 @@
+import { promises as fs, readFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { describeSitemapLocsDiff, diffSitemapLocs, getSitemapLocs } from './sitemapLocs';
+
+/**
+ * The sitemap page is a chicken-and-egg case: it lists the pages in the sitemap, but the sitemap is
+ * only generated once every page — including this one — has been built. So the page renders from a
+ * *previous* sitemap (the on-disk cache, or the live site) and the build may have to run a second
+ * time to re-render it against the sitemap it just generated.
+ *
+ * This record is how the build finds out whether that second build is actually needed: the page
+ * writes down which sitemap it rendered from, and `buildWithSitemapCache` compares that against the
+ * sitemap the build went on to generate.
+ */
+export type ConsumedSitemapRecord = {
+    /** Where the sitemap came from — the on-disk cache, or a fetch from the live site. */
+    source: 'cache' | 'live';
+    /** Set when `source` is `live`. */
+    sitemapUrl?: string;
+    locs: string[];
+};
+
+const RECORD_FILE_NAME = 'consumed-sitemap.json';
+
+export const getConsumedSitemapRecordPath = (recordDir: string) => path.join(path.resolve(recordDir), RECORD_FILE_NAME);
+
+// Every page that renders the sitemap writes the same record, and Astro builds pages concurrently,
+// so write to a private path and rename it into place — a plain write can interleave into a torn
+// file that then reads back as no record at all.
+let writeCount = 0;
+
+export const writeConsumedSitemapRecord = async ({
+    recordDir,
+    xmlSitemap,
+    source,
+    sitemapUrl,
+}: {
+    recordDir: string;
+    xmlSitemap: string;
+    source: ConsumedSitemapRecord['source'];
+    sitemapUrl?: string;
+}) => {
+    const recordPath = getConsumedSitemapRecordPath(recordDir);
+    const record: ConsumedSitemapRecord = { source, sitemapUrl, locs: getSitemapLocs(xmlSitemap) };
+    const tempPath = `${recordPath}.${process.pid}-${++writeCount}.tmp`;
+
+    await fs.mkdir(path.dirname(recordPath), { recursive: true });
+    await fs.writeFile(tempPath, JSON.stringify(record), 'utf8');
+    await fs.rename(tempPath, recordPath);
+};
+
+/** Null when no usable record was written, which is treated as "assume the pages are out of date". */
+export const readConsumedSitemapRecord = (recordDir: string): ConsumedSitemapRecord | null => {
+    let raw: string;
+    try {
+        raw = readFileSync(getConsumedSitemapRecordPath(recordDir), 'utf8');
+    } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+            return null;
+        }
+
+        throw error;
+    }
+
+    try {
+        const record = JSON.parse(raw);
+        return Array.isArray(record?.locs) ? record : null;
+    } catch {
+        return null;
+    }
+};
+
+export type SecondBuildDecision = {
+    needed: boolean;
+    /** Why, for the build log. */
+    reason: string;
+};
+
+/**
+ * Whether the sitemap pages the first build produced are already correct.
+ *
+ * Anything unexpected resolves to "build again": a redundant build only costs time, whereas a stale
+ * sitemap page ships.
+ */
+export const decideSecondBuild = ({
+    generatedXml,
+    record,
+}: {
+    /** The sitemap this build generated, or null if it generated none (archive builds). */
+    generatedXml: string | null;
+    record: ConsumedSitemapRecord | null;
+}): SecondBuildDecision => {
+    if (generatedXml == null) {
+        return { needed: false, reason: 'this build generates no sitemap, so the sitemap page cannot be out of date' };
+    }
+
+    if (record == null) {
+        return { needed: true, reason: 'no record of which sitemap the first build rendered from' };
+    }
+
+    const diff = diffSitemapLocs(record.locs, getSitemapLocs(generatedXml));
+    if (diff.matches) {
+        const from = record.source === 'live' ? `the live sitemap (${record.sitemapUrl})` : 'the cached sitemap';
+        return { needed: false, reason: `sitemap unchanged since ${from} — ${record.locs.length} page(s)` };
+    }
+
+    return { needed: true, reason: describeSitemapLocsDiff(diff) };
+};

--- a/external/ag-website-shared/src/utils/getSitemapXml.test.ts
+++ b/external/ag-website-shared/src/utils/getSitemapXml.test.ts
@@ -1,6 +1,10 @@
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import { vi } from 'vitest';
 
 import { BUILD_USER_AGENT } from '../constants';
+import { getConsumedSitemapRecordPath } from './consumedSitemapRecord';
 import { getSitemapXml } from './getSitemapXml';
 
 const SITEMAP_URL = 'https://www.ag-grid.com/sitemap-0.xml';
@@ -40,5 +44,63 @@ describe('getSitemapXml', () => {
         );
 
         await expect(fetchSitemap()).rejects.toThrow(`Failed to fetch sitemap ${SITEMAP_URL}: 503 Service Unavailable`);
+    });
+
+    describe('recording which sitemap was used', () => {
+        let tempDir: string;
+
+        const readRecord = async (recordDir: string) =>
+            JSON.parse(await fs.readFile(getConsumedSitemapRecordPath(recordDir), 'utf8'));
+
+        beforeEach(async () => {
+            tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ag-sitemap-'));
+        });
+
+        afterEach(async () => {
+            await fs.rm(tempDir, { recursive: true, force: true });
+        });
+
+        test('records a sitemap fetched from the live site', async () => {
+            vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, text: async () => SITEMAP_XML }));
+            const recordDir = path.join(tempDir, 'sitemap-build');
+
+            await getSitemapXml({
+                cacheDir: MISSING_CACHE_DIR,
+                sitemapUrl: SITEMAP_URL,
+                logger,
+                gitHash: 'test-hash',
+                recordDir,
+            });
+
+            expect(await readRecord(recordDir)).toEqual({
+                source: 'live',
+                sitemapUrl: SITEMAP_URL,
+                locs: ['https://www.ag-grid.com/'],
+            });
+        });
+
+        test('records a sitemap read from the cache', async () => {
+            const cacheDir = path.join(tempDir, 'sitemap');
+            const recordDir = path.join(tempDir, 'sitemap-build');
+            await fs.mkdir(path.join(cacheDir, 'debug'), { recursive: true });
+            await fs.writeFile(path.join(cacheDir, 'sitemap-0.xml'), SITEMAP_XML, 'utf8');
+            await fs.writeFile(
+                path.join(cacheDir, 'debug', 'meta.json'),
+                JSON.stringify({ git: { hash: 'test-hash' } }),
+                'utf8'
+            );
+
+            await getSitemapXml({ cacheDir, sitemapUrl: SITEMAP_URL, logger, gitHash: 'test-hash', recordDir });
+
+            expect(await readRecord(recordDir)).toEqual({ source: 'cache', locs: ['https://www.ag-grid.com/'] });
+        });
+
+        test('records nothing when no record folder is given', async () => {
+            vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, text: async () => SITEMAP_XML }));
+
+            await fetchSitemap();
+
+            await expect(fs.readdir(tempDir)).resolves.toEqual([]);
+        });
     });
 });

--- a/external/ag-website-shared/src/utils/getSitemapXml.ts
+++ b/external/ag-website-shared/src/utils/getSitemapXml.ts
@@ -2,6 +2,7 @@ import { promises as fs } from 'node:fs';
 import path from 'node:path';
 
 import { BUILD_USER_AGENT } from '../constants';
+import { type ConsumedSitemapRecord, writeConsumedSitemapRecord } from './consumedSitemapRecord';
 import { getGitHash } from './gitUtils';
 
 type Logger = Pick<Console, 'info' | 'warn' | 'log'>;
@@ -11,6 +12,12 @@ type GetSitemapXmlOptions = {
     sitemapUrl: string;
     logger?: Logger;
     gitHash?: string;
+    /**
+     * When set, the resolved sitemap is recorded here so `buildWithSitemapCache` can tell whether
+     * the sitemap this page rendered from matches the one the build then generated, and skip the
+     * second build when it does. Omit to record nothing.
+     */
+    recordDir?: string;
 };
 
 const readCachedHash = async (cachedMetaPath: string) => {
@@ -32,6 +39,7 @@ export const getSitemapXml = async ({
     sitemapUrl,
     logger = console,
     gitHash,
+    recordDir,
 }: GetSitemapXmlOptions): Promise<string> => {
     const cacheFolder = path.resolve(cacheDir);
     const cachedSitemapPath = path.join(cacheFolder, 'sitemap-0.xml');
@@ -39,6 +47,7 @@ export const getSitemapXml = async ({
     const currentHash = gitHash ?? getGitHash();
 
     let xmlSitemap: string | null = null;
+    let source: ConsumedSitemapRecord['source'] = 'cache';
     try {
         await fs.access(cachedSitemapPath);
         const cachedHash = await readCachedHash(cachedMetaPath);
@@ -63,7 +72,22 @@ export const getSitemapXml = async ({
             throw new Error(`Failed to fetch sitemap ${sitemapUrl}: ${response.status} ${response.statusText}`);
         }
         xmlSitemap = await response.text();
+        source = 'live';
         logger.log(`⚠️ No cached sitemap found, fetched from live site: ${sitemapUrl}`);
+    }
+
+    if (recordDir) {
+        try {
+            await writeConsumedSitemapRecord({
+                recordDir,
+                xmlSitemap,
+                source,
+                sitemapUrl: source === 'live' ? sitemapUrl : undefined,
+            });
+        } catch (error) {
+            // Only costs a redundant second build, so never fail the page over it.
+            logger.warn(`⚠️ Could not record the sitemap this build rendered from: ${error}`);
+        }
     }
 
     return xmlSitemap;

--- a/external/ag-website-shared/src/utils/sitemapLocs.test.ts
+++ b/external/ag-website-shared/src/utils/sitemapLocs.test.ts
@@ -1,0 +1,79 @@
+import { describeSitemapLocsDiff, diffSitemapLocs, getSitemapLocs } from './sitemapLocs';
+
+const sitemapXml = (...locs: string[]) =>
+    `<?xml version="1.0" encoding="UTF-8"?><urlset>${locs
+        .map((loc) => `<url><loc>${loc}</loc><lastmod>2026-08-21T00:00:00.000Z</lastmod></url>`)
+        .join('')}</urlset>`;
+
+const HOME = 'https://www.ag-grid.com/';
+const ABOUT = 'https://www.ag-grid.com/about/';
+const PIPELINE = 'https://www.ag-grid.com/pipeline/';
+
+describe('getSitemapLocs', () => {
+    test('reads the locs in sitemap order', () => {
+        expect(getSitemapLocs(sitemapXml(HOME, ABOUT))).toEqual([HOME, ABOUT]);
+    });
+
+    test('returns nothing for a sitemap with no urls', () => {
+        expect(getSitemapLocs(sitemapXml())).toEqual([]);
+    });
+});
+
+describe('diffSitemapLocs', () => {
+    test('matches sitemaps whose lastmod differs but whose pages do not', () => {
+        const before = getSitemapLocs(sitemapXml(HOME, ABOUT));
+        const after = getSitemapLocs(sitemapXml(HOME, ABOUT).replace('2026-08-21', '2026-08-22'));
+
+        expect(diffSitemapLocs(before, after).matches).toBe(true);
+    });
+
+    test('reports an added page', () => {
+        const diff = diffSitemapLocs([HOME, ABOUT], [HOME, ABOUT, PIPELINE]);
+
+        expect(diff).toEqual({ matches: false, added: [PIPELINE], removed: [], reordered: false });
+    });
+
+    test('reports a removed page', () => {
+        const diff = diffSitemapLocs([HOME, ABOUT, PIPELINE], [HOME, ABOUT]);
+
+        expect(diff).toEqual({ matches: false, added: [], removed: [PIPELINE], reordered: false });
+    });
+
+    test('treats a reorder as a change, because the page lists pages in sitemap order', () => {
+        const diff = diffSitemapLocs([HOME, ABOUT], [ABOUT, HOME]);
+
+        expect(diff).toEqual({ matches: false, added: [], removed: [], reordered: true });
+    });
+
+    test('treats a repeated page as a change, so a duplicate is not lost to set comparison', () => {
+        const diff = diffSitemapLocs([HOME], [HOME, HOME]);
+
+        expect(diff).toEqual({ matches: false, added: [], removed: [], reordered: false });
+        expect(describeSitemapLocsDiff(diff)).toBe('the page list changed');
+    });
+
+    test('does not match an empty sitemap against a populated one', () => {
+        expect(diffSitemapLocs([], [HOME]).matches).toBe(false);
+    });
+});
+
+describe('describeSitemapLocsDiff', () => {
+    test('summarises additions and removals', () => {
+        const diff = diffSitemapLocs([HOME, ABOUT], [HOME, PIPELINE]);
+
+        expect(describeSitemapLocsDiff(diff)).toBe(`1 added (${PIPELINE}), 1 removed (${ABOUT})`);
+    });
+
+    test('truncates a long list of changes', () => {
+        const added = ['/a/', '/b/', '/c/', '/d/'];
+        const diff = diffSitemapLocs([], added);
+
+        expect(describeSitemapLocsDiff(diff)).toBe('4 added (/a/, /b/, /c/, …)');
+    });
+
+    test('calls out a reorder', () => {
+        expect(describeSitemapLocsDiff(diffSitemapLocs([HOME, ABOUT], [ABOUT, HOME]))).toBe(
+            'same pages in a different order'
+        );
+    });
+});

--- a/external/ag-website-shared/src/utils/sitemapLocs.ts
+++ b/external/ag-website-shared/src/utils/sitemapLocs.ts
@@ -1,0 +1,58 @@
+/**
+ * The `/sitemap` page and its `/sitemap.md` twin render nothing but the `<loc>` list of the sitemap
+ * XML, in sitemap order (see `parseSitemap`). `<lastmod>` is rewritten on every build and never
+ * reaches either page, so two sitemaps with the same locs in the same order produce byte-identical
+ * sitemap pages.
+ *
+ * That makes the loc list — not the raw XML, and not the git hash — the right cache key for both the
+ * sitemap cache and the build's decision on whether the sitemap pages need re-rendering.
+ */
+
+const LOC_REGEX = /<loc>([^<]+)<\/loc>/g;
+
+export const getSitemapLocs = (xml: string): string[] => [...xml.matchAll(LOC_REGEX)].map(([, loc]) => loc.trim());
+
+export type SitemapLocsDiff = {
+    /** The two loc lists render the same sitemap page. */
+    matches: boolean;
+    added: string[];
+    removed: string[];
+    /** The same URLs in a different order. The page lists them in sitemap order, so still a change. */
+    reordered: boolean;
+};
+
+export const diffSitemapLocs = (before: string[], after: string[]): SitemapLocsDiff => {
+    const matches = before.length === after.length && before.every((loc, index) => loc === after[index]);
+    const beforeSet = new Set(before);
+    const afterSet = new Set(after);
+    const added = after.filter((loc) => !beforeSet.has(loc));
+    const removed = before.filter((loc) => !afterSet.has(loc));
+
+    return {
+        matches,
+        added,
+        removed,
+        reordered: !matches && before.length === after.length && added.length === 0 && removed.length === 0,
+    };
+};
+
+/** One-line summary of a diff, for build logs. */
+export const describeSitemapLocsDiff = ({ matches, added, removed, reordered }: SitemapLocsDiff): string => {
+    if (matches) {
+        return 'no change';
+    }
+    if (reordered) {
+        return 'same pages in a different order';
+    }
+
+    const summarise = (label: string, locs: string[]) =>
+        locs.length === 0
+            ? null
+            : `${locs.length} ${label} (${locs.slice(0, 3).join(', ')}${locs.length > 3 ? ', …' : ''})`;
+
+    // The fallback covers a page listed a different number of times, which shows up as neither an
+    // addition nor a removal.
+    return (
+        [summarise('added', added), summarise('removed', removed)].filter(Boolean).join(', ') || 'the page list changed'
+    );
+};


### PR DESCRIPTION
Follow up to https://github.com/ag-grid/ag-grid/pull/12901, which made production and archive builds run `nx build` twice so the `/sitemap` page picks up the sitemap generated by the same build. The second build is a full site build, and most builds do not add or remove a page — this makes it conditional.

## Changes

* **Use the sitemap as the cache key.** The first build records which sitemap its sitemap pages rendered from (the cache, or the live-site fetch), and `buildWithSitemapCache` only builds again when that differs from the sitemap the build went on to generate. The comparison is on the `<loc>` list rather than the raw XML: `parseSitemap` reads nothing else, and `agSitemapLastmod` rewrites `<lastmod>` on every build, so a byte comparison would never match.
* **Archive builds skip the second build outright.** `astro.config.mjs` registers no sitemap integrations when `PUBLIC_BASE_URL` contains `archive`, and deletes `dist/sitemap/`, so nothing writes the sitemap cache and the second build was byte-identical work. Archive builds now always halve.
* **`agCacheSitemap` keys the cache on the page list, not the git hash.** The hash answered neither question the cache needs: a commit can touch no page (cache needlessly refreshed), and a rebuild at the same commit can still change the page list (cache left stale — the staleness `--clean-cache=true` was papering over).
* **Narrow the docs `build` nx input** from `.astro/cache/sitemap/**` to `.astro/cache/sitemap/sitemap-0.xml`. The cached `meta.json` carries a `buildDate`, so the old glob changed on every build and the docs build could never be an nx cache hit twice in a row on a warm workspace.

Anything unexpected — no record, an unreadable record — falls through to building again, so a lost signal costs time rather than shipping a stale sitemap page.

## Impact

* Archive builds: second build always skipped.
* Production builds: skipped whenever the page set is unchanged since the live sitemap. A release that adds docs pages still builds twice, correctly.

Removing the second build for production entirely would mean generating the sitemap before pages render, which collides with `agSitemapFilterNoindex` needing built HTML to detect `noindex`. Not attempted here.

## Testing

* 18 new unit tests covering the loc diff, the second-build decision, and — at the filesystem level — that the record is written on both the cache and live-fetch paths.
* Smoke-tested the wrapper against a stubbed `astro`, counting real invocations: sitemap unchanged → 1 build; page added → 2; no record → 2; archive-style with no sitemap generated → 1.

## Follow up

`external/ag-website-shared` is duplicated into ag-charts and ag-studio (identical copies today), so these shared files need porting there separately.