### PR TITLE
chore(website-shared): sync ag-website-shared to latest

### DIFF
--- a/external/ag-website-shared/.gitrepo
+++ b/external/ag-website-shared/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 remote = git@github.com:ag-grid/ag-website-shared.git
 branch = latest
-	commit = 33a9edfb59b108a89ecc16aabbc395ca96118713
-	parent = 3f6d6ac9e128944c8ec07f6b1c61233dc0d672c3
+	commit = 059105305a11da66a2fef3ffdae7ab955ea5c75a
+	parent = 05baa39bab73eee36c7663962c93eccfcf3c3fbc
 	method = rebase
 	cmdver = 0.4.9

--- a/external/ag-website-shared/plugins/agLinkChecker.ts
+++ b/external/ag-website-shared/plugins/agLinkChecker.ts
@@ -10,6 +10,12 @@ const { TestSuites, TestSuite, TestCase } = junitProcessor;
 type Options = {
     include: boolean;
     prefix?: string;
+    /**
+     * Framework agnostic redirect pages, eg `/r/{page}`, which forward the visitor's query
+     * and fragment on to `/{framework}/{page}`. Their own markup is a redirecting stub, so
+     * anchor links to them are validated against the framework pages they forward to.
+     */
+    frameworkRedirect?: { path: string; frameworks: readonly string[] };
 };
 
 const IGNORED_PATHS = ['/archive'];
@@ -80,7 +86,7 @@ function outputJunitReport(validationResults: any) {
 const checkLinks = async (dir: string, files: string[], options: Options) => {
     const anchors = new Set<string>();
     const linksToValidate: Record<string, { filePaths: Set<string> }> = {};
-    const { prefix } = options;
+    const { prefix, frameworkRedirect } = options;
 
     for (let i = 0; i < files.length; i++) {
         const filePath = files[i];
@@ -177,6 +183,25 @@ const checkLinks = async (dir: string, files: string[], options: Options) => {
         }
     }
 
+    const hasAnchor = (link: string) => anchors.has(link) || anchors.has(link.replace('#', '/#'));
+
+    /**
+     * The framework specific equivalents of a link to a framework agnostic redirect page,
+     * which sends the visitor on to whichever framework they last used, fragment included.
+     * Empty for any other link, and when the site has no such pages.
+     */
+    const frameworkRedirectLinks = (link: string): string[] => {
+        if (frameworkRedirect == null) {
+            return [];
+        }
+        const { path, frameworks } = frameworkRedirect;
+        const redirectPrefix = `/${path}/`;
+        if (!link.startsWith(redirectPrefix)) {
+            return [];
+        }
+        return frameworks.map((framework) => `/${framework}/${link.slice(redirectPrefix.length)}`);
+    };
+
     // for junit reporting
     const validationResults = {};
 
@@ -225,8 +250,10 @@ const checkLinks = async (dir: string, files: string[], options: Options) => {
             validationResults[link] = { error };
             return;
         } else {
-            // Check if the hash exists in the file
-            if (!anchors.has(linkWithoutPrefix) && !anchors.has(linkWithoutPrefix.replace('#', '/#'))) {
+            // Check if the hash exists in the file, or in the pages a framework redirect
+            // page forwards the fragment on to
+            const candidates = [linkWithoutPrefix, ...frameworkRedirectLinks(linkWithoutPrefix)];
+            if (!candidates.some(hasAnchor)) {
                 errors.push(
                     `Link to ${originalLink} could not be resolved in (${filePathsString(filePaths, options)}).`
                 );

--- a/external/ag-website-shared/src/components/changelog/Pipeline.tsx
+++ b/external/ag-website-shared/src/components/changelog/Pipeline.tsx
@@ -39,11 +39,11 @@ const getColDefs = (library: Library) => [
             if (hasFixVersion) {
                 const latestFixVersion = fixVersionsArr.length - 1;
                 const fixVersion = fixVersionsArr[latestFixVersion];
-                if (fixVersion.toUpperCase() === 'NEXT') {
+                if (!fixVersion || fixVersion.toUpperCase() === 'NEXT') {
                     return 'Scheduled';
                 } else {
                     const version = library in transformVersion ? transformVersion[library](fixVersion) : fixVersion;
-                    return `Scheduled for ${version}`;
+                    return version ? `Scheduled for ${version}` : 'Scheduled';
                 }
             }
             return 'Backlog';

--- a/external/ag-website-shared/src/components/changelog/transformVersion.test.ts
+++ b/external/ag-website-shared/src/components/changelog/transformVersion.test.ts
@@ -1,0 +1,14 @@
+import { transformVersion } from './transformVersion';
+
+describe.each([
+    { gridVersion: '34.0.2', chartVersion: '12.0.2' },
+    { gridVersion: '22.0.0', chartVersion: '0.0.0' },
+    { gridVersion: 'Next', chartVersion: null },
+    { gridVersion: '', chartVersion: null },
+    { gridVersion: '34.0', chartVersion: null },
+    { gridVersion: '34.0.x', chartVersion: null },
+])('transformVersion.charts', ({ gridVersion, chartVersion }) => {
+    it(`grid version: "${gridVersion}" transforms to ${JSON.stringify(chartVersion)}`, () => {
+        expect(transformVersion.charts(gridVersion)).toEqual(chartVersion);
+    });
+});

--- a/external/ag-website-shared/src/components/changelog/transformVersion.ts
+++ b/external/ag-website-shared/src/components/changelog/transformVersion.ts
@@ -1,13 +1,17 @@
 import type { Library } from '@ag-grid-types';
 
-const gridToChartVersion = (gridVersion: string) => {
+const gridToChartVersion = (gridVersion: string): string | null => {
     const versionParts = gridVersion.split('.');
+    if (versionParts.length !== 3 || versionParts.some((part) => !/^\d+$/.test(part))) {
+        // Not a real grid release version (e.g. a placeholder like "Future" or "TBD") - nothing to transform.
+        return null;
+    }
 
     // The first charts release was on grid version 22 - we'll keep in lock step release wise going forward so this works
-    const chartMajorVersion = parseInt(versionParts[0]) - 22;
+    const chartMajorVersion = parseInt(versionParts[0], 10) - 22;
     return `${chartMajorVersion}.${versionParts[1]}.${versionParts[2]}`;
 };
 
-export const transformVersion: Record<Library, (version: string) => string> = {
+export const transformVersion: Record<Library, (version: string) => string | null> = {
     charts: gridToChartVersion,
 };

--- a/external/ag-website-shared/src/components/demo-page/DemoPage.module.scss
+++ b/external/ag-website-shared/src/components/demo-page/DemoPage.module.scss
@@ -214,6 +214,13 @@ $breakpoint-demo-fits: $demo-held-width + $hero-max-width + $demo-column-gap + $
         // the state that applies it.
         &:has([data-cutoff='true']) {
             margin-right: calc(-1 * var(--demo-gutter));
+
+            // The bleed lands this edge on the screen edge, where it reads as where the
+            // demo was cut off rather than as a side of the card. Square it and drop the
+            // rule so it cuts cleanly instead of curving away from the viewport.
+            border-top-right-radius: 0;
+            border-bottom-right-radius: 0;
+            border-right-width: 0;
         }
     }
 

--- a/external/ag-website-shared/src/components/docs-navigation/DocsNav.module.scss
+++ b/external/ag-website-shared/src/components/docs-navigation/DocsNav.module.scss
@@ -235,6 +235,10 @@
     }
 }
 
+.titleTail {
+    white-space: nowrap;
+}
+
 .itemIcon:global(.icon),
 .externalIcon:global(.icon) {
     fill: var(--color-fg-secondary);

--- a/external/ag-website-shared/src/components/docs-navigation/DocsNav.tsx
+++ b/external/ag-website-shared/src/components/docs-navigation/DocsNav.tsx
@@ -58,16 +58,24 @@ function Item({ itemData, framework, pageName }: { itemData?: any; framework?: F
 
     const className = classnames(styles.item, itemData.icon ? styles.hasIcon : '', isActive ? styles.isActive : '');
 
+    // Split off the final word so the trailing icons can never wrap onto a line of their own.
+    const titleWords = String(itemData.title ?? '').split(' ');
+    const titleTail = titleWords.pop();
+    const titleLead = titleWords.join(' ');
+
     return (
         isCorrectFramework && (
             <>
-                <a href={linkUrl} className={className} {...(isExternalURL && { target: '_blank' })}>
+                <a href={linkUrl} tabIndex={0} className={className} {...(isExternalURL && { target: '_blank' })}>
                     {itemData.icon && <Icon name={itemData.icon} svgClasses={styles.itemIcon} />}
 
                     <span>
-                        {itemData.title}
-                        {itemData.isEnterprise && <Icon name="enterprise" svgClasses={styles.enterpriseIcon} />}
-                        {isExternalURL && <Icon name="newTab" svgClasses={styles.externalIcon} />}
+                        {titleLead && `${titleLead} `}
+                        <span className={styles.titleTail}>
+                            {titleTail}
+                            {itemData.isEnterprise && <Icon name="enterprise" svgClasses={styles.enterpriseIcon} />}
+                            {isExternalURL && <Icon name="newTab" svgClasses={styles.externalIcon} />}
+                        </span>
                     </span>
                 </a>
 
@@ -167,7 +175,7 @@ function Group({
 
     return (
         <div ref={groupRef} className={classnames(styles.group, isOpen ? styles.isOpen : '')}>
-            <button className={classnames('button-style-none', styles.groupTitle)} onClick={handleClick}>
+            <button tabIndex={0} className={classnames('button-style-none', styles.groupTitle)} onClick={handleClick}>
                 <Icon name="chevronRight" svgClasses={styles.groupChevron} />
 
                 <span>{groupData.title}</span>
@@ -266,7 +274,9 @@ export function DocsNav({
                 <div className={styles.docsNavInner}>
                     {showWhatsNew && (
                         <div className={styles.whatsNewLink}>
-                            <a href={urlWithBaseUrl('/whats-new')}>What's New</a>
+                            <a tabIndex={0} href={urlWithBaseUrl('/whats-new')}>
+                                What's New
+                            </a>
                         </div>
                     )}
 

--- a/external/ag-website-shared/src/components/example-runner/components/ExampleRunnerClient.tsx
+++ b/external/ag-website-shared/src/components/example-runner/components/ExampleRunnerClient.tsx
@@ -1,0 +1,42 @@
+import { exampleRunnerAsset } from '@ag-website-shared/components/example-runner/utils/exampleRunnerAsset';
+
+export const EXAMPLE_RUNNER_SCRIPT_FILE_NAME = 'example-runner.js';
+
+const NAMESPACE = 'agExampleRunner';
+
+/** An export is handed its own copy, so it keeps working with no request back to the site */
+export const exampleRunnerScriptSrc = (isExported?: boolean) =>
+    isExported ? `./${EXAMPLE_RUNNER_SCRIPT_FILE_NAME}` : exampleRunnerAsset(EXAMPLE_RUNNER_SCRIPT_FILE_NAME);
+
+interface ClientProps {
+    isExported?: boolean;
+    /** The page's CSP nonce, on the sites that set one */
+    nonce?: string;
+}
+
+/** A file rather than inline bodies, so an export shows the example, not its machinery */
+export const ExampleRunnerClient = ({ isExported, nonce }: ClientProps) => (
+    <script nonce={nonce} src={exampleRunnerScriptSrc(isExported)} crossOrigin={isExported ? undefined : 'anonymous'} />
+);
+
+/** What survives a round trip through `JSON.stringify`, and so can be passed to the runner */
+export type JsonValue = string | number | boolean | null | JsonValue[] | { [key: string]: JsonValue };
+
+/** `<` is escaped so a value containing `</script>` cannot end the element early */
+const toScriptLiteral = (value: JsonValue) => JSON.stringify(value).replaceAll('<', '\\u003c');
+
+interface CallProps {
+    fn: string;
+    args?: JsonValue[];
+    nonce?: string;
+}
+
+/** The only inline script left in an example page: the per-example call into the runtime */
+export const ExampleRunnerCall = ({ fn, args = [], nonce }: CallProps) => (
+    <script
+        nonce={nonce}
+        dangerouslySetInnerHTML={{
+            __html: `${NAMESPACE}.${fn}(${args.map(toScriptLiteral).join(', ')});`,
+        }}
+    />
+);

--- a/external/ag-website-shared/src/components/example-runner/styles/example-controls.css
+++ b/external/ag-website-shared/src/components/example-runner/styles/example-controls.css
@@ -13,6 +13,11 @@
     --button-border: #d0d5dd;
     --button-hover-bg: rgba(0, 0, 0, 0.1);
 
+    --button-active-fg: #101828;
+    --button-active-bg: #eaecf0;
+    --button-active-border: #d0d5dd;
+    --button-active-hover-bg: #dfe2e8;
+
     --input-accent: #0e4491;
     --input-focus-border: #3d7acd;
     --range-track-bg: #efefef;
@@ -34,6 +39,11 @@
     --button-bg: transparent;
     --button-border: rgba(255, 255, 255, 0.2);
     --button-hover-bg: #2a343e;
+
+    --button-active-fg: #f2f4f7;
+    --button-active-bg: #344054;
+    --button-active-border: #475467;
+    --button-active-hover-bg: #3d4a5f;
 
     --input-accent: #a9c5ec;
     --input-focus-border: #3d7acd;
@@ -80,7 +90,16 @@ body > #highlighter {
     color: var(--main-fg);
 }
 
-.example-controls :where(button, textarea, select, input[type='submit'], input[type='text'], input[type='number']) {
+.example-controls
+    :where(
+        button,
+        textarea,
+        select,
+        input[type='submit'],
+        input[type='text'],
+        input[type='number'],
+        .button-group > label
+    ) {
     appearance: none;
     display: inline-block;
     height: 36px;
@@ -98,7 +117,7 @@ body > #highlighter {
     align-self: flex-start;
 }
 
-.example-controls :where(button, select, input[type='submit']) {
+.example-controls :where(button, select, input[type='submit'], .button-group > label) {
     cursor: pointer;
 }
 
@@ -212,6 +231,94 @@ body > #highlighter {
     outline: none;
 }
 
+/* Toggle buttons: a pressed button reflects that its single on/off option is applied */
+.example-controls :is(button, input[type='submit'])[aria-pressed='true'] {
+    background-color: var(--button-active-bg);
+    border-color: var(--button-active-border);
+}
+
+/* The descendant selector is needed because `.example-controls *` colours a nested <code> */
+.example-controls :is(button, input[type='submit'])[aria-pressed='true'],
+.example-controls :is(button, input[type='submit'])[aria-pressed='true'] * {
+    color: var(--button-active-fg);
+}
+
+.example-controls :is(button, input[type='submit'])[aria-pressed='true']:hover {
+    background-color: var(--button-active-hover-bg);
+}
+
+/* Button groups: radio inputs styled as a joined row of buttons. Each radio must be immediately
+   followed by its own label — the sibling selectors below depend on that order. */
+.example-controls .button-group {
+    display: inline-flex;
+    align-self: flex-start;
+    /* A group cannot wrap, so let one too wide for the row scroll rather than clip */
+    min-width: 0;
+    overflow-x: auto;
+}
+
+/* Visually hidden, but still focusable and keyboard navigable — the label is the visible control */
+.example-controls .button-group input[type='radio'],
+.example-controls .button-group input[type='radio']:checked {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    margin: 0;
+    padding: 0;
+    border: 0;
+    box-shadow: none;
+    clip-path: inset(50%);
+    overflow: hidden;
+    white-space: nowrap;
+}
+
+/* A button centres its own content, a label does not, so the segments centre theirs explicitly */
+.example-controls .button-group label {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 0;
+}
+
+.example-controls .button-group label:not(:first-of-type) {
+    margin-left: -1px;
+}
+
+.example-controls .button-group label:first-of-type {
+    border-top-left-radius: 6px;
+    border-bottom-left-radius: 6px;
+}
+
+.example-controls .button-group label:last-of-type {
+    border-top-right-radius: 6px;
+    border-bottom-right-radius: 6px;
+}
+
+.example-controls .button-group input[type='radio']:not(:checked, :disabled) + label:hover {
+    background-color: var(--button-hover-bg);
+}
+
+.example-controls .button-group input[type='radio']:checked + label {
+    position: relative;
+    z-index: 1;
+    background-color: var(--button-active-bg);
+    border-color: var(--button-active-border);
+}
+
+.example-controls .button-group input[type='radio']:checked + label,
+.example-controls .button-group input[type='radio']:checked + label * {
+    color: var(--button-active-fg);
+}
+
+.example-controls .button-group input[type='radio']:focus-visible + label {
+    position: relative;
+    z-index: 2;
+    border-color: var(--input-focus-border);
+    box-shadow:
+        inset 0 0 0 1px var(--input-focus-border),
+        inset 0 0 0 2px var(--main-bg);
+}
+
 /* Groups controls (e.g. a label, input and value) so they can be enabled/disabled together
    without affecting the row layout. */
 .example-controls fieldset.control-group {
@@ -226,6 +333,7 @@ body > #highlighter {
 .example-controls select:disabled,
 .example-controls textarea:disabled,
 .example-controls input:disabled,
+.example-controls .button-group input[type='radio']:disabled + label,
 .example-controls fieldset:disabled :is(label, span) {
     cursor: not-allowed;
     opacity: 0.5;
@@ -237,6 +345,10 @@ body > #highlighter {
     flex-wrap: wrap;
     gap: var(--row-gap);
     font-variant: tabular-nums;
+    /* .example-controls is a wrapping column flex container, so its cross size is content-based
+       and a row would otherwise grow past the example's width */
+    max-width: 100%;
+    min-width: 0;
 }
 
 .controls-row + .controls-row {

--- a/external/ag-website-shared/src/components/example-runner/utils/exampleRunnerAsset.ts
+++ b/external/ag-website-shared/src/components/example-runner/utils/exampleRunnerAsset.ts
@@ -1,0 +1,8 @@
+import { SITE_BASE_URL } from '@constants';
+import { pathJoin } from '@utils/pathJoin';
+
+const EXAMPLE_RUNNER_PATH = '/example-runner';
+
+/** Absolute URL of a file served verbatim from the site's `public/example-runner/` */
+export const exampleRunnerAsset = (fileName: string): string =>
+    pathJoin(import.meta.env?.PUBLIC_SITE_URL, SITE_BASE_URL, EXAMPLE_RUNNER_PATH, fileName);

--- a/external/ag-website-shared/src/components/example-runner/utils/transformExampleModule.test.ts
+++ b/external/ag-website-shared/src/components/example-runner/utils/transformExampleModule.test.ts
@@ -1,0 +1,177 @@
+import {
+    getModuleSourceFileName,
+    isTransformableModule,
+    toModuleFileName,
+    transformExampleModule,
+} from './transformExampleModule';
+
+const transform = (fileName: string, source: string) => transformExampleModule({ fileName, source });
+
+describe('isTransformableModule', () => {
+    test.each([
+        ['main.ts', true],
+        ['index.tsx', true],
+        ['index.jsx', true],
+        ['main.js', false],
+        ['styles.css', false],
+        ['index.html', false],
+    ])('%s is %s', (fileName, expected) => {
+        expect(isTransformableModule(fileName)).toBe(expected);
+    });
+});
+
+describe('getModuleSourceFileName', () => {
+    const files = ['main.ts', 'index.jsx', 'data.js', 'styles.css'];
+
+    test('maps a requested .js name back to its source', () => {
+        expect(getModuleSourceFileName('main.js', files)).toBe('main.ts');
+        expect(getModuleSourceFileName('index.js', files)).toBe('index.jsx');
+    });
+
+    test('leaves files that need no transpiling alone', () => {
+        expect(getModuleSourceFileName('data.js', files)).toBeUndefined();
+        expect(getModuleSourceFileName('styles.css', files)).toBeUndefined();
+    });
+
+    test('leaves the source extensions serving source', () => {
+        expect(getModuleSourceFileName('main.ts', files)).toBeUndefined();
+        expect(getModuleSourceFileName('index.jsx', files)).toBeUndefined();
+    });
+
+    test('is undefined when there is no matching source', () => {
+        expect(getModuleSourceFileName('missing.js', files)).toBeUndefined();
+    });
+});
+
+describe('transformExampleModule', () => {
+    test('strips types and keeps bare specifiers for the import map to resolve', () => {
+        const code = transform(
+            'main.ts',
+            [
+                "import type { AgCartesianChartOptions } from 'ag-charts-community';",
+                "import { AgCharts } from 'ag-charts-community';",
+                'const options: AgCartesianChartOptions = { container: document.body };',
+                'AgCharts.create(options);',
+            ].join('\n')
+        );
+
+        expect(code).toContain("from 'ag-charts-community'");
+        expect(code).not.toContain('AgCartesianChartOptions');
+    });
+
+    test('gives relative specifiers the extension native resolution needs', () => {
+        const code = transform(
+            'main.ts',
+            [
+                "import { getData } from './data';",
+                "import { Renderer } from './renderer.ts';",
+                'getData(Renderer);',
+            ].join('\n')
+        );
+
+        expect(code).toContain("'./data.js'");
+        expect(code).toContain("'./renderer.js'");
+    });
+
+    test('leaves relative specifiers that name another file type', () => {
+        const code = transform(
+            'main.ts',
+            ["import data from './values.json';", "import './styles.css';", 'export const x = data;'].join('\n')
+        );
+
+        expect(code).toContain("'./values.json'");
+        expect(code).not.toContain('values.json.js');
+    });
+
+    test('rewrites a relative specifier whose name contains a dot', () => {
+        const code = transform(
+            'main.ts',
+            ["import { AppComponent } from './app.component';", 'console.log(AppComponent);'].join('\n')
+        );
+
+        expect(code).toContain("'./app.component.js'");
+    });
+
+    test('compiles JSX', () => {
+        const code = transform(
+            'index.jsx',
+            ["import React from 'react';", 'export const App = () => <div className="grid" />;'].join('\n')
+        );
+
+        expect(code).toContain('React.createElement');
+        expect(code).not.toContain('<div');
+    });
+
+    test('emits decorator metadata, which the Angular JIT compiler needs for injection', () => {
+        const code = transform(
+            'app.component.ts',
+            [
+                "import { Component, ElementRef } from '@angular/core';",
+                "@Component({ selector: 'my-app', template: '<div></div>' })",
+                'export class AppComponent {',
+                '    constructor(private elementRef: ElementRef) {}',
+                '}',
+            ].join('\n')
+        );
+
+        expect(code).toContain('Component({');
+        // design:paramtypes is what makes constructor injection resolvable (NG0202 without it)
+        expect(code).toContain('design:paramtypes');
+    });
+
+    test('turns package stylesheet imports into a link element', () => {
+        const code = transform('main.ts', "import 'ag-charts-community/styles/ag-charts.css';");
+
+        expect(code).toContain(
+            'await __agLoadStylesheet(import.meta.resolve("ag-charts-community/styles/ag-charts.css"))'
+        );
+        expect(code).toContain("link.rel = 'stylesheet'");
+    });
+
+    test('turns relative stylesheet imports into a link element too, awaited before the module runs', () => {
+        const code = transform('main.ts', ["import './styles.css';", 'export const x = 1;'].join('\n'));
+
+        expect(code).toContain('await __agLoadStylesheet(import.meta.resolve("./styles.css"))');
+        // The template links the stylesheet itself for some frameworks, so it must not be loaded twice
+        expect(code).toContain('link[rel="stylesheet"]');
+    });
+
+    test('leaves process.env.NODE_ENV for the page to define', () => {
+        const code = transform(
+            'main.ts',
+            ['if (process.env.NODE_ENV !== "production") {', '    console.log("dev");', '}'].join('\n')
+        );
+
+        expect(code).toContain('process.env.NODE_ENV');
+    });
+
+    test('rewrites the path of a specifier that carries a query or fragment, keeping the suffix', () => {
+        const code = transformExampleModule({
+            fileName: 'main.ts',
+            source: "export { default as worker } from './worker.ts?v=1';\nexport { m } from './mod#frag';\n",
+        });
+
+        expect(code).toContain("'./worker.js?v=1'");
+        expect(code).toContain("'./mod.js#frag'");
+    });
+
+    test('leaves an asset that carries a query as authored', () => {
+        const code = transformExampleModule({
+            fileName: 'main.ts',
+            source: "export { default as data } from './data.json?v=1';\n",
+        });
+
+        expect(code).toContain("'./data.json?v=1'");
+    });
+});
+
+describe('toModuleFileName', () => {
+    test.each([
+        ['main.ts', 'main.js'],
+        ['index.tsx', 'index.js'],
+        ['index.jsx', 'index.js'],
+        ['data.js', 'data.js'],
+    ])('%s -> %s', (fileName, expected) => {
+        expect(toModuleFileName(fileName)).toBe(expected);
+    });
+});

--- a/external/ag-website-shared/src/components/example-runner/utils/transformExampleModule.ts
+++ b/external/ag-website-shared/src/components/example-runner/utils/transformExampleModule.ts
@@ -1,0 +1,173 @@
+import ts from 'typescript';
+
+/**
+ * Examples are authored in TypeScript (and JSX/TSX for React), which browsers cannot
+ * execute. Transpiling here lets the browser load the result as a plain ES module, with no
+ * loader or in-browser compiler in the page.
+ *
+ * Shared by every documentation site. The one thing that varies between them is which
+ * compiler options an example is built with, so those arrive as data rather than being
+ * decided here -- see `NamedCompilerOptions`.
+ */
+
+export const EXTENSIONS = ['.ts', '.tsx', '.jsx'] as const;
+
+const EXTENSION_REGEX = /\.(tsx?|jsx)$/;
+
+/** Matches the specifier of a static import/export, or a dynamic `import()` */
+export const SPECIFIER_REGEX = /(\bfrom\s*|\bimport\s*\(?\s*|\bexport\s*\*\s*from\s*)(['"])([^'"]+)\2/g;
+
+/** A bare `import 'foo.css';` with no bindings */
+export const CSS_IMPORT_REGEX = /^[ \t]*import\s+(['"])([^'"]+\.css)\1;?[ \t]*$/gm;
+
+/** The options whose value names a TypeScript enum member rather than being one */
+export const COMPILER_OPTION_ENUMS = { module: 'ModuleKind', target: 'ScriptTarget', jsx: 'JsxEmit' } as const;
+
+/**
+ * Compiler options named rather than resolved, so the in-page transpiler can be handed them
+ * as data: a page cannot serialise a TypeScript enum, so it names the member instead.
+ */
+export type NamedCompilerOptions = Record<string, string | boolean>;
+
+/**
+ * The options every example is transpiled with unless a site narrows them.
+ * `emitDecoratorMetadata` is what lets the Angular JIT compiler resolve constructor
+ * injection: without the emitted `design:paramtypes`, any component or service with
+ * constructor dependencies fails to instantiate (NG0202).
+ */
+export const COMPILER_OPTION_NAMES: NamedCompilerOptions = {
+    module: 'ESNext',
+    // ES2022 so the top-level `await` a stylesheet import compiles to is emitted as authored
+    target: 'ES2022',
+    jsx: 'React',
+    experimentalDecorators: true,
+    emitDecoratorMetadata: true,
+};
+
+export const resolveCompilerOptions = (tsModule: typeof ts, named: NamedCompilerOptions): ts.CompilerOptions =>
+    Object.fromEntries(
+        Object.entries(named).map(([name, value]) => {
+            const tsModuleKey = COMPILER_OPTION_ENUMS[name as keyof typeof COMPILER_OPTION_ENUMS];
+
+            return [name, tsModuleKey ? tsModule[tsModuleKey][value as any] : value];
+        })
+    );
+
+export const getCompilerOptions = (
+    tsModule: typeof ts,
+    named: NamedCompilerOptions = COMPILER_OPTION_NAMES
+): ts.CompilerOptions => resolveCompilerOptions(tsModule, named);
+
+/** Playwright specs live alongside an example but are not part of it, and are never served */
+export const isSpecFile = (fileName: string) => fileName.includes('.spec.') || fileName.includes('.test.');
+
+export const isTransformableModule = (fileName: string) => EXTENSION_REGEX.test(fileName) && !isSpecFile(fileName);
+
+/** The name a transpiled module is served under, which is what other modules import */
+export const toModuleFileName = (fileName: string) => fileName.replace(EXTENSION_REGEX, '.js');
+
+/**
+ * The source file a browser request for `fileName` should be transpiled from, if any.
+ * Requests arrive for `.js`, because that is what the rewritten specifiers point at; the
+ * original extensions keep serving the source, which is what the code viewer shows.
+ */
+export const getModuleSourceFileName = (fileName: string, availableFiles: string[]) => {
+    if (!fileName.endsWith('.js') || availableFiles.includes(fileName)) {
+        return undefined;
+    }
+
+    const withoutExtension = fileName.slice(0, -'.js'.length);
+    return EXTENSIONS.map((ext) => `${withoutExtension}${ext}`).find((candidate) => availableFiles.includes(candidate));
+};
+
+const isRelative = (specifier: string) => specifier.startsWith('./') || specifier.startsWith('../');
+
+/**
+ * What a specifier can end with and already be servable as authored: an asset, or a module
+ * extension a browser resolves itself. Recognised by extension rather than by "has any
+ * extension at all", because a specifier can carry a dot and still name a module --
+ * `./app.component` is how Angular examples import theirs.
+ */
+export const SERVED_AS_AUTHORED_REGEX = /\.(css|json|html|svg|png|jpe?g|gif|webp|wasm|txt|js|mjs|cjs)$/i;
+
+/** The subset of the above that is not a module, and so can never be transpiled */
+export const ASSET_REGEX = /\.(css|json|html|svg|png|jpe?g|gif|webp|wasm|txt)$/i;
+
+/**
+ * Native module resolution has no notion of a "default extension", so every relative
+ * specifier needs an explicit one. Transpiled sources are served as `.js`; anything already
+ * naming a non-module file (a stylesheet, a JSON asset) is left as authored.
+ */
+const rewriteRelativeSpecifiers = (source: string) =>
+    source.replace(SPECIFIER_REGEX, (match, prefix, quote, specifier) => {
+        // A specifier can carry a query or fragment (`./worker.ts?v=1`). Only the path part
+        // names the file, so the extension is read from -- and rewritten on -- that alone.
+        const [, path, suffix = ''] = specifier.match(/^([^?#]*)(.*)$/) as RegExpMatchArray;
+        const servedAsAuthored = SERVED_AS_AUTHORED_REGEX.test(path) && !isTransformableModule(path);
+
+        if (!isRelative(path) || servedAsAuthored) {
+            return match;
+        }
+
+        const rewritten = toModuleFileName(path);
+
+        return `${prefix}${quote}${rewritten.endsWith('.js') ? rewritten : `${rewritten}.js`}${suffix}${quote}`;
+    });
+
+export const STYLESHEET_LOADER_NAME = '__agLoadStylesheet';
+
+/**
+ * Awaited, so a module never reaches the code that measures the page before the styles it
+ * imported apply -- an example whose layout comes from its own stylesheet would otherwise
+ * create its grid in a collapsed container. A stylesheet the template already linked is
+ * matched by path, since the template's href can carry a cache-busting query.
+ */
+const STYLESHEET_LOADER = `const ${STYLESHEET_LOADER_NAME} = (href) => new Promise((resolve) => {
+    const { pathname } = new URL(href, document.baseURI);
+    const linked = (link) => new URL(link.href, document.baseURI).pathname === pathname;
+    if (Array.from(document.querySelectorAll('link[rel="stylesheet"]')).some(linked)) {
+        resolve();
+        return;
+    }
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = href;
+    link.addEventListener('load', () => resolve());
+    link.addEventListener('error', () => resolve());
+    document.head.appendChild(link);
+});
+`;
+
+/**
+ * `import 'some.css'` is not valid without a CSS module attribute, so CSS imports become
+ * `<link>` elements instead. `import.meta.resolve` maps a package stylesheet through the
+ * page's import map and a relative one against the module's own URL.
+ */
+const rewriteCssImports = (source: string) => {
+    const rewritten = source.replace(
+        CSS_IMPORT_REGEX,
+        // Serialised rather than re-quoted, so a path containing a quote stays valid JS
+        (_match, _quote, specifier) =>
+            `await ${STYLESHEET_LOADER_NAME}(import.meta.resolve(${JSON.stringify(specifier)}));`
+    );
+
+    return rewritten === source ? source : `${STYLESHEET_LOADER}${rewritten}`;
+};
+
+export const transformExampleModule = ({
+    fileName,
+    source,
+    compilerOptionNames = COMPILER_OPTION_NAMES,
+}: {
+    fileName: string;
+    source: string;
+    /** Defaults to every option; a site that builds examples per framework narrows them */
+    compilerOptionNames?: NamedCompilerOptions;
+}) => {
+    const { outputText } = ts.transpileModule(rewriteCssImports(rewriteRelativeSpecifiers(source)), {
+        fileName,
+        compilerOptions: getCompilerOptions(ts, compilerOptionNames),
+    });
+
+    return outputText;
+};

--- a/external/ag-website-shared/src/components/footer/Footer.tsx
+++ b/external/ag-website-shared/src/components/footer/Footer.tsx
@@ -38,6 +38,7 @@ const MenuColumns = ({ footerItems }: { footerItems: FooterItem[] }) => {
                         <li key={`${title}_${name}`}>
                             <a
                                 id={`${slugger.slug(name)}-nav`}
+                                tabIndex={0}
                                 href={urlWithBaseUrl(url)}
                                 onClick={showCookiesPrefs ? toggleCookiesPrefs : undefined}
                                 {...(newTab ? { target: '_blank', rel: 'noreferrer' } : {})}

--- a/external/ag-website-shared/src/components/markdown-actions/MarkdownActions.tsx
+++ b/external/ag-website-shared/src/components/markdown-actions/MarkdownActions.tsx
@@ -92,7 +92,7 @@ export const MarkdownActions: FunctionComponent<Props> = ({ markdownHref, framew
 
     return (
         <div className={styles.markdownActions}>
-            <button type="button" className={styles.primaryAction} onClick={copyMarkdown}>
+            <button type="button" tabIndex={0} className={styles.primaryAction} onClick={copyMarkdown}>
                 {/* The hidden copy reserves room for the longest label so confirming a
                     copy cannot resize the button and shift the controls beside it. */}
                 <span className={styles.labelStack}>
@@ -104,7 +104,7 @@ export const MarkdownActions: FunctionComponent<Props> = ({ markdownHref, framew
             </button>
 
             <DropdownMenu.Root>
-                <DropdownMenu.Trigger className={styles.trigger} aria-label="More markdown actions">
+                <DropdownMenu.Trigger tabIndex={0} className={styles.trigger} aria-label="More markdown actions">
                     <ChevronDown className={styles.chevron} />
                 </DropdownMenu.Trigger>
 

--- a/external/ag-website-shared/src/components/page-styles/docs.module.scss
+++ b/external/ag-website-shared/src/components/page-styles/docs.module.scss
@@ -9,10 +9,25 @@
         flex-direction: row;
     }
 
-    // .docPage caps its width to leave room for the 3-12 menu column, which isn't there.
     &.noLeftMenu .docPage {
         width: 100%;
-        max-width: 100%;
+    }
+
+    @media (min-width: $breakpoint-docs-nav-large) {
+        &.noLeftMenu .docPage {
+            width: var(--layout-width-9-12);
+            margin-left: calc(var(--layout-width-3-12) + var(--layout-gap));
+        }
+    }
+
+    @media (max-width: $breakpoint-docs-nav-extra-large) {
+        &.noLeftMenu .docPage {
+            width: var(--layout-width-6-12);
+        }
+    }
+
+    &.noLeftMenu .docPage {
+        width: 100%;
     }
 }
 

--- a/external/ag-website-shared/src/components/product-dropdown/ProductDropdown.tsx
+++ b/external/ag-website-shared/src/components/product-dropdown/ProductDropdown.tsx
@@ -136,7 +136,11 @@ export const ProductDropdown = ({ items, children }: { items: ProductMenu; child
 
     return (
         <div ref={dropdownRef} className={`${styles.customMenu} ${isOpen ? styles.open : ''}`}>
-            <button className={`${styles.customTrigger} ${isOpen ? styles.open : ''}`} onClick={handleMenuToggle}>
+            <button
+                className={`${styles.customTrigger} ${isOpen ? styles.open : ''}`}
+                onClick={handleMenuToggle}
+                tabIndex={0}
+            >
                 Products
                 <span className={styles.arrow}></span>
             </button>
@@ -162,7 +166,7 @@ export const ProductDropdown = ({ items, children }: { items: ProductMenu; child
                                             {item.inlineHeading}
                                         </div>
                                     )}
-                                    <a href={item.url} className={styles.itemsWrapper}>
+                                    <a tabIndex={0} href={item.url} className={styles.itemsWrapper}>
                                         <div className={placeholderClass}>{getIconComponent(item)}</div>
                                         <div className={styles.productsWrapper}>
                                             <div className={styles.productTitle}>{item.title}</div>

--- a/external/ag-website-shared/src/components/site-header/DarkModeToggle.tsx
+++ b/external/ag-website-shared/src/components/site-header/DarkModeToggle.tsx
@@ -11,6 +11,7 @@ export const DarkModeToggle = () => {
             <button
                 className={classNames(styles.navLink, 'button-style-none')}
                 aria-label="Dark mode selector"
+                tabIndex={0}
                 onClick={() => setDarkmode(!darkmode)}
             >
                 <div className={classNames(styles.icon, styles.pseudoIcon)} />

--- a/external/ag-website-shared/src/components/site-header/HeaderNav.tsx
+++ b/external/ag-website-shared/src/components/site-header/HeaderNav.tsx
@@ -82,6 +82,7 @@ const HeaderLinks = ({
                             id={`${toggleIsOpen ? 'mobile-' : ''}${slugger.slug(title)}-nav`}
                             className={styles.navLink}
                             href={href}
+                            tabIndex={0}
                             onClick={() => {
                                 if (isOpen) {
                                     toggleIsOpen?.();

--- a/external/ag-website-shared/src/components/site-header/SiteHeader.astro
+++ b/external/ag-website-shared/src/components/site-header/SiteHeader.astro
@@ -50,6 +50,7 @@ const allPaths = [
                             id="top-bar-docs-button"
                             class:list={[styles.mobileNavButton, 'button-secondary']}
                             type="button"
+                            tabindex={0}
                             data-toggle="collapse"
                             data-target="#side-nav"
                             aria-controls="side-nav"

--- a/external/ag-website-shared/src/components/tabs/TabNavItem.tsx
+++ b/external/ag-website-shared/src/components/tabs/TabNavItem.tsx
@@ -20,6 +20,7 @@ export const TabNavItem = ({
                     onSelect(label);
                 }}
                 role="tab"
+                tabIndex={0}
                 disabled={selected}
             >
                 {label}


### PR DESCRIPTION
Catch-up `git subrepo pull` of `external/ag-website-shared`, which was 11 commits behind (pinned at `33a9edf`, now `0591053`).

Also repairs the stale `.gitrepo` parent left by the squash-merge of #14905 — `subrepo check` now passes.

No hand-edits: the whole diff is the pull. Prerequisite for #14958.