### PR TITLE
AG-18264 advanced filter and filter parity

### DIFF
--- a/.rulesync/rules/testing.md
+++ b/.rulesync/rules/testing.md
@@ -55,7 +55,11 @@ Pick the input that *separates* the two behaviours. A test that passes against b
 
 **Never run `./behave.sh`, `./checks.sh`, `./benches.sh` or `./docs-e2e.sh` in the foreground** — while a Bash call is in flight the user cannot reach the agent at all. Launch with the harness's background mechanism, which delivers a completion event in a later turn, and do other work meanwhile. (`--async` detaches the script itself and reports back to the terminal it was launched from when it ends — useful to a human, useless to an agent, which cannot be woken that way.)
 
-**Never `sleep` to wait for a run.** One you backgrounded wakes the agent by itself; one started elsewhere has `--async-status` (exit 3 = still running) and `--wait`, below. For progress mid-run, grep the log — it is written live.
+**Locally, never `sleep` to wait for a run — no exceptions, and no duration is the right one.** A backgrounded run wakes the agent by itself, so after starting one there are exactly two correct moves: **do other work**, or **end the turn**. Ending the turn is not giving up; it is the mechanism. One started elsewhere has `--async-status` (exit 3 = still running) and `--wait`, below. For progress mid-run, grep the log — it is written live. (This rule exists to keep an interactive session reachable, so like the foreground rule below it is local-only: under `CI` the gate runs in the foreground and there is nothing to wait on.)
+
+**If you are typing a duration, you are guessing, and the guess is always wrong.** Too short and the call buys nothing but still has to be repeated; too long and it is killed at the harness's 2-minute cap, so it does not even finish the wait it blocked the console for.
+
+**`sleep N; grep …` is how this gets past the rule.** As a compound it reads like *checking*, not like *waiting*, so it never trips. Any `sleep` anywhere in a command line is the violation, whatever follows the semicolon — as is a poll loop, or "just a short one to let the log settle". The three rationalisations to kill by name: *"I want to report in this turn"* (that pull is the whole cause — the user needs the console free, not the answer inside one turn), *"the notification came but the log looks stale"* (if the notification came, the run is over: re-read in a fresh call), and *"it's only a small suite"* (size judgement is what keeps failing, and backgrounding costs nothing, so there is nothing to trade).
 
 **Never pipe a gate — not into `tail`, `head`, `grep` or anything else.** A pipeline exits with its **last** command's status, so `./behave.sh … | tail -40` reports `tail`'s `0` and a red run arrives labelled green; backgrounded, that bogus `0` is what the completion event carries, so the failure is never surfaced at all. Ask the script for less instead — these filter the console and still exit with the run's own status:
 
@@ -66,7 +70,11 @@ Pick the input that *separates* the two behaviours. A test that passes against b
 ./behave.sh --log-grep PROBE --log-tail 5 <path>    # combined: the last 5 matches
 ```
 
+**`2>&1 | tail -N` is how this rule gets broken.** It is the reflex ending for any long-running shell command, typed without a thought, so it never registers as a decision about exit status. **The tell is the `|` character, not the intent** — before running a gate, look at the line for a pipe, and if there is one, a flag above replaces it. `--log-tail 30` *is* `| tail -30`, minus the lost verdict; there is no filtering a pipe can do that the flags cannot.
+
 **`--quiet` is the one to reach for.** Each gate declares its own `failRe`/`summaryRe`, which is what `--quiet` prints, so hand-writing `--log-grep '×|FAIL|Tests '` is a worse and vitest-only spelling of it. Keep `--log-grep` for what `--quiet` does not show: a probe's `console.log`, or vitest's `Errors  N error` line, which reports a throw from outside a test body and **still exits 0**.
+
+**A killed run's `0` is not a pass.** `--kill` ends the run, but the completion event that follows still reports `exit code 0`. After killing, re-run — never read the dead run's status as a verdict.
 
 **Every local run captures itself, and prints the log path as its first line** — `▶ tmp/_behave-output/<id>/output.log`, the whole of stdout and stderr with the colour codes stripped. That line is also the only proof a run happened, so treat a missing `▶` as "nothing ran". No redirect has to be arranged in advance and a red run needs no second run: grep that file, during the run or after it, or pass `--bail 1` to make the run stop at the first failure itself. Beside it sit the `command` and a `status`, plus `result.json` (vitest's machine-readable results) for `./behave.sh` only. `latest` symlinks the newest and week-old runs are pruned.
 

--- a/documentation/ag-grid-docs/src/content/docs/filter-advanced/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/filter-advanced/index.mdoc
@@ -141,6 +141,8 @@ The available options are as follows:
 
 For `text` and `object` Cell Data Types, `caseSensitive = true` can be set to enable case sensitivity.
 
+Where the column's own filter is the Text Filter, its `textMatcher`, `textFormatter` and `trimInput` decide the matching for the Advanced Filter too, so a column that normalises or replaces its own matching is filtered the same way by both. Likewise, where the column's own filter is the Date Filter, its `comparator` and `isValidDate` decide the comparison. A column using a different filter is unaffected: these properties mean different things to a Set Filter.
+
 For `number`, `date`, `dateString`, `dateTime` and `dateTimeString` Cell Data Types, the following properties can be set to include blank values for the relevant options:
 
 - `includeBlanksInEquals = true`

--- a/packages/ag-grid-community/src/filter/filterDataTypeUtils.ts
+++ b/packages/ag-grid-community/src/filter/filterDataTypeUtils.ts
@@ -12,6 +12,7 @@ import type {
     DateStringDataTypeDefinition,
 } from '../entities/dataType';
 import type { ISetFilterParams } from '../interfaces/iSetFilter';
+import { _getUsableFilterOptions } from './filterOptionSupport';
 import type { IBigIntFilterParams } from './provided/bigInt/iBigIntFilter';
 import type { IDateFilterParams } from './provided/date/iDateFilter';
 import type { ISimpleFilterParams } from './provided/iSimpleFilter';
@@ -75,7 +76,11 @@ function setFilterBigIntComparator<TValue = any>(a: TValue | null, b: TValue | n
     return String(a).localeCompare(String(b));
 }
 
-function isValidDate(value: any): boolean {
+/**
+ * What a date column means by a readable date, shared so the Advanced Filter cannot mean something else.
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
+ */
+export function _isValidDate(value: any): boolean {
     return value instanceof Date && !isNaN(value.getTime());
 }
 
@@ -122,9 +127,12 @@ const filterParamsForEachDataType: FilterParamsDefMap = {
                 predicate: (_filterValues: any[], cellValue: any) => cellValue === false,
                 numberOfInputs: 0,
             },
+            // Offered as they are by every other data type, and as the Advanced Filter already offers them here.
+            'blank',
+            'notBlank',
         ],
     }),
-    date: () => ({ isValidDate }),
+    date: () => ({ isValidDate: _isValidDate }),
     dateString: ({ dataTypeDefinition }) => ({
         comparator: (filterDate: Date, cellValue: string | undefined) => {
             const cellAsDate = (dataTypeDefinition as DateStringDataTypeDefinition).dateParser!(cellValue)!;
@@ -138,7 +146,7 @@ const filterParamsForEachDataType: FilterParamsDefMap = {
         },
         isValidDate: (value: any) =>
             typeof value === 'string' &&
-            isValidDate((dataTypeDefinition as DateStringDataTypeDefinition).dateParser!(value)),
+            _isValidDate((dataTypeDefinition as DateStringDataTypeDefinition).dateParser!(value)),
     }),
     dateTime: (args) => filterParamsForEachDataType.date(args),
     dateTimeString: (args) => filterParamsForEachDataType.dateString(args),
@@ -238,6 +246,14 @@ export function _getFilterParamsForDataType(
                   ...existingFilterParams,
               }
             : newFilterParams;
+    // Here rather than where the filter is built: a column filter is built when the user opens it, so a list
+    // validated there says nothing until someone clicks. Both branches above are freshly allocated.
+    if (filterParams) {
+        const usableOptions = _getUsableFilterOptions(beans.log, filter, filterParams);
+        if (usableOptions !== filterParams.filterOptions) {
+            filterParams.filterOptions = usableOptions;
+        }
+    }
     return { filterParams, filterValueGetter };
 }
 

--- a/packages/ag-grid-community/src/filter/filterOptionSupport.ts
+++ b/packages/ag-grid-community/src/filter/filterOptionSupport.ts
@@ -1,0 +1,135 @@
+import type { LogService } from '../validation/logService';
+import type {
+    DateFilterOptionKey,
+    IFilterOptionDef,
+    ISimpleFilterParams,
+    ScalarFilterOptionKey,
+    TextFilterOptionKey,
+} from './provided/iSimpleFilter';
+import { _getMissingOptionProperties } from './provided/optionsFactory';
+import type { ITextFilterParams } from './provided/text/iTextFilter';
+
+/**
+ * Every built-in key each filter can answer, as a `Record` so a key added to the union stops compiling until it
+ * is answered here. The lists are what the dropdown may offer, so they are also what a model may name.
+ */
+const TEXT_OPTION_KEYS: Record<TextFilterOptionKey, true> = {
+    empty: true,
+    blank: true,
+    notBlank: true,
+    equals: true,
+    notEqual: true,
+    contains: true,
+    notContains: true,
+    startsWith: true,
+    endsWith: true,
+};
+
+const SCALAR_OPTION_KEYS: Record<ScalarFilterOptionKey, true> = {
+    empty: true,
+    blank: true,
+    notBlank: true,
+    equals: true,
+    notEqual: true,
+    lessThan: true,
+    lessThanOrEqual: true,
+    greaterThan: true,
+    greaterThanOrEqual: true,
+    inRange: true,
+};
+
+const DATE_OPTION_KEYS: Record<DateFilterOptionKey, true> = {
+    ...SCALAR_OPTION_KEYS,
+    today: true,
+    yesterday: true,
+    tomorrow: true,
+    thisWeek: true,
+    lastWeek: true,
+    nextWeek: true,
+    thisMonth: true,
+    lastMonth: true,
+    nextMonth: true,
+    thisQuarter: true,
+    lastQuarter: true,
+    nextQuarter: true,
+    thisYear: true,
+    lastYear: true,
+    nextYear: true,
+    yearToDate: true,
+    last7Days: true,
+    last30Days: true,
+    last90Days: true,
+    last6Months: true,
+    last12Months: true,
+    last24Months: true,
+};
+
+/** By filter name, because the filter is what evaluates the option; the data type only chooses the filter. */
+const OPTION_KEYS_BY_FILTER: Record<string, Record<string, true>> = {
+    agTextColumnFilter: TEXT_OPTION_KEYS,
+    agNumberColumnFilter: SCALAR_OPTION_KEYS,
+    agBigIntColumnFilter: SCALAR_OPTION_KEYS,
+    agDateColumnFilter: DATE_OPTION_KEYS,
+};
+
+/**
+ * The `filterOptions` a column can actually offer, reported and dropped where it cannot. Asked when the column
+ * definition is read: a column filter is built when the user opens it, so a list checked there says nothing
+ * about a misconfigured column until someone clicks it, and each layer that reads the list checks it again.
+ */
+export function _getUsableFilterOptions(
+    log: LogService,
+    filter: string,
+    filterParams: ISimpleFilterParams
+): (IFilterOptionDef | string)[] | undefined {
+    const configuredOptions = filterParams.filterOptions;
+    const supportedKeys = OPTION_KEYS_BY_FILTER[filter];
+    if (!configuredOptions || !supportedKeys) {
+        return configuredOptions;
+    }
+    // A `textMatcher` answers for itself, so it can mean any key the built-in matching cannot. Read as the
+    // Text Filter's params because that is the filter the name resolved to.
+    const anyKeyEvaluates = filter === 'agTextColumnFilter' && (filterParams as ITextFilterParams).textMatcher != null;
+
+    let dropped = false;
+    const usable: (IFilterOptionDef | string)[] = [];
+    for (let i = 0, len = configuredOptions.length; i < len; ++i) {
+        const option = configuredOptions[i];
+        if (option == null) {
+            continue; // `typeof null` is `'object'`, so a hole would read as an option with no properties
+        }
+        if (typeof option === 'string') {
+            if (!anyKeyEvaluates && !supportedKeys[option]) {
+                log.warn(76, { filterModelType: option });
+                dropped = true;
+                continue;
+            }
+        } else {
+            const missing = _getMissingOptionProperties(option);
+            if (missing) {
+                log.warn(72, { keys: missing });
+                dropped = true;
+                continue;
+            }
+        }
+        usable.push(option);
+    }
+
+    // Only an option the dropdown will list can be selected into it, so a `defaultOption` naming one that was
+    // never offered is reported here too rather than when the filter opens.
+    const defaultOption = filterParams.defaultOption;
+    if (defaultOption != null && usable.length && !offersOption(usable, defaultOption)) {
+        log.warn(326, { defaultOption });
+    }
+    return dropped ? usable : configuredOptions;
+}
+
+function offersOption(options: (IFilterOptionDef | string)[], key: string): boolean {
+    for (let i = 0, len = options.length; i < len; ++i) {
+        const option = options[i];
+        if ((typeof option === 'string' ? option : option.displayKey) === key) {
+            return true;
+        }
+    }
+    return false;
+}

--- a/packages/ag-grid-community/src/filter/provided/date/dateFilterHandler.test.ts
+++ b/packages/ag-grid-community/src/filter/provided/date/dateFilterHandler.test.ts
@@ -1,11 +1,10 @@
 import type { ISimpleFilterModelPresetType } from '../iSimpleFilter';
-import { DateFilterHandler, presetDateFilterTypeRelativeFromToMap } from './dateFilterHandler';
+import { DateFilterHandler, presetDateRanges, relativeDateHelpers } from './dateFilterHandler';
 
-type PresetKey = keyof typeof presetDateFilterTypeRelativeFromToMap;
-type RangeFn = (from: Date, to: Date) => [Date, Date];
-type DateFn = (date: Date) => Date;
+type PresetKey = keyof typeof presetDateRanges;
+type HelperKey = keyof typeof relativeDateHelpers;
 
-describe('presetDateFilterTypeRelativeFromToMap', () => {
+describe('presetDateRanges', () => {
     beforeAll(() => {
         if (typeof navigator === 'undefined') {
             return;
@@ -89,11 +88,9 @@ describe('presetDateFilterTypeRelativeFromToMap', () => {
         ['last24Months', [ANSWERS.startOfTodayMinus24months, ANSWERS.startOfTomorrow]],
     ])('%s', (fnName, expected) =>
         it('returns correct from/to', () =>
-            expect(
-                (presetDateFilterTypeRelativeFromToMap[fnName] as RangeFn)(FROM, TO).map((d: Date) => d.toString())
-            ).toStrictEqual(expected))
+            expect(presetDateRanges[fnName](FROM, TO).map((d: Date) => d.toString())).toStrictEqual(expected))
     );
-    describe.each<[PresetKey, string]>([
+    describe.each<[HelperKey, string]>([
         ['setStartOfDay', ANSWERS.startOfToday],
         ['setStartOfWeek', ANSWERS.startOfCurrentWeek],
         ['setStartOfNextDay', ANSWERS.startOfTomorrow],
@@ -109,8 +106,7 @@ describe('presetDateFilterTypeRelativeFromToMap', () => {
         ['setPreviousMonth', ANSWERS.previousMonth],
         ['setPreviousQuarter', ANSWERS.previousQuarter],
     ])('%s', (fnName, expected) =>
-        it('works', () =>
-            expect((presetDateFilterTypeRelativeFromToMap[fnName] as DateFn)(FROM).toString()).toContain(expected))
+        it('works', () => expect(relativeDateHelpers[fnName](FROM).toString()).toContain(expected))
     );
 });
 
@@ -146,8 +142,8 @@ describe('getFirstDayOfWeek', () => {
             value: { language: 'en-US', languages: ['en-US'] },
         });
 
-        const { presetDateFilterTypeRelativeFromToMap: map } = await import('./dateFilterHandler');
-        const result = (map.setStartOfWeek as DateFn)(new Date(base));
+        const { relativeDateHelpers: helpers } = await import('./dateFilterHandler');
+        const result = helpers.setStartOfWeek(new Date(base));
         expect(result.toUTCString()).toContain('Sun, 05 Apr 2020');
 
         expect(getWeekInfo).toHaveBeenCalledTimes(1);

--- a/packages/ag-grid-community/src/filter/provided/date/dateFilterHandler.ts
+++ b/packages/ag-grid-community/src/filter/provided/date/dateFilterHandler.ts
@@ -1,3 +1,5 @@
+import { _hasOwn } from 'ag-stack';
+
 import type { Column } from '../../../interfaces/iColumn';
 import type { Comparator } from '../iScalarFilter';
 import type { ISimpleFilterModelPresetType, Tuple } from '../iSimpleFilter';
@@ -82,12 +84,12 @@ export class DateFilterHandler extends ScalarFilterHandler<DateFilterModel, Date
         const type = filterModel.type;
 
         if (!this.isValid(cellValue)) {
-            return type === 'notEqual' || type === 'notBlank';
+            return type === 'notEqual';
         }
         const maybeTypeAsPreset = type as ISimpleFilterModelPresetType;
-        const presetDateRangeFn = presetDateFilterTypeRelativeFromToMap[maybeTypeAsPreset] as
-            | RelativeRangeFn
-            | undefined;
+        const presetDateRangeFn = _hasOwn(presetDateRanges, maybeTypeAsPreset)
+            ? presetDateRanges[maybeTypeAsPreset]
+            : undefined;
         if (presetDateRangeFn) {
             // user selected a preset, calculate what they mean
             const { fromTime, toTime } = this.getOrRefreshRangeCacheItem(maybeTypeAsPreset, presetDateRangeFn);
@@ -292,24 +294,7 @@ const tomorrow: RelativeRangeFn = (from: Date, to: Date) => {
  * Last 24 months          last24Months        [startOfToday − 24 months, startOfTomorrow)
  * @knipIgnore Used in tests
  */
-export const presetDateFilterTypeRelativeFromToMap: Record<
-    | ISimpleFilterModelPresetType
-    | 'setStartOfDay'
-    | 'setStartOfWeek'
-    | 'setStartOfNextDay'
-    | 'setStartOfNextWeek'
-    | 'setStartOfMonth'
-    | 'setStartOfNextMonth'
-    | 'setStartOfQuarter'
-    | 'setStartOfNextQuarter'
-    | 'setStartOfYear'
-    | 'setStartOfNextYear'
-    | 'setPreviousDay'
-    | 'setPreviousWeek'
-    | 'setPreviousMonth'
-    | 'setPreviousQuarter',
-    RelativeRangeFn | RelativeDateFn
-> = {
+export const presetDateRanges: Record<ISimpleFilterModelPresetType, RelativeRangeFn> = {
     today,
     yesterday,
     tomorrow,
@@ -332,6 +317,13 @@ export const presetDateFilterTypeRelativeFromToMap: Record<
     last6Months,
     last12Months,
     last24Months,
+};
+
+/**
+ * The pieces the ranges are built from. Not options: each returns one date where a range needs two.
+ * @knipIgnore Used in tests
+ */
+export const relativeDateHelpers = {
     setStartOfDay,
     setStartOfWeek,
     setStartOfNextDay,
@@ -346,4 +338,4 @@ export const presetDateFilterTypeRelativeFromToMap: Record<
     setPreviousWeek,
     setPreviousMonth,
     setPreviousQuarter,
-};
+} satisfies Record<string, RelativeDateFn>;

--- a/packages/ag-grid-community/src/filter/provided/optionsFactory.ts
+++ b/packages/ag-grid-community/src/filter/provided/optionsFactory.ts
@@ -4,6 +4,22 @@ import type { IFilterOptionDef, ISimpleFilterParams } from './iSimpleFilter';
 /** An entry missing any of these cannot be offered; they are listed so the warning can name the missing one. */
 const REQUIRED_OPTION_PROPERTIES: (keyof IFilterOptionDef)[] = ['displayKey', 'displayName', 'predicate'];
 
+/**
+ * The properties that stop an entry being offered, or `null` when it can be. Shared so a list read at column
+ * definition time and the same list read again for the dropdown cannot disagree about what is malformed.
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
+ */
+export function _getMissingOptionProperties(option: IFilterOptionDef): (keyof IFilterOptionDef)[] | null {
+    let missing: (keyof IFilterOptionDef)[] | null = null;
+    for (let i = 0, len = REQUIRED_OPTION_PROPERTIES.length; i < len; ++i) {
+        const name = REQUIRED_OPTION_PROPERTIES[i];
+        if (option[name] == null) {
+            (missing ??= []).push(name);
+        }
+    }
+    return missing;
+}
+
 /* Common logic for options, used by both filters and floating filters. */
 export class OptionsFactory {
     private customFilterOptions: Map<string, IFilterOptionDef>;
@@ -50,8 +66,8 @@ export class OptionsFactory {
             } else if (typeof option === 'string') {
                 offered.set(option, offered.get(option) ?? option); // a definition already stored outranks a bare key
             } else {
-                const missing = REQUIRED_OPTION_PROPERTIES.filter((name) => option[name] == null);
-                if (missing.length) {
+                const missing = _getMissingOptionProperties(option);
+                if (missing) {
                     log.warn(72, { keys: missing });
                     continue;
                 }

--- a/packages/ag-grid-community/src/filter/provided/scalarFilterHandler.ts
+++ b/packages/ag-grid-community/src/filter/provided/scalarFilterHandler.ts
@@ -1,7 +1,6 @@
 import type { Comparator, IScalarFilterParams } from './iScalarFilter';
 import type { FilterOptionKey, ISimpleFilterModel, Tuple } from './iSimpleFilter';
 import { SimpleFilterHandler } from './simpleFilterHandler';
-import { isBlank } from './simpleFilterUtils';
 
 export abstract class ScalarFilterHandler<
     TModel extends ISimpleFilterModel,
@@ -49,10 +48,6 @@ export abstract class ScalarFilterHandler<
                     return true;
                 }
                 break;
-            case 'blank':
-                return true;
-            case 'notBlank':
-                return false;
         }
 
         return false;
@@ -61,7 +56,7 @@ export abstract class ScalarFilterHandler<
     protected evaluateNonNullValue(values: Tuple<TValue>, cellValue: TValue, filterModel: TModel): boolean {
         const type = filterModel.type;
         if (!this.isValid(cellValue)) {
-            return type === 'notEqual' || type === 'notBlank';
+            return type === 'notEqual';
         }
 
         const comparator = this.comparator();
@@ -94,15 +89,8 @@ export abstract class ScalarFilterHandler<
                     : compareResult > 0 && compareToResult < 0;
             }
 
-            case 'blank':
-                return isBlank(cellValue);
-
-            case 'notBlank':
-                return !isBlank(cellValue);
-
             default:
-                this.warnUnexpectedFilterType(type);
-                return true;
+                return false;
         }
     }
 }

--- a/packages/ag-grid-community/src/filter/provided/simpleFilterHandler.ts
+++ b/packages/ag-grid-community/src/filter/provided/simpleFilterHandler.ts
@@ -17,7 +17,7 @@ import type {
 import { isCombinedFilterModel } from './iSimpleFilter';
 import { OptionsFactory } from './optionsFactory';
 import type { SimpleFilterModelFormatter } from './simpleFilterModelFormatter';
-import { evaluateCustomFilter, getConditionLimit } from './simpleFilterUtils';
+import { evaluateCustomFilter, getConditionLimit, isBlank } from './simpleFilterUtils';
 
 export abstract class SimpleFilterHandler<
     TModel extends ISimpleFilterModel,
@@ -40,7 +40,6 @@ export abstract class SimpleFilterHandler<
     protected params: FilterHandlerParams<any, any, TModel | ICombinedSimpleModel<TModel>, TParams>;
     private optionsFactory: OptionsFactory;
     private filterModelFormatter: SimpleFilterModelFormatter<ISimpleFilterParams>;
-    private readonly warnedKeys = new Set<FilterOptionKey | null | undefined>();
 
     constructor(
         private readonly mapValuesFromModel: MapValuesFromSimpleFilterModel<TModel, TValue>,
@@ -50,18 +49,6 @@ export abstract class SimpleFilterHandler<
     }
 
     protected abstract evaluateNullValue(filterType?: FilterOptionKey | null): boolean;
-
-    /**
-     * Once per key, never per row: a log call formats its message and doc URL before the once-per-message guard
-     * discards the duplicate. A Custom Filter Option owns its key, so a skipped predicate is a missing value.
-     */
-    protected warnUnexpectedFilterType(type?: FilterOptionKey | null): void {
-        if (this.optionsFactory.getCustomOption(type) || this.warnedKeys.has(type)) {
-            return;
-        }
-        this.warnedKeys.add(type);
-        this.warn(76, { filterModelType: type });
-    }
 
     protected abstract evaluateNonNullValue(
         range: Tuple<TValue>,
@@ -215,8 +202,18 @@ export abstract class SimpleFilterHandler<
             return customFilterResult;
         }
 
+        const type = filterModel.type;
+        // Answered ahead of every type-specific path: blankness is a property of the value alone, so it needs
+        // no comparison, no matcher, and none of the validity gates a comparison is held to.
+        if (type === 'blank') {
+            return isBlank(cellValue);
+        }
+        if (type === 'notBlank') {
+            return !isBlank(cellValue);
+        }
+
         if (cellValue == null) {
-            return this.evaluateNullValue(filterModel.type);
+            return this.evaluateNullValue(type);
         }
 
         return this.evaluateNonNullValue(values, cellValue, filterModel, params);

--- a/packages/ag-grid-community/src/filter/provided/simpleFilterUtils.ts
+++ b/packages/ag-grid-community/src/filter/provided/simpleFilterUtils.ts
@@ -42,6 +42,11 @@ export function removeItems<T>(items: T[], startPosition: number, deleteCount?: 
     return deleteCount == null ? items.splice(startPosition) : items.splice(startPosition, deleteCount);
 }
 
+/**
+ * What every filter means by blank, so `blank` cannot mean one thing in a column filter and another in the
+ * Advanced Filter.
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
+ */
 export function isBlank<V>(cellValue: V) {
     return cellValue == null || (typeof cellValue === 'string' && cellValue.trim().length === 0);
 }

--- a/packages/ag-grid-community/src/filter/provided/text/textFilterHandler.ts
+++ b/packages/ag-grid-community/src/filter/provided/text/textFilterHandler.ts
@@ -1,54 +1,42 @@
 import type { Column } from '../../../interfaces/iColumn';
 import type { FilterHandlerParams, IDoesFilterPassParams } from '../../../interfaces/iFilter';
-import type { FilterOptionKey, ICombinedSimpleModel, TextFilterOptionKey, Tuple } from '../iSimpleFilter';
+import type { FilterOptionKey, ICombinedSimpleModel, Tuple } from '../iSimpleFilter';
 import { isCombinedFilterModel } from '../iSimpleFilter';
 import type { OptionsFactory } from '../optionsFactory';
 import { SimpleFilterHandler } from '../simpleFilterHandler';
-import { isBlank } from '../simpleFilterUtils';
 import type { ITextFilterParams, TextFilterModel, TextFormatter, TextMatcher } from './iTextFilter';
 import { DEFAULT_TEXT_FILTER_OPTIONS } from './textFilterConstants';
 import { TextFilterModelFormatter } from './textFilterModelFormatter';
-import { mapValuesFromTextFilterModel, trimInputForFilter } from './textFilterUtils';
-
-/** Every key `defaultMatcher` answers; anything else needs a `textMatcher` to mean something. */
-const DEFAULT_MATCHER_KEYS: ReadonlySet<string> = new Set<TextFilterOptionKey>([
-    'contains',
-    'notContains',
-    'equals',
-    'notEqual',
-    'startsWith',
-    'endsWith',
-]);
+import {
+    _TEXT_FILTER_PREDICATES,
+    _getTextFormatter,
+    mapValuesFromTextFilterModel,
+    trimInputForFilter,
+} from './textFilterUtils';
 
 const defaultMatcher: TextMatcher = ({ filterOption, value, filterText }) => {
     if (filterText == null) {
         return false;
     }
 
+    // Dispatched by `switch` rather than by key: this runs per row, and the option set is fixed.
     switch (filterOption) {
         case 'contains':
-            return value.includes(filterText);
+            return _TEXT_FILTER_PREDICATES.contains(value, filterText);
         case 'notContains':
-            return !value.includes(filterText);
+            return _TEXT_FILTER_PREDICATES.notContains(value, filterText);
         case 'equals':
-            return value === filterText;
+            return _TEXT_FILTER_PREDICATES.equals(value, filterText);
         case 'notEqual':
-            return value != filterText;
+            return _TEXT_FILTER_PREDICATES.notEqual(value, filterText);
         case 'startsWith':
-            return value.indexOf(filterText) === 0;
-        case 'endsWith': {
-            const index = value.lastIndexOf(filterText);
-            return index >= 0 && index === value.length - filterText.length;
-        }
+            return _TEXT_FILTER_PREDICATES.startsWith(value, filterText);
+        case 'endsWith':
+            return _TEXT_FILTER_PREDICATES.endsWith(value, filterText);
         default:
             return false;
     }
 };
-
-const defaultFormatter: TextFormatter = (from: string) => from;
-
-const defaultLowercaseFormatter: TextFormatter = (from: string) =>
-    from == null ? null : from.toString().toLowerCase();
 
 export class TextFilterHandler extends SimpleFilterHandler<TextFilterModel, string, ITextFilterParams> {
     public readonly filterType = 'text' as const;
@@ -80,22 +68,11 @@ export class TextFilterHandler extends SimpleFilterHandler<TextFilterModel, stri
         const filterParams = params.filterParams;
 
         this.matcher = filterParams.textMatcher ?? defaultMatcher;
-        this.formatter =
-            filterParams.textFormatter ?? (filterParams.caseSensitive ? defaultFormatter : defaultLowercaseFormatter);
-    }
-
-    /** The key is checked rather than the matcher's answer, which cannot distinguish "no match" from "unknown". */
-    private isUnmatchable(type?: FilterOptionKey | null): boolean {
-        return this.matcher === defaultMatcher && (type == null || !DEFAULT_MATCHER_KEYS.has(type));
+        this.formatter = _getTextFormatter(filterParams);
     }
 
     protected override evaluateNullValue(filterType: FilterOptionKey | null) {
-        // Presence is decided without the matcher, so an unusable key is reported for a blank column too.
-        if (filterType !== 'blank' && filterType !== 'notBlank' && this.isUnmatchable(filterType)) {
-            this.warnUnexpectedFilterType(filterType);
-            return false;
-        }
-        return filterType === 'notEqual' || filterType === 'notContains' || filterType === 'blank';
+        return filterType === 'notEqual' || filterType === 'notContains';
     }
 
     protected override evaluateNonNullValue(
@@ -115,17 +92,6 @@ export class TextFilterHandler extends SimpleFilterHandler<TextFilterModel, stri
         } = this.params;
 
         const type = filterModel.type;
-        if (type === 'blank') {
-            return isBlank(cellValue);
-        } else if (type === 'notBlank') {
-            return !isBlank(cellValue);
-        }
-
-        if (this.isUnmatchable(type)) {
-            this.warnUnexpectedFilterType(type);
-            return false;
-        }
-
         const matcher = this.matcher;
         const matcherParams = {
             api,

--- a/packages/ag-grid-community/src/filter/provided/text/textFilterUtils.ts
+++ b/packages/ag-grid-community/src/filter/provided/text/textFilterUtils.ts
@@ -1,8 +1,41 @@
 import type { Tuple } from '../iSimpleFilter';
 import type { OptionsFactory } from '../optionsFactory';
 import { getNumberOfInputs } from '../simpleFilterUtils';
-import type { TextFilterModel } from './iTextFilter';
+import type { ITextFilterParams, TextFilterModel, TextFormatter } from './iTextFilter';
 
+/**
+ * What each built-in text option means, read by the column filter's matcher and the Advanced Filter's
+ * operators alike so an option cannot mean two things. By static property, never by key: this runs per row.
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
+ */
+export const _TEXT_FILTER_PREDICATES = {
+    contains: (value: string, filterText: string): boolean => value.includes(filterText),
+    notContains: (value: string, filterText: string): boolean => !value.includes(filterText),
+    equals: (value: string, filterText: string): boolean => value === filterText,
+    // Loose, as it has always been: a `textFormatter` can leave a non-string on either side.
+    notEqual: (value: string, filterText: string): boolean => value != filterText,
+    startsWith: (value: string, filterText: string): boolean => value.startsWith(filterText),
+    endsWith: (value: string, filterText: string): boolean => value.endsWith(filterText),
+} as const;
+
+const defaultFormatter: TextFormatter = (from) => from ?? null;
+
+/** Locale-aware: the Turkish dotted and dotless I are two letters, and `toLowerCase` folds them to one. */
+const defaultLowercaseFormatter: TextFormatter = (from) => (from == null ? null : from.toString().toLocaleLowerCase());
+
+/**
+ * How a text column normalises both sides before comparing, so the cell value and the filter text are always
+ * put through the same one, whichever filter is asking.
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
+ */
+export function _getTextFormatter(filterParams: ITextFilterParams): TextFormatter {
+    return filterParams.textFormatter ?? (filterParams.caseSensitive ? defaultFormatter : defaultLowercaseFormatter);
+}
+
+/**
+ * What `trimInput` does to an entry, whichever filter the entry was made in.
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
+ */
 export function trimInputForFilter(value?: string | null): string | null | undefined {
     const trimmedInput = value?.trim();
 

--- a/packages/ag-grid-community/src/interfaces/advancedFilterModel.ts
+++ b/packages/ag-grid-community/src/interfaces/advancedFilterModel.ts
@@ -31,7 +31,7 @@ export type ScalarAdvancedFilterModelType =
     | 'blank'
     | 'notBlank';
 
-export type BooleanAdvancedFilterModelType = 'true' | 'false';
+export type BooleanAdvancedFilterModelType = 'true' | 'false' | 'blank' | 'notBlank';
 
 /** Represents a single filter condition for a text column */
 export interface TextAdvancedFilterModel {

--- a/packages/ag-grid-community/src/main-internal.ts
+++ b/packages/ag-grid-community/src/main-internal.ts
@@ -136,14 +136,19 @@ export {
 export { AgFilterButtonSelector, FilterButtonComp } from './filter/filterButtonComp';
 export type { FilterButton, FilterButtonEvent } from './filter/filterButtonComp';
 export { FilterComp } from './filter/filterComp';
-export { _getDefaultSimpleFilter, _getFilterParamsForDataType } from './filter/filterDataTypeUtils';
+export { _getDefaultSimpleFilter, _getFilterParamsForDataType, _isValidDate } from './filter/filterDataTypeUtils';
 export { translateForFilter as _translateForFilter } from './filter/filterLocaleText';
 export type { FilterManager } from './filter/filterManager';
 export type { FilterValueService } from './filter/filterValueService';
 export { FilterWrapperComp } from './filter/filterWrapperComp';
 export { _getDefaultFloatingFilterType } from './filter/floating/floatingFilterMapper';
 export { _isUseApplyButton } from './filter/provided/providedFilterUtils';
-export { _bindFilterCallback } from './filter/provided/simpleFilterUtils';
+export { _bindFilterCallback, isBlank as _isBlank } from './filter/provided/simpleFilterUtils';
+export {
+    _TEXT_FILTER_PREDICATES,
+    _getTextFormatter,
+    trimInputForFilter as _trimInputForFilter,
+} from './filter/provided/text/textFilterUtils';
 export type { FocusService } from './focusService';
 export { _getGlobalGridOption } from './globalGridOptions';
 export { GridCoreCreator } from './grid';

--- a/packages/ag-grid-enterprise/src/advancedFilter/advancedFilterExpressionService.ts
+++ b/packages/ag-grid-enterprise/src/advancedFilter/advancedFilterExpressionService.ts
@@ -13,7 +13,7 @@ import type {
     NamedBean,
     ValueService,
 } from 'ag-grid-community';
-import { BeanStub, _toFiniteNumber } from 'ag-grid-community';
+import { BeanStub, _addGridCommonParams, _getTextFormatter, _isValidDate, _toFiniteNumber } from 'ag-grid-community';
 
 import { ADVANCED_FILTER_LOCALE_TEXT } from './advancedFilterLocaleText';
 import type { AutocompleteEntry, AutocompleteListParams } from './autocomplete/autocompleteParams';
@@ -50,9 +50,33 @@ function quoteChar(operand: string): `'` | `"` | null {
     return operand.includes(`'`) ? null : `'`;
 }
 
+/**
+ * Each data type's own comparison, in the sign convention a column `comparator` uses: positive where the cell
+ * value sorts after the operand. The validity gates mirror each column filter handler's `isValid`, so a value
+ * the comparison cannot read is rejected before it, rather than compared as if it could be.
+ */
+const compareOrdered = <V extends number | bigint>(operand: V, value: V): number => {
+    if (value === operand) {
+        return 0;
+    }
+    if (value > operand) {
+        return 1;
+    }
+    if (value < operand) {
+        return -1;
+    }
+    // Neither equal nor ordered, as a NaN is: no comparison holds against it, and every negation of one does.
+    return NaN;
+};
+
+const compareDates = (operand: Date, value: Date): number => compareOrdered(operand.getTime(), value.getTime());
+
+const isReadableNumber = (value: number): boolean => !isNaN(value);
+
+const isReadableBigInt = (value: unknown): boolean => _parseBigIntOrNull(value) !== null;
+
 /** The `filterParams` an Advanced Filter evaluator honours; the rest are column-filter UI concerns. */
 const COPIED_FILTER_PARAMS: (keyof FilterExpressionEvaluatorParams<any>)[] = [
-    'caseSensitive',
     'includeBlanksInEquals',
     'includeBlanksInNotEqual',
     'includeBlanksInLessThan',
@@ -189,6 +213,15 @@ export class AdvancedFilterExpressionService extends BeanStub implements NamedBe
             columnName = colId;
         }
         return columnName;
+    }
+
+    /** The filter this column would build, so a `filterParams` name is read only as that filter means it. */
+    private getOwnFilterName(column: AgColumn): string | undefined {
+        const filter = column.colDef.filter;
+        if (filter === true) {
+            return this.beans.colFilter?.getDefaultFilter(column);
+        }
+        return typeof filter === 'string' ? filter : undefined;
     }
 
     /**
@@ -417,6 +450,13 @@ export class AdvancedFilterExpressionService extends BeanStub implements NamedBe
             return { valueConverter: (v: any) => v };
         }
 
+        const { filterParams } = column.colDef;
+        // Each of these names belongs to one filter: `comparator` sorts a Set Filter's values list where it
+        // compares a Date Filter's, so reading it from the wrong filter inverts the comparison silently.
+        const ownFilter = this.getOwnFilterName(column);
+        const dateFilterParams = ownFilter === 'agDateColumnFilter' ? filterParams : undefined;
+        const textFilterParams = ownFilter === 'agTextColumnFilter' ? filterParams : undefined;
+
         const baseCellDataType = this.dataTypeSvc?.getBaseDataType(column);
         switch (baseCellDataType) {
             case 'dateTimeString':
@@ -445,7 +485,32 @@ export class AdvancedFilterExpressionService extends BeanStub implements NamedBe
                 params = { valueConverter: (v: any) => v };
                 break;
         }
-        const { filterParams } = column.colDef;
+        // `caseSensitive` from any column, since every filter means the same thing by it; the formatter itself
+        // only from the filter that means normalising the value it is about to compare.
+        const textFormatter = textFilterParams?.textFormatter;
+        params.textFormatter = _getTextFormatter({ caseSensitive: filterParams?.caseSensitive, textFormatter });
+        if (dateFilterParams) {
+            params.comparator = dateFilterParams.comparator;
+            params.isValidDate = dateFilterParams.isValidDate;
+        }
+        if (textFilterParams) {
+            params.trimInput = textFilterParams.trimInput;
+            const textMatcher = textFilterParams.textMatcher;
+            if (textMatcher) {
+                // Bound to the column here, where the grid params are to hand, so the operators need only the row.
+                const columnParams = _addGridCommonParams(this.gos, { column, colDef: column.colDef });
+                params.textMatches = (filterOption, value, filterText, node) =>
+                    textMatcher({
+                        ...columnParams,
+                        node,
+                        data: node.data,
+                        filterOption,
+                        value,
+                        filterText,
+                        textFormatter,
+                    });
+            }
+        }
         if (filterParams) {
             for (let i = 0, len = COPIED_FILTER_PARAMS.length; i < len; ++i) {
                 const param = COPIED_FILTER_PARAMS[i];
@@ -469,17 +534,18 @@ export class AdvancedFilterExpressionService extends BeanStub implements NamedBe
     public generateExpressionOperators(): FilterExpressionOperators {
         const translate = (key: keyof typeof ADVANCED_FILTER_LOCALE_TEXT, variableValues?: string[]) =>
             this.translate(key, variableValues);
-        const dateOperatorsParams = {
-            translate,
-            equals: (v: Date, o: Date) => v.getTime() === o.getTime(),
-        };
+        const dateOperatorsParams = { translate, compare: compareDates, isValid: _isValidDate };
+        const orderedOperatorsParams = { translate, compare: compareOrdered, isValid: isReadableNumber };
 
         return {
             text: new TextFilterExpressionOperators({ translate }),
             boolean: new BooleanFilterExpressionOperators({ translate }),
             object: new TextFilterExpressionOperators<any>({ translate }),
-            number: new ScalarFilterExpressionOperators<number>({ translate, equals: (v, o) => v === o }),
-            bigint: new ScalarFilterExpressionOperators<bigint>({ translate, equals: (v, o) => v === o }),
+            number: new ScalarFilterExpressionOperators<number>(orderedOperatorsParams),
+            bigint: new ScalarFilterExpressionOperators<bigint>({
+                ...orderedOperatorsParams,
+                isValid: isReadableBigInt,
+            }),
             date: new ScalarFilterExpressionOperators<Date>(dateOperatorsParams),
             dateString: new ScalarFilterExpressionOperators<Date, string>(dateOperatorsParams),
             dateTime: new ScalarFilterExpressionOperators<Date>(dateOperatorsParams),

--- a/packages/ag-grid-enterprise/src/advancedFilter/filterExpressionOperators.ts
+++ b/packages/ag-grid-enterprise/src/advancedFilter/filterExpressionOperators.ts
@@ -1,16 +1,23 @@
 import { _hasOwn } from 'ag-stack';
 
-import type { BaseCellDataType, IRowNode } from 'ag-grid-community';
+import type { BaseCellDataType, IRowNode, TextFormatter } from 'ag-grid-community';
+import { _TEXT_FILTER_PREDICATES, _getTextFormatter, _isBlank, _trimInputForFilter } from 'ag-grid-community';
 
 import type { ADVANCED_FILTER_LOCALE_TEXT } from './advancedFilterLocaleText';
 import type { AutocompleteEntry } from './autocomplete/autocompleteParams';
 
 export interface FilterExpressionEvaluatorParams<ConvertedTValue, TValue = ConvertedTValue> {
-    caseSensitive?: boolean;
     includeBlanksInEquals?: boolean;
     includeBlanksInNotEqual?: boolean;
     includeBlanksInLessThan?: boolean;
     includeBlanksInGreaterThan?: boolean;
+    /** The column's own comparison and validity gate, read only by the scalar operators. */
+    comparator?: (operand: ConvertedTValue, value: any) => number;
+    isValidDate?: (value: any) => boolean;
+    /** The column's own text normalisation, matching and trimming, read only by the text operators. */
+    textFormatter?: TextFormatter;
+    textMatches?: (filterOption: string, value: string, filterText: string, node: IRowNode) => boolean;
+    trimInput?: boolean;
     valueConverter: (value: TValue, node: IRowNode) => ConvertedTValue;
 }
 
@@ -97,6 +104,9 @@ function getEntries<ConvertedTValue, TValue = ConvertedTValue>(
     return entries;
 }
 
+/** Only reached for a condition whose column no longer resolves, which has no `filterParams` to read. */
+const defaultTextFormatter: TextFormatter = _getTextFormatter({});
+
 interface FilterExpressionOperatorsParams {
     translate: (key: keyof typeof ADVANCED_FILTER_LOCALE_TEXT, variableValues?: string[]) => string;
 }
@@ -115,77 +125,81 @@ export class TextFilterExpressionOperators<TValue = string> implements DataTypeF
         return getEntries(this.operators, activeOperators);
     }
 
+    /** The predicate is read from the key, so the two cannot name different comparisons. */
+    private textOperator(
+        displayValue: string,
+        filterOption: keyof typeof _TEXT_FILTER_PREDICATES,
+        nullsMatch: boolean
+    ): FilterExpressionOperator<string, TValue> {
+        const expression = _TEXT_FILTER_PREDICATES[filterOption];
+        return {
+            displayValue,
+            evaluator: (value, node, params, operand1) =>
+                this.evaluateExpression(value, node, params, operand1!, nullsMatch, expression, filterOption),
+            numOperands: 1,
+        };
+    }
+
     private initOperators(): void {
         const { translate } = this.params;
         this.operators = {
-            contains: {
-                displayValue: translate('advancedFilterContains'),
-                evaluator: (value, node, params, operand1) =>
-                    this.evaluateExpression(value, node, params, operand1!, false, (v, o) => v.includes(o)),
-                numOperands: 1,
-            },
-            notContains: {
-                displayValue: translate('advancedFilterNotContains'),
-                evaluator: (value, node, params, operand1) =>
-                    this.evaluateExpression(value, node, params, operand1!, true, (v, o) => !v.includes(o)),
-                numOperands: 1,
-            },
-            equals: {
-                displayValue: translate('advancedFilterTextEquals'),
-                evaluator: (value, node, params, operand1) =>
-                    this.evaluateExpression(value, node, params, operand1!, false, (v, o) => v === o),
-                numOperands: 1,
-            },
-            notEqual: {
-                displayValue: translate('advancedFilterTextNotEqual'),
-                evaluator: (value, node, params, operand1) =>
-                    this.evaluateExpression(value, node, params, operand1!, true, (v, o) => v != o),
-                numOperands: 1,
-            },
-            startsWith: {
-                displayValue: translate('advancedFilterStartsWith'),
-                evaluator: (value, node, params, operand1) =>
-                    this.evaluateExpression(value, node, params, operand1!, false, (v, o) => v.startsWith(o)),
-                numOperands: 1,
-            },
-            endsWith: {
-                displayValue: translate('advancedFilterEndsWith'),
-                evaluator: (value, node, params, operand1) =>
-                    this.evaluateExpression(value, node, params, operand1!, false, (v, o) => v.endsWith(o)),
-                numOperands: 1,
-            },
+            contains: this.textOperator(translate('advancedFilterContains'), 'contains', false),
+            notContains: this.textOperator(translate('advancedFilterNotContains'), 'notContains', true),
+            equals: this.textOperator(translate('advancedFilterTextEquals'), 'equals', false),
+            notEqual: this.textOperator(translate('advancedFilterTextNotEqual'), 'notEqual', true),
+            startsWith: this.textOperator(translate('advancedFilterStartsWith'), 'startsWith', false),
+            endsWith: this.textOperator(translate('advancedFilterEndsWith'), 'endsWith', false),
+            // The column filter's own test, so `blank` means one thing whichever filter asks a text column.
             blank: {
                 displayValue: translate('advancedFilterBlank'),
-                evaluator: (value) => value == null || (typeof value === 'string' && value.trim().length === 0),
+                evaluator: (value) => _isBlank(value),
                 numOperands: 0,
             },
             notBlank: {
                 displayValue: translate('advancedFilterNotBlank'),
-                evaluator: (value) => value != null && (typeof value !== 'string' || value.trim().length > 0),
+                evaluator: (value) => !_isBlank(value),
                 numOperands: 0,
             },
         };
     }
 
+    /** The column filter's own order: trim the filter text, normalise both sides through one formatter, then
+     * match. A supplied `textMatcher` replaces the comparison itself, exactly as it does in the column filter. */
     private evaluateExpression(
         value: TValue | null | undefined,
         node: IRowNode,
         params: FilterExpressionEvaluatorParams<string, TValue>,
         operand: string,
         nullsMatch: boolean,
-        expression: (value: string, operand: string) => boolean
+        expression: (value: string, operand: string) => boolean,
+        filterOption: string
     ): boolean {
         if (value == null) {
             return nullsMatch;
         }
-        return params.caseSensitive
-            ? expression(params.valueConverter(value, node), operand)
-            : expression(params.valueConverter(value, node).toLocaleLowerCase(), operand.toLocaleLowerCase());
+        const format = params.textFormatter ?? defaultTextFormatter;
+        const filterText = format(params.trimInput ? _trimInputForFilter(operand) : operand) ?? '';
+        const formattedValue = format(params.valueConverter(value, node)) ?? '';
+        const textMatches = params.textMatches;
+        return textMatches
+            ? textMatches(filterOption, formattedValue, filterText, node)
+            : expression(formattedValue, filterText);
     }
 }
 
+/** The sign tests a comparison result is read through, named so a flame graph says which one ran. */
+const isZero = (compareResult: number): boolean => compareResult === 0;
+const isNotZero = (compareResult: number): boolean => compareResult !== 0;
+const isAfter = (compareResult: number): boolean => compareResult > 0;
+const isAtOrAfter = (compareResult: number): boolean => compareResult >= 0;
+const isBefore = (compareResult: number): boolean => compareResult < 0;
+const isAtOrBefore = (compareResult: number): boolean => compareResult <= 0;
+
 interface ScalarFilterExpressionOperatorsParams<ConvertedTValue> extends FilterExpressionOperatorsParams {
-    equals: (value: ConvertedTValue, operand: ConvertedTValue) => boolean;
+    /** The data type's own comparison, in the sign convention a column `comparator` uses. */
+    compare: (operand: ConvertedTValue, value: ConvertedTValue) => number;
+    /** What the comparison can read, mirroring each column filter handler's own gate. */
+    isValid: (value: any) => boolean;
 }
 
 export class ScalarFilterExpressionOperators<
@@ -203,31 +217,24 @@ export class ScalarFilterExpressionOperators<
     }
 
     private initOperators(): void {
-        const { translate, equals } = this.params;
+        const translate = this.params.translate;
         this.operators = {
             equals: {
                 displayValue: translate('advancedFilterEquals'),
                 evaluator: (value, node, params, operand1) =>
-                    this.evaluateSingleOperandExpression(
-                        value,
-                        node,
-                        params,
-                        operand1!,
-                        !!params.includeBlanksInEquals,
-                        equals
-                    ),
+                    this.evaluateComparison(value, node, params, operand1!, !!params.includeBlanksInEquals, isZero),
                 numOperands: 1,
             },
             notEqual: {
                 displayValue: translate('advancedFilterNotEqual'),
                 evaluator: (value, node, params, operand1) =>
-                    this.evaluateSingleOperandExpression(
+                    this.evaluateComparison(
                         value,
                         node,
                         params,
                         operand1!,
                         !!params.includeBlanksInNotEqual,
-                        (v, o) => !equals(v, o),
+                        isNotZero,
                         true
                     ),
                 numOperands: 1,
@@ -235,87 +242,93 @@ export class ScalarFilterExpressionOperators<
             greaterThan: {
                 displayValue: translate('advancedFilterGreaterThan'),
                 evaluator: (value, node, params, operand1) =>
-                    this.evaluateSingleOperandExpression(
+                    this.evaluateComparison(
                         value,
                         node,
                         params,
                         operand1!,
                         !!params.includeBlanksInGreaterThan,
-                        (v, o) => v > o
+                        isAfter
                     ),
                 numOperands: 1,
             },
             greaterThanOrEqual: {
                 displayValue: translate('advancedFilterGreaterThanOrEqual'),
                 evaluator: (value, node, params, operand1) =>
-                    this.evaluateSingleOperandExpression(
+                    this.evaluateComparison(
                         value,
                         node,
                         params,
                         operand1!,
                         !!params.includeBlanksInGreaterThan,
-                        (v, o) => v >= o
+                        isAtOrAfter
                     ),
                 numOperands: 1,
             },
             lessThan: {
                 displayValue: translate('advancedFilterLessThan'),
                 evaluator: (value, node, params, operand1) =>
-                    this.evaluateSingleOperandExpression(
-                        value,
-                        node,
-                        params,
-                        operand1!,
-                        !!params.includeBlanksInLessThan,
-                        (v, o) => v < o
-                    ),
+                    this.evaluateComparison(value, node, params, operand1!, !!params.includeBlanksInLessThan, isBefore),
                 numOperands: 1,
             },
             lessThanOrEqual: {
                 displayValue: translate('advancedFilterLessThanOrEqual'),
                 evaluator: (value, node, params, operand1) =>
-                    this.evaluateSingleOperandExpression(
+                    this.evaluateComparison(
                         value,
                         node,
                         params,
                         operand1!,
                         !!params.includeBlanksInLessThan,
-                        (v, o) => v <= o
+                        isAtOrBefore
                     ),
                 numOperands: 1,
             },
             blank: {
                 displayValue: translate('advancedFilterBlank'),
-                evaluator: (value) => value == null,
+                evaluator: (value) => _isBlank(value),
                 numOperands: 0,
             },
             notBlank: {
                 displayValue: translate('advancedFilterNotBlank'),
-                evaluator: (value) => value != null,
+                evaluator: (value) => !_isBlank(value),
                 numOperands: 0,
             },
         };
     }
 
-    private evaluateSingleOperandExpression(
+    /**
+     * The column filter's own order: the validity gate, then the comparison, then the sign of its result.
+     * A value the comparison cannot read matches nothing, and so matches every negation of a comparison.
+     */
+    private evaluateComparison(
         value: TValue | null | undefined,
         node: IRowNode,
         params: FilterExpressionEvaluatorParams<ConvertedTValue, TValue>,
         operand: ConvertedTValue,
         nullsMatch: boolean,
-        expression: (value: ConvertedTValue, operand: ConvertedTValue) => boolean,
+        passes: (compareResult: number) => boolean,
         isNegated?: boolean
     ): boolean {
         if (value == null) {
             return nullsMatch;
         }
-        const convertedValue = params.valueConverter(value, node);
-        // A value the data type cannot read is nothing to compare against, as the column filter's own validity
-        // gate decides: it matches no comparison, and so matches every negation of one.
-        if (convertedValue == null) {
+        // Handed the value the column filter hands it, unconverted: a string date column's `isValidDate`
+        // reads the string itself, and one written for that column must not be given something else.
+        const isValidDate = params.isValidDate;
+        if (isValidDate && !isValidDate(value)) {
             return !!isNegated;
         }
-        return expression(convertedValue, operand);
+        const comparator = params.comparator;
+        if (comparator) {
+            return passes(comparator(operand, value));
+        }
+        const convertedValue = params.valueConverter(value, node);
+        // The data type's own gate, on the value its comparison is about to read rather than on the raw one.
+        if (convertedValue == null || !this.params.isValid(convertedValue)) {
+            return !!isNegated;
+        }
+        return passes(this.params.compare(operand, convertedValue));
     }
 }
 
@@ -345,12 +358,12 @@ export class BooleanFilterExpressionOperators implements DataTypeFilterExpressio
             },
             blank: {
                 displayValue: translate('advancedFilterBlank'),
-                evaluator: (value) => value == null,
+                evaluator: (value) => _isBlank(value),
                 numOperands: 0,
             },
             notBlank: {
                 displayValue: translate('advancedFilterNotBlank'),
-                evaluator: (value) => value != null,
+                evaluator: (value) => !_isBlank(value),
                 numOperands: 0,
             },
         };

--- a/packages/ag-grid-enterprise/src/setFilter/setFilterHandler.ts
+++ b/packages/ag-grid-enterprise/src/setFilter/setFilterHandler.ts
@@ -247,7 +247,8 @@ export class SetFilterHandler<TValue = string>
         if (valueToFormat == null || typeof valueToFormat !== 'string') {
             return valueToFormat;
         }
-        return this.caseSensitive ? valueToFormat : (valueToFormat.toUpperCase() as T);
+        // Locale-aware, as every filter's case folding is: the Turkish dotted and dotless I are two letters.
+        return this.caseSensitive ? valueToFormat : (valueToFormat.toLocaleUpperCase() as T);
     }
 
     private addEventListenersForDataChanges(): void {

--- a/testing/behavioural/src/ai-toolkit/structured-schema.test.ts
+++ b/testing/behavioural/src/ai-toolkit/structured-schema.test.ts
@@ -710,7 +710,10 @@ describe('getStructuredSchema - filter feature', () => {
                         field: 'name',
                         filter: 'agTextColumnFilter',
                         filterParams: {
-                            filterOptions: ['contains', { displayKey: 'customEquals' }],
+                            filterOptions: [
+                                'contains',
+                                { displayKey: 'customEquals', displayName: 'Custom Equals', predicate: () => true },
+                            ],
                         },
                     },
                 ],

--- a/testing/behavioural/src/filters/advanced-filter/advanced-filter-column-filter-parity.test.ts
+++ b/testing/behavioural/src/filters/advanced-filter/advanced-filter-column-filter-parity.test.ts
@@ -1,8 +1,14 @@
-import { TestGridsManager, asyncSetTimeout } from 'ag-test-utils';
+import { ALL_SEVERITIES, TestGridsManager, asyncSetTimeout } from 'ag-test-utils';
 
 import type { AdvancedFilterModel, ColumnAdvancedFilterModel, GridApi, GridOptions } from 'ag-grid-community';
-import { ClientSideRowModelModule, DateFilterModule, NumberFilterModule, TextFilterModule } from 'ag-grid-community';
-import { AdvancedFilterModule } from 'ag-grid-enterprise';
+import {
+    ClientSideRowModelModule,
+    DateFilterModule,
+    NumberFilterModule,
+    TextFilterModule,
+    enableDevValidations,
+} from 'ag-grid-community';
+import { AdvancedFilterModule, SetFilterModule } from 'ag-grid-enterprise';
 
 interface TestRow {
     id: number;
@@ -26,7 +32,21 @@ const COLUMN_DEFS: GridOptions<TestRow>['columnDefs'] = [
     { field: 'date', cellDataType: 'dateString', filter: 'agDateColumnFilter' },
 ];
 
-function getDisplayedIds(api: GridApi<TestRow>): number[] {
+/** Ignores the time of day, which is the whole reason a column supplies its own comparator. */
+function byCalendarDay(filterDate: Date, cellValue: Date): number {
+    const startOfDay = (d: Date) => new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime();
+    const cellDay = startOfDay(cellValue);
+    const filterDay = startOfDay(filterDate);
+    if (cellDay === filterDay) {
+        return 0;
+    }
+    return cellDay > filterDay ? 1 : -1;
+}
+
+/** Every fixture row carries an `id`, which is what a parity assertion compares. */
+type IdRow = { id: number };
+
+function getDisplayedIds(api: GridApi<any>): number[] {
     const result: number[] = [];
     for (let i = 0; i < api.getDisplayedRowCount(); i++) {
         result.push(api.getDisplayedRowAtIndex(i)!.data!.id);
@@ -45,11 +65,19 @@ describe('Advanced Filter matches the column filter', () => {
         ],
     });
 
-    afterEach(() => gridsManager.reset());
+    afterEach(() => {
+        gridsManager.reset();
+        vi.restoreAllMocks();
+    });
 
     /** The rows a column filter shows for `model`, applied to a grid with no Advanced Filter. */
-    async function withColumnFilter(colId: string, model: object): Promise<number[]> {
-        const api = gridsManager.createGrid('columnFilterGrid', { columnDefs: COLUMN_DEFS, rowData: ROW_DATA });
+    async function withColumnFilter(
+        colId: string,
+        model: object,
+        columnDefs: GridOptions<any>['columnDefs'] = COLUMN_DEFS,
+        rowData: IdRow[] = ROW_DATA
+    ): Promise<number[]> {
+        const api = gridsManager.createGrid<any>('columnFilterGrid', { columnDefs, rowData });
         await asyncSetTimeout(0);
         await api.setColumnFilterModel(colId, model);
         api.onFilterChanged();
@@ -60,10 +88,14 @@ describe('Advanced Filter matches the column filter', () => {
     }
 
     /** The rows the Advanced Filter shows for the equivalent condition. */
-    async function withAdvancedFilter(model: AdvancedFilterModel): Promise<number[]> {
-        const api = gridsManager.createGrid('advancedFilterGrid', {
-            columnDefs: COLUMN_DEFS,
-            rowData: ROW_DATA,
+    async function withAdvancedFilter(
+        model: AdvancedFilterModel,
+        columnDefs: GridOptions<any>['columnDefs'] = COLUMN_DEFS,
+        rowData: IdRow[] = ROW_DATA
+    ): Promise<number[]> {
+        const api = gridsManager.createGrid<any>('advancedFilterGrid', {
+            columnDefs,
+            rowData,
             enableAdvancedFilter: true,
         });
         await asyncSetTimeout(0);
@@ -166,14 +198,321 @@ describe('Advanced Filter matches the column filter', () => {
         ).toEqual(columnFilterIds);
     });
 
-    // A whitespace date is rejected as an invalid date before either filter asks whether it is blank, so
-    // `isBlank`'s treatment of whitespace never reaches it. Pinned because it is the surprise.
-    test('a whitespace `dateString` is not blank to either', async () => {
+    // An option the column's filter cannot evaluate is dropped from its list when the colDef is read, so a
+    // model naming it names an option the column does not offer. Neither engine applies such a model.
+    test('a model naming a key the column cannot evaluate is cleared in both', async () => {
+        enableDevValidations({ throwOn: ALL_SEVERITIES, suppress: [76] });
+        vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const columnDefs: GridOptions<TestRow>['columnDefs'] = [
+            { field: 'age', filter: 'agNumberColumnFilter', filterParams: { filterOptions: ['equals', 'contains'] } },
+        ];
+        const model = { filterType: 'number' as const, type: 'contains', filter: 2 };
+        const columnFilterIds = await withColumnFilter('age', model, columnDefs);
+
+        // Nothing is filtered, rather than everything being filtered out.
+        expect(columnFilterIds).toEqual([0, 1, 2, 3, 4, 5]);
+        // Asserted deliberately outside the model type: `contains` is not a number filter's option.
+        expect(await withAdvancedFilter({ ...model, colId: 'age' } as ColumnAdvancedFilterModel, columnDefs)).toEqual(
+            columnFilterIds
+        );
+    });
+
+    // A join is asserted as a whole, so one condition naming an option the column does not offer makes the
+    // whole model unofferable: neither engine applies half of what was asked for.
+    test('a combined model naming a key the column cannot evaluate is cleared whole in both', async () => {
+        enableDevValidations({ throwOn: ALL_SEVERITIES, suppress: [76] });
+        vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const columnDefs: GridOptions<TestRow>['columnDefs'] = [
+            {
+                field: 'age',
+                filter: 'agNumberColumnFilter',
+                filterParams: { filterOptions: ['equals', 'contains'], maxNumConditions: 2 },
+            },
+        ];
+
+        const columnFilterIds = await withColumnFilter(
+            'age',
+            {
+                filterType: 'number',
+                operator: 'OR',
+                conditions: [
+                    { filterType: 'number', type: 'contains', filter: 2 },
+                    { filterType: 'number', type: 'equals', filter: 3 },
+                ],
+            },
+            columnDefs
+        );
+
+        // Not `[2]`: the offered half is not applied on its own.
+        expect(columnFilterIds).toEqual([0, 1, 2, 3, 4, 5]);
+        expect(
+            await withAdvancedFilter(
+                {
+                    filterType: 'join',
+                    type: 'OR',
+                    conditions: [
+                        { filterType: 'number', colId: 'age', type: 'contains', filter: 2 },
+                        { filterType: 'number', colId: 'age', type: 'equals', filter: 3 },
+                    ],
+                } as AdvancedFilterModel,
+                columnDefs
+            )
+        ).toEqual(columnFilterIds);
+    });
+
+    // Blankness is a property of the value, so a whitespace date is blank even though nothing can read it
+    // as a date: the same answer either filter's `blank` gives, and the same one the Set Filter gives.
+    test('a whitespace `dateString` is blank to both', async () => {
         const columnFilterIds = await withColumnFilter('date', { filterType: 'date', type: 'blank' });
 
-        expect(columnFilterIds).toEqual([2]);
+        expect(columnFilterIds).toEqual([1, 2]);
         expect(await withAdvancedFilter({ filterType: 'dateString', colId: 'date', type: 'blank' })).toEqual(
             columnFilterIds
         );
+    });
+
+    /** Text-column parity, each case driven by a `filterParams` that decides the column filter's matching. */
+    describe.each([
+        {
+            name: 'a `textMatcher` decides the matching',
+            filterParams: {
+                // Word-boundary matching: only a whitespace-delimited token counts, so `car` misses `carpet`.
+                textMatcher: ({ value, filterText }: { value: string; filterText: string | null }) =>
+                    filterText != null && value.split(' ').includes(filterText),
+            },
+            operand: 'car',
+            expected: [0],
+        },
+        {
+            name: 'a `textFormatter` normalises both sides',
+            filterParams: {
+                textFormatter: (from: string) =>
+                    from
+                        .normalize('NFD')
+                        .replace(/\p{Diacritic}/gu, '')
+                        .toLowerCase(),
+            },
+            operand: 'cafe',
+            expected: [1, 2],
+        },
+    ])('$name, in both', ({ filterParams, operand, expected }) => {
+        const columnDefs: GridOptions['columnDefs'] = [
+            { field: 'name', filter: 'agTextColumnFilter', filterParams: { ...filterParams, maxNumConditions: 1 } },
+        ];
+        const rowData = [
+            { id: 0, name: 'red car' },
+            { id: 1, name: 'Café' },
+            { id: 2, name: 'cafe' },
+            { id: 3, name: 'carpet' },
+        ];
+
+        test('same rows', async () => {
+            const columnFilterIds = await withColumnFilter(
+                'name',
+                { filterType: 'text', type: 'contains', filter: operand },
+                columnDefs,
+                rowData
+            );
+
+            expect(columnFilterIds).toEqual(expected);
+            expect(
+                await withAdvancedFilter(
+                    { filterType: 'text', colId: 'name', type: 'contains', filter: operand },
+                    columnDefs,
+                    rowData
+                )
+            ).toEqual(columnFilterIds);
+        });
+    });
+
+    // The column filter trims what was typed into the model it applies; the Advanced Filter's operand is
+    // itself what was typed, so `trimInput` has to be honoured at the comparison instead.
+    test('`trimInput` trims the operand the expression carries', async () => {
+        const rowData = [
+            { id: 0, name: 'red car' },
+            { id: 1, name: 'carpet' },
+        ];
+        const model: AdvancedFilterModel = {
+            filterType: 'text',
+            colId: 'name',
+            type: 'startsWith',
+            filter: '  car ',
+        };
+
+        expect(
+            await withAdvancedFilter(
+                model,
+                [{ field: 'name', filter: 'agTextColumnFilter', filterParams: { trimInput: true } }],
+                rowData
+            )
+        ).toEqual([1]);
+
+        // The control: without it the spaces are part of the value to look for, so nothing starts with them.
+        expect(await withAdvancedFilter(model, [{ field: 'name', filter: 'agTextColumnFilter' }], rowData)).toEqual([]);
+    });
+
+    // A column whose values carry a time can only be compared by day through its own `comparator`, so the
+    // filter that ignores it answers a different question from the one that does not.
+    test('a `comparator` decides the comparison in both', async () => {
+        const columnDefs: GridOptions['columnDefs'] = [
+            {
+                field: 'when',
+                cellDataType: 'date',
+                filter: 'agDateColumnFilter',
+                filterParams: { comparator: byCalendarDay },
+            },
+        ];
+        const rowData = [
+            { id: 0, when: new Date('2008-08-24T13:45:00') },
+            { id: 1, when: new Date('2012-08-05T09:00:00') },
+        ];
+
+        const columnFilterIds = await withColumnFilter(
+            'when',
+            { filterType: 'date', type: 'equals', dateFrom: '2008-08-24' },
+            columnDefs,
+            rowData
+        );
+
+        expect(columnFilterIds).toEqual([0]);
+        expect(
+            await withAdvancedFilter(
+                { filterType: 'date', colId: 'when', type: 'equals', filter: '2008-08-24' },
+                columnDefs,
+                rowData
+            )
+        ).toEqual(columnFilterIds);
+    });
+
+    // The gate the column filter holds a comparison to, on the value it hands it: a date column's own
+    // `isValidDate` decides what can be compared at all, before any comparison is asked for.
+    test('a user `isValidDate` decides what can be compared in both', async () => {
+        const columnDefs: GridOptions['columnDefs'] = [
+            {
+                field: 'when',
+                cellDataType: 'date',
+                filter: 'agDateColumnFilter',
+                // Anything before 2010 is not a date this column will compare.
+                filterParams: { isValidDate: (value: any) => value instanceof Date && value.getFullYear() >= 2010 },
+            },
+        ];
+        const rowData = [
+            { id: 0, when: new Date('2008-08-24T13:45:00') },
+            { id: 1, when: new Date('2012-08-05T09:00:00') },
+        ];
+
+        const columnFilterIds = await withColumnFilter(
+            'when',
+            { filterType: 'date', type: 'greaterThan', dateFrom: '2000-01-01' },
+            columnDefs,
+            rowData
+        );
+
+        // The 2008 row is after the operand, so only the gate can keep it out.
+        expect(columnFilterIds).toEqual([1]);
+        expect(
+            await withAdvancedFilter(
+                { filterType: 'date', colId: 'when', type: 'greaterThan', filter: '2000-01-01' },
+                columnDefs,
+                rowData
+            )
+        ).toEqual(columnFilterIds);
+    });
+
+    // The dotted and dotless I are one letter to `toLowerCase` and two to `toLocaleLowerCase`, so which rows
+    // match depends on the host locale. Which engine matches them must not: asserted against each other only.
+    test('the dotted and dotless I fold the same way in both', async () => {
+        const columnDefs: GridOptions['columnDefs'] = [{ field: 'name', filter: 'agTextColumnFilter' }];
+        const rowData = [
+            { id: 0, name: 'IRMAK' },
+            { id: 1, name: 'ırmak' },
+            { id: 2, name: 'irmak' },
+        ];
+
+        const columnFilterIds = await withColumnFilter(
+            'name',
+            { filterType: 'text', type: 'equals', filter: 'irmak' },
+            columnDefs,
+            rowData
+        );
+
+        // The exactly-typed row matches under either folding; the other two are what the locale decides.
+        expect(columnFilterIds).toContain(2);
+        expect(
+            await withAdvancedFilter(
+                { filterType: 'text', colId: 'name', type: 'equals', filter: 'irmak' },
+                columnDefs,
+                rowData
+            )
+        ).toEqual(columnFilterIds);
+    });
+
+    /**
+     * Whitespace reaches `blank` on both sides, where nothing rejects it first, including on a boolean column,
+     * whose own list omitted the two keys and whose filter has no comparison to gate them with.
+     */
+    describe.each([
+        { cellDataType: 'number', present: 1, columnFilterType: 'number', advancedFilterType: 'number' } as const,
+        { cellDataType: 'boolean', present: true, columnFilterType: 'text', advancedFilterType: 'boolean' } as const,
+    ])(
+        'a whitespace value on a $cellDataType column',
+        ({ cellDataType, present, columnFilterType, advancedFilterType }) => {
+            const columnDefs: GridOptions['columnDefs'] = [{ field: 'value', cellDataType, filter: true }];
+            const rowData = [
+                { id: 0, value: present },
+                { id: 1, value: '   ' },
+                { id: 2, value: null },
+            ];
+
+            test.each([
+                { type: 'blank' as const, expected: [1, 2] },
+                { type: 'notBlank' as const, expected: [0] },
+            ])('is `$type` to both', async ({ type, expected }) => {
+                const columnFilterIds = await withColumnFilter(
+                    'value',
+                    { filterType: columnFilterType, type },
+                    columnDefs,
+                    rowData
+                );
+
+                expect(columnFilterIds).toEqual(expected);
+                expect(
+                    await withAdvancedFilter(
+                        { filterType: advancedFilterType, colId: 'value', type },
+                        columnDefs,
+                        rowData
+                    )
+                ).toEqual(columnFilterIds);
+            });
+        }
+    );
+});
+
+describe('Advanced Filter and a Set Filter column', () => {
+    const gridsManager = new TestGridsManager({
+        modules: [SetFilterModule, AdvancedFilterModule, ClientSideRowModelModule],
+    });
+
+    afterEach(() => gridsManager.reset());
+
+    // `comparator` means "sort the values list" to a Set Filter and "compare against the operand" to a scalar
+    // one, so only the column whose own filter means the latter may have it read as a comparison. The number
+    // data type supplies the Set Filter one itself, so the default column is the case that has to hold.
+    test.each([
+        { name: 'the data type supplies', filterParams: undefined },
+        // Ascending, as a values list is sorted: `(a, b)` are two cell values, never an operand.
+        { name: 'the column supplies', filterParams: { comparator: (a: number, b: number) => a - b } },
+    ])('a Set Filter sorting `comparator` $name is not read as the comparison', async ({ filterParams }) => {
+        const api = gridsManager.createGrid('setComparatorAdvanced', {
+            columnDefs: [{ field: 'age', filter: true, filterParams }],
+            rowData: ROW_DATA,
+            enableAdvancedFilter: true,
+        });
+        await asyncSetTimeout(0);
+        api.setAdvancedFilterModel({ filterType: 'number', colId: 'age', type: 'greaterThan', filter: 1 });
+        api.onFilterChanged();
+        await asyncSetTimeout(0);
+        expect(getDisplayedIds(api)).toEqual([1, 2]);
+        api.destroy();
     });
 });

--- a/testing/behavioural/src/filters/filter-behaviour/date-filter-conditions.test.ts
+++ b/testing/behavioural/src/filters/filter-behaviour/date-filter-conditions.test.ts
@@ -255,6 +255,35 @@ describe('Date Filter — conditions coverage', () => {
         expect(filter.getModel()).toMatchObject({ type: 'notBlank' });
     });
 
+    // A date column holds strings, so it has an empty one to account for: blankness is a property of the
+    // value, not of whether the date parser could read it.
+    test('an empty or whitespace date is blank, where an unreadable one is not', async () => {
+        const api: GridApi = await gridsManager.createGridAndWait('grid1', {
+            columnDefs: [{ field: 'date', filter: 'agDateColumnFilter', filterParams: { debounceMs: 0 } }],
+            rowData: [{ date: '2024-01-10' }, { date: '' }, { date: null }, { date: '   ' }, { date: 'not a date' }],
+        });
+
+        const filter = await ColumnFilterHarness.open(api, 'date');
+
+        await filter.selectOperator('Blank');
+        await asyncSetTimeout(0);
+        await new GridRows(api, 'blank rows').check(`
+            ROOT id:ROOT_NODE_ID
+            ├── LEAF id:1 date:""
+            ├── LEAF id:2 date:null
+            └── LEAF id:3 date:""
+        `);
+
+        // Row 4 holds `'not a date'`, which the column's formatter prints as empty: unreadable, not blank.
+        await filter.selectOperator('Not blank');
+        await asyncSetTimeout(0);
+        await new GridRows(api, 'notBlank rows').check(`
+            ROOT id:ROOT_NODE_ID
+            ├── LEAF id:0 date:"2024-01-10"
+            └── LEAF id:4 date:""
+        `);
+    });
+
     const BOUNDARY = [
         { date: '2024-01-10' },
         { date: '2024-03-15' },

--- a/testing/behavioural/src/filters/filter-options-validation.test.ts
+++ b/testing/behavioural/src/filters/filter-options-validation.test.ts
@@ -360,114 +360,50 @@ describe('Column filter — a built-in option the filter cannot evaluate', () =>
             rowData: [{ athlete: 'Bolt' }, { athlete: 'Ng' }],
         } as GridOptions);
 
-    // The reported case: a key that is not a filter option at all, rather than one belonging elsewhere.
-    test('a key no filter defines is offered under its own name, and reported when it is evaluated', async () => {
+    /**
+     * Each key is unusable for a different reason: one no filter defines, one belonging to another filter type,
+     * and a relative date range. All three are dropped from the list rather than offered and then unanswerable.
+     */
+    test.each([
+        { name: 'a key no filter defines', key: 'wrong' },
+        { name: 'an option belonging to another filter type', key: 'inRange' },
+        { name: 'a relative date range on a text filter', key: 'lastYear' },
+    ])('$name is dropped from the list and reported', async ({ key }) => {
         enableDevValidations({ throwOn: ALL_SEVERITIES, suppress: [76] });
         const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
-        const api: GridApi = await createGrid(['equals', 'notEqual', 'wrong']);
-        const filter = await ColumnFilterHarness.open(api, 'athlete');
-        // Nothing localises it, so the key stands in for the label it has no translation for.
-        expect(await filter.operatorOptions()).toEqual(['Equals', 'Does not equal', 'wrong']);
-        expect(warnSpy).not.toHaveBeenCalled();
+        const api: GridApi = await createGrid(['equals', 'notEqual', key]);
 
-        await filter.selectOperator('wrong');
-        await filter.setText('Bolt', 0);
-        await asyncSetTimeout(0);
-
-        expect(api.getColumnFilterModel('athlete')).toEqual({
-            filterType: 'text',
-            type: 'wrong',
-            filter: 'Bolt',
-        });
-        // `Bolt` is in the data, so a key that matched anything would leave a row behind.
-        await new GridRows(api, 'a key no filter defines').check(`
-            ROOT id:ROOT_NODE_ID
-        `);
+        // Before the filter is opened: a column filter is built when the user clicks it, and a misconfigured
+        // column that looks fine until then is the whole complaint.
         const warnings = warnSpy.mock.calls.flat().join(' ');
         expect(warnings).toContain('warning #76');
-        expect(warnings).toContain('wrong');
-        await new FilterDom(api, 'a key no filter defines', { colId: 'athlete' }).checkFilterDom(`
-            COLUMN FILTER
-            operator: "wrong"
-            input: "Bolt"
-            model:
-              filterType: "text"
-              type: "wrong"
-              filter: "Bolt"
-        `);
+        expect(warnings).toContain(key);
+
+        const filter = await ColumnFilterHarness.open(api, 'athlete');
+        expect(await filter.operatorOptions()).toEqual(['Equals', 'Does not equal']);
     });
 
-    // The option is offered as configured: only a `textMatcher` or a `predicate` can say what it means,
-    // and either may supply one, so it is the evaluation with neither that reports.
-    test('an option belonging to another filter type is offered, and reported when it is evaluated', async () => {
+    // A model may only name an option the list offers, so one naming a dropped key is cleared like any other.
+    test('a model naming a dropped key is cleared rather than applied', async () => {
         enableDevValidations({ throwOn: ALL_SEVERITIES, suppress: [76] });
-        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        vi.spyOn(console, 'warn').mockImplementation(() => {});
 
-        const api: GridApi = await createGrid(['contains', 'inRange']);
-        const filter = await ColumnFilterHarness.open(api, 'athlete');
-        expect(await filter.operatorOptions()).toEqual(['Contains', 'Between']);
-        expect(warnSpy).not.toHaveBeenCalled();
+        const api: GridApi = await createGrid(['equals', 'wrong']);
+        await api.setColumnFilterModel('athlete', { filterType: 'text', type: 'wrong', filter: 'Bolt' });
+        await api.onFilterChanged();
 
-        await filter.selectOperator('Between');
-        await filter.setText('A', 0);
-        await filter.setText('Z', 1);
-        await asyncSetTimeout(0);
-
-        expect(api.getColumnFilterModel('athlete')).toEqual({
-            filterType: 'text',
-            type: 'inRange',
-            filter: 'A',
-            filterTo: 'Z',
-        });
-        await new GridRows(api, 'a text `inRange` the matcher cannot answer').check(`
+        expect(api.getColumnFilterModel('athlete')).toBeNull();
+        // `Bolt` is in the data, so a filter that had applied would have left one row rather than both.
+        await new GridRows(api, 'a model naming a dropped key').check(`
             ROOT id:ROOT_NODE_ID
-        `);
-        const warnings = warnSpy.mock.calls.flat().join(' ');
-        expect(warnings).toContain('warning #76');
-        expect(warnings).toContain('inRange');
-        await new FilterDom(api, 'an option belonging to another filter type', { colId: 'athlete' }).checkFilterDom(`
-            COLUMN FILTER
-            operator: "Between"
-            input [0]: "A"
-            input [1]: "Z"
-            model:
-              filterType: "text"
-              type: "inRange"
-              filter: "A"
-              filterTo: "Z"
+            ├── LEAF id:0 athlete:"Bolt"
+            └── LEAF id:1 athlete:"Ng"
         `);
     });
 
-    test('a relative date range on a text filter is offered with no inputs, and reported the same way', async () => {
-        enableDevValidations({ throwOn: ALL_SEVERITIES, suppress: [76] });
-        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-
-        const api: GridApi = await createGrid(['contains', 'lastYear']);
-        const filter = await ColumnFilterHarness.open(api, 'athlete');
-
-        await filter.selectOperator('Last Year');
-        await asyncSetTimeout(0);
-
-        expect(filter.inputs('text')).toEqual([]);
-        expect(api.getColumnFilterModel('athlete')).toEqual({ filterType: 'text', type: 'lastYear' });
-        await new GridRows(api, 'a text `lastYear` the matcher cannot answer').check(`
-            ROOT id:ROOT_NODE_ID
-        `);
-        const warnings = warnSpy.mock.calls.flat().join(' ');
-        expect(warnings).toContain('warning #76');
-        expect(warnings).toContain('lastYear');
-        await new FilterDom(api, 'a relative date range on a text filter', { colId: 'athlete' }).checkFilterDom(`
-            COLUMN FILTER
-            operator: "Last Year"
-            model:
-              filterType: "text"
-              type: "lastYear"
-        `);
-    });
-
-    // Both filters report `#76`; the scalar filters admit the row they cannot judge, the text filter excludes it.
-    test('a number filter shows every row for the option it cannot evaluate', async () => {
+    // The list is the filter's, not the data type's: the same key is usable on one column and not on another.
+    test('a key the number filter cannot evaluate is dropped from its list too', async () => {
         enableDevValidations({ throwOn: ALL_SEVERITIES, suppress: [76] });
         const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
@@ -476,70 +412,18 @@ describe('Column filter — a built-in option the filter cannot evaluate', () =>
                 {
                     field: 'age',
                     filter: 'agNumberColumnFilter',
-                    filterParams: { filterOptions: ['equals', 'contains'], debounceMs: 0 },
+                    filterParams: { filterOptions: ['equals', 'notEqual', 'contains'], debounceMs: 0 },
                 },
             ],
             rowData: [{ age: 25 }, { age: 40 }],
         } as GridOptions);
 
-        const filter = await ColumnFilterHarness.open(api, 'age');
-        await filter.selectOperator('Contains');
-        await filter.setNumber(25, 0);
-        await asyncSetTimeout(0);
-
-        // The scalar filters admit the row they cannot judge; the text filter excludes it.
-        await new GridRows(api, 'a number `contains` the comparison cannot answer').check(`
-            ROOT id:ROOT_NODE_ID
-            ├── LEAF id:0 age:25
-            └── LEAF id:1 age:40
-        `);
         const warnings = warnSpy.mock.calls.flat().join(' ');
         expect(warnings).toContain('warning #76');
         expect(warnings).toContain('contains');
-        await new FilterDom(api, 'a number filter shows every row', { colId: 'age' }).checkFilterDom(`
-            COLUMN FILTER
-            operator: "Contains"
-            input: "25"
-            AND
-            operator: "Equals"
-            input: "" ⟨Filter...⟩
-            model:
-              filterType: "number"
-              type: "contains"
-              filter: 25
-        `);
-    });
 
-    // Presence is decided without the matcher, so a column that never reaches it must still report.
-    test('a column of blank values still reports the key it cannot evaluate', async () => {
-        enableDevValidations({ throwOn: ALL_SEVERITIES, suppress: [76] });
-        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-
-        const api: GridApi = await gridsManager.createGridAndWait('grid1', {
-            columnDefs: [
-                {
-                    field: 'athlete',
-                    filter: 'agTextColumnFilter',
-                    filterParams: { filterOptions: ['contains', 'inRange'], debounceMs: 0, maxNumConditions: 1 },
-                },
-            ],
-            rowData: [{ athlete: null }, { athlete: null }],
-        } as GridOptions);
-
-        await api.setColumnFilterModel('athlete', {
-            filterType: 'text',
-            type: 'inRange',
-            filter: 'A',
-            filterTo: 'Z',
-        });
-        await api.onFilterChanged();
-
-        const warnings = warnSpy.mock.calls.flat().join(' ');
-        expect(warnings).toContain('warning #76');
-        expect(warnings).toContain('inRange');
-        await new GridRows(api, 'a blank column with an unusable key').check(`
-            ROOT id:ROOT_NODE_ID
-        `);
+        const filter = await ColumnFilterHarness.open(api, 'age');
+        expect(await filter.operatorOptions()).toEqual(['Equals', 'Does not equal']);
     });
 
     // The option is configured correctly and only its value is missing, so the key is not what went wrong.
@@ -655,6 +539,55 @@ describe('Column filter — a built-in option the filter cannot evaluate', () =>
     });
 });
 
+describe('Column filter — the list is validated when the column definition is read', () => {
+    const gridsManager = new TestGridsManager({
+        modules: [TextFilterModule, NumberFilterModule, ColumnMenuModule, ClientSideRowModelModule],
+    });
+
+    beforeAll(() => {
+        setupAgTestIds();
+        installFilterLayoutMock();
+    });
+    afterAll(() => uninstallFilterLayoutMock());
+    afterEach(() => {
+        gridsManager.reset();
+        vi.restoreAllMocks();
+        enableDevValidations({ throwOn: ALL_SEVERITIES });
+    });
+
+    // A column filter is built when the user opens it, so a list checked there leaves a misconfigured column
+    // looking fine until someone clicks it. Every report below is asserted with no filter ever opened.
+    test('reports every fault in the list at startup, before any filter is opened', async () => {
+        enableDevValidations({ throwOn: ALL_SEVERITIES, suppress: [72, 76, 326] });
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+        await gridsManager.createGridAndWait('grid1', {
+            columnDefs: [
+                {
+                    field: 'athlete',
+                    filter: 'agTextColumnFilter',
+                    filterParams: {
+                        filterOptions: ['contains', 'wrong', NO_PREDICATE_OPTION],
+                        defaultOption: 'startsWith',
+                        debounceMs: 0,
+                    },
+                },
+            ],
+            rowData: [{ athlete: 'Bolt' }],
+        } as GridOptions);
+
+        const warnings = warnSpy.mock.calls.flat().join(' ');
+        // The key the filter cannot evaluate.
+        expect(warnings).toContain('warning #76');
+        expect(warnings).toContain('wrong');
+        // The custom option with no `predicate`.
+        expect(warnings).toContain('warning #72');
+        // The `defaultOption` naming an option the list does not offer.
+        expect(warnings).toContain('warning #326');
+        expect(warnings).toContain('startsWith');
+    });
+});
+
 describe('Column filter — localising the option keys', () => {
     const gridsManager = new TestGridsManager({
         modules: [TextFilterModule, LocaleModule, ColumnMenuModule, ClientSideRowModelModule],
@@ -669,13 +602,14 @@ describe('Column filter — localising the option keys', () => {
 
     test('`getLocaleText` is given a real default for every offered option', async () => {
         const calls: { key: string; defaultValue: unknown }[] = [];
-        // A JavaScript config: `ITextFilterParams` rejects `'soundsLike'`, but the grid still offers what it is given.
+        // A `textMatcher` answers for itself, so `'soundsLike'` stays offered with nothing to name it by.
         const filterParams = {
             filterOptions: [
                 'contains',
                 'soundsLike',
                 { displayKey: 'multipleOf', displayName: 'Multiple of', predicate: () => true },
             ],
+            textMatcher: () => true,
             debounceMs: 0,
             maxNumConditions: 1,
         };
@@ -1028,9 +962,10 @@ describe('Column filter — a malformed `filterOptions` list', () => {
 
     test('`filterPlaceholder` is given a bare key the grid does not define, not an empty string', async () => {
         const seen: { filterOptionKey: string; filterOption: string }[] = [];
-        // A JavaScript config: `INumberFilterParams` rejects `'withinOf'`, but the grid still offers what it is given.
+        // A `textMatcher` answers for itself, so `'withinOf'` stays offered with nothing to name it by.
         const filterParams = {
             filterOptions: ['equals', 'withinOf'],
+            textMatcher: () => true,
             filterPlaceholder: ({ filterOptionKey, filterOption, placeholder }: any) => {
                 seen.push({ filterOptionKey, filterOption });
                 return placeholder;
@@ -1039,11 +974,11 @@ describe('Column filter — a malformed `filterOptions` list', () => {
             maxNumConditions: 1,
         };
         const api = await gridsManager.createGridAndWait('grid1', {
-            columnDefs: [{ field: 'age', filter: 'agNumberColumnFilter', filterParams }],
-            rowData: [{ age: 25 }, { age: 40 }],
+            columnDefs: [{ field: 'athlete', filter: 'agTextColumnFilter', filterParams }],
+            rowData: [{ athlete: 'Bolt' }, { athlete: 'Ng' }],
         });
 
-        const harness = await ColumnFilterHarness.open(api, 'age');
+        const harness = await ColumnFilterHarness.open(api, 'athlete');
         await harness.selectOperator('withinOf');
 
         // With no built-in locale text and no custom option to name it, the key stands in as its own display name.
@@ -1494,42 +1429,6 @@ describe('Column filter — the date summary for an option the grid does not def
         enableDevValidations({ throwOn: ALL_SEVERITIES });
     });
 
-    // A read-only floating filter shows `getModelAsString`, which is where a valueless date condition is named.
-    test('names the key itself rather than resolving to nothing', async () => {
-        // Deliberate: the date filter cannot evaluate the key, which triggers warning #76.
-        enableDevValidations({ throwOn: ALL_SEVERITIES, suppress: [76] });
-        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-
-        // A JavaScript config: `IDateFilterParams` rejects `'soundsLike'`, but the grid still offers what it is given.
-        const filterParams = { filterOptions: ['equals', 'soundsLike'], readOnly: true, debounceMs: 0 };
-        const api: GridApi = await gridsManager.createGridAndWait('grid1', {
-            columnDefs: [{ field: 'date', filter: 'agDateColumnFilter', floatingFilter: true, filterParams }],
-            rowData: [{ date: '2024-01-01' }],
-        } as GridOptions);
-
-        await api.setColumnFilterModel('date', {
-            filterType: 'date',
-            type: 'soundsLike',
-            dateFrom: null,
-            dateTo: null,
-        });
-        await api.onFilterChanged();
-        await asyncSetTimeout(0);
-
-        expect(warnSpy.mock.calls.flat().join(' ')).toContain('warning #76');
-        await new FilterDom(api, 'a valueless condition the grid does not define', { colId: 'date' }).checkFilterDom(`
-            FLOATING FILTER date
-            input: "soundsLike" ⊘
-            active: true
-            model:
-              filterType: "date"
-              type: "soundsLike"
-              dateFrom: null
-              dateTo: null
-        `);
-    });
-
-    // Settles whether a zero-input custom option reaches the key-based path: it is resolved before that.
     test('a zero-input custom option is named by its `displayName`, not its key', async () => {
         const filterParams = {
             filterOptions: [
@@ -1557,6 +1456,55 @@ describe('Column filter — the date summary for an option the grid does not def
               type: "isWeekend"
               dateFrom: null
               dateTo: null
+        `);
+    });
+});
+
+describe('Column filter — a boolean column', () => {
+    const gridsManager = new TestGridsManager({
+        modules: [TextFilterModule, ColumnMenuModule, ClientSideRowModelModule],
+    });
+
+    beforeAll(() => {
+        setupAgTestIds();
+        installFilterLayoutMock();
+    });
+    afterAll(() => uninstallFilterLayoutMock());
+    afterEach(() => gridsManager.reset());
+
+    // `CommonFilterOptionKey`'s contract: no data type may fail to support blankness.
+    test('a boolean column offers blank and notBlank, as every other data type does', async () => {
+        const api: GridApi = await gridsManager.createGridAndWait('grid1', {
+            columnDefs: [{ field: 'done', cellDataType: 'boolean', filter: true }],
+            rowData: [{ done: true }, { done: false }, { done: null }],
+        } as GridOptions);
+
+        const filter = await ColumnFilterHarness.open(api, 'done');
+
+        // `'empty'` renders as the "Choose one" placeholder the boolean list opens with.
+        expect(await filter.operatorOptions()).toEqual(['Choose one', 'True', 'False', 'Blank', 'Not blank']);
+
+        await filter.selectOperator('Blank');
+        await asyncSetTimeout(0);
+        await new GridRows(api, 'blank rows').check(`
+            ROOT id:ROOT_NODE_ID
+            └── LEAF id:2 done:null
+        `);
+
+        // `false` is a value, so the half that is easy to get wrong is the one where it must stay.
+        await filter.selectOperator('Not blank');
+        await asyncSetTimeout(0);
+        await new GridRows(api, 'notBlank rows').check(`
+            ROOT id:ROOT_NODE_ID
+            ├── LEAF id:0 done:true
+            └── LEAF id:1 done:false
+        `);
+        await new FilterDom(api, 'a boolean filter on notBlank', { colId: 'done' }).checkFilterDom(`
+            COLUMN FILTER
+            operator: "Not blank"
+            model:
+              filterType: "text"
+              type: "notBlank"
         `);
     });
 });


### PR DESCRIPTION
<!-- base: latest -->

# Every filter answers an option the same way, and rejects one it cannot use

FIX AG-18264
FIX AG-16738
FIX AG-13360
FIX AG-11294
FIX AG-18277

Five ways a filter option could mean one thing to a column filter and another to the Advanced Filter, each
settled by deciding it once: whether the column offers the option at all, when that is checked, and how a value
is compared, matched and tested for blankness.

| scope  | net lines |    lines changed | hunks |      files changed |
| ------ | --------: | ---------------: | ----: | -----------------: |
| source |      +355 | 1081 (+718 -363) |   146 | 32 (+1, 31 edited) |
| tests  |      +650 | 1070 (+860 -210) |    61 |           7 edited |
| docs   |       +10 |      12 (+11 -1) |     4 |           2 edited |

## Breaking bug fixes

Both need a release note. Neither has a migration step.

### An empty or whitespace cell is blank, not zero

`includeBlanksInEquals` and its four siblings are `colDef.filterParams` settings with no control in the grid's
own UI, and belong to the number, bigint and date filters. The column filter and the Advanced Filter both read
them; the Quick Filter has no comparisons and no notion of blank, so none of this reaches it.

A cell holding `''` or only spaces:

| filter         | filtering by                             | before               | after    |
| -------------- | ---------------------------------------- | -------------------- | -------- |
| Number, BigInt | `lessThan 5`                             | matches, read as `0` | no match |
| Number, BigInt | `lessThan 5` + `includeBlanksInLessThan` | no match             | matches  |
| Date           | `blank`                                  | no match             | matches  |
| Date           | `notEqual`                               | matches              | no match |
| Date           | `notEqual` + `includeBlanksInNotEqual`   | no match             | matches  |

Excel does the same with comparisons: a numeric filter there never coerces, so neither an empty cell nor a text
cell passes `less than 5`, and blanks are ticked in the list instead. It counts a cell of spaces as text rather
than blank, where `isBlank` counts it as blank and `(Blanks)` follows it. Sorting decides that same question
separately in [AG-4861](https://ag-grid.atlassian.net/browse/AG-4861), where the proposal treats `null` and
`undefined` as missing and `''` as text.

### Case folding follows the locale

The column filter, the Set Filter and the Quick Filter fold with `toLocaleLowerCase` and `toLocaleUpperCase` in
place of `toLowerCase` and `toUpperCase`, which the Advanced Filter already used. Those two treat the Turkish
dotted and dotless I as one letter and they are two, so on a Turkish or Azeri machine a cell reading `IRMAK` is
found by typing `ırmak` and no longer by typing `irmak`.

## [AG-18264](https://ag-grid.atlassian.net/browse/AG-18264): A key the column cannot evaluate is never offered

A `filterOptions` entry the column's filter cannot evaluate is accepted, offered, then answered three ways: a
number column shows every row and warns `#76`, a text column shows none and says nothing, and the Advanced
Filter shows every row with the expression marked invalid. It is dropped from the list when the column
definition is read, so nothing offers it and nothing has to answer it. A model naming it is cleared, and a
combined model naming it is cleared whole, as both engines already did for an option left out of the list. A
column supplying a `textMatcher` keeps every key, since the matcher decides what they mean. One list also means
the structured schema `getStructuredSchema()` publishes stops advertising options the filter would refuse.

## [AG-16738](https://ag-grid.atlassian.net/browse/AG-16738): A misconfigured list is reported at startup

Every report about a `filterOptions` list came from the options a filter builds for its own dropdown, and a
column filter is built when the user opens it, so a misconfigured column said nothing until someone clicked it.
The list is read where a column definition is read instead: a malformed entry, an option the filter cannot
evaluate and a `defaultOption` the offered list does not contain are all reported before the grid renders a row.
Every column passes through there, so a column that names its filter is checked whether or not a cell data type
resolved for it, which a column outside the Client-Side Row Model or carrying a `cellRenderer`, `valueGetter`,
`valueParser` or `refData` never does. The data type's own path carries the same check to a Multi Filter's
children and the Filters Tool Panel's selectable definitions.

Each report names the column it came from, so a grid whose columns share a mistake reports it once per column
rather than once for the message. A column left with nothing it can offer falls back to the built-in list, which
`#74` has always reported.

## [AG-13360](https://ag-grid.atlassian.net/browse/AG-13360): The column's `comparator` decides the comparison in the Advanced Filter too

A date column whose values carry a time can only be compared by day through its own `comparator`, which the
Advanced Filter ignored. Its scalar operators now evaluate in the column handler's order, validity gate then
comparison then the sign of the result, with the column's `comparator` and `isValidDate` replacing the data
type's defaults and handed the unconverted value the column filter hands them. Read only from a column whose own
filter is the Date Filter: `comparator` names a sorting order to a Set Filter, and the number and bigint
handlers fix their own comparison whatever `filterParams` carries.

## [AG-18277](https://ag-grid.atlassian.net/browse/AG-18277): Text is matched the column's way in both

`textMatcher`, `textFormatter` and `trimInput` were honoured by the column filter and ignored by the Advanced
Filter, so a column that normalised or replaced its own matching was filtered two different ways. The Advanced
Filter's text operators read all three from the column, where the column's own filter is the Text Filter.

The Advanced Filter also applies the column's `textFormatter` and `trimInput` to the operand where the
expression is compiled rather than once per row, so a column that supplies one is asked about the value only.

## [AG-11294](https://ag-grid.atlassian.net/browse/AG-11294): Blank is a property of the value

`''` was not blank to a date column, because the validity gate rejected it as an unreadable date before anything
asked. `blank` and `notBlank` are answered ahead of every type-specific path, from one `isBlank` that both
engines read; an unreadable date is still not blank. A boolean column offers them too now, against
`CommonFilterOptionKey`'s contract that no data type can fail to support them. The six built-in text comparisons
likewise move to a shared table that the column filter's matcher and the Advanced Filter's operators both read.

## Along the way

`BooleanAdvancedFilterModelType` widens to `'true' | 'false' | 'blank' | 'notBlank'`: the Advanced Filter has
always offered both for a boolean column and returns them from `getAdvancedFilterModel()`, so the union
described a model the grid produces. Only an exhaustiveness assert over the old two members stops compiling.

Warnings `#72`, `#74`, `#76` and `#326` gain the column id, so their text changes.

A key is now looked for on the list of options a filter supports rather than read off it, so `filterOptions:
['toString']` is a key the filter cannot evaluate rather than one that answers truthy through `Object.prototype`.
A bare key naming a Custom Filter Option defined further down the same list still resolves to that definition.

A `filter` naming a provided filter through `{ component: 'agDateColumnFilter' }` is read as that filter
wherever naming it as a string already was, so such a column stops missing the `filterParams` its data type
supplies. The two tool panels' search boxes fold case the locale's way too.

The Advanced Filter re-reads a column's `filterParams` when new column definitions arrive, so replacing a
column's `comparator`, `textMatcher` or `textFormatter` replaces the rule it filters by. The default date
comparison and the number and bigint validity gates are each one definition that both engines read.
