### PR TITLE
SE-86 Allow the /feed suffix on the renamed legacy-slug redirects

### DIFF
--- a/documentation/ag-grid-docs/src/utils/htaccess/__snapshots__/htaccessRules.test.ts.snap
+++ b/documentation/ag-grid-docs/src/utils/htaccess/__snapshots__/htaccessRules.test.ts.snap
@@ -397,15 +397,15 @@ AddCharset utf-8 .md
     # checked and its derived target status-verified: 15 resolve, 6 needed an explicit
     # remap because the slug changed. The remaps MUST precede the generic dated rule.
     RewriteCond %{HTTP_HOST} ^blog\\.ag-grid\\.com$ [NC]
-    RewriteRule ^/?(?:index\\.php/)?[0-9]{4}/[0-9]{2}/[0-9]{2}/get-started-with-react-grid-in-5-minutes/?$ https://www.ag-grid.com/blog/react-get-started-with-react-grid-in-5-minutes/ [R=301,NC,L]
+    RewriteRule ^/?(?:index\\.php/)?[0-9]{4}/[0-9]{2}/[0-9]{2}/get-started-with-react-grid-in-5-minutes(?:/feed)?/?$ https://www.ag-grid.com/blog/react-get-started-with-react-grid-in-5-minutes/ [R=301,NC,L]
     RewriteCond %{HTTP_HOST} ^blog\\.ag-grid\\.com$ [NC]
-    RewriteRule ^/?(?:index\\.php/)?[0-9]{4}/[0-9]{2}/[0-9]{2}/customise-react-grid/?$ https://www.ag-grid.com/blog/learn-to-customize-react-grid-in-less-than-10-minutes/ [R=301,NC,L]
+    RewriteRule ^/?(?:index\\.php/)?[0-9]{4}/[0-9]{2}/[0-9]{2}/customise-react-grid(?:/feed)?/?$ https://www.ag-grid.com/blog/learn-to-customize-react-grid-in-less-than-10-minutes/ [R=301,NC,L]
     RewriteCond %{HTTP_HOST} ^blog\\.ag-grid\\.com$ [NC]
-    RewriteRule ^/?(?:index\\.php/)?[0-9]{4}/[0-9]{2}/[0-9]{2}/customize-angular-grid/?$ https://www.ag-grid.com/blog/learn-to-customize-angular-grid-in-less-than-10-minutes/ [R=301,NC,L]
+    RewriteRule ^/?(?:index\\.php/)?[0-9]{4}/[0-9]{2}/[0-9]{2}/customize-angular-grid(?:/feed)?/?$ https://www.ag-grid.com/blog/learn-to-customize-angular-grid-in-less-than-10-minutes/ [R=301,NC,L]
     RewriteCond %{HTTP_HOST} ^blog\\.ag-grid\\.com$ [NC]
-    RewriteRule ^/?(?:index\\.php/)?[0-9]{4}/[0-9]{2}/[0-9]{2}/customize-javascript-grid/?$ https://www.ag-grid.com/blog/learn-to-customize-javascript-grid-in-less-than-10-minutes/ [R=301,NC,L]
+    RewriteRule ^/?(?:index\\.php/)?[0-9]{4}/[0-9]{2}/[0-9]{2}/customize-javascript-grid(?:/feed)?/?$ https://www.ag-grid.com/blog/learn-to-customize-javascript-grid-in-less-than-10-minutes/ [R=301,NC,L]
     RewriteCond %{HTTP_HOST} ^blog\\.ag-grid\\.com$ [NC]
-    RewriteRule ^/?(?:index\\.php/)?[0-9]{4}/[0-9]{2}/[0-9]{2}/inside-fiber-in-depth-overview-of-the-new-reconciliation-algorithm(?:-in-react)?/?$ https://www.ag-grid.com/blog/inside-fiber-an-in-depth-overview-of-the-new-reconciliation-algorithm-in-react/ [R=301,NC,L]
+    RewriteRule ^/?(?:index\\.php/)?[0-9]{4}/[0-9]{2}/[0-9]{2}/inside-fiber-in-depth-overview-of-the-new-reconciliation-algorithm(?:-in-react)?(?:/feed)?/?$ https://www.ag-grid.com/blog/inside-fiber-an-in-depth-overview-of-the-new-reconciliation-algorithm-in-react/ [R=301,NC,L]
 
     # Generic dated permalink: the slug survived the WordPress -> Ghost move.
     RewriteCond %{HTTP_HOST} ^blog\\.ag-grid\\.com$ [NC]

--- a/documentation/ag-grid-docs/src/utils/htaccess/htaccessRules.ts
+++ b/documentation/ag-grid-docs/src/utils/htaccess/htaccessRules.ts
@@ -262,15 +262,15 @@ ${SITE_SINGLE_HOP_REWRITES.map((r) => {
     # checked and its derived target status-verified: 15 resolve, 6 needed an explicit
     # remap because the slug changed. The remaps MUST precede the generic dated rule.
     RewriteCond %{HTTP_HOST} ^blog\\.ag-grid\\.com$ [NC]
-    RewriteRule ^/?(?:index\\.php/)?[0-9]{4}/[0-9]{2}/[0-9]{2}/get-started-with-react-grid-in-5-minutes/?$ https://www.ag-grid.com/blog/react-get-started-with-react-grid-in-5-minutes/ [R=301,NC,L]
+    RewriteRule ^/?(?:index\\.php/)?[0-9]{4}/[0-9]{2}/[0-9]{2}/get-started-with-react-grid-in-5-minutes(?:/feed)?/?$ https://www.ag-grid.com/blog/react-get-started-with-react-grid-in-5-minutes/ [R=301,NC,L]
     RewriteCond %{HTTP_HOST} ^blog\\.ag-grid\\.com$ [NC]
-    RewriteRule ^/?(?:index\\.php/)?[0-9]{4}/[0-9]{2}/[0-9]{2}/customise-react-grid/?$ https://www.ag-grid.com/blog/learn-to-customize-react-grid-in-less-than-10-minutes/ [R=301,NC,L]
+    RewriteRule ^/?(?:index\\.php/)?[0-9]{4}/[0-9]{2}/[0-9]{2}/customise-react-grid(?:/feed)?/?$ https://www.ag-grid.com/blog/learn-to-customize-react-grid-in-less-than-10-minutes/ [R=301,NC,L]
     RewriteCond %{HTTP_HOST} ^blog\\.ag-grid\\.com$ [NC]
-    RewriteRule ^/?(?:index\\.php/)?[0-9]{4}/[0-9]{2}/[0-9]{2}/customize-angular-grid/?$ https://www.ag-grid.com/blog/learn-to-customize-angular-grid-in-less-than-10-minutes/ [R=301,NC,L]
+    RewriteRule ^/?(?:index\\.php/)?[0-9]{4}/[0-9]{2}/[0-9]{2}/customize-angular-grid(?:/feed)?/?$ https://www.ag-grid.com/blog/learn-to-customize-angular-grid-in-less-than-10-minutes/ [R=301,NC,L]
     RewriteCond %{HTTP_HOST} ^blog\\.ag-grid\\.com$ [NC]
-    RewriteRule ^/?(?:index\\.php/)?[0-9]{4}/[0-9]{2}/[0-9]{2}/customize-javascript-grid/?$ https://www.ag-grid.com/blog/learn-to-customize-javascript-grid-in-less-than-10-minutes/ [R=301,NC,L]
+    RewriteRule ^/?(?:index\\.php/)?[0-9]{4}/[0-9]{2}/[0-9]{2}/customize-javascript-grid(?:/feed)?/?$ https://www.ag-grid.com/blog/learn-to-customize-javascript-grid-in-less-than-10-minutes/ [R=301,NC,L]
     RewriteCond %{HTTP_HOST} ^blog\\.ag-grid\\.com$ [NC]
-    RewriteRule ^/?(?:index\\.php/)?[0-9]{4}/[0-9]{2}/[0-9]{2}/inside-fiber-in-depth-overview-of-the-new-reconciliation-algorithm(?:-in-react)?/?$ https://www.ag-grid.com/blog/inside-fiber-an-in-depth-overview-of-the-new-reconciliation-algorithm-in-react/ [R=301,NC,L]
+    RewriteRule ^/?(?:index\\.php/)?[0-9]{4}/[0-9]{2}/[0-9]{2}/inside-fiber-in-depth-overview-of-the-new-reconciliation-algorithm(?:-in-react)?(?:/feed)?/?$ https://www.ag-grid.com/blog/inside-fiber-an-in-depth-overview-of-the-new-reconciliation-algorithm-in-react/ [R=301,NC,L]
 
     # Generic dated permalink: the slug survived the WordPress -> Ghost move.
     RewriteCond %{HTTP_HOST} ^blog\\.ag-grid\\.com$ [NC]

--- a/documentation/ag-grid-docs/testing/htaccess-harness/expectations.tsv
+++ b/documentation/ag-grid-docs/testing/htaccess-harness/expectations.tsv
@@ -316,4 +316,16 @@ blog	/index.php/2018/10/30/customize-angular-grid/feed/	301	https://www.ag-grid.
 blog	/index.php/2018/10/16/customise-react-grid/feed/	301	https://www.ag-grid.com/blog/learn-to-customize-react-grid-in-less-than-10-minutes/
 blog	/index.php/2018/08/07/get-started-with-react-grid-in-5-minutes/feed/	301	https://www.ag-grid.com/blog/react-get-started-with-react-grid-in-5-minutes/
 blog	/index.php/2018/10/30/customize-javascript-grid/feed/	301	https://www.ag-grid.com/blog/learn-to-customize-javascript-grid-in-less-than-10-minutes/
+# PR 14932 [P2]: the fifth renamed-slug remap carries TWO adjacent optional groups,
+# (?:-in-react)?(?:/feed)?. Full variant matrix below. The bare-dated forms are the
+# ones that actually exercise this rule -- the /index.php/ forms are caught earlier
+# by the unanchored legacy inside-fiber rule, so on their own they prove nothing.
+blog	/index.php/2018/11/29/inside-fiber-in-depth-overview-of-the-new-reconciliation-algorithm/feed/	301	https://www.ag-grid.com/blog/inside-fiber-an-in-depth-overview-of-the-new-reconciliation-algorithm-in-react/
+blog	/index.php/2018/11/29/inside-fiber-in-depth-overview-of-the-new-reconciliation-algorithm/	301	https://www.ag-grid.com/blog/inside-fiber-an-in-depth-overview-of-the-new-reconciliation-algorithm-in-react/
+blog	/index.php/2018/11/29/inside-fiber-in-depth-overview-of-the-new-reconciliation-algorithm-in-react/feed/	301	https://www.ag-grid.com/blog/inside-fiber-an-in-depth-overview-of-the-new-reconciliation-algorithm-in-react/
+blog	/index.php/2018/11/29/inside-fiber-in-depth-overview-of-the-new-reconciliation-algorithm-in-react/	301	https://www.ag-grid.com/blog/inside-fiber-an-in-depth-overview-of-the-new-reconciliation-algorithm-in-react/
+blog	/2018/11/29/inside-fiber-in-depth-overview-of-the-new-reconciliation-algorithm/feed/	301	https://www.ag-grid.com/blog/inside-fiber-an-in-depth-overview-of-the-new-reconciliation-algorithm-in-react/
+blog	/2018/11/29/inside-fiber-in-depth-overview-of-the-new-reconciliation-algorithm/	301	https://www.ag-grid.com/blog/inside-fiber-an-in-depth-overview-of-the-new-reconciliation-algorithm-in-react/
+blog	/2018/11/29/inside-fiber-in-depth-overview-of-the-new-reconciliation-algorithm-in-react/feed/	301	https://www.ag-grid.com/blog/inside-fiber-an-in-depth-overview-of-the-new-reconciliation-algorithm-in-react/
+blog	/2018/11/29/inside-fiber-in-depth-overview-of-the-new-reconciliation-algorithm-in-react/	301	https://www.ag-grid.com/blog/inside-fiber-an-in-depth-overview-of-the-new-reconciliation-algorithm-in-react/
 

--- a/documentation/ag-grid-docs/testing/htaccess-harness/expectations.tsv
+++ b/documentation/ag-grid-docs/testing/htaccess-harness/expectations.tsv
@@ -310,4 +310,10 @@ blog	/index.php/tag/react/	301	https://www.ag-grid.com/blog/tag/react-data-grid/
 # regressions: a non-renamed tag and a plain dated post must be unaffected
 blog	/index.php/tag/angular/	301	https://www.ag-grid.com/blog/tag/angular/
 blog	/index.php/2018/07/23/using-angular-forms-with-ag-grid/	301	https://www.ag-grid.com/blog/using-angular-forms-with-ag-grid/
+# PR 14931 [P2 #3]: /feed/ variants of the RENAMED slugs must reach the new slug, not
+# fall to the generic rule which strips /feed but keeps the obsolete slug (a 404).
+blog	/index.php/2018/10/30/customize-angular-grid/feed/	301	https://www.ag-grid.com/blog/learn-to-customize-angular-grid-in-less-than-10-minutes/
+blog	/index.php/2018/10/16/customise-react-grid/feed/	301	https://www.ag-grid.com/blog/learn-to-customize-react-grid-in-less-than-10-minutes/
+blog	/index.php/2018/08/07/get-started-with-react-grid-in-5-minutes/feed/	301	https://www.ag-grid.com/blog/react-get-started-with-react-grid-in-5-minutes/
+blog	/index.php/2018/10/30/customize-javascript-grid/feed/	301	https://www.ag-grid.com/blog/learn-to-customize-javascript-grid-in-less-than-10-minutes/
 


### PR DESCRIPTION
Follow-up to #14931, which merged before this last review fix could be pushed.
