### PR TITLE
AG-18149 Remove 1px minimum height for empty row container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .idea
 .vscode
 .junie
+.playwright-mcp
 
 vite.config.ts.timestamp-*.mjs
 vite.config.mts.timestamp-*.mjs

--- a/packages/ag-grid-angular/projects/ag-grid-angular/src/lib/tests/quick-filter.spec.ts
+++ b/packages/ag-grid-angular/projects/ag-grid-angular/src/lib/tests/quick-filter.spec.ts
@@ -88,7 +88,7 @@ describe('Quick Filter', () => {
         validateState({ gridRows: 17, displayedRows: 0, templateRows: 0 });
 
         // To have all the async functions run we flush our fakeAsync test environment. This empties the call stack
-        flush(25);
+        flush(40);
         // So now our component has its displayedRows property updated as the grid callback has been run
         // However, this has not been reflected in our template yet as change detection has not run.
         validateState({ gridRows: 17, displayedRows: 17, templateRows: 0 });
@@ -114,7 +114,7 @@ describe('Quick Filter', () => {
         validateState({ gridRows: 10, displayedRows: 17, templateRows: 17 });
 
         // We now flush out all the async callbacks
-        flush(25);
+        flush(40);
         // Our component event handler has now been run and updated its displayedRows value
         validateState({ gridRows: 10, displayedRows: 10, templateRows: 17 });
 
@@ -127,7 +127,7 @@ describe('Quick Filter', () => {
 
     it('should filter rows by quickFilterText', fakeAsync(() => {
         fixture.detectChanges();
-        flush(25);
+        flush(40);
         fixture.detectChanges();
 
         validateState({ gridRows: 17, displayedRows: 17, templateRows: 17 });
@@ -136,7 +136,7 @@ describe('Quick Filter', () => {
         quickFilterDE.nativeElement.dispatchEvent(new Event('input'));
 
         fixture.detectChanges();
-        flush(25);
+        flush(40);
         fixture.detectChanges();
 
         validateState({ gridRows: 10, displayedRows: 10, templateRows: 10 });

--- a/packages/ag-grid-community/src/rendering/rowRenderer.ts
+++ b/packages/ag-grid-community/src/rendering/rowRenderer.ts
@@ -734,15 +734,7 @@ export class RowRenderer extends BeanStub implements NamedBean {
             return;
         }
 
-        let containerHeight = this.pageBounds.getCurrentPageHeight();
-        // we need at least 1 pixel for the horizontal scroll to work. so if there are now rows,
-        // we still want the scroll to be present, otherwise there would be no way to scroll the header
-        // which might be needed us user wants to access columns
-        // on the RHS - and if that was where the filter was that cause no rows to be presented, there
-        // is no way to remove the filter.
-        if (containerHeight === 0) {
-            containerHeight = 1;
-        }
+        const containerHeight = this.pageBounds.getCurrentPageHeight();
 
         rowContainerHeight.setModelHeight(containerHeight + additionalHeight);
     }


### PR DESCRIPTION
Fix [AG-18149](https://ag-grid.atlassian.net/browse/AG-18149)

The 1px minimum height on the grid body is no longer necessary now that we render the header and body in the same container, removing it fixes the bug in AG-18149

Note, had to replace some `flush(25)` with `flush(40)` in angular tests. Flush is a utility that clears async operations like setTimeout, the argument (25) is the limit of timers to clear. 25 was a magic number just above the actual number required. This change creates 2 extra async operations and pushes it above the threshold. Changed to 40 to give us some headroom.