### PR TITLE
AG-3390 - Read the scorecard from api.scorecard.dev, not the deprecated host

### DIFF
--- a/external/ag-shared/scripts/ossf-scorecard/getAndCheckResults.mjs
+++ b/external/ag-shared/scripts/ossf-scorecard/getAndCheckResults.mjs
@@ -6,8 +6,8 @@ export async function getOSSFScorecardResults({ project, threshold }) {
         process.exit(1);
     }
 
-    const scorecardJsonUrl = `https://api.securityscorecards.dev/projects/github.com/ag-grid/ag-${project}`;
-    const response = await fetch(scorecardJsonUrl);
+    const scorecardJsonUrl = `https://api.scorecard.dev/projects/github.com/ag-grid/ag-${project}`;
+    const response = await fetch(`${scorecardJsonUrl}?cachebust=${Date.now()}`);
     const results = await response.json();
 
     const score = results.score;
@@ -37,7 +37,7 @@ export async function getOSSFScorecardResults({ project, threshold }) {
             tests: [
                 {
                     name: `OpenSSF Score >= ${threshold}`,
-                    message: `Score = ${score}, from ${scorecardJsonUrl}. See ${resultsUrl} for full details.`,
+                    message: `Score = ${score}, scanned ${results.date}, from ${scorecardJsonUrl}. See ${resultsUrl} for full details.`,
                     status,
                     duration: 0,
                 },


### PR DESCRIPTION
Mirrors ag-grid/ag-charts#7895 in this repo, so the shared `ag-shared` script stays consistent across both. The diff here is byte-identical to the one on the charts side.

## Problem

The OSS Scorecard gate fetched `api.securityscorecards.dev` — the hostname Scorecard used before it moved under the OpenSSF umbrella and was [renamed to `scorecard.dev`](https://openssf.org/blog/2024/03/05/openssf-scorecard-evaluating-and-improving-the-health-of-critical-oss-projects/). The old host still resolves, but its CDN edge is serving objects **days** past their advertised 10-minute `max-age`.

It surfaced on charts, where the gate reported `Score = 7` while the [viewer](https://scorecard.dev/viewer/?uri=github.com/ag-grid/ag-charts) showed `6.9`. This repo is affected identically — the legacy host returns `age: 235481` (~2.7 days), frozen on a scan from 2026-08-21. It went unnoticed here only because the grid score happened not to move in the meantime.

The origin is healthy: a cache-buster against the *same* legacy host returns the current result, so this is purely edge staleness.

## Change

In `external/ag-shared/scripts/ossf-scorecard/getAndCheckResults.mjs`:

- Point at `api.scorecard.dev`.
- Add a cache-buster to the fetch. The new host carries the same 10-minute `max-age` behind the same CDN, so it can go stale the same way. A `Cache-Control: no-cache` *request* header does not work — verified, the edge ignores it and still returns `x-cache: HIT` with a multi-day `age`.
- Include the scan date in the CTRF test message, so a stale read shows up in the `#ci-grid-gate` Slack notification. Commit and scan date were already in the GitHub step summary via `generateGithubSummary.mjs`; the Slack path had neither.

## Verification

Ran the patched module in this worktree against the live API:

```
grid: score 7.8  scanned 2026-08-24T07:54:03Z  commit e92aa71cf76  passed=true
```

`e92aa71cf76` is the current head of `latest`, so the fresh result reflects this repo as it stands. Comfortably over the `7.3` threshold, so no gate change here — this fixes the data being read, not the score. `node --check` passes; `external/ag-shared/` sits outside the repo's prettier and eslint scope, so no lint target covers this file.

## Notes

`external/ag-shared` is a git-subrepo of `ag-grid/ag-shared`. Once the copies land, one of them needs a `git subrepo push` so the fix reaches the shared repo itself rather than living only in the consumers.
