### PR TITLE
AG-18256 Apply the docs example colour scheme before the example runs (integrated-charts dark mode)

### DIFF
--- a/documentation/ag-grid-docs/public/example-runner/example-runner.js
+++ b/documentation/ag-grid-docs/public/example-runner/example-runner.js
@@ -16,6 +16,8 @@
 (function () {
     const VERSION_PARAM = 'version';
     const PROD_PARAM = 'prod';
+    const THEME_MODE_PARAM = 'agThemeMode';
+    const THEME_MODES = { 'dark-blue': 'dark', light: 'light' };
     const VERSION_PLACEHOLDER = '0.0.0-ag-framework-version';
     const VERSION_PATTERN = '^\\d+\\.\\d+\\.\\d+(?:-[\\w.-]+)?(?:\\+[\\w.-]+)?$';
     const BUILD_TOKENS = {
@@ -25,8 +27,25 @@
 
     const COMPILER_OPTION_ENUMS = { module: 'ModuleKind', target: 'ScriptTarget', jsx: 'JsxEmit' };
 
+    function applyThemeMode() {
+        const themeMode = new URLSearchParams(window.location.search).get(THEME_MODE_PARAM);
+        const colorScheme =
+            themeMode !== null && Object.prototype.hasOwnProperty.call(THEME_MODES, themeMode)
+                ? THEME_MODES[themeMode]
+                : undefined;
+
+        if (!colorScheme) {
+            return;
+        }
+
+        document.documentElement.dataset.agThemeMode = themeMode;
+        document.documentElement.dataset.colorScheme = colorScheme;
+    }
+
     function setUpPage() {
         window.process = { env: { NODE_ENV: 'development' } };
+
+        applyThemeMode();
 
         window.addEventListener('error', function (e) {
             console.error('ERROR', e.message, e.filename);

--- a/documentation/ag-grid-docs/src/components/example-runner/components/ExampleIFrame.tsx
+++ b/documentation/ag-grid-docs/src/components/example-runner/components/ExampleIFrame.tsx
@@ -1,11 +1,13 @@
 import { EXAMPLE_RELOADING_MESSAGE_TYPE } from '@ag-website-shared/components/loading-logo/messages';
 import { useIntersectionObserver } from '@ag-website-shared/utils/hooks/useIntersectionObserver';
+import { getDarkmode } from '@stores/darkmodeStore';
 import { useDarkmode } from '@utils/hooks/useDarkmode';
 import classnames from 'classnames';
 import { type FunctionComponent, useCallback, useEffect, useRef, useState } from 'react';
 
 import styles from './ExampleIFrame.module.scss';
 import exampleRuntimeInjectedStyles from './exampleRuntimeInjectedStyles';
+import { shouldNavigateExample, withThemeMode } from './exampleThemeMode';
 
 interface Props {
     title: string;
@@ -26,6 +28,7 @@ export const ExampleIFrame: FunctionComponent<Props> = ({
     const iFrameRef = useRef<HTMLIFrameElement>(null);
     const [darkMode] = useDarkmode();
     const [isScrolling, setIsScrolling] = useState(false);
+    const pendingSrcRef = useRef<string | undefined>(undefined);
 
     useEffect(() => {
         const scrollListener = () => {
@@ -56,8 +59,21 @@ export const ExampleIFrame: FunctionComponent<Props> = ({
     });
 
     useEffect(() => {
-        const currentSrc = iFrameRef.current?.src && new URL(iFrameRef.current.src);
-        if (!isIntersecting || !url || !iFrameRef.current || (currentSrc as URL)?.pathname === url || isScrolling) {
+        const iframe = iFrameRef.current;
+        const currentSrc = iframe?.src && new URL(iframe.src);
+        if (!isIntersecting || !url || !iframe || isScrolling) {
+            return;
+        }
+
+        const nextSrc = withThemeMode(url, darkMode ?? getDarkmode(), suppressDarkMode);
+
+        const navigate = shouldNavigateExample({
+            currentPathname: (currentSrc as URL)?.pathname,
+            url,
+            nextSrc,
+            pendingSrc: pendingSrcRef.current,
+        });
+        if (!navigate) {
             return;
         }
 
@@ -67,8 +83,9 @@ export const ExampleIFrame: FunctionComponent<Props> = ({
             window.postMessage({ type: EXAMPLE_RELOADING_MESSAGE_TYPE, loadingIFrameId });
         }
 
-        iFrameRef.current.src = url;
-    }, [isIntersecting, url, isScrolling, loadingIFrameId]);
+        pendingSrcRef.current = nextSrc;
+        iframe.src = nextSrc;
+    }, [isIntersecting, url, isScrolling, loadingIFrameId, darkMode, suppressDarkMode]);
 
     // when dark mode is changed, applies it to the iframe.
     useEffect(() => {
@@ -79,6 +96,7 @@ export const ExampleIFrame: FunctionComponent<Props> = ({
     }, [darkMode, suppressDarkMode]);
 
     const handleOnLoad = useCallback(() => {
+        pendingSrcRef.current = undefined;
         if (!iFrameRef.current) {
             return;
         }

--- a/documentation/ag-grid-docs/src/components/example-runner/components/exampleThemeMode.test.ts
+++ b/documentation/ag-grid-docs/src/components/example-runner/components/exampleThemeMode.test.ts
@@ -1,0 +1,58 @@
+import { shouldNavigateExample, withThemeMode } from './exampleThemeMode';
+
+describe('withThemeMode', () => {
+    test('appends the dark theme mode when the site is in dark mode', () => {
+        expect(withThemeMode('/examples/grid/vanilla/', true)).toBe('/examples/grid/vanilla/?agThemeMode=dark-blue');
+    });
+
+    test('appends the light theme mode when the site is in light mode', () => {
+        expect(withThemeMode('/examples/grid/vanilla/', false)).toBe('/examples/grid/vanilla/?agThemeMode=light');
+    });
+
+    test('appends nothing when the example suppresses dark mode', () => {
+        expect(withThemeMode('/examples/grid/vanilla/', true, true)).toBe('/examples/grid/vanilla/');
+    });
+
+    test('appends nothing when the colour scheme has not resolved yet', () => {
+        expect(withThemeMode('/examples/grid/vanilla/', undefined)).toBe('/examples/grid/vanilla/');
+    });
+
+    test('preserves an existing query string', () => {
+        expect(withThemeMode('/examples/grid/vanilla/?prod=false', true)).toBe(
+            '/examples/grid/vanilla/?prod=false&agThemeMode=dark-blue'
+        );
+    });
+
+    test('leaves the pathname untouched, so the iframe re-navigation guard still matches', () => {
+        const url = '/examples/grid/vanilla/';
+
+        expect(new URL(withThemeMode(url, true), 'https://ag-grid.invalid').pathname).toBe(url);
+        expect(new URL(withThemeMode(url, false), 'https://ag-grid.invalid').pathname).toBe(url);
+    });
+});
+
+describe('shouldNavigateExample', () => {
+    const url = '/examples/grid/vanilla/';
+    const dark = `${url}?agThemeMode=dark-blue`;
+    const light = `${url}?agThemeMode=light`;
+
+    test('navigates when the iframe has not loaded anything yet', () => {
+        expect(shouldNavigateExample({ currentPathname: undefined, url, nextSrc: light })).toBe(true);
+    });
+
+    test('navigates when the example itself changed', () => {
+        expect(shouldNavigateExample({ currentPathname: '/examples/grid/other/', url, nextSrc: light })).toBe(true);
+    });
+
+    test('does not reload a loaded example when the colour scheme changes', () => {
+        expect(shouldNavigateExample({ currentPathname: url, url, nextSrc: dark })).toBe(false);
+    });
+
+    test('re-points an in-flight navigation whose theme mode has been superseded', () => {
+        expect(shouldNavigateExample({ currentPathname: url, url, nextSrc: dark, pendingSrc: light })).toBe(true);
+    });
+
+    test('leaves an in-flight navigation alone when its theme mode still matches', () => {
+        expect(shouldNavigateExample({ currentPathname: url, url, nextSrc: dark, pendingSrc: dark })).toBe(false);
+    });
+});

--- a/documentation/ag-grid-docs/src/components/example-runner/components/exampleThemeMode.ts
+++ b/documentation/ag-grid-docs/src/components/example-runner/components/exampleThemeMode.ts
@@ -1,0 +1,33 @@
+export const AG_THEME_MODE_PARAM = 'agThemeMode';
+
+export const DARK_THEME_MODE = 'dark-blue';
+export const LIGHT_THEME_MODE = 'light';
+
+export const withThemeMode = (url: string, darkMode?: boolean, suppressDarkMode?: boolean): string => {
+    if (suppressDarkMode || darkMode === undefined) {
+        return url;
+    }
+
+    const resolved = new URL(url, 'https://ag-grid.invalid');
+    resolved.searchParams.set(AG_THEME_MODE_PARAM, darkMode ? DARK_THEME_MODE : LIGHT_THEME_MODE);
+
+    return `${resolved.pathname}${resolved.search}${resolved.hash}`;
+};
+
+export const shouldNavigateExample = ({
+    currentPathname,
+    url,
+    nextSrc,
+    pendingSrc,
+}: {
+    currentPathname?: string;
+    url: string;
+    nextSrc: string;
+    pendingSrc?: string;
+}): boolean => {
+    if (currentPathname !== url) {
+        return true;
+    }
+
+    return pendingSrc !== undefined && pendingSrc !== nextSrc;
+};

--- a/documentation/ag-grid-docs/src/content/docs/integrated-charts-chart-tool-panels/_examples/chart-tool-panels/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/integrated-charts-chart-tool-panels/_examples/chart-tool-panels/example.spec.ts
@@ -31,4 +31,42 @@ test.agExample(import.meta, () => {
         await page.locator('.ag-tab', { hasText: 'Chart' }).click();
         await expect(page.locator('.ag-chart-settings-mini-charts-container')).toBeVisible();
     });
+
+    test.describe('chart themes follow the colour scheme the example was loaded with', () => {
+        test.describe('dark', () => {
+            test.use({ loadPageOptions: { agThemeMode: 'dark-blue' } });
+
+            test.eachFramework('chart themes are dark, matching the grid', async ({ page, remoteGrid }) => {
+                await ensureGridReady(page);
+                await waitForGridContent(page);
+                await expect(page.locator('.ag-chart-tabbed-menu')).toBeVisible();
+
+                expect(await page.evaluate(() => document.documentElement.dataset.agThemeMode)).toBe('dark-blue');
+                expect(await page.evaluate(() => document.documentElement.dataset.colorScheme)).toBe('dark');
+
+                const themes = await remoteGrid(page).getGridOption('chartThemes');
+
+                expect(themes).toBeTruthy();
+                expect(themes).not.toHaveLength(0);
+                expect(themes!.filter((theme) => !theme.endsWith('-dark'))).toEqual([]);
+            });
+        });
+
+        test.describe('light', () => {
+            test.use({ loadPageOptions: { agThemeMode: 'light' } });
+
+            test.eachFramework('chart themes stay light', async ({ page, remoteGrid }) => {
+                await ensureGridReady(page);
+                await waitForGridContent(page);
+                await expect(page.locator('.ag-chart-tabbed-menu')).toBeVisible();
+
+                expect(await page.evaluate(() => document.documentElement.dataset.agThemeMode)).toBe('light');
+
+                const themes = await remoteGrid(page).getGridOption('chartThemes');
+
+                expect(themes).toBeTruthy();
+                expect(themes!.filter((theme) => theme.endsWith('-dark'))).toEqual([]);
+            });
+        });
+    });
 });

--- a/documentation/ag-grid-docs/src/utils/grid/test-utils.ts
+++ b/documentation/ag-grid-docs/src/utils/grid/test-utils.ts
@@ -16,8 +16,9 @@ type PlaywrightFixtures = ExtractFixtures<typeof base>;
 
 type AgIdFor = ReturnType<typeof wrapAgTestIdFor<Locator>>;
 type LoadPageOptions = {
-    prod: boolean;
-    version: string;
+    prod?: boolean;
+    version?: string;
+    agThemeMode?: 'dark-blue' | 'light';
 };
 
 type RemoteGrid = ((page: Page, gridId?: string) => AsyncGridApi) & {
@@ -161,6 +162,10 @@ async function loadPage(
 
     if (loadPageOptions?.version) {
         queryOptions.version = loadPageOptions.version;
+    }
+
+    if (loadPageOptions?.agThemeMode) {
+        queryOptions.agThemeMode = loadPageOptions.agThemeMode;
     }
 
     if (agModules && agModules.length > 0) {

--- a/plugins/ag-grid-generate-example-files/src/executors/generate/generator/transformation-scripts/parser-utils.test.ts
+++ b/plugins/ag-grid-generate-example-files/src/executors/generate/generator/transformation-scripts/parser-utils.test.ts
@@ -1,0 +1,49 @@
+import { getIntegratedDarkModeCode } from './parser-utils';
+
+describe('getIntegratedDarkModeCode', () => {
+    const exampleName = '/documentation/integrated-charts-chart-tool-panels/_examples/chart-tool-panels';
+
+    it('returns nothing for an example that does not use charts', () => {
+        expect(getIntegratedDarkModeCode('/documentation/row-sorting/_examples/basic')).toBeUndefined();
+    });
+
+    it('rewrites the api name', () => {
+        const code = getIntegratedDarkModeCode(exampleName, false, 'gridApi')!;
+
+        expect(code).toContain("gridApi.setGridOption('chartThemes'");
+        expect(code).not.toContain('params.api');
+    });
+
+    describe.each([
+        ['typescript', true],
+        ['javascript', false],
+    ])('%s', (_language, typescript) => {
+        const code = getIntegratedDarkModeCode(exampleName, typescript)!;
+
+        it('reads the theme mode at apply time rather than capturing it when the module runs', () => {
+            expect(code).toContain('const readThemeMode =');
+            expect(code).toContain('const themeMode = readThemeMode();');
+        });
+
+        it('waits for both the grid api and the theme mode before applying the initial themes', () => {
+            expect(code).toContain('if (params.api && (themeMode !== undefined || lastTry))');
+            expect(code).toContain('setTimeout(trySetInitial, 250);');
+        });
+
+        it('registers the color-scheme-change listener before the initial apply, so a change during the retry window is kept', () => {
+            expect(code.indexOf("addEventListener('color-scheme-change'")).toBeLessThan(
+                code.indexOf('trySetInitial();')
+            );
+        });
+
+        it('falls back to light once the retry budget is spent, so an example that owns its theming still gets themes', () => {
+            expect(code).toContain('const lastTry = tries >= maxTries;');
+            expect(code).toContain('if (params.api && (themeMode !== undefined || lastTry))');
+            expect(code).toContain("updateChartThemes(themeMode !== undefined && themeMode.includes('dark'));");
+        });
+
+        it('does not push an unchanged theme list, which would re-render the chart', () => {
+            expect(code).toContain('currentThemes.every((theme, i) => theme === modifiedThemes[i])');
+        });
+    });
+});

--- a/plugins/ag-grid-generate-example-files/src/executors/generate/generator/transformation-scripts/parser-utils.ts
+++ b/plugins/ag-grid-generate-example-files/src/executors/generate/generator/transformation-scripts/parser-utils.ts
@@ -711,8 +711,8 @@ export function getIntegratedDarkModeCode(
 }
 
 const darkModeTs = `
-        const isInitialModeDark = document.documentElement.dataset.agThemeMode?.includes("dark");
-                  
+        const readThemeMode = (): string | undefined => document.documentElement.dataset.agThemeMode;
+
         // update chart themes based on dark mode status
         const updateChartThemes = (isDark: boolean): void => {
             const themes: string[] = ['ag-default', 'ag-material', 'ag-sheets', 'ag-polychroma', 'ag-vivid'];            
@@ -723,27 +723,14 @@ const darkModeTs = `
                 ? (isDark ? ['my-custom-theme-dark', 'my-custom-theme-light'] : ['my-custom-theme-light', 'my-custom-theme-dark'])
                 : Array.from(new Set(themes.map((theme) => theme + (isDark ? '-dark' : ''))));                      
 
+            if (currentThemes && currentThemes.length === modifiedThemes.length && currentThemes.every((theme, i) => theme === modifiedThemes[i])) {
+                return;
+            }
+
             // updating the 'chartThemes' grid option will cause the chart to reactively update!
             params.api.setGridOption('chartThemes', modifiedThemes);
         };
         
-        // update chart themes when example first loads
-        let initialSet = false;
-        const maxTries = 5;
-        let tries = 0;
-        const trySetInitial = (delay) => {
-            if(params.api){
-                initialSet = true;
-                updateChartThemes(isInitialModeDark);
-            }else{
-                if(tries < maxTries){
-                    setTimeout(() => trySetInitial(), 250);
-                    tries++;
-                }   
-            }
-        }
-        trySetInitial(0);
-                      
         interface ColorSchemeChangeEventDetail {
             darkMode: boolean;
         }
@@ -755,12 +742,26 @@ const darkModeTs = `
         }
         
         // listen for user-triggered dark mode changes (not removing listener is fine here!)
-        document.addEventListener('color-scheme-change', handleColorSchemeChange as EventListener);                
+        document.addEventListener('color-scheme-change', handleColorSchemeChange as EventListener);
+
+        const maxTries = 5;
+        let tries = 0;
+        const trySetInitial = (): void => {
+            const themeMode = readThemeMode();
+            const lastTry = tries >= maxTries;
+            if (params.api && (themeMode !== undefined || lastTry)) {
+                updateChartThemes(themeMode !== undefined && themeMode.includes('dark'));
+            } else if (!lastTry) {
+                tries++;
+                setTimeout(trySetInitial, 250);
+            }
+        };
+        trySetInitial();
     `;
 
 const darkModeJS = `
-        const isInitialModeDark = document.documentElement.dataset.agThemeMode?.includes("dark");
-      
+        const readThemeMode = () => document.documentElement.dataset.agThemeMode;
+
         const updateChartThemes = (isDark) => { 
             const themes = ['ag-default', 'ag-material', 'ag-sheets', 'ag-polychroma', 'ag-vivid'];            
             const currentThemes = params.api.getGridOption('chartThemes');                    
@@ -770,26 +771,13 @@ const darkModeJS = `
                 ? (isDark ? ['my-custom-theme-dark', 'my-custom-theme-light'] : ['my-custom-theme-light', 'my-custom-theme-dark'])
                 : Array.from(new Set(themes.map((theme) => theme + (isDark ? '-dark' : ''))));                      
 
+            if (currentThemes && currentThemes.length === modifiedThemes.length && currentThemes.every((theme, i) => theme === modifiedThemes[i])) {
+                return;
+            }
+
             // updating the 'chartThemes' grid option will cause the chart to reactively update!
             params.api.setGridOption('chartThemes', modifiedThemes);
         };
-
-        // update chart themes when example first loads
-        let initialSet = false;
-        const maxTries = 5;
-        let tries = 0;
-        const trySetInitial = (delay) => {
-            if(params.api){
-                initialSet = true;
-                updateChartThemes(isInitialModeDark);
-            }else{
-                if(tries < maxTries){
-                    setTimeout(() => trySetInitial(), 250);
-                    tries++;
-                }   
-            }
-        }
-        trySetInitial(0);
 
         const handleColorSchemeChange = (event) => {
             const { darkMode } = event.detail;
@@ -798,6 +786,20 @@ const darkModeJS = `
 
         // listen for user-triggered dark mode changes (not removing listener is fine here!)
         document.addEventListener('color-scheme-change', handleColorSchemeChange);
+
+        const maxTries = 5;
+        let tries = 0;
+        const trySetInitial = () => {
+            const themeMode = readThemeMode();
+            const lastTry = tries >= maxTries;
+            if (params.api && (themeMode !== undefined || lastTry)) {
+                updateChartThemes(themeMode !== undefined && themeMode.includes('dark'));
+            } else if (!lastTry) {
+                tries++;
+                setTimeout(trySetInitial, 250);
+            }
+        };
+        trySetInitial();
     `;
 
 export function wrapTearDownExample(method: string) {


### PR DESCRIPTION
Backport of #14917 to b36.1.0 (cherry-pick of 6a81bdd).

Fix [AG-18256](https://ag-grid.atlassian.net/browse/AG-18256)