### PR TITLE
SE-128 Fail the docs build on a "Demo - {name}" fallback title

### DIFF
--- a/documentation/ag-grid-docs/astro.config.mjs
+++ b/documentation/ag-grid-docs/astro.config.mjs
@@ -19,6 +19,7 @@ import agSitemapLastmod from '../../external/ag-website-shared/plugins/agSitemap
 import agSourcemapCors from '../../external/ag-website-shared/plugins/agSourcemapCors';
 import { SITEMAP_CACHE_DIR } from '../../external/ag-website-shared/src/constants';
 import buildTime from './plugins/agBuildTime';
+import agDemoTitleChecker from './plugins/agDemoTitleChecker';
 import agDevCsp from './plugins/agDevCsp';
 import agDevExampleAssetCors from './plugins/agDevExampleAssetCors';
 import agDevMarkdownNegotiation from './plugins/agDevMarkdownNegotiation';
@@ -357,6 +358,7 @@ export default defineConfig({
                   },
               ]),
         agHtaccessGen({ htaccessEnv: HTACCESS }),
+        agDemoTitleChecker(),
         agRedirectsChecker({
             skip: CHECK_REDIRECTS !== 'true',
         }),

--- a/documentation/ag-grid-docs/plugins/agDemoTitleChecker.ts
+++ b/documentation/ag-grid-docs/plugins/agDemoTitleChecker.ts
@@ -1,0 +1,15 @@
+import type { AstroIntegration } from 'astro';
+import { fileURLToPath } from 'node:url';
+
+import { demoTitleChecker } from '../src/utils/seo/demoTitleChecker';
+
+export default function createPlugin(): AstroIntegration {
+    return {
+        name: 'ag-demo-title-checker',
+        hooks: {
+            'astro:build:done': async ({ dir, logger }) => {
+                demoTitleChecker({ buildDir: fileURLToPath(dir), logger });
+            },
+        },
+    };
+}

--- a/documentation/ag-grid-docs/src/utils/seo/demoTitleChecker.test.ts
+++ b/documentation/ag-grid-docs/src/utils/seo/demoTitleChecker.test.ts
@@ -1,0 +1,58 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { findFallbackDemoTitles } from './demoTitleChecker';
+
+function writeHtmlPage(buildDir: string, relativePath: string, title: string) {
+    const fullPath = path.join(buildDir, relativePath);
+    mkdirSync(path.dirname(fullPath), { recursive: true });
+    writeFileSync(fullPath, `<!doctype html><html><head><title>${title}</title></head><body></body></html>`);
+}
+
+describe('findFallbackDemoTitles', () => {
+    let buildDir: string;
+
+    beforeEach(() => {
+        buildDir = mkdtempSync(path.join(tmpdir(), 'demo-title-checker-'));
+    });
+
+    afterEach(() => {
+        rmSync(buildDir, { recursive: true, force: true });
+    });
+
+    it('flags a page whose title is the "Demo - {name}" fallback', () => {
+        writeHtmlPage(buildDir, 'example-finance/index.html', 'Demo - Finance');
+
+        expect(findFallbackDemoTitles(buildDir)).toEqual([
+            { path: 'example-finance/index.html', title: 'Demo - Finance' },
+        ]);
+    });
+
+    it('does not flag an approved title that merely contains "Demo" elsewhere', () => {
+        writeHtmlPage(
+            buildDir,
+            'example-inventory/index.html',
+            'Inventory Management System Demo - Data Grid | AG Grid'
+        );
+
+        expect(findFallbackDemoTitles(buildDir)).toEqual([]);
+    });
+
+    it('does not flag a page with no fallback title', () => {
+        writeHtmlPage(buildDir, 'getting-started/index.html', 'Getting Started | AG Grid');
+
+        expect(findFallbackDemoTitles(buildDir)).toEqual([]);
+    });
+
+    it('reports every offending page when several are affected', () => {
+        writeHtmlPage(buildDir, 'example/index.html', 'Demo - Performance Grid');
+        writeHtmlPage(buildDir, 'example-hr/index.html', 'Demo - HR Management');
+        writeHtmlPage(buildDir, 'getting-started/index.html', 'Getting Started | AG Grid');
+
+        expect(findFallbackDemoTitles(buildDir)).toEqual([
+            { path: 'example-hr/index.html', title: 'Demo - HR Management' },
+            { path: 'example/index.html', title: 'Demo - Performance Grid' },
+        ]);
+    });
+});

--- a/documentation/ag-grid-docs/src/utils/seo/demoTitleChecker.ts
+++ b/documentation/ag-grid-docs/src/utils/seo/demoTitleChecker.ts
@@ -1,0 +1,44 @@
+import type { AstroIntegrationLogger } from 'astro';
+import { readFileSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+
+// The layout has no title fallback of its own (see Layout.astro) — this is the literal template
+// every demo page used before it had a real SEO title. Anchored at the start so an approved title
+// that merely contains "Demo" elsewhere (eg "Inventory Management System Demo - Data Grid | AG
+// Grid") still passes.
+const FALLBACK_TITLE_PATTERN = /^Demo - /;
+
+type Violation = {
+    path: string;
+    title: string;
+};
+
+function findHtmlFiles(buildDir: string): string[] {
+    return (readdirSync(buildDir, { recursive: true }) as string[]).filter((file) => file.endsWith('.html'));
+}
+
+function extractTitle(html: string): string | undefined {
+    return /<title>([^<]*)<\/title>/i.exec(html)?.[1];
+}
+
+export function findFallbackDemoTitles(buildDir: string): Violation[] {
+    return findHtmlFiles(buildDir)
+        .flatMap((file) => {
+            const title = extractTitle(readFileSync(path.join(buildDir, file), 'utf8'));
+            return title && FALLBACK_TITLE_PATTERN.test(title) ? [{ path: file, title }] : [];
+        })
+        .sort((a, b) => a.path.localeCompare(b.path));
+}
+
+export function demoTitleChecker({ buildDir, logger }: { buildDir: string; logger: AstroIntegrationLogger }) {
+    const violations = findFallbackDemoTitles(buildDir);
+
+    if (violations.length) {
+        const details = violations.map(({ path, title }) => `  ${path}: "${title}"`).join('\n');
+        throw new Error(
+            `Page(s) still resolve to the "Demo - {name}" fallback title. Give them a real SEO title:\n${details}`
+        );
+    }
+
+    logger.info('Demo title checker: no pages resolve to the "Demo - " fallback title.');
+}


### PR DESCRIPTION
## Summary
- Adds a build-time check (`agDemoTitleChecker` Astro integration) that scans every generated page's `<title>` tag and fails the build if it matches the layout's old `Demo - {name}` fallback, anchored at the start of the string so an approved title that merely contains "Demo" elsewhere (e.g. `Inventory Management System Demo - Data Grid | AG Grid`) still passes
- Wired in unconditionally in `astro.config.mjs`, same as `agHtaccessGen` — runs on every build, local or CI, with no skip flag

## Note
This will currently fail the docs build: all four demo pages (`example`, `example-hr`, `example-inventory`, `example-finance`) still resolve to the `Demo - {name}` fallback title. SE-125 needs to land (or be included in this same release) to give them real SEO titles before this can merge.

## Test plan
- [x] Added `demoTitleChecker.test.ts` — unit tests for the fallback-detection logic (4 cases, all passing)
- [x] Verified against the local `dist/` build: correctly flags all 4 current demo pages and would pass the ticket's approved `example-inventory` title
- [x] `./checks.sh` (type-check + lint, full repo) passes