### PR TITLE
AG-18284: keep the label colour on .button-style-none hover

### DIFF
--- a/external/ag-website-shared/src/design-system/elements/_button.scss
+++ b/external/ag-website-shared/src/design-system/elements/_button.scss
@@ -35,10 +35,12 @@ input[type='submit']#{$selector-exclude-grid-bryntum},
         border $transition-default-timing,
         box-shadow $transition-default-timing;
 
+    // No `color` here: it would apply to `.button-style-none` too, whose reset drops the
+    // fill this colour is meant to read against. Each variant that keeps a fill declares
+    // its own hover colour below, and links are covered by the `a.button*:hover` rules.
     &:hover,
     &.hover {
         background-color: var(--color-button-primary-bg-hover);
-        color: var(--color-button-primary-fg);
 
         &[aria-disabled] {
             background-color: var(--color-button-primary-bg);


### PR DESCRIPTION
[AG-18284](https://ag-grid.atlassian.net/browse/AG-18284)

The base button rule group restated `color: var(--color-button-primary-fg)` on `:hover`/`.hover`. That group also matches `.button-style-none`, whose reset drops the fill the colour is meant to read against, so the label turned the colour of the page background and became invisible — white on white in light mode, `--color-bg-primary` on itself in dark.

The declaration was redundant everywhere it was wanted: `button`, `input[type="submit"|"reset"]` and `.button` already carry that colour from the base rule with nothing changing it on hover, `.button-secondary`/`.button-tertiary` declare their own hover colour, and links are covered by the dedicated `a.button*:hover` rules. Removing it fixes the leak without adding a declaration that would compete with call-site hover colours.

Verified with real Chrome over every variant and state in both themes: `.button-style-none` now keeps `--color-fg-primary` on hover, and the computed colour and background of all 20 other cases are unchanged. Also swept the call sites in ag-grid, ag-charts and ag-studio — three (`.imageButton` in ag-charts, `VideoOverlay`'s close button in ag-studio, the shared `AnnouncementBanner` close) were latent instances of the same defect and are fixed by this too; nothing else changes.

Note: this touches the `ag-website-shared` subrepo, so it needs a `subrepo push` to reach ag-charts/ag-studio.
