### PR TITLE
AG-17426 add CI-read scopes to the agent-run job permissions

### DIFF
--- a/.github/workflows/jira-agent-pipeline.yml
+++ b/.github/workflows/jira-agent-pipeline.yml
@@ -186,6 +186,9 @@ jobs:
         permissions:
             contents: read
             packages: read
+            pull-requests: read
+            checks: read
+            statuses: read
         steps:
             - uses: actions/checkout@v4
               with:


### PR DESCRIPTION
Adds `pull-requests: read`, `checks: read` and `statuses: read` to the `agent-run` job's `permissions:` block in the AI Workflow stub.

https://ag-grid.atlassian.net/browse/AG-17426