### PR TITLE
Grant agent-run `actions: read` for the CI rollup (AG-18323)

### DIFF
--- a/.github/workflows/jira-agent-pipeline.yml
+++ b/.github/workflows/jira-agent-pipeline.yml
@@ -189,6 +189,7 @@ jobs:
             pull-requests: read
             checks: read
             statuses: read
+            actions: read
         steps:
             - uses: actions/checkout@v7
               with:


### PR DESCRIPTION
Adds `actions: read` to the `agent-run` job of `jira-agent-pipeline.yml`.

### Why

`gh pr view --json statusCheckRollup` always expands `checkSuite.workflowRun`, which sits behind `actions: read`. Without that scope GitHub answers with a **partial** GraphQL result (the PR's own fields resolved, the rollup refused) and `gh` still exits 1, so the pre step's whole feedback bundle was discarded rather than just the CI slice. `pr-feedback.md` was written as the UNREAD sentinel and the agent iterated with no sight of the review threads.

Caught on ag-studio, [AS-1220](https://ag-grid.atlassian.net/browse/AS-1220) (run [32861099190](https://github.com/ag-grid/ag-studio/actions/runs/32861099190)):

```
Resource not accessible by integration
...statusCheckRollup.nodes.0.commit.statusCheckRollup.contexts.nodes.0.checkSuite.workflowRun
```

The diagnostic that run emitted blamed a missing `pull-requests: read`, which this job already grants. That misdirection is fixed separately in ag-dev-prompts. This repo was not the one observed failing, but its `agent-run` block was byte-identical and carries the same gap.

### Why it is a config gap and not a GitHub incident

- `Resource not accessible by integration` is the authorization-denial string, not a 5xx or `SERVICE_UNAVAILABLE`.
- It was a partial error on one node path while all ten sibling rollup entries resolved and returned data.
- The same call succeeds under a credential that carries Actions read: run against ag-studio PR #2487 with a `repo`+`workflow` scoped token it exits 0 and returns 10 entries, each with `workflowName`, which is the field derived from `checkSuite.workflowRun`.

### Scope choice

`permissions:` **replaces** the defaults, so the scope has to be named explicitly. #2463 added the adjacent CI-read scopes (`pull-requests`, `checks`, `statuses`) and missed this one.

`read` is sufficient: the only pipeline call needing `actions: write` is the CI-flake `gh run rerun`, which lives in the `preflight` job and already has it.

The credential is `github.token` (the pre step sets `GH_TOKEN: ${{ github.token }}`), so this job's `permissions:` block is the governing scope. The App token is overlaid only for post-step writes.

### Fleet consistency

ag-studio, ag-grid and ag-charts all had byte-identical `agent-run` blocks with this scope missing. The same one-line change is going to ag-studio and ag-charts. All three already grant `actions: read` to `ci-success-handler`.

⚠️ For `repository_dispatch` / `workflow_run`, GitHub reads the workflow file from the default branch, so this takes effect on merge to `latest`.

https://ag-grid.atlassian.net/browse/AG-18323
