### PR TITLE
Bump GitHub Actions off the deprecated Node.js 20 runtime

### DIFF
--- a/.github/actions/module-size-test/action.yml
+++ b/.github/actions/module-size-test/action.yml
@@ -34,14 +34,14 @@ runs:
   using: composite
   steps:
     - name: Checkout source
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         ref: ${{ inputs.ref }}
         fetch-depth: 1
 
     - name: Checkout actions from actions-ref
       if: inputs.actions-ref != '' && inputs.actions-ref != inputs.ref
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         ref: ${{ inputs.actions-ref }}
         sparse-checkout: |
@@ -86,7 +86,7 @@ runs:
         mv module-size-results.json module-size-results-shard-${{ inputs.shard }}.json
 
     - name: Upload shard results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: ${{ inputs.artifact-prefix }}-shard-${{ inputs.shard }}${{ inputs.artifact-suffix && format('-{0}', inputs.artifact-suffix) || '' }}
         path: testing/module-size/module-size-results-shard-${{ inputs.shard }}.json

--- a/.github/actions/test-framework-examples/action.yml
+++ b/.github/actions/test-framework-examples/action.yml
@@ -23,7 +23,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         fetch-depth: 1
 
@@ -57,7 +57,7 @@ runs:
 
     - name: Restore Playwright browsers
       id: pw-cache
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v6
       with:
         path: ~/.cache/ms-playwright
         key: playwright-${{ runner.os }}-${{ steps.pw.outputs.version }}
@@ -90,7 +90,7 @@ runs:
     
     - name: Upload Test Report
       id: upload-recipes-report
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: ${{ !cancelled() }}
       with:
         name: playwright-${{ inputs.framework }}-examples-${{ matrix.shardIndex }}-of-${{ matrix.shardTotal }}

--- a/.github/workflows/accessibility.yml
+++ b/.github/workflows/accessibility.yml
@@ -62,7 +62,7 @@ jobs:
     steps:
       - name: Checkout
         id: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1 # shallow copy
 
@@ -100,7 +100,7 @@ jobs:
     steps:
       - name: Checkout
         id: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1 # shallow copy
 
@@ -118,7 +118,7 @@ jobs:
 
       - name: Persist test results
         if: always() && matrix.shard != 0
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-results-e2e-accessiblity-shard-${{matrix.shard}}
           path: ${{ env.REPORTS_PATH }}
@@ -131,7 +131,7 @@ jobs:
     steps:
       - name: Checkout
         id: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 
@@ -147,13 +147,13 @@ jobs:
           cache_mode: ro
 
       - name: Download all test reports
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: ${{ env.REPORTS_PATH }}/
 
       - name: Publish Combined Test Report
         id: ctrf
-        uses: ctrf-io/github-test-reporter@bb6b54d6514e0952c3eea739be0c641143d1f06c # v1.0.17
+        uses: ctrf-io/github-test-reporter@e500b992f936420eb633c91644cf10d4d71df700 # v1.1.0
         with:
           report-path: '${{ env.REPORTS_PATH }}/**/*.json'
           summary-report: true
@@ -164,7 +164,7 @@ jobs:
 
       - name: Get previous run commit SHA
         id: prev-commit-sha
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v6
         with:
           restore-keys: |
             accessibility-prev-commit-
@@ -216,7 +216,7 @@ jobs:
           echo ${{ github.sha }} > ${{ env.PREV_COMMIT_SHA_FILE }}
 
       - name: Save Current Commit Hash
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v6
         with:
           path: ${{ env.PREV_COMMIT_SHA_FILE }}
           key: ${{ steps.prev-commit-sha.outputs.cache-primary-key }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,14 +70,14 @@ jobs:
       run_docs_ci: ${{ steps.decide.outputs.run_docs_ci }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 
       - name: Detect file changes (PR only)
         id: filter
         if: github.event_name == 'pull_request'
-        uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
+        uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         with:
           filters: |
             code:
@@ -161,7 +161,7 @@ jobs:
     steps:
       - name: Checkout
         id: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1 # shallow copy
 
@@ -248,7 +248,7 @@ jobs:
     steps:
       - name: Checkout
         id: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1 # shallow copy
 
@@ -306,7 +306,7 @@ jobs:
         # Shards 1-3 emit reports/workspace.xml (a subset each); shard 0 emits the tooling projects' JUnit
         # XMLs. Artifact names are keyed by shard; the report job merges by basename across shard artifacts.
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-results-${{matrix.shard}}
           path: |
@@ -332,7 +332,7 @@ jobs:
     steps:
       - name: Checkout
         id: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1 # shallow copy
 
@@ -350,7 +350,7 @@ jobs:
 
       - name: Persist test results
         if: always() && matrix.shard != 0
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-results-e2e-shard-${{matrix.shard}}
           path: |
@@ -368,7 +368,7 @@ jobs:
     steps:
       - name: Checkout
         id: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1 # shallow copy
 
@@ -406,7 +406,7 @@ jobs:
     steps:
       - name: Checkout
         id: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1 # shallow copy
 
@@ -431,7 +431,7 @@ jobs:
 
       - name: Upload UMD bundles for PR preview
         if: github.event_name == 'pull_request' && steps.build_umd.outcome == 'success'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: pr-preview-umd
           if-no-files-found: ignore
@@ -468,13 +468,13 @@ jobs:
     steps:
       # Needed for the local shared action below; same-repo gate (job if) is the guard.
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 
       - name: Download UMD artifact
         id: download
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         continue-on-error: true
         with:
           name: pr-preview-umd
@@ -516,7 +516,7 @@ jobs:
 
       - name: Post sticky PR comment
         if: steps.stage.outputs.publish == 'true'
-        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
+        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
         with:
           header: pr-preview-umd
           message: |
@@ -546,7 +546,7 @@ jobs:
     steps:
       - name: Checkout
         id: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1 # shallow copy
 
@@ -590,7 +590,7 @@ jobs:
 
       - name: Persist test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-results-docs
           path: |
@@ -614,7 +614,7 @@ jobs:
       - name: Checkout
         id: checkout
         if: matrix.framework != 'none'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 
@@ -665,7 +665,7 @@ jobs:
     steps:
       - name: Checkout
         id: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 
@@ -675,7 +675,7 @@ jobs:
       # skip the full setup-nx (node_modules restore + yarn install) and just provide
       # a node runtime — this is the main time sink for what is otherwise a fast job.
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version-file: package.json
 
@@ -684,7 +684,7 @@ jobs:
           git fetch origin --depth 1 latest
           git fetch origin --depth 1 tag latest-success
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         if: needs.test.result == 'success' || needs.test.result == 'failure' ||
           needs.e2e.result == 'success' || needs.e2e.result == 'failure'
         with:
@@ -711,7 +711,7 @@ jobs:
           done)
 
       - name: Test Report
-        uses: dorny/test-reporter@3eeb9fc888e82e8be2fb356bbeec2750231672bc # v1
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
         if: needs.test.result == 'success' || needs.test.result == 'failure' ||
           needs.e2e.result == 'success' || needs.e2e.result == 'failure'
         id: testReport
@@ -831,7 +831,7 @@ jobs:
     timeout-minutes: 30
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 1
 
@@ -856,7 +856,7 @@ jobs:
     timeout-minutes: 30
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 1
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -46,7 +46,7 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v4
+              uses: actions/checkout@v7
               with:
                   fetch-depth: 1 # shallow copy
 
@@ -64,7 +64,7 @@ jobs:
                   yarn nx pack:verify --prod
 
             - name: Initialize CodeQL (PR)
-              uses: github/codeql-action/init@v3
+              uses: github/codeql-action/init@v4
               if: steps.setup.outputs.type == 'pr'
               with:
                   config-file: ./.github/codeql/codeql-config-pr.yml
@@ -73,7 +73,7 @@ jobs:
                   trap-caching: false
 
             - name: Initialize CodeQL (latest)
-              uses: github/codeql-action/init@v3
+              uses: github/codeql-action/init@v4
               if: steps.setup.outputs.type != 'pr'
               with:
                   config-file: ./.github/codeql/codeql-config-latest.yml
@@ -82,6 +82,6 @@ jobs:
                   trap-caching: false
 
             - name: Perform CodeQL Analysis
-              uses: github/codeql-action/analyze@v3
+              uses: github/codeql-action/analyze@v4
               with:
                   category: '/language:${{matrix.language}}'

--- a/.github/workflows/csp.yml
+++ b/.github/workflows/csp.yml
@@ -30,7 +30,7 @@ jobs:
         steps:
             - name: Checkout
               id: checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@v7
               with:
                 fetch-depth: 1
 
@@ -47,7 +47,7 @@ jobs:
 
             - name: Upload CSP Report
               id: upload-report
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v7
               if: ${{ !cancelled() }}
               with:
                 name: playwright-report

--- a/.github/workflows/doc-tests.yml
+++ b/.github/workflows/doc-tests.yml
@@ -94,7 +94,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 90
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 1
       - name: Warm node_modules and Nx caches
@@ -116,7 +116,7 @@ jobs:
         run: echo "version=$(node -e "console.log(require('@playwright/test/package.json').version)")" >> "$GITHUB_OUTPUT"
       - name: Cache Playwright browsers
         id: pw-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ steps.pw.outputs.version }}
@@ -142,7 +142,7 @@ jobs:
         shardIndex: [1, 2]
         shardTotal: [2]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/test-framework-examples
         with:
           base_url: ${{github.event.inputs.base_url}}
@@ -164,7 +164,7 @@ jobs:
         shardIndex: [1]
         shardTotal: [1]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/test-framework-examples
         with:
           base_url: ${{github.event.inputs.base_url}}
@@ -186,7 +186,7 @@ jobs:
         shardIndex: [1, 2, 3]
         shardTotal: [3]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/test-framework-examples
         with:
           base_url: ${{github.event.inputs.base_url}}
@@ -208,7 +208,7 @@ jobs:
         shardIndex: [1]
         shardTotal: [1]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/test-framework-examples
         with:
           base_url: ${{github.event.inputs.base_url}}
@@ -230,7 +230,7 @@ jobs:
         shardIndex: [1, 2]
         shardTotal: [2]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/test-framework-examples
         with:
           base_url: ${{github.event.inputs.base_url}}
@@ -248,7 +248,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 
@@ -261,7 +261,7 @@ jobs:
         run: yarn nx run ag-grid-public-e2e-testing-recipes:test:recipes -c staging
       - name: Upload Test Report
         id: upload-recipes-report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: ${{ !cancelled() }}
         with:
           name: playwright-report-recipes
@@ -285,12 +285,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 90
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 1
 
       - name: Download all test reports
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: combined-reports
 
@@ -304,7 +304,7 @@ jobs:
       # summary always renders.
       - name: Publish Combined Test Report
         id: ctrf
-        uses: ctrf-io/github-test-reporter@bb6b54d6514e0952c3eea739be0c641143d1f06c # v1.0.17
+        uses: ctrf-io/github-test-reporter@e500b992f936420eb633c91644cf10d4d71df700 # v1.1.0
         with:
           report-path: 'combined-reports/**/*.json'
           summary-report: true
@@ -319,7 +319,7 @@ jobs:
 
       - name: Upload combined CTRF report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ctrf-report
           path: ${{ env.CTRF_FILE }}
@@ -327,7 +327,7 @@ jobs:
 
       - name: Get previous run commit SHA
         id: prev-commit-sha
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v6
         with:
           restore-keys: |
             doc-tests-prev-commit-
@@ -379,7 +379,7 @@ jobs:
           echo ${{ github.sha }} > ${{ env.PREV_COMMIT_SHA_FILE }}
 
       - name: Save Current Commit Hash
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v6
         with:
           path: ${{ env.PREV_COMMIT_SHA_FILE }}
           key: ${{ steps.prev-commit-sha.outputs.cache-primary-key }}

--- a/.github/workflows/gh-comment-hook.yml
+++ b/.github/workflows/gh-comment-hook.yml
@@ -25,14 +25,14 @@ jobs:
     steps:
       - name: Checkout repository
         if: github.event.action == 'opened' || github.event.action == 'edited'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           sparse-checkout:
             'scripts/ci/_utils.mjs'
 
       - name: Replace mention with jira link
         id: notify-start
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         continue-on-error: true
         env:
           PR_BODY: ${{ github.event.pull_request.body }}

--- a/.github/workflows/gh-pages-janitor.yml
+++ b/.github/workflows/gh-pages-janitor.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
       # Needed for the local shared action below; it clones the publish branch itself.
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 

--- a/.github/workflows/github-triage-pipeline.yml
+++ b/.github/workflows/github-triage-pipeline.yml
@@ -246,7 +246,7 @@ jobs:
             stage: ${{ steps.pf.outputs.stage }}
             issue_key: ${{ steps.pf.outputs.issue_key }}
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
               with:
                   fetch-depth: 1
             - name: Install @ag-grid/dev-prompts
@@ -307,7 +307,7 @@ jobs:
             # action's CLAUDE.md § "Confidence-gap auto-refresh".
             confidence_gap: ${{ steps.pipeline.outputs.confidence_gap }}
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
               with:
                   fetch-depth: 1
             - name: Install @ag-grid/dev-prompts
@@ -374,7 +374,7 @@ jobs:
             issues: write # mint → reply → label → close, all mechanical
             packages: read
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
               with:
                   fetch-depth: 1
             - name: Install @ag-grid/dev-prompts
@@ -437,7 +437,7 @@ jobs:
         outputs:
             reproduces: ${{ steps.pipeline.outputs.reproduces }}
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
               with:
                   fetch-depth: 1
             - name: Install @ag-grid/dev-prompts
@@ -485,7 +485,7 @@ jobs:
             issues: read
             packages: read
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
               with:
                   fetch-depth: 1
             - name: Install @ag-grid/dev-prompts
@@ -544,7 +544,7 @@ jobs:
             issues: read
             packages: read
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
               with:
                   fetch-depth: 1
             - name: Install @ag-grid/dev-prompts

--- a/.github/workflows/jira-agent-pipeline.yml
+++ b/.github/workflows/jira-agent-pipeline.yml
@@ -76,7 +76,7 @@ jobs:
             group: ${{ steps.key.outputs.group || steps.fallback.outputs.group }}
             issue_key: ${{ steps.key.outputs.issue_key }}
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
               continue-on-error: true
               with:
                   fetch-depth: 1
@@ -128,7 +128,7 @@ jobs:
             # Per-effort agent wall clock, read from AI model effort.
             agent_timeout_minutes: ${{ steps.resume.outputs.agent_timeout_minutes }}
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
               with:
                   fetch-depth: 1
 
@@ -190,13 +190,13 @@ jobs:
             checks: read
             statuses: read
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
               with:
                   fetch-depth: 1
 
             - name: Mint ag-dev-prompts read token
               id: prompts-token
-              uses: actions/create-github-app-token@v1
+              uses: actions/create-github-app-token@v3
               with:
                   app-id: ${{ vars.JIRA_AGENT_APP_ID }}
                   private-key: ${{ secrets.JIRA_AGENT_APP_PRIVATE_KEY }}
@@ -319,7 +319,7 @@ jobs:
             # Green CI held on open P0/P1 review findings; routed into agent-run.
             dispatch_pr_iterate: ${{ steps.handler.outputs.dispatch_pr_iterate }}
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
               with:
                   fetch-depth: 1
 
@@ -365,7 +365,7 @@ jobs:
             # The agent posts a marker comment on the PR (re-run idempotency).
             pull-requests: write
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
               with:
                   fetch-depth: 1
 
@@ -373,7 +373,7 @@ jobs:
             # action verifies. No repo build runs here.
             - name: Mint ag-dev-prompts read token
               id: prompts-token
-              uses: actions/create-github-app-token@v1
+              uses: actions/create-github-app-token@v3
               with:
                   app-id: ${{ vars.JIRA_AGENT_APP_ID }}
                   private-key: ${{ secrets.JIRA_AGENT_APP_PRIVATE_KEY }}

--- a/.github/workflows/l10n-translation-review.yml
+++ b/.github/workflows/l10n-translation-review.yml
@@ -34,11 +34,11 @@ jobs:
                 github.event.pull_request.head.repo.full_name == github.repository) ||
             github.event_name == 'workflow_dispatch'
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
               with:
                   fetch-depth: 0
 
-            - uses: actions/setup-node@v4
+            - uses: actions/setup-node@v7
               with:
                   node-version: 22
 
@@ -84,7 +84,7 @@ jobs:
 
             - name: Post review comment
               if: hashFiles('l10n-review.md') != ''
-              uses: actions/github-script@v7
+              uses: actions/github-script@v9
               with:
                   script: |
                       const fs = require('fs');

--- a/.github/workflows/module-size-comparison.yml
+++ b/.github/workflows/module-size-comparison.yml
@@ -51,7 +51,7 @@ jobs:
     steps:
       - name: Resolve PR details
         id: resolve
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           SHARD_COUNT: ${{ env.SHARD_COUNT }}
         with:
@@ -107,12 +107,12 @@ jobs:
       relevant: ${{ steps.filter.outputs.size }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
       - name: Detect file changes
         id: filter
-        uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
+        uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         with:
           filters: |
             size:
@@ -139,7 +139,7 @@ jobs:
       base-sha: ${{ steps.get-merge-base.outputs.sha }}
     steps:
       - name: Checkout to find merge base
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ needs.prepare.outputs.head-sha }}
           fetch-depth: 0
@@ -163,7 +163,7 @@ jobs:
 
       - name: Check cache for base results
         id: cache-check
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v6
         with:
           path: ./base-results.json
           key: module-size-base-${{ steps.get-merge-base.outputs.sha }}
@@ -181,7 +181,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout for actions
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ needs.prepare.outputs.head-sha }}
           fetch-depth: 1
@@ -207,7 +207,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout for actions
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ needs.prepare.outputs.head-sha }}
           fetch-depth: 1
@@ -231,18 +231,18 @@ jobs:
     if: always() && needs.module-size-base.result == 'success'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           sparse-checkout: |
             scripts/ci/merge-module-size-results.mjs
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '22'
 
       - name: Download all base shard results
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: module-size-base-shard-*-${{ needs.prepare.outputs.pr-number }}
           path: ./base-shards
@@ -253,7 +253,7 @@ jobs:
           node scripts/ci/merge-module-size-results.mjs ./base-shards ./base-results.json
 
       - name: Save to cache
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v6
         with:
           path: ./base-results.json
           key: module-size-base-${{ needs.check-base-cache.outputs.base-sha }}
@@ -274,19 +274,19 @@ jobs:
       BASE_SHA: ${{ needs.check-base-cache.outputs.base-sha }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           sparse-checkout: |
             scripts/ci/compare-module-sizes.mjs
             scripts/ci/merge-module-size-results.mjs
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '22'
 
       - name: Download all PR shard results
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: module-size-pr-shard-*-${{ env.PR_NUMBER }}
           path: ./pr-shards
@@ -299,7 +299,7 @@ jobs:
       # If cache hit, restore from cache
       - name: Restore base results from cache
         if: env.CACHE_HIT == 'true'
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v6
         with:
           path: ./base-results.json
           key: module-size-base-${{ env.BASE_SHA }}
@@ -308,7 +308,7 @@ jobs:
       # If cache miss, download artifacts and merge
       - name: Download all base shard results
         if: env.CACHE_HIT != 'true'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: module-size-base-shard-*-${{ env.PR_NUMBER }}
           path: ./base-shards
@@ -329,7 +329,7 @@ jobs:
 
       - name: Find existing comment
         id: find-comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           result-encoding: string
           script: |
@@ -347,7 +347,7 @@ jobs:
             return botComment ? botComment.id : '';
 
       - name: Post or update comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           COMMENT_ID: ${{ steps.find-comment.outputs.result }}
         with:
@@ -380,7 +380,7 @@ jobs:
             }
 
       - name: Upload comparison report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: module-size-comparison-${{ env.PR_NUMBER }}
           path: ./comparison-report.md

--- a/.github/workflows/module-size-vs-release.yml
+++ b/.github/workflows/module-size-vs-release.yml
@@ -66,7 +66,7 @@ jobs:
     steps:
       - name: Resolve release tag and test branch
         id: resolve
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           SHARD_COUNT: ${{ env.SHARD_COUNT }}
           INPUT_TAG: ${{ inputs.release_tag }}
@@ -120,7 +120,7 @@ jobs:
     steps:
       - name: Check cache for release results
         id: cache-check
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v6
         with:
           path: ./release-results.json
           key: module-size-release-${{ needs.prepare.outputs.release-tag }}
@@ -139,7 +139,7 @@ jobs:
       TEST_BRANCH: ${{ needs.prepare.outputs.test-branch }}
     steps:
       - name: Checkout for actions
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ env.TEST_BRANCH }}
           fetch-depth: 1
@@ -167,7 +167,7 @@ jobs:
       TEST_BRANCH: ${{ needs.prepare.outputs.test-branch }}
     steps:
       - name: Checkout for actions
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ env.TEST_BRANCH }}
           fetch-depth: 1
@@ -192,19 +192,19 @@ jobs:
       TEST_BRANCH: ${{ needs.prepare.outputs.test-branch }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ env.TEST_BRANCH }}
           sparse-checkout: |
             scripts/ci/merge-module-size-results.mjs
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '22'
 
       - name: Download all release shard results
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: module-size-release-shard-*
           path: ./release-shards
@@ -215,7 +215,7 @@ jobs:
           node scripts/ci/merge-module-size-results.mjs ./release-shards ./release-results.json
 
       - name: Save to cache
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v6
         with:
           path: ./release-results.json
           key: module-size-release-${{ needs.prepare.outputs.release-tag }}
@@ -235,7 +235,7 @@ jobs:
       TEST_BRANCH: ${{ needs.prepare.outputs.test-branch }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ env.TEST_BRANCH }}
           sparse-checkout: |
@@ -243,12 +243,12 @@ jobs:
             scripts/ci/merge-module-size-results.mjs
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '22'
 
       - name: Download all latest shard results
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: module-size-latest-shard-*
           path: ./latest-shards
@@ -261,7 +261,7 @@ jobs:
       # If cache hit, restore from cache
       - name: Restore release results from cache
         if: env.CACHE_HIT == 'true'
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v6
         with:
           path: ./release-results.json
           key: module-size-release-${{ env.RELEASE_TAG }}
@@ -270,7 +270,7 @@ jobs:
       # If cache miss, download artifacts and merge
       - name: Download all release shard results
         if: env.CACHE_HIT != 'true'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: module-size-release-shard-*
           path: ./release-shards
@@ -295,7 +295,7 @@ jobs:
           cat ./comparison-report.md >> $GITHUB_STEP_SUMMARY
 
       - name: Upload comparison report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: module-size-vs-release-${{ env.RELEASE_TAG }}
           path: ./comparison-report.md

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -64,7 +64,7 @@ jobs:
       allowed: ${{ steps.check.outputs.allowed }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1 # shallow copy
           sparse-checkout:
@@ -90,7 +90,7 @@ jobs:
     steps:
       - name: Notify start
         id: notify-start
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         continue-on-error: true
         if: ${{ env.PR_ID }}
         with:
@@ -124,7 +124,7 @@ jobs:
           fi
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
           ref: ${{ steps.get-branch.outputs.branch }}
@@ -135,7 +135,7 @@ jobs:
           git fetch origin --depth 1 tag latest-success
 
       - name: Notify Progress
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         continue-on-error: true
         if: ${{ steps.notify-start.outputs.result }}
         with:
@@ -154,7 +154,7 @@ jobs:
           cache_mode: rw
 
       - name: Notify Progress
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         continue-on-error: true
         if: ${{ steps.notify-start.outputs.result }}
         with:
@@ -174,7 +174,7 @@ jobs:
           npx nx run-many -t build --projects=ag-grid-{enterprise,community}
 
       - name: Notify Progress
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         continue-on-error: true
         if: ${{ steps.notify-start.outputs.result }}
         with:
@@ -194,7 +194,7 @@ jobs:
           npx playwright install --with-deps
 
       - name: Notify Progress
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         continue-on-error: true
         if: ${{ steps.notify-start.outputs.result }}
         with:
@@ -222,7 +222,7 @@ jobs:
 
       - name: Test Reporter
         id: ctrf
-        uses: ctrf-io/github-test-reporter@bb6b54d6514e0952c3eea739be0c641143d1f06c # v1.0.17
+        uses: ctrf-io/github-test-reporter@e500b992f936420eb633c91644cf10d4d71df700 # v1.1.0
         with:
           report-path: ${{ env.PW_REPORT_PATH }}
           summary-report: true
@@ -251,7 +251,7 @@ jobs:
           SLACK_CHANNEL: ${{ env.SLACK_CHANNEL }}
 
       - name: Final Notify Progress
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         continue-on-error: true
         if: ${{ steps.notify-start.outputs.result }}
         env:

--- a/.github/workflows/post-deploy-verification.yml
+++ b/.github/workflows/post-deploy-verification.yml
@@ -46,7 +46,7 @@ jobs:
        github.event.workflow_run.head_repository.full_name == github.repository)
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           # Check out the default-branch HEAD (github.sha). In a workflow_run
           # context this is the branch the run was triggered on; combined with the
@@ -57,7 +57,7 @@ jobs:
           fetch-depth: 1
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version-file: '.nvmrc'
 
@@ -93,7 +93,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: page-verification-results
           path: |
@@ -107,7 +107,7 @@ jobs:
       # while describing a different site.
       - name: Upload CSP report
         if: always() && inputs.staging_url == ''
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: csp-violations
           path: reports/ag-grid-csp-violations.json
@@ -167,13 +167,13 @@ jobs:
       needs.page-verification.result != 'cancelled'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.sha }}
           fetch-depth: 1
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version-file: '.nvmrc'
 
@@ -181,7 +181,7 @@ jobs:
         # Tolerated: the suite can die before writing one, and that failure is the
         # verification job's to report.
         continue-on-error: true
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: csp-violations
           path: csp/current

--- a/.github/workflows/post-scorecard-check.yml
+++ b/.github/workflows/post-scorecard-check.yml
@@ -23,14 +23,14 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1 # shallow copy
 
       # NOTE: This is done outside of the `scorecard` workflow as there are restrictions on `ossf/scorecard-action`
       - name: "Check Results"
         id: check_results
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         continue-on-error: true
         with:
           result-encoding: string
@@ -69,14 +69,14 @@ jobs:
 
       - name: Persist scorecard report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
             name: oss-scorecard-results
             path: ${{ env.REPORT_FILE }}
 
       - name: Persist scorecard response
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
             name: oss-scorecard-response
             path: ${{ env.SCORECARD_FILE }}

--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       # Needed for the local shared action below; the action clones gh-pages itself.
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -67,12 +67,12 @@ jobs:
             packages: read
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@v7
               with:
                   fetch-depth: 1
 
             - name: Setup Node (GitHub Packages for @ag-grid scope)
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v7
               with:
                   node-version-file: package.json
                   registry-url: https://npm.pkg.github.com

--- a/.github/workflows/prod-release.yml
+++ b/.github/workflows/prod-release.yml
@@ -31,7 +31,7 @@ jobs:
     environment: production
     steps:
       - name: Authenticate with GitHub App
-        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
           app-id: ${{ env.DEPLOYMENT_APP_ID }}
@@ -39,7 +39,7 @@ jobs:
 
       - name: Checkout
         id: checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 1 # shallow copy
@@ -53,7 +53,7 @@ jobs:
           RELEASE_VERSION=$(echo $TAG_NAME | sed 's/release-//')
           echo "RELEASE_VERSION=$RELEASE_VERSION" >> $GITHUB_ENV
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: package.json
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -32,7 +32,7 @@ jobs:
           publish_results: true
 
       - name: "Upload artifact"
-        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: SARIF file
           path: results.sarif

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -34,12 +34,12 @@ jobs:
     #     runs-on: ubuntu-latest
     #     steps:
     #         - name: Checkout
-    #           uses: actions/checkout@v4
+    #           uses: actions/checkout@v7
     #           with:
     #               fetch-depth: 1
     #
     #         - name: Setup Node
-    #           uses: actions/setup-node@v4
+    #           uses: actions/setup-node@v7
     #           with:
     #               node-version-file: '.nvmrc'
     #               cache: 'yarn'
@@ -85,7 +85,7 @@ jobs:
         steps:
             - name: Checkout
               id: checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@v7
               with:
                   fetch-depth: 1
 
@@ -109,7 +109,7 @@ jobs:
 
             - name: Persist scan results
               if: always()
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v7
               with:
                   name: code-dependency-scan
                   path: ${{ env.OUTPUT_DIR }}
@@ -126,7 +126,7 @@ jobs:
         steps:
             - name: Checkout
               id: checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@v7
               with:
                   fetch-depth: 1
 
@@ -142,7 +142,7 @@ jobs:
 
             - name: Persist scan results
               if: always()
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v7
               with:
                   name: sast-code-scan
                   path: ${{ env.OUTPUT_DIR }}
@@ -159,16 +159,16 @@ jobs:
       runs-on: ubuntu-latest
       if: ${{ always() }}
       steps:
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@v7
           with:
             fetch-depth: 1
 
-        - uses: actions/download-artifact@v4
+        - uses: actions/download-artifact@v8
           with:
             path: ${{ env.OUTPUT_DIR }}
 
         - name: Combine reports
-          uses: actions/github-script@v7
+          uses: actions/github-script@v9
           if: ${{ github.event_name == 'schedule' || inputs.notify }}
           with:
             script: |
@@ -201,7 +201,7 @@ jobs:
 
         - name: Get previous run commit SHA
           id: prev-commit-sha
-          uses: actions/cache/restore@v4
+          uses: actions/cache/restore@v6
           with:
             restore-keys: |
               security-prev-commit-
@@ -252,7 +252,7 @@ jobs:
           run: echo ${{ github.sha }} > ${{ env.PREV_COMMIT_SHA_FILE }}
 
         - name: Save Current Commit Hash
-          uses: actions/cache/save@v4
+          uses: actions/cache/save@v6
           with:
             path: ${{ env.PREV_COMMIT_SHA_FILE }}
             key: ${{ steps.prev-commit-sha.outputs.cache-primary-key }}

--- a/.github/workflows/update-jira-ticket.yml
+++ b/.github/workflows/update-jira-ticket.yml
@@ -31,12 +31,12 @@ jobs:
       issues: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           sparse-checkout:
             'scripts/ci/_utils.mjs'
       - name: Check if PR is merged
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         continue-on-error: true
         env:
           PR_ID: ${{ github.event.inputs.debug_pr_id || github.event.pull_request.number }}

--- a/external/ag-shared/github/actions/check-issue-comment-permissions/action.yml
+++ b/external/ag-shared/github/actions/check-issue-comment-permissions/action.yml
@@ -99,7 +99,7 @@ runs:
               startsWith(github.event.comment.body, inputs.command) &&
               steps.check.outputs.allowed == 'false' &&
               inputs.post_denial_message == 'true'
-          uses: actions/github-script@v7
+          uses: actions/github-script@v9
           with:
               script: |
                   const template = `${{ inputs.denial_message_template }}`;

--- a/external/ag-shared/github/actions/codex-pr-review/action.yml
+++ b/external/ag-shared/github/actions/codex-pr-review/action.yml
@@ -102,7 +102,7 @@ runs:
         - name: React Started
           if: steps.check-auth.outputs.skipped != 'true'
           id: react-started
-          uses: actions/github-script@v7
+          uses: actions/github-script@v9
           continue-on-error: true
           env:
               PR_NUMBER: ${{ inputs.pr-number }}
@@ -123,7 +123,7 @@ runs:
           # so this could theoretically remove reactions from other workflows. Accepted trade-off:
           # GitHub limits each user to one reaction per type per issue, so blast radius is minimal.
           if: steps.check-auth.outputs.skipped != 'true'
-          uses: actions/github-script@v7
+          uses: actions/github-script@v9
           continue-on-error: true
           env:
               PR_NUMBER: ${{ inputs.pr-number }}
@@ -229,7 +229,7 @@ runs:
           # references $NODE_AUTH_TOKEN literally (not interpolated), so the
           # token is never persisted to disk. See AG-17085 review.
           if: steps.check-auth.outputs.skipped != 'true'
-          uses: actions/setup-node@v4
+          uses: actions/setup-node@v7
           with:
               node-version-file: package.json
               registry-url: https://npm.pkg.github.com
@@ -491,7 +491,7 @@ runs:
         - name: Post Review Comment
           id: post-comment
           if: steps.check-auth.outputs.skipped != 'true' && steps.verify.outputs.success == 'true' && inputs.post-comment == 'true'
-          uses: actions/github-script@v7
+          uses: actions/github-script@v9
           env:
               OUTPUT_FILE: ${{ steps.codex.outputs.output_file }}
               PR_NUMBER: ${{ inputs.pr-number }}
@@ -748,7 +748,7 @@ runs:
 
         - name: Remove Eyes Reaction
           if: always() && steps.check-auth.outputs.skipped != 'true' && steps.react-started.outputs.reaction_id != ''
-          uses: actions/github-script@v7
+          uses: actions/github-script@v9
           continue-on-error: true
           env:
               PR_NUMBER: ${{ inputs.pr-number }}
@@ -765,7 +765,7 @@ runs:
 
         - name: React Success
           if: steps.check-auth.outputs.skipped != 'true' && steps.verify.outputs.success == 'true' && steps.post-comment.outputs.has_findings == 'false'
-          uses: actions/github-script@v7
+          uses: actions/github-script@v9
           continue-on-error: true
           env:
               PR_NUMBER: ${{ inputs.pr-number }}
@@ -781,7 +781,7 @@ runs:
 
         - name: React Has Findings
           if: steps.check-auth.outputs.skipped != 'true' && steps.verify.outputs.success == 'true' && steps.post-comment.outputs.has_findings == 'true'
-          uses: actions/github-script@v7
+          uses: actions/github-script@v9
           continue-on-error: true
           env:
               PR_NUMBER: ${{ inputs.pr-number }}

--- a/external/ag-shared/github/actions/get-last-failed-step/action.yml
+++ b/external/ag-shared/github/actions/get-last-failed-step/action.yml
@@ -16,7 +16,7 @@ runs:
     using: composite
     steps:
         - name: Get Failed Step Info
-          uses: actions/github-script@v7
+          uses: actions/github-script@v9
           env:
               JOB_ID: ${{ inputs.JOB_ID }}
               REPO_NAME: ${{ inputs.REPO_NAME }}

--- a/external/ag-shared/github/actions/install-ag-dev-prompts/action.yml
+++ b/external/ag-shared/github/actions/install-ag-dev-prompts/action.yml
@@ -18,7 +18,7 @@ runs:
     using: composite
     steps:
         - name: Setup Node (GitHub Packages for @ag-grid scope)
-          uses: actions/setup-node@v4
+          uses: actions/setup-node@v7
           with:
               node-version: ${{ inputs.node-version || '' }}
               node-version-file: ${{ inputs.node-version == '' && 'package.json' || '' }}

--- a/external/ag-shared/github/actions/setup-nx-core/action.yml
+++ b/external/ag-shared/github/actions/setup-nx-core/action.yml
@@ -179,7 +179,7 @@ runs:
         - name: Restore node_modules
           if: inputs.cache_mode == 'ro'
           id: cache_ro
-          uses: actions/cache/restore@v4
+          uses: actions/cache/restore@v6
           with:
               path: ${{ inputs.node_modules_paths }}
               key: node_modules-${{ runner.os }}-${{ steps.nx_config.outputs.release_branch && format('release-{0}-{1}', steps.nx_config.outputs.release_branch, inputs.node_modules_hash) || inputs.node_modules_hash }}
@@ -189,12 +189,12 @@ runs:
 
         - name: Restore node_modules
           # Restore only; saved by the explicit "Save node_modules" step after yarn install.
-          # actions/cache@v4's post-save hook cannot be used: expression contexts are lost
+          # actions/cache@v6's post-save hook cannot be used: expression contexts are lost
           # in post steps of nested composite actions (actions/runner#2009), so its `path`
           # resolves empty and the save is silently skipped.
           if: inputs.cache_mode == 'rw'
           id: cache_rw
-          uses: actions/cache/restore@v4
+          uses: actions/cache/restore@v6
           with:
               path: ${{ inputs.node_modules_paths }}
               key: node_modules-${{ runner.os }}-${{ steps.nx_config.outputs.release_branch && format('release-{0}-{1}', steps.nx_config.outputs.release_branch, inputs.node_modules_hash) || inputs.node_modules_hash }}
@@ -205,7 +205,7 @@ runs:
           # Post-save works here only because `path` is a literal (see "Restore node_modules");
           # do not parameterise it via inputs.
           if: inputs.cache_mode == 'rw' && inputs.nx_restore != 'false'
-          uses: actions/cache@v4
+          uses: actions/cache@v6
           with:
               path: |
                   .nx/cache
@@ -216,7 +216,7 @@ runs:
         - name: Restore Nx
           if: inputs.cache_mode == 'ro' && inputs.nx_restore != 'false'
           id: cache_nx_ro
-          uses: actions/cache/restore@v4
+          uses: actions/cache/restore@v6
           with:
               path: |
                   .nx/cache
@@ -227,7 +227,7 @@ runs:
 
         - name: Setup Node.js
           id: setup_node
-          uses: actions/setup-node@v4
+          uses: actions/setup-node@v7
           with:
               node-version-file: package.json
 
@@ -268,7 +268,7 @@ runs:
           # wasted (matters only on an inexact node_modules restore — a degraded path).
           if: inputs.cache_mode != 'off' && inputs.yarn_postinstall != 'no-install' && (inputs.yarn_postinstall != 'false' || inputs.cache_mode == 'rw') && steps.cache_rw.outputs.cache-hit != 'true' && steps.cache_ro.outputs.cache-hit != 'true'
           id: yarn_cache
-          uses: actions/cache/restore@v4
+          uses: actions/cache/restore@v6
           with:
               path: ${{ steps.yarn_cache_dir.outputs.dir }}
               key: yarn-cache-${{ runner.os }}-${{ inputs.node_modules_hash }}
@@ -348,7 +348,7 @@ runs:
           # why the post-save hook cannot be used). Skipped on an exact restore — the
           # cache already exists under this key.
           if: inputs.cache_mode == 'rw' && steps.cache_rw.outputs.cache-hit != 'true'
-          uses: actions/cache/save@v4
+          uses: actions/cache/save@v6
           with:
               path: ${{ inputs.node_modules_paths }}
               key: node_modules-${{ runner.os }}-${{ steps.nx_config.outputs.release_branch && format('release-{0}-{1}', steps.nx_config.outputs.release_branch, inputs.node_modules_hash) || inputs.node_modules_hash }}
@@ -364,7 +364,7 @@ runs:
           # (nothing new to save otherwise). Without this, an exact-node_modules-hit job would
           # skip the restore yet still attempt a save of an unpopulated/stale cache dir.
           if: inputs.cache_mode == 'rw' && inputs.yarn_postinstall != 'no-install' && steps.cache_rw.outputs.cache-hit != 'true' && steps.yarn_cache.outputs.cache-hit != 'true'
-          uses: actions/cache/save@v4
+          uses: actions/cache/save@v6
           with:
               path: ${{ steps.yarn_cache_dir.outputs.dir }}
               key: yarn-cache-${{ runner.os }}-${{ inputs.node_modules_hash }}

--- a/external/ag-shared/github/actions/snyk-code-scan/action.yml
+++ b/external/ag-shared/github/actions/snyk-code-scan/action.yml
@@ -21,7 +21,7 @@ runs:
     using: 'composite'
     steps:
         - name: Create output directory if required
-          uses: actions/github-script@v7
+          uses: actions/github-script@v9
           env:
               OUTPUT_DIR: ${{ inputs.output_dir }}
           with:

--- a/external/ag-shared/github/actions/snyk-scan-workspaces/action.yml
+++ b/external/ag-shared/github/actions/snyk-scan-workspaces/action.yml
@@ -28,7 +28,7 @@ runs:
     using: 'composite'
     steps:
         - name: Create output directory if required
-          uses: actions/github-script@v7
+          uses: actions/github-script@v9
           env:
               OUTPUT_DIR: ${{ inputs.output_dir }}
           with:

--- a/external/ag-shared/github/actions/tidy-nx-cache/action.yml
+++ b/external/ag-shared/github/actions/tidy-nx-cache/action.yml
@@ -8,6 +8,6 @@ inputs:
         default: 'pr'
 
 runs:
-    using: 'node20'
+    using: 'node24'
     main: 'main.mjs'
     post: 'post.mjs'


### PR DESCRIPTION
## Summary

GitHub Actions is [deprecating the Node.js 20 runtime](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) (forced to Node 24 from 16 June 2026, removed entirely later in 2026), which is why every job log shows the "Node.js 20 actions are deprecated" warning today.

This bumps every Node-based action used across `.github/workflows/`, `.github/actions/` and the vendored `external/ag-shared/github/actions/` composite actions to a major version that runs on Node 24:

- `actions/checkout` v4 → v7
- `actions/setup-node` v4 → v7
- `actions/upload-artifact` v4 → v7
- `actions/download-artifact` v4 → v8
- `actions/cache` (incl. `cache/restore`, `cache/save`) v4 → v6
- `actions/github-script` v7 → v9
- `actions/create-github-app-token` v1 → v3
- `github/codeql-action/{init,analyze}` v3 → v4
- `dorny/paths-filter` v3.0.3 → v4.0.3
- `dorny/test-reporter` v1 → v3.0.0
- `marocchino/sticky-pull-request-comment` v2.9.4 → v3.0.5
- `ctrf-io/github-test-reporter` v1.0.17 → v1.1.0 (aligning with the v1.1.0 already used elsewhere in the repo)
- the locally-authored `tidy-nx-cache` composite action's declared runtime: `node20` → `node24`

Before pinning each one, I checked its release notes/changelog for breaking changes and diffed its `action.yml` inputs/outputs against what these workflows actually pass — none of the bumps change behaviour for this repo's usage. The two exceptions I deliberately left alone: `ossf/scorecard-action` and `SonarSource/sonarqube-scan-action` are Docker/composite actions (not Node-based, so not part of this warning), and `SamhammerAG/last-successful-build-action` has no Node 24 release yet upstream.

All modified YAML was verified to still parse correctly.

## Test plan

- [ ] CI runs green on this PR across the affected workflows (ci.yml, codeql.yml, accessibility.yml, etc.)


---
_Generated by [Claude Code](https://claude.ai/code/session_01RZhSWuhhVKynSep3JdsHMv)_