### PR TITLE
[AG-4093] Feature(columns): continuous auto-sizing

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/column-sizing/_examples/continuous-auto-size/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/column-sizing/_examples/continuous-auto-size/example.spec.ts
@@ -32,7 +32,7 @@ test.agExample(import.meta, () => {
         expect(await columnWidth(page, 'athlete')).toBe(athleteWidth);
     });
 
-    test.eachFramework('the column with an explicit width keeps it after the initial sizing', async ({ page }) => {
+    test.eachFramework('the `suppressAutoSize` column keeps its starting width', async ({ page }) => {
         await waitForGridContent(page);
         await waitForWidths(page);
 

--- a/documentation/ag-grid-docs/src/content/docs/column-sizing/_examples/continuous-auto-size/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/column-sizing/_examples/continuous-auto-size/example.spec.ts
@@ -1,0 +1,41 @@
+import { expect, test, waitForGridContent } from '@utils/grid/test-utils';
+import type { Locator, Page } from 'playwright/test';
+
+async function width(locator: Locator): Promise<number> {
+    return (await locator.boundingBox())?.width ?? 0;
+}
+
+function columnWidth(page: Page, colId: string): Promise<number> {
+    return width(page.locator(`.ag-header-cell[col-id="${colId}"]`).first());
+}
+
+/** Settle the width animation so measurements are stable. */
+async function waitForWidths(page: Page): Promise<void> {
+    await expect(page.locator('.ag-animate-autosize')).toHaveCount(0);
+}
+
+test.agExample(import.meta, () => {
+    test.eachFramework('longer data re-sizes the eligible columns but not the fixed one', async ({ page }) => {
+        await waitForGridContent(page);
+        await waitForWidths(page);
+
+        const athleteWidth = await columnWidth(page, 'athlete');
+        const sportWidth = await columnWidth(page, 'sport');
+
+        await page.locator('button.longer-values-button').click();
+        await waitForGridContent(page);
+        await waitForWidths(page);
+
+        await expect(async () => {
+            expect(await columnWidth(page, 'sport')).toBeGreaterThan(sportWidth);
+        }).toPass();
+        expect(await columnWidth(page, 'athlete')).toBe(athleteWidth);
+    });
+
+    test.eachFramework('the column with an explicit width keeps it after the initial sizing', async ({ page }) => {
+        await waitForGridContent(page);
+        await waitForWidths(page);
+
+        expect(await columnWidth(page, 'athlete')).toBe(150);
+    });
+});

--- a/documentation/ag-grid-docs/src/content/docs/column-sizing/_examples/continuous-auto-size/index.html
+++ b/documentation/ag-grid-docs/src/content/docs/column-sizing/_examples/continuous-auto-size/index.html
@@ -1,0 +1,9 @@
+<div class="outer-div">
+    <div class="interaction-bar">
+        <button class="longer-values-button" onclick="useLongerValues()">Use Longer Values</button>
+        <span>The Athlete column has an explicit width, so it stays fixed</span>
+    </div>
+    <div class="grid-wrapper">
+        <div id="myGrid" style="height: 100%"></div>
+    </div>
+</div>

--- a/documentation/ag-grid-docs/src/content/docs/column-sizing/_examples/continuous-auto-size/index.html
+++ b/documentation/ag-grid-docs/src/content/docs/column-sizing/_examples/continuous-auto-size/index.html
@@ -1,7 +1,7 @@
 <div class="outer-div">
     <div class="interaction-bar">
         <button class="longer-values-button" onclick="useLongerValues()">Use Longer Values</button>
-        <span>The Athlete column has an explicit width, so it stays fixed</span>
+        <span>The Athlete column sets suppressAutoSize, so it stays fixed</span>
     </div>
     <div class="grid-wrapper">
         <div id="myGrid" style="height: 100%"></div>

--- a/documentation/ag-grid-docs/src/content/docs/column-sizing/_examples/continuous-auto-size/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/column-sizing/_examples/continuous-auto-size/main.ts
@@ -21,7 +21,7 @@ interface IRow {
 }
 
 const columnDefs: ColDef<IRow>[] = [
-    { field: 'athlete', width: 150 },
+    { field: 'athlete', width: 150, suppressAutoSize: true },
     { field: 'country', initialWidth: 120 },
     { field: 'sport' },
 ];

--- a/documentation/ag-grid-docs/src/content/docs/column-sizing/_examples/continuous-auto-size/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/column-sizing/_examples/continuous-auto-size/main.ts
@@ -1,0 +1,72 @@
+import type { ColDef, GridApi, GridOptions } from 'ag-grid-community';
+import {
+    ClientSideRowModelModule,
+    ColumnAutoSizeModule,
+    ModuleRegistry,
+    createGrid,
+    enableDevValidations,
+} from 'ag-grid-community';
+
+if (process.env.NODE_ENV !== 'production') {
+    // Enable extended validations only for development
+    enableDevValidations();
+}
+
+ModuleRegistry.registerModules([ColumnAutoSizeModule, ClientSideRowModelModule]);
+
+interface IRow {
+    athlete: string;
+    country: string;
+    sport: string;
+}
+
+const columnDefs: ColDef<IRow>[] = [
+    { field: 'athlete', width: 150 },
+    { field: 'country', initialWidth: 120 },
+    { field: 'sport' },
+];
+
+const shortRowData: IRow[] = [
+    { athlete: 'Michael Phelps', country: 'US', sport: 'Swimming' },
+    { athlete: 'Natalie Coughlin', country: 'US', sport: 'Swimming' },
+    { athlete: 'Aleksey Nemov', country: 'RU', sport: 'Gymnastics' },
+];
+
+const longRowData: IRow[] = [
+    {
+        athlete: 'Michael Fred Phelps II, the most decorated Olympian',
+        country: 'United States of America',
+        sport: 'Swimming, Individual Medley and Butterfly',
+    },
+    {
+        athlete: 'Natalie Anne Coughlin Hall, twelve-time medallist',
+        country: 'United States of America',
+        sport: 'Swimming, Backstroke and Freestyle',
+    },
+    {
+        athlete: 'Aleksey Yuryevich Nemov, twelve-time medallist',
+        country: 'Russian Federation',
+        sport: 'Artistic Gymnastics, All-Around',
+    },
+];
+
+let gridApi: GridApi<IRow>;
+
+const gridOptions: GridOptions<IRow> = {
+    columnDefs: columnDefs,
+    rowData: shortRowData,
+    autoSizeStrategy: {
+        type: 'fitCellContents',
+        continuous: true,
+    },
+};
+
+function useLongerValues() {
+    gridApi!.setGridOption('rowData', longRowData);
+}
+
+// setup the grid after the page has finished loading
+document.addEventListener('DOMContentLoaded', () => {
+    const gridDiv = document.querySelector<HTMLElement>('#myGrid')!;
+    gridApi = createGrid(gridDiv, gridOptions);
+});

--- a/documentation/ag-grid-docs/src/content/docs/column-sizing/_examples/continuous-auto-size/styles.css
+++ b/documentation/ag-grid-docs/src/content/docs/column-sizing/_examples/continuous-auto-size/styles.css
@@ -1,0 +1,20 @@
+.outer-div {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+}
+
+.interaction-bar {
+    margin-bottom: 1rem;
+    display: flex;
+    gap: 1em;
+    align-items: center;
+}
+
+.longer-values-button {
+    margin: 0px !important;
+}
+
+.grid-wrapper {
+    flex: 1 1 auto;
+}

--- a/documentation/ag-grid-docs/src/content/docs/column-sizing/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/column-sizing/index.mdoc
@@ -178,41 +178,6 @@ In the example below, narrow the columns and then run **Autosize All Columns** f
 
 {% gridExampleRunner title="Auto-Size Actions Respecting the Strategy" name="auto-size-ui-actions" /%}
 
-#### Continuous Auto-Sizing
-
-By default the columns are sized to fit their cell contents once, when the first data is rendered. Set `continuous` to have the grid re-size them whenever the data, the displayed columns, the viewport or the grid size changes.
-
-```{% frameworkTransform=true %}
-const gridOptions = {
-    autoSizeStrategy: {
-        type: 'fitCellContents',
-        continuous: true,
-        shouldAutoSizeColumns: (params) => {
-            // skip re-sizing while the user is scrolling through the data
-            return params.reason !== 'viewportChanged';
-        }
-    }
-}
-```
-
-Provide `shouldAutoSizeColumns` to take control of each re-size. It is called before the columns are measured, with the eligible `columns` and a `reason` of `'dataChanged'`, `'columnsChanged'`, `'viewportChanged'` or `'gridSizeChanged'`. Return `false` to skip that re-size, leaving the widths untouched. The callback has no effect unless `continuous` is `true`.
-
-Continuous sizing never changes the width of a column that is already owned, either by the developer or by the user. A column becomes owned through an explicit `width` in its column definition, a header drag resize, a keyboard resize, a double-click auto-size, or `applyColumnState` with an explicit `width`. Use `initialWidth` instead of `width` to seed a starting width that stays eligible for re-sizing.
-
-Columns with `suppressAutoSize = true`, [flex](#column-flex) columns, and the special [Selection](./row-selection-multi-row/#customising-the-checkbox-column) and [Row Numbers](./row-numbers/) columns are excluded as well.
-
-When `scaleUpToFitGridWidth` is also set, only the eligible columns are scaled. Owned columns keep their fixed width, and the grid allows horizontal overflow — a scrollbar — when those fixed widths alone cannot fit.
-
-In the example below the "Athlete" column has an explicit `width`, so it is left alone, while the remaining columns re-size themselves each time the data changes. Press the button to load longer values and watch the eligible columns grow.
-
-{% gridExampleRunner title="Continuous Auto-Sizing" name="continuous-auto-size" /%}
-
-{% note %}
-Only the cells that are currently rendered can be measured, so with row or column virtualisation the columns may be sized progressively as you scroll and more content is rendered.
-
-Continuous auto-sizing is not supported by the [Viewport Row Model](./viewport/). The grid logs a warning and ignores the option there.
-{% /note %}
-
 This can also be performed on demand via the following API methods:
 
 {% apiDocumentation source="grid-api/api.json" section="columnSizing" names=["autoSizeColumns", "autoSizeAllColumns"] /%}
@@ -228,6 +193,47 @@ Just like Excel, each column can also be auto-resized by double clicking the rig
 - Column Virtualisation is the technique the grid uses to render large amounts of columns without degrading performance by only rendering columns that are visible due to the horizontal scroll positions. For example, the grid can have 1,000 columns with only 10 rendered if the horizontal scroll is only showing 10 columns. To get around this, you can turn off column virtualisation by setting grid property `suppressColumnVirtualisation=true`. The choice is yours to decide whether you want column virtualisation working OR auto-size working using off-screen columns.
 - Note that [Pinned Columns](./column-pinning), the [Selection Column](./row-selection-multi-row/#customising-the-checkbox-column) and the [Row Numbers](./row-numbers) column will not be scaled up to fill any empty space when using `scaleUpToFitGridWidth`.
 
+{% /note %}
+
+## Continuous Auto-Sizing
+
+By default `autoSizeStrategy` is applied once, when the grid first renders. Set `continuous` to have the grid re-apply the configured strategy whenever the grid changes in a way that affects column widths. It works with all three strategies, and the strategy itself is unchanged — only how often it runs.
+
+```{% frameworkTransform=true %}
+const gridOptions = {
+    autoSizeStrategy: {
+        type: 'fitCellContents',
+        continuous: true,
+        shouldAutoSizeColumns: (params) => {
+            // skip re-sizing while the user is scrolling through the data
+            return params.reason !== 'viewportChanged';
+        }
+    }
+}
+```
+
+Every strategy re-runs on data changes, displayed-column changes and grid resizes. `fitCellContents` additionally re-runs on viewport changes, because scrolling is what brings new cell content into view to be measured; the width-distribution strategies are arithmetic over the current column set, so scrolling cannot change their result. Triggers arriving in the same frame are coalesced into a single re-size.
+
+Provide `shouldAutoSizeColumns` to take control of each re-size. It is called first, with the eligible `columns` and a `reason` of `'dataChanged'`, `'columnsChanged'`, `'viewportChanged'` or `'gridSizeChanged'`. Return `false` to skip that re-size, leaving the widths untouched. The callback has no effect unless `continuous` is `true`.
+
+### Column Width Ownership
+
+Continuous sizing never changes the width of a column that is already owned, either by the developer or by the user. A column becomes owned through an explicit `width` in its column definition, a header drag resize, a keyboard resize, a double-click auto-size, or `applyColumnState` with an explicit `width`. Use `initialWidth` instead of `width` to seed a starting width that stays eligible for re-sizing.
+
+Owned columns are treated as fixed width, so the width-distribution strategies hold them out of the distribution and share the remaining space between the eligible columns only.
+
+Columns excluded for other reasons are [flex](#column-flex) columns and the special [Selection](./row-selection-multi-row/#customising-the-checkbox-column) and [Row Numbers](./row-numbers/) columns, plus `suppressAutoSize` columns for `fitCellContents` and `suppressSizeToFit` columns for the width-distribution strategies.
+
+When `scaleUpToFitGridWidth` is also set, only the eligible columns are scaled, and the grid allows horizontal overflow — a scrollbar — when the fixed widths alone cannot fit.
+
+In the example below the "Athlete" column has an explicit `width`, so it is left alone, while the remaining columns re-size themselves each time the data changes. Press the button to load longer values and watch the eligible columns grow.
+
+{% gridExampleRunner title="Continuous Auto-Sizing" name="continuous-auto-size" /%}
+
+{% note %}
+For `fitCellContents`, only the cells that are currently rendered can be measured, so with row or column virtualisation the columns may be sized progressively as you scroll and more content is rendered.
+
+Continuous `fitCellContents` is not supported by the [Viewport Row Model](./viewport/). The grid logs a warning and ignores the option there.
 {% /note %}
 
 ## Resize via Keyboard

--- a/documentation/ag-grid-docs/src/content/docs/column-sizing/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/column-sizing/index.mdoc
@@ -197,7 +197,7 @@ Just like Excel, each column can also be auto-resized by double clicking the rig
 
 ## Continuous Auto-Sizing
 
-By default `autoSizeStrategy` is applied once, when the grid first renders. Set `continuous` to have the grid re-apply the configured strategy whenever the grid changes in a way that affects column widths. 
+By default `autoSizeStrategy` is applied once, when the grid first renders. Set `continuous` to have the grid re-apply the configured strategy whenever the grid changes in a way that affects column widths.
 
 ```{% frameworkTransform=true %}
 const gridOptions = {

--- a/documentation/ag-grid-docs/src/content/docs/column-sizing/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/column-sizing/index.mdoc
@@ -197,7 +197,7 @@ Just like Excel, each column can also be auto-resized by double clicking the rig
 
 ## Continuous Auto-Sizing
 
-By default `autoSizeStrategy` is applied once, when the grid first renders. Set `continuous` to have the grid re-apply the configured strategy whenever the grid changes in a way that affects column widths. It works with all three strategies, and the strategy itself is unchanged — only how often it runs.
+By default `autoSizeStrategy` is applied once, when the grid first renders. Set `continuous` to have the grid re-apply the configured strategy whenever the grid changes in a way that affects column widths. 
 
 ```{% frameworkTransform=true %}
 const gridOptions = {

--- a/documentation/ag-grid-docs/src/content/docs/column-sizing/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/column-sizing/index.mdoc
@@ -178,6 +178,41 @@ In the example below, narrow the columns and then run **Autosize All Columns** f
 
 {% gridExampleRunner title="Auto-Size Actions Respecting the Strategy" name="auto-size-ui-actions" /%}
 
+#### Continuous Auto-Sizing
+
+By default the columns are sized to fit their cell contents once, when the first data is rendered. Set `continuous` to have the grid re-size them whenever the data, the displayed columns, the viewport or the grid size changes.
+
+```{% frameworkTransform=true %}
+const gridOptions = {
+    autoSizeStrategy: {
+        type: 'fitCellContents',
+        continuous: true,
+        shouldAutoSizeColumns: (params) => {
+            // skip re-sizing while the user is scrolling through the data
+            return params.reason !== 'viewportChanged';
+        }
+    }
+}
+```
+
+Provide `shouldAutoSizeColumns` to take control of each re-size. It is called before the columns are measured, with the eligible `columns` and a `reason` of `'dataChanged'`, `'columnsChanged'`, `'viewportChanged'` or `'gridSizeChanged'`. Return `false` to skip that re-size, leaving the widths untouched. The callback has no effect unless `continuous` is `true`.
+
+Continuous sizing never changes the width of a column that is already owned, either by the developer or by the user. A column becomes owned through an explicit `width` in its column definition, a header drag resize, a keyboard resize, a double-click auto-size, or `applyColumnState` with an explicit `width`. Use `initialWidth` instead of `width` to seed a starting width that stays eligible for re-sizing.
+
+Columns with `suppressAutoSize = true`, [flex](#column-flex) columns, and the special [Selection](./row-selection-multi-row/#customising-the-checkbox-column) and [Row Numbers](./row-numbers/) columns are excluded as well.
+
+When `scaleUpToFitGridWidth` is also set, only the eligible columns are scaled. Owned columns keep their fixed width, and the grid allows horizontal overflow — a scrollbar — when those fixed widths alone cannot fit.
+
+In the example below the "Athlete" column has an explicit `width`, so it is left alone, while the remaining columns re-size themselves each time the data changes. Press the button to load longer values and watch the eligible columns grow.
+
+{% gridExampleRunner title="Continuous Auto-Sizing" name="continuous-auto-size" /%}
+
+{% note %}
+Only the cells that are currently rendered can be measured, so with row or column virtualisation the columns may be sized progressively as you scroll and more content is rendered.
+
+Continuous auto-sizing is not supported by the [Viewport Row Model](./viewport/). The grid logs a warning and ignores the option there.
+{% /note %}
+
 This can also be performed on demand via the following API methods:
 
 {% apiDocumentation source="grid-api/api.json" section="columnSizing" names=["autoSizeColumns", "autoSizeAllColumns"] /%}

--- a/documentation/ag-grid-docs/src/content/docs/column-sizing/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/column-sizing/index.mdoc
@@ -212,7 +212,12 @@ const gridOptions = {
 }
 ```
 
-Every strategy re-runs on data changes, displayed-column changes and grid resizes. `fitCellContents` additionally re-runs on viewport changes, because scrolling is what brings new cell content into view to be measured; the width-distribution strategies are arithmetic over the current column set, so scrolling cannot change their result. Triggers arriving in the same frame are coalesced into a single re-size.
+Every strategy re-runs when the displayed columns change and when the grid is resized. Beyond that the two kinds of strategy react to different things:
+
+- `fitCellContents` re-runs on any change to the row data, and on viewport changes, because both change what there is to measure — scrolling is what brings new cell content into view.
+- The width-distribution strategies, `fitGridWidth` and `fitProvidedWidth`, are arithmetic over the current column set, so scrolling cannot change their result. They re-run on new data, a page change, and a scrollbar appearing or disappearing — the changes to the width there is to share out.
+
+Triggers arriving in the same frame are coalesced into a single re-size.
 
 Provide `shouldAutoSizeColumns` to take control of each re-size. It is called first, with the eligible `columns` and a `reason` of `'dataChanged'`, `'columnsChanged'`, `'viewportChanged'` or `'gridSizeChanged'`. Return `false` to skip that re-size, leaving the widths untouched. The callback has no effect unless `continuous` is `true`.
 

--- a/documentation/ag-grid-docs/src/content/docs/column-sizing/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/column-sizing/index.mdoc
@@ -218,15 +218,15 @@ Provide `shouldAutoSizeColumns` to take control of each re-size. It is called fi
 
 ### Column Width Ownership
 
-Continuous sizing never changes the width of a column that is already owned, either by the developer or by the user. A column becomes owned through an explicit `width` in its column definition, a header drag resize, a keyboard resize, a double-click auto-size, or `applyColumnState` with an explicit `width`. Use `initialWidth` instead of `width` to seed a starting width that stays eligible for re-sizing.
+Continuous sizing never changes the width of a column the user has sized themselves. A column becomes theirs through a header drag resize, a keyboard resize or a double-click auto-size, and through `applyColumnState` with an explicit `width`. Their width is then treated as fixed, so the width-distribution strategies hold the column out of the distribution and share the remaining space between the rest.
 
-Owned columns are treated as fixed width, so the width-distribution strategies hold them out of the distribution and share the remaining space between the eligible columns only.
+`width` and `initialWidth` in a column definition are both only starting widths: the grid may re-size either of them. To hold a column at a fixed width, set `suppressAutoSize` for `fitCellContents` or `suppressSizeToFit` for the width-distribution strategies — those are the explicit opt-outs, and unlike a starting width they say so.
 
-Columns excluded for other reasons are [flex](#column-flex) columns and the special [Selection](./row-selection-multi-row/#customising-the-checkbox-column) and [Row Numbers](./row-numbers/) columns, plus `suppressAutoSize` columns for `fitCellContents` and `suppressSizeToFit` columns for the width-distribution strategies.
+Also excluded are [flex](#column-flex) columns and the special [Selection](./row-selection-multi-row/#customising-the-checkbox-column) and [Row Numbers](./row-numbers/) columns.
 
 When `scaleUpToFitGridWidth` is also set, only the eligible columns are scaled, and the grid allows horizontal overflow — a scrollbar — when the fixed widths alone cannot fit.
 
-In the example below the "Athlete" column has an explicit `width`, so it is left alone, while the remaining columns re-size themselves each time the data changes. Press the button to load longer values and watch the eligible columns grow.
+In the example below the "Athlete" column sets `suppressAutoSize`, so it is left alone, while the remaining columns re-size themselves each time the data changes. Press the button to load longer values and watch the eligible columns grow.
 
 {% gridExampleRunner title="Continuous Auto-Sizing" name="continuous-auto-size" /%}
 

--- a/packages/ag-grid-community/src/columnAutosize/columnAutosizeService.ts
+++ b/packages/ag-grid-community/src/columnAutosize/columnAutosizeService.ts
@@ -1,4 +1,4 @@
-import { _getInnerWidth, _removeFromArray } from 'ag-stack';
+import { _getInnerWidth, _removeFromArray, _requestAnimationFrame } from 'ag-stack';
 
 import { dispatchColumnResizedEvent } from '../columns/columnEventUtils';
 import { getWidthOfColsInList, isSpecialCol } from '../columns/columnUtils';
@@ -8,10 +8,12 @@ import type { BeanCollection } from '../context/context';
 import type { AgColumn } from '../entities/agColumn';
 import type { AgColumnGroup } from '../entities/agColumnGroup';
 import type { ColKey } from '../entities/colDef';
-import type { ColumnEventType } from '../events';
-import { _isClientSideRowModel } from '../gridOptionsUtils';
+import type { BodyScrollEvent, ColumnEventType } from '../events';
+import type { GridOptionsService } from '../gridOptionsService';
+import { _addGridCommonParams, _isClientSideRowModel } from '../gridOptionsUtils';
 import type { HeaderGroupCellCtrl } from '../headerRendering/cells/columnGroup/headerGroupCellCtrl';
 import type {
+    AutoSizeColumnsTriggerParams,
     IColumnLimit,
     ISizeColumnsToFitParams,
     SizeColumnsToContentColumnLimits,
@@ -36,6 +38,16 @@ interface AutoSizeColumnParams {
 /** Sources used by the built-in Column Menu and Context Menu auto-size actions. */
 const UI_MENU_SOURCES: ReadonlySet<ColumnEventType> = new Set(['columnMenu', 'contextMenu']);
 
+type AutoSizeReason = AutoSizeColumnsTriggerParams['reason'];
+
+/** Most to least significant; the reason reported when several triggers coalesce into one frame. */
+const CONTINUOUS_REASON_PRIORITY: readonly AutoSizeReason[] = [
+    'dataChanged',
+    'columnsChanged',
+    'gridSizeChanged',
+    'viewportChanged',
+];
+
 export class ColumnAutosizeService extends BeanStub implements NamedBean {
     beanName = 'colAutosize' as const;
 
@@ -44,6 +56,11 @@ export class ColumnAutosizeService extends BeanStub implements NamedBean {
     /** when we're waiting for cell data types to be inferred, we need to defer column resizing */
     public shouldQueueResizeOperations: boolean = false;
     private resizeOperationQueue: (() => void)[] = [];
+
+    private continuousStrategy: SizeColumnsToContentStrategy | null = null;
+    private continuousRunning = false;
+    private continuousFrameScheduled = false;
+    private pendingReasons: Set<AutoSizeReason> | null = null;
 
     public postConstruct(): void {
         const { gos } = this;
@@ -56,6 +73,9 @@ export class ColumnAutosizeService extends BeanStub implements NamedBean {
                 shouldHideColumns = true;
             } else if (type === 'fitCellContents') {
                 this.addManagedEventListeners({ firstDataRendered: () => this.onFirstDataRendered(autoSizeStrategy) });
+                if (autoSizeStrategy.continuous) {
+                    this.initContinuousAutoSize(autoSizeStrategy);
+                }
                 // Hide columns when we already have row data to display. This avoids jittering when we initially
                 // render columns at default width, only to immediately resize them when rows are rendered.
                 const rowData = gos.get('rowData');
@@ -97,18 +117,24 @@ export class ColumnAutosizeService extends BeanStub implements NamedBean {
     }
 
     public autoSizeCols(paramsInput: AutoSizeColumnParams): void {
-        const params = this.withUiActionStrategyParams(paramsInput);
-        const { eventSvc, colModel } = this.beans;
+        this.autoSizeColsAsync(this.withUiActionStrategyParams(paramsInput)).then((columnsAutoSized) =>
+            dispatchColumnResizedEvent(this.beans.eventSvc, Array.from(columnsAutoSized), true, 'autosizeColumns')
+        );
+    }
+
+    /**
+     * Measures and applies widths, resolving with the columns that were sized. Continuous auto-sizing awaits
+     * this to track its running state, so the resolved promise must outlive every width write.
+     */
+    private autoSizeColsAsync(params: AutoSizeColumnParams): Promise<Set<AgColumn>> {
+        const { colModel } = this.beans;
 
         setWidthAnimation(this.beans, true);
 
-        this.innerAutoSizeCols(params).then((columnsAutoSized) => {
-            const dispatch = (cols: Set<AgColumn>) =>
-                dispatchColumnResizedEvent(eventSvc, Array.from(cols), true, 'autosizeColumns');
-
+        return this.innerAutoSizeCols(params).then((columnsAutoSized) => {
             if (!params.scaleUpToFitGridWidth) {
                 setWidthAnimation(this.beans, false);
-                return dispatch(columnsAutoSized);
+                return columnsAutoSized;
             }
 
             const availableGridWidth = getAvailableWidth(this.beans);
@@ -134,7 +160,7 @@ export class ColumnAutosizeService extends BeanStub implements NamedBean {
 
             setWidthAnimation(this.beans, false);
 
-            dispatch(columnsAutoSized);
+            return columnsAutoSized;
         });
     }
 
@@ -200,6 +226,9 @@ export class ColumnAutosizeService extends BeanStub implements NamedBean {
 
             while (changesThisTimeAround !== 0) {
                 changesThisTimeAround = 0;
+                // only a real width change may refresh, else the events it dispatches re-trigger
+                // continuous auto-sizing indefinitely
+                let widthsChanged = false;
 
                 const updatedColumns: AgColumn[] = [];
 
@@ -226,6 +255,7 @@ export class ColumnAutosizeService extends BeanStub implements NamedBean {
                         columnLimit.minWidth ??= defaultMinWidth;
                         columnLimit.maxWidth ??= defaultMaxWidth;
                         const newWidth = normaliseColumnWidth(column, preferredWidth, columnLimit);
+                        widthsChanged ||= newWidth !== column.getActualWidth();
                         column.setActualWidth(newWidth, source);
                         columnsAutoSized.add(column);
                         changesThisTimeAround++;
@@ -234,7 +264,7 @@ export class ColumnAutosizeService extends BeanStub implements NamedBean {
                     updatedColumns.push(column);
                 }
 
-                if (updatedColumns.length) {
+                if (updatedColumns.length && widthsChanged) {
                     // skipTreeBuild=true: autosize only changes widths, leaving liveCols/pins/visibility — and
                     // thus the section/group trees — unchanged.
                     visibleCols.refresh(source, true);
@@ -589,7 +619,8 @@ export class ColumnAutosizeService extends BeanStub implements NamedBean {
         });
     }
 
-    private onFirstDataRendered({ colIds: colKeys, ...params }: SizeColumnsToContentStrategy): void {
+    private onFirstDataRendered(strategy: SizeColumnsToContentStrategy): void {
+        const { colIds: colKeys, ...params } = strategy;
         // ensure render has finished
         setTimeout(() => {
             if (!this.isAlive()) {
@@ -597,13 +628,155 @@ export class ColumnAutosizeService extends BeanStub implements NamedBean {
             }
             const source = 'autosizeColumns';
 
-            if (colKeys) {
+            if (this.continuousStrategy) {
+                // ownership must hold from the first pass, else `colDef.width` is measured away before
+                // continuous mode starts protecting it
+                this.autoSizeCols({ ...params, source, colKeys: this.getAutoSizeCandidates(strategy) });
+            } else if (colKeys) {
                 this.autoSizeCols({ ...params, source, colKeys });
             } else {
                 this.autoSizeAllColumns({ ...params, source });
             }
             this.beans.colDelayRenderSvc?.revealColumns(params.type);
         });
+    }
+
+    /**
+     * Registers the triggers for continuous `fitCellContents` sizing. Only the events that genuinely change
+     * what a column should measure are used: `modelUpdated` is deliberately not one of them, as it also fires
+     * for sorting, filtering, grouping and row-height work.
+     */
+    private initContinuousAutoSize(strategy: SizeColumnsToContentStrategy): void {
+        if (!isContinuousSupported(this.gos)) {
+            this.warn(328, { rowModel: this.gos.get('rowModelType') });
+            return;
+        }
+
+        this.continuousStrategy = strategy;
+
+        this.addManagedEventListeners({
+            rowDataUpdated: () => this.scheduleContinuousAutoSize('dataChanged'),
+            cellValueChanged: () => this.scheduleContinuousAutoSize('dataChanged'),
+            displayedColumnsChanged: () => this.scheduleContinuousAutoSize('columnsChanged'),
+            newColumnsLoaded: () => this.scheduleContinuousAutoSize('columnsChanged'),
+            // horizontal virtualisation renders new columns, which are then measurable for the first time
+            virtualColumnsChanged: () => this.scheduleContinuousAutoSize('viewportChanged'),
+            viewportChanged: () => this.scheduleContinuousAutoSize('viewportChanged'),
+            bodyScroll: (event: BodyScrollEvent) => {
+                if (event.direction === 'horizontal') {
+                    this.scheduleContinuousAutoSize('viewportChanged');
+                }
+            },
+            gridSizeChanged: () => this.scheduleContinuousAutoSize('gridSizeChanged'),
+        });
+    }
+
+    /** Coalesces every trigger in the current frame into at most one evaluation. */
+    private scheduleContinuousAutoSize(reason: AutoSizeReason): void {
+        const pendingReasons = (this.pendingReasons ??= new Set());
+        pendingReasons.add(reason);
+
+        // a run in flight picks these up on completion, so no nested run may start
+        if (this.continuousRunning || this.continuousFrameScheduled) {
+            return;
+        }
+
+        this.continuousFrameScheduled = true;
+        _requestAnimationFrame(this.beans, () => {
+            this.continuousFrameScheduled = false;
+            if (this.isAlive()) {
+                this.runContinuousAutoSize();
+            }
+        });
+    }
+
+    private runContinuousAutoSize(): void {
+        const strategy = this.continuousStrategy;
+        if (!strategy || this.continuousRunning || !this.pendingReasons?.size) {
+            return;
+        }
+
+        // an unlaid-out grid measures nothing, so drop the trigger rather than churning until it has a size
+        if (getAvailableWidth(this.beans) <= 0) {
+            this.pendingReasons = null;
+            return;
+        }
+
+        const pendingReasons = this.pendingReasons;
+        this.pendingReasons = null;
+
+        const candidates = this.getAutoSizeCandidates(strategy);
+        if (!candidates.length) {
+            return;
+        }
+
+        const reason = CONTINUOUS_REASON_PRIORITY.find((candidate) => pendingReasons.has(candidate))!;
+        const callback = strategy.shouldAutoSizeColumns;
+        if (callback) {
+            let shouldAutoSize: boolean;
+            try {
+                shouldAutoSize = callback(_addGridCommonParams(this.gos, { reason, columns: candidates }));
+            } catch (error) {
+                // dropped rather than retried, so a throwing callback cannot wedge the frame
+                this.warn(329, { error });
+                return;
+            }
+            if (!shouldAutoSize) {
+                return;
+            }
+        }
+
+        this.continuousRunning = true;
+        const { skipHeader, defaultMinWidth, defaultMaxWidth, columnLimits, scaleUpToFitGridWidth } = strategy;
+
+        this.autoSizeColsAsync({
+            colKeys: candidates,
+            skipHeader,
+            defaultMinWidth,
+            defaultMaxWidth,
+            columnLimits,
+            scaleUpToFitGridWidth,
+            source: 'autosizeColumns',
+        }).then(
+            () => this.onContinuousAutoSizeComplete(),
+            () => this.onContinuousAutoSizeComplete()
+        );
+    }
+
+    private onContinuousAutoSizeComplete(): void {
+        this.continuousRunning = false;
+        if (this.pendingReasons?.size && this.isAlive()) {
+            // re-enter through the scheduler rather than recursing, so the follow-up still gets its own frame
+            const reasons = this.pendingReasons;
+            this.pendingReasons = null;
+            for (const reason of reasons) {
+                this.scheduleContinuousAutoSize(reason);
+            }
+        }
+    }
+
+    /**
+     * The columns continuous sizing is allowed to change. Excludes columns whose width is owned by the
+     * developer or user, plus everything the measurement pipeline cannot or must not size.
+     */
+    private getAutoSizeCandidates(strategy: SizeColumnsToContentStrategy): AgColumn[] {
+        const { colModel, visibleCols } = this.beans;
+        const { colIds } = strategy;
+        const cols = colIds ? colIds.map((colId) => colModel.getCol(colId)) : visibleCols.allCols;
+
+        const candidates: AgColumn[] = [];
+        for (let i = 0, len = cols.length; i < len; ++i) {
+            const col = cols[i];
+            if (!col || col.isUserSized() || col.colDef.suppressAutoSize || isSpecialCol(col)) {
+                continue;
+            }
+            const flex = col.getFlex();
+            if (flex != null && flex > 0) {
+                continue;
+            }
+            candidates.push(col);
+        }
+        return candidates;
     }
 
     public processResizeOperations(): void {
@@ -620,6 +793,8 @@ export class ColumnAutosizeService extends BeanStub implements NamedBean {
     }
 
     public override destroy(): void {
+        this.continuousStrategy = null;
+        this.pendingReasons = null;
         this.resizeOperationQueue.length = 0;
         super.destroy();
     }
@@ -643,6 +818,11 @@ function normaliseColumnWidth(
     }
 
     return newWidth;
+}
+
+/** The Viewport Row Model never renders a measurable cell set, so content measurement cannot be repeated. */
+function isContinuousSupported(gos: GridOptionsService): boolean {
+    return gos.get('rowModelType') !== 'viewport';
 }
 
 function getAvailableWidth({ ctrlsSvc, scrollVisibleSvc }: BeanCollection): number {

--- a/packages/ag-grid-community/src/columnAutosize/columnAutosizeService.ts
+++ b/packages/ag-grid-community/src/columnAutosize/columnAutosizeService.ts
@@ -14,6 +14,7 @@ import { _addGridCommonParams, _isClientSideRowModel } from '../gridOptionsUtils
 import type { HeaderGroupCellCtrl } from '../headerRendering/cells/columnGroup/headerGroupCellCtrl';
 import type {
     AutoSizeColumnsTriggerParams,
+    AutoSizeStrategy,
     IColumnLimit,
     ISizeColumnsToFitParams,
     SizeColumnsToContentColumnLimits,
@@ -57,7 +58,7 @@ export class ColumnAutosizeService extends BeanStub implements NamedBean {
     public shouldQueueResizeOperations: boolean = false;
     private resizeOperationQueue: (() => void)[] = [];
 
-    private continuousStrategy: SizeColumnsToContentStrategy | null = null;
+    private continuousStrategy: AutoSizeStrategy | null = null;
     private continuousRunning = false;
     private continuousFrameScheduled = false;
     private pendingReasons: Set<AutoSizeReason> | null = null;
@@ -73,13 +74,13 @@ export class ColumnAutosizeService extends BeanStub implements NamedBean {
                 shouldHideColumns = true;
             } else if (type === 'fitCellContents') {
                 this.addManagedEventListeners({ firstDataRendered: () => this.onFirstDataRendered(autoSizeStrategy) });
-                if (autoSizeStrategy.continuous) {
-                    this.initContinuousAutoSize(autoSizeStrategy);
-                }
                 // Hide columns when we already have row data to display. This avoids jittering when we initially
                 // render columns at default width, only to immediately resize them when rows are rendered.
                 const rowData = gos.get('rowData');
                 shouldHideColumns = rowData != null && rowData.length > 0 && _isClientSideRowModel(gos);
+            }
+            if (autoSizeStrategy.continuous) {
+                this.initContinuousAutoSize(autoSizeStrategy);
             }
             if (shouldHideColumns) {
                 this.beans.colDelayRenderSvc?.hideColumns(type);
@@ -377,7 +378,10 @@ export class ColumnAutosizeService extends BeanStub implements NamedBean {
 
     // method will call itself if no available width. this covers if the grid
     // isn't visible, but is just about to be visible.
-    public sizeColumnsToFitGridBody(params?: ISizeColumnsToFitParams, nextTimeout?: number): void {
+    public sizeColumnsToFitGridBody(
+        params?: ISizeColumnsToFitParams & { colKeys?: ColKey[] },
+        nextTimeout?: number
+    ): void {
         if (!this.isAlive()) {
             return;
         }
@@ -600,7 +604,11 @@ export class ColumnAutosizeService extends BeanStub implements NamedBean {
                 return;
             }
             const type = autoSizeStrategy.type;
-            if (type === 'fitGridWidth') {
+            if (this.continuousStrategy) {
+                // ownership must hold from the first pass, else a `colDef.width` is distributed away before
+                // continuous mode starts protecting it
+                this.reapplyStrategy(autoSizeStrategy, this.getAutoSizeCandidates(autoSizeStrategy));
+            } else if (type === 'fitGridWidth') {
                 const { columnLimits: propColumnLimits, defaultMinWidth, defaultMaxWidth } = autoSizeStrategy;
                 const columnLimits = propColumnLimits?.map(({ colId: key, minWidth, maxWidth }) => ({
                     key,
@@ -612,7 +620,7 @@ export class ColumnAutosizeService extends BeanStub implements NamedBean {
                     defaultMaxWidth,
                     columnLimits,
                 });
-            } else if (type === 'fitProvidedWidth') {
+            } else {
                 this.sizeColumnsToFit(autoSizeStrategy.width, 'sizeColumnsToFit');
             }
             colDelayRenderSvc?.revealColumns(type);
@@ -642,12 +650,13 @@ export class ColumnAutosizeService extends BeanStub implements NamedBean {
     }
 
     /**
-     * Registers the triggers for continuous `fitCellContents` sizing. Only the events that genuinely change
-     * what a column should measure are used: `modelUpdated` is deliberately not one of them, as it also fires
-     * for sorting, filtering, grouping and row-height work.
+     * Registers the triggers for continuous sizing. Every strategy responds to data, column and grid-size
+     * changes; only `fitCellContents` also responds to the viewport, since scrolling changes what can be
+     * measured but not the arithmetic of the width-distribution strategies.
      */
-    private initContinuousAutoSize(strategy: SizeColumnsToContentStrategy): void {
-        if (!isContinuousSupported(this.gos)) {
+    private initContinuousAutoSize(strategy: AutoSizeStrategy): void {
+        const measuresContent = strategy.type === 'fitCellContents';
+        if (measuresContent && !isContinuousSupported(this.gos)) {
             this.warn(328, { rowModel: this.gos.get('rowModelType') });
             return;
         }
@@ -655,10 +664,24 @@ export class ColumnAutosizeService extends BeanStub implements NamedBean {
         this.continuousStrategy = strategy;
 
         this.addManagedEventListeners({
-            rowDataUpdated: () => this.scheduleContinuousAutoSize('dataChanged'),
+            // the one content-changed signal every row model dispatches: CSRM replacements and transactions,
+            // SSRM and infinite store loads, and pagination. Its `newData`/`newPage` flags are not usable as a
+            // filter because SSRM always reports both as false.
+            modelUpdated: () => this.scheduleContinuousAutoSize('dataChanged'),
+            // an edit need not refresh the model, so it is not covered above
             cellValueChanged: () => this.scheduleContinuousAutoSize('dataChanged'),
             displayedColumnsChanged: () => this.scheduleContinuousAutoSize('columnsChanged'),
             newColumnsLoaded: () => this.scheduleContinuousAutoSize('columnsChanged'),
+            gridSizeChanged: () => this.scheduleContinuousAutoSize('gridSizeChanged'),
+        });
+
+        if (!measuresContent) {
+            // the width-distribution strategies are arithmetic over the current column set, so what is
+            // scrolled into view cannot change their result
+            return;
+        }
+
+        this.addManagedEventListeners({
             // horizontal virtualisation renders new columns, which are then measurable for the first time
             virtualColumnsChanged: () => this.scheduleContinuousAutoSize('viewportChanged'),
             viewportChanged: () => this.scheduleContinuousAutoSize('viewportChanged'),
@@ -667,7 +690,6 @@ export class ColumnAutosizeService extends BeanStub implements NamedBean {
                     this.scheduleContinuousAutoSize('viewportChanged');
                 }
             },
-            gridSizeChanged: () => this.scheduleContinuousAutoSize('gridSizeChanged'),
         });
     }
 
@@ -727,20 +749,44 @@ export class ColumnAutosizeService extends BeanStub implements NamedBean {
         }
 
         this.continuousRunning = true;
-        const { skipHeader, defaultMinWidth, defaultMaxWidth, columnLimits, scaleUpToFitGridWidth } = strategy;
-
-        this.autoSizeColsAsync({
-            colKeys: candidates,
-            skipHeader,
-            defaultMinWidth,
-            defaultMaxWidth,
-            columnLimits,
-            scaleUpToFitGridWidth,
-            source: 'autosizeColumns',
-        }).then(
+        this.reapplyStrategy(strategy, candidates).then(
             () => this.onContinuousAutoSizeComplete(),
             () => this.onContinuousAutoSizeComplete()
         );
+    }
+
+    /** Re-runs the configured strategy over `candidates`, leaving every other column at its current width. */
+    private reapplyStrategy(strategy: AutoSizeStrategy, candidates: AgColumn[]): Promise<unknown> {
+        const type = strategy.type;
+        if (type === 'fitCellContents') {
+            const { skipHeader, defaultMinWidth, defaultMaxWidth, columnLimits, scaleUpToFitGridWidth } = strategy;
+            return this.autoSizeColsAsync({
+                colKeys: candidates,
+                skipHeader,
+                defaultMinWidth,
+                defaultMaxWidth,
+                columnLimits,
+                scaleUpToFitGridWidth,
+                source: 'autosizeColumns',
+            });
+        }
+
+        if (type === 'fitProvidedWidth') {
+            this.sizeColumnsToFit(strategy.width, 'sizeColumnsToFit', false, { colKeys: candidates });
+        } else {
+            const { defaultMinWidth, defaultMaxWidth, columnLimits } = strategy;
+            this.sizeColumnsToFitGridBody({
+                defaultMinWidth,
+                defaultMaxWidth,
+                colKeys: candidates,
+                columnLimits: columnLimits?.map(({ colId, minWidth, maxWidth }) => ({
+                    key: colId,
+                    minWidth,
+                    maxWidth,
+                })),
+            });
+        }
+        return Promise.resolve();
     }
 
     private onContinuousAutoSizeComplete(): void {
@@ -759,15 +805,21 @@ export class ColumnAutosizeService extends BeanStub implements NamedBean {
      * The columns continuous sizing is allowed to change. Excludes columns whose width is owned by the
      * developer or user, plus everything the measurement pipeline cannot or must not size.
      */
-    private getAutoSizeCandidates(strategy: SizeColumnsToContentStrategy): AgColumn[] {
+    private getAutoSizeCandidates(strategy: AutoSizeStrategy): AgColumn[] {
         const { colModel, visibleCols } = this.beans;
-        const { colIds } = strategy;
+        const measuresContent = strategy.type === 'fitCellContents';
+        const colIds = measuresContent ? strategy.colIds : undefined;
         const cols = colIds ? colIds.map((colId) => colModel.getCol(colId)) : visibleCols.allCols;
 
         const candidates: AgColumn[] = [];
         for (let i = 0, len = cols.length; i < len; ++i) {
             const col = cols[i];
-            if (!col || col.isUserSized() || col.colDef.suppressAutoSize || isSpecialCol(col)) {
+            if (!col || col.isUserSized() || isSpecialCol(col)) {
+                continue;
+            }
+            // the two suppress flags govern different operations: measurement vs grid-width distribution
+            const colDef = col.colDef;
+            if (measuresContent ? colDef.suppressAutoSize : colDef.suppressSizeToFit) {
                 continue;
             }
             const flex = col.getFlex();

--- a/packages/ag-grid-community/src/columnAutosize/columnAutosizeService.ts
+++ b/packages/ag-grid-community/src/columnAutosize/columnAutosizeService.ts
@@ -118,9 +118,13 @@ export class ColumnAutosizeService extends BeanStub implements NamedBean {
     }
 
     public autoSizeCols(paramsInput: AutoSizeColumnParams): void {
-        this.autoSizeColsAsync(this.withUiActionStrategyParams(paramsInput)).then((columnsAutoSized) =>
-            dispatchColumnResizedEvent(this.beans.eventSvc, Array.from(columnsAutoSized), true, 'autosizeColumns')
+        this.autoSizeColsAsync(this.withUiActionStrategyParams(paramsInput)).then((cols) =>
+            this.dispatchAutoSized(cols)
         );
+    }
+
+    private dispatchAutoSized(columnsAutoSized: Set<AgColumn>): void {
+        dispatchColumnResizedEvent(this.beans.eventSvc, Array.from(columnsAutoSized), true, 'autosizeColumns');
     }
 
     /**
@@ -605,9 +609,7 @@ export class ColumnAutosizeService extends BeanStub implements NamedBean {
             }
             const type = autoSizeStrategy.type;
             if (this.continuousStrategy) {
-                // ownership must hold from the first pass, else a `colDef.width` is distributed away before
-                // continuous mode starts protecting it
-                this.reapplyStrategy(autoSizeStrategy, this.getAutoSizeCandidates(autoSizeStrategy));
+                this.runContinuousNow('dataChanged');
             } else if (type === 'fitGridWidth') {
                 const { columnLimits: propColumnLimits, defaultMinWidth, defaultMaxWidth } = autoSizeStrategy;
                 const columnLimits = propColumnLimits?.map(({ colId: key, minWidth, maxWidth }) => ({
@@ -637,9 +639,7 @@ export class ColumnAutosizeService extends BeanStub implements NamedBean {
             const source = 'autosizeColumns';
 
             if (this.continuousStrategy) {
-                // ownership must hold from the first pass, else `colDef.width` is measured away before
-                // continuous mode starts protecting it
-                this.autoSizeCols({ ...params, source, colKeys: this.getAutoSizeCandidates(strategy) });
+                this.runContinuousNow('dataChanged');
             } else if (colKeys) {
                 this.autoSizeCols({ ...params, source, colKeys });
             } else {
@@ -713,26 +713,33 @@ export class ColumnAutosizeService extends BeanStub implements NamedBean {
     }
 
     private runContinuousAutoSize(): void {
+        if (!this.pendingReasons?.size) {
+            return;
+        }
+        const pendingReasons = this.pendingReasons;
+        this.pendingReasons = null;
+        this.runContinuousNow(CONTINUOUS_REASON_PRIORITY.find((candidate) => pendingReasons.has(candidate))!);
+    }
+
+    /**
+     * The one guarded path to a continuous re-size: the initial strategy pass uses it too, so the callback
+     * gets to veto that pass and it cannot overlap a trigger that has already started one.
+     */
+    private runContinuousNow(reason: AutoSizeReason): void {
         const strategy = this.continuousStrategy;
-        if (!strategy || this.continuousRunning || !this.pendingReasons?.size) {
+        if (!strategy || this.continuousRunning) {
             return;
         }
 
         // an unlaid-out grid measures nothing, so drop the trigger rather than churning until it has a size
         if (getAvailableWidth(this.beans) <= 0) {
-            this.pendingReasons = null;
             return;
         }
-
-        const pendingReasons = this.pendingReasons;
-        this.pendingReasons = null;
 
         const candidates = this.getAutoSizeCandidates(strategy);
         if (!candidates.length) {
             return;
         }
-
-        const reason = CONTINUOUS_REASON_PRIORITY.find((candidate) => pendingReasons.has(candidate))!;
         const callback = strategy.shouldAutoSizeColumns;
         if (callback) {
             let shouldAutoSize: boolean;
@@ -768,7 +775,7 @@ export class ColumnAutosizeService extends BeanStub implements NamedBean {
                 columnLimits,
                 scaleUpToFitGridWidth,
                 source: 'autosizeColumns',
-            });
+            }).then((cols) => this.dispatchAutoSized(cols));
         }
 
         if (type === 'fitProvidedWidth') {

--- a/packages/ag-grid-community/src/columnAutosize/columnAutosizeService.ts
+++ b/packages/ag-grid-community/src/columnAutosize/columnAutosizeService.ts
@@ -8,7 +8,7 @@ import type { BeanCollection } from '../context/context';
 import type { AgColumn } from '../entities/agColumn';
 import type { AgColumnGroup } from '../entities/agColumnGroup';
 import type { ColKey } from '../entities/colDef';
-import type { BodyScrollEvent, ColumnEventType } from '../events';
+import type { BodyScrollEvent, ColumnEventType, ModelUpdatedEvent } from '../events';
 import type { GridOptionsService } from '../gridOptionsService';
 import { _addGridCommonParams, _isClientSideRowModel } from '../gridOptionsUtils';
 import type { HeaderGroupCellCtrl } from '../headerRendering/cells/columnGroup/headerGroupCellCtrl';
@@ -665,14 +665,24 @@ export class ColumnAutosizeService extends BeanStub implements NamedBean {
 
         this.addManagedEventListeners({
             // the one content-changed signal every row model dispatches: CSRM replacements and transactions,
-            // SSRM and infinite store loads, and pagination. Its `newData`/`newPage` flags are not usable as a
-            // filter because SSRM always reports both as false.
-            modelUpdated: () => this.scheduleContinuousAutoSize('dataChanged'),
-            // an edit need not refresh the model, so it is not covered above
+            // SSRM and infinite store loads, and pagination. It also covers sorting, filtering and expansion,
+            // which change what a cell renders — so the content strategy wants all of them, while the
+            // width-distribution strategies only care about genuinely new rows.
+            modelUpdated: (event: ModelUpdatedEvent) => {
+                if (measuresContent || event.newData || event.newPage || event.newPageSize) {
+                    this.scheduleContinuousAutoSize('dataChanged');
+                }
+            },
+            // neither an edit nor `rowNode.setData` need refresh the model, so they are not covered above
             cellValueChanged: () => this.scheduleContinuousAutoSize('dataChanged'),
             displayedColumnsChanged: () => this.scheduleContinuousAutoSize('columnsChanged'),
             newColumnsLoaded: () => this.scheduleContinuousAutoSize('columnsChanged'),
             gridSizeChanged: () => this.scheduleContinuousAutoSize('gridSizeChanged'),
+        });
+
+        // `rowNode.setData`/`updateData` and pinned-row replacements report per row, not through the model
+        this.addManagedEventListeners({
+            rowNodeDataChanged: () => this.scheduleContinuousAutoSize('dataChanged'),
         });
 
         if (!measuresContent) {
@@ -731,8 +741,9 @@ export class ColumnAutosizeService extends BeanStub implements NamedBean {
             return;
         }
 
-        // an unlaid-out grid measures nothing, so drop the trigger rather than churning until it has a size
-        if (getAvailableWidth(this.beans) <= 0) {
+        // an unlaid-out grid measures nothing and has no width to distribute, so drop the trigger rather
+        // than churning until it has a size. `fitProvidedWidth` depends on neither, so it still runs.
+        if (strategy.type !== 'fitProvidedWidth' && getAvailableWidth(this.beans) <= 0) {
             return;
         }
 

--- a/packages/ag-grid-community/src/columnAutosize/columnAutosizeService.ts
+++ b/packages/ag-grid-community/src/columnAutosize/columnAutosizeService.ts
@@ -41,6 +41,9 @@ const UI_MENU_SOURCES: ReadonlySet<ColumnEventType> = new Set(['columnMenu', 'co
 
 type AutoSizeReason = AutoSizeColumnsTriggerParams['reason'];
 
+/** Escalating waits for a continuous re-size that arrived before the grid had a width. */
+const CONTINUOUS_RETRY_DELAYS: readonly number[] = [0, 100, 500];
+
 /** Most to least significant; the reason reported when several triggers coalesce into one frame. */
 const CONTINUOUS_REASON_PRIORITY: readonly AutoSizeReason[] = [
     'dataChanged',
@@ -62,6 +65,8 @@ export class ColumnAutosizeService extends BeanStub implements NamedBean {
     private continuousRunning = false;
     private continuousFrameScheduled = false;
     private pendingReasons: Set<AutoSizeReason> | null = null;
+    private continuousRetries = 0;
+    private continuousRetryScheduled = false;
 
     public postConstruct(): void {
         const { gos } = this;
@@ -678,6 +683,10 @@ export class ColumnAutosizeService extends BeanStub implements NamedBean {
             displayedColumnsChanged: () => this.scheduleContinuousAutoSize('columnsChanged'),
             newColumnsLoaded: () => this.scheduleContinuousAutoSize('columnsChanged'),
             gridSizeChanged: () => this.scheduleContinuousAutoSize('gridSizeChanged'),
+            // a scrollbar appearing or disappearing changes the width there is to work with. A row count
+            // change is the usual cause, and a transaction reports neither `newData` nor `newPage`, so for
+            // the width-distribution strategies this is the only signal that one happened
+            scrollVisibilityChanged: () => this.scheduleContinuousAutoSize('gridSizeChanged'),
         });
 
         // `rowNode.setData`/`updateData` and pinned-row replacements report per row, not through the model
@@ -741,11 +750,14 @@ export class ColumnAutosizeService extends BeanStub implements NamedBean {
             return;
         }
 
-        // an unlaid-out grid measures nothing and has no width to distribute, so drop the trigger rather
-        // than churning until it has a size. `fitProvidedWidth` depends on neither, so it still runs.
+        // an unlaid-out grid measures nothing and has no width to distribute. `fitProvidedWidth` depends on
+        // neither, so it still runs; the others retry on the same escalating schedule as the one-shot
+        // `fitGridWidth` pass, so a grid that is hidden when the trigger arrives is still sized once shown.
         if (strategy.type !== 'fitProvidedWidth' && getAvailableWidth(this.beans) <= 0) {
+            this.retryContinuousWhenSized(reason);
             return;
         }
+        this.continuousRetries = 0;
 
         const candidates = this.getAutoSizeCandidates(strategy);
         if (!candidates.length) {
@@ -805,6 +817,23 @@ export class ColumnAutosizeService extends BeanStub implements NamedBean {
             });
         }
         return Promise.resolve();
+    }
+
+    /** Re-tries a re-size that found no width, on an escalating schedule, then gives up. */
+    private retryContinuousWhenSized(reason: AutoSizeReason): void {
+        const delay = CONTINUOUS_RETRY_DELAYS[this.continuousRetries];
+        // one chain at a time: a trigger arriving mid-wait is covered by the retry already pending
+        if (delay === undefined || this.continuousRetryScheduled) {
+            return;
+        }
+        this.continuousRetries++;
+        this.continuousRetryScheduled = true;
+        window.setTimeout(() => {
+            this.continuousRetryScheduled = false;
+            if (this.isAlive()) {
+                this.runContinuousNow(reason);
+            }
+        }, delay);
     }
 
     private onContinuousAutoSizeComplete(): void {

--- a/packages/ag-grid-community/src/columns/columnStateUtils.ts
+++ b/packages/ag-grid-community/src/columns/columnStateUtils.ts
@@ -499,9 +499,9 @@ export function _resetColumnState(beans: BeanCollection, source: ColumnEventType
         for (let i = 0, len = primaryCols.length; i < len; ++i) {
             const col = primaryCols[i];
             col.pivotSort = _resolvePivotSortFromColDef(col.colDef);
-            // the state above carries `width ?? initialWidth`, so `applyFieldState` cannot tell them
-            // apart and would wrongly mark an `initialWidth` column as owned
-            col.initWidthOwnership();
+            // the state above carries the colDef width, which `applyFieldState` would otherwise read as a
+            // deliberate resize
+            col.resetWidthOwnership();
         }
 
         // Order from the now-current service cols: auto cols may have been recreated above (their colIds change

--- a/packages/ag-grid-community/src/columns/columnStateUtils.ts
+++ b/packages/ag-grid-community/src/columns/columnStateUtils.ts
@@ -395,6 +395,9 @@ function applyFieldState(
             // Apply width only if valid (>= min), else keep the old width.
             const minColWidth = column.colDef.minWidth ?? beans.environment.getDefaultColumnMinWidth();
             if (minColWidth != null && width >= minColWidth) {
+                // an explicit valid width is intent, so it takes ownership; an omitted or `null`
+                // width leaves ownership as it was
+                column.setUserSized(true);
                 column.setActualWidth(width, source);
             }
         }
@@ -496,6 +499,9 @@ export function _resetColumnState(beans: BeanCollection, source: ColumnEventType
         for (let i = 0, len = primaryCols.length; i < len; ++i) {
             const col = primaryCols[i];
             col.pivotSort = _resolvePivotSortFromColDef(col.colDef);
+            // the state above carries `width ?? initialWidth`, so `applyFieldState` cannot tell them
+            // apart and would wrongly mark an `initialWidth` column as owned
+            col.initWidthOwnership();
         }
 
         // Order from the now-current service cols: auto cols may have been recreated above (their colIds change

--- a/packages/ag-grid-community/src/entities/agColumn.ts
+++ b/packages/ag-grid-community/src/entities/agColumn.ts
@@ -130,6 +130,8 @@ export class AgColumn<TValue = any>
     public actualWidth: number = 0;
     public minWidth: number = 0;
     private maxWidth: number = 0;
+    /** Width explicitly owned by the developer or user, so continuous auto-sizing must not change it. */
+    private userSized: boolean = false;
     public flex: number | null = null;
     public pinned: ColumnPinnedType = null;
     public left: number | null = null;
@@ -309,7 +311,12 @@ export class AgColumn<TValue = any>
             // Read `flex` after the state update so a flex→fixed switch applies before width.
             const colFlex = this.flex;
             if (colFlex == null || colFlex <= 0) {
-                this.setActualWidth(merged.width ?? this.actualWidth, source);
+                const mergedWidth = merged.width;
+                // an explicit `width` re-establishes ownership; its absence leaves ownership alone
+                if (mergedWidth != null) {
+                    this.userSized = true;
+                }
+                this.setActualWidth(mergedWidth ?? this.actualWidth, source);
             }
         }
     }
@@ -333,6 +340,7 @@ export class AgColumn<TValue = any>
         this.initState();
         this.initMinAndMaxWidths();
         this.resetActualWidth('gridInitializing');
+        this.initWidthOwnership();
         this.initDotNotation();
         this.initTooltip();
     }
@@ -358,6 +366,11 @@ export class AgColumn<TValue = any>
 
     private initTooltip(): void {
         this.beans.tooltipSvc?.initCol(this);
+    }
+
+    /** Kept apart from `resetActualWidth`, which `sizeColumnsToFit` also uses and must not change ownership. */
+    public initWidthOwnership(): void {
+        this.userSized = this.colDef.width != null;
     }
 
     public resetActualWidth(source: ColumnEventType): void {
@@ -745,6 +758,14 @@ export class AgColumn<TValue = any>
         return this.actualWidth;
     }
 
+    public isUserSized(): boolean {
+        return this.userSized;
+    }
+
+    public setUserSized(userSized: boolean): void {
+        this.userSized = userSized;
+    }
+
     public getAutoHeaderHeight(): number | null {
         return this.autoHeaderHeight;
     }
@@ -781,6 +802,11 @@ export class AgColumn<TValue = any>
     public setActualWidth(actualWidth: number, source: ColumnEventType, silent: boolean = false): void {
         actualWidth = Math.max(actualWidth, this.minWidth);
         actualWidth = Math.min(actualWidth, this.maxWidth);
+        // every user-driven resize arrives with this source and takes ownership. Not widened to all
+        // sources: flex, `sizeColumnsToFit` and the auto-size API must leave ownership alone.
+        if (source === 'uiColumnResized') {
+            this.userSized = true;
+        }
         if (this.actualWidth !== actualWidth) {
             // disable flex for this column if it was manually resized.
             this.actualWidth = actualWidth;

--- a/packages/ag-grid-community/src/entities/agColumn.ts
+++ b/packages/ag-grid-community/src/entities/agColumn.ts
@@ -130,7 +130,7 @@ export class AgColumn<TValue = any>
     public actualWidth: number = 0;
     public minWidth: number = 0;
     private maxWidth: number = 0;
-    /** Width explicitly owned by the developer or user, so continuous auto-sizing must not change it. */
+    /** Width set by a deliberate user resize, so continuous auto-sizing must not change it. */
     private userSized: boolean = false;
     public flex: number | null = null;
     public pinned: ColumnPinnedType = null;
@@ -311,12 +311,7 @@ export class AgColumn<TValue = any>
             // Read `flex` after the state update so a flex→fixed switch applies before width.
             const colFlex = this.flex;
             if (colFlex == null || colFlex <= 0) {
-                const mergedWidth = merged.width;
-                // an explicit `width` re-establishes ownership; its absence leaves ownership alone
-                if (mergedWidth != null) {
-                    this.userSized = true;
-                }
-                this.setActualWidth(mergedWidth ?? this.actualWidth, source);
+                this.setActualWidth(merged.width ?? this.actualWidth, source);
             }
         }
     }
@@ -340,7 +335,6 @@ export class AgColumn<TValue = any>
         this.initState();
         this.initMinAndMaxWidths();
         this.resetActualWidth('gridInitializing');
-        this.initWidthOwnership();
         this.initDotNotation();
         this.initTooltip();
     }
@@ -369,8 +363,8 @@ export class AgColumn<TValue = any>
     }
 
     /** Kept apart from `resetActualWidth`, which `sizeColumnsToFit` also uses and must not change ownership. */
-    public initWidthOwnership(): void {
-        this.userSized = this.colDef.width != null;
+    public resetWidthOwnership(): void {
+        this.userSized = false;
     }
 
     public resetActualWidth(source: ColumnEventType): void {

--- a/packages/ag-grid-community/src/entities/colDef.ts
+++ b/packages/ag-grid-community/src/entities/colDef.ts
@@ -1059,16 +1059,10 @@ export interface ColDef<TData = any, TValue = any> extends AbstractColDef<TData,
     /**
      * Initial width in pixels for the cell.
      * If no width or flex properties set, cell width will default to 200 pixels.
-     *
-     * This width is owned by the application, so continuous `fitCellContents` auto-sizing leaves it alone.
-     * Use `initialWidth` to seed a width that stays eligible for auto-sizing.
      */
     width?: number;
     /**
      * Same as `width`, except only applied when creating a new column. Not applied when updating column definitions.
-     *
-     * Unlike `width`, this only seeds the width, so the column stays eligible for continuous
-     * `fitCellContents` auto-sizing.
      * @initial
      */
     initialWidth?: number;

--- a/packages/ag-grid-community/src/entities/colDef.ts
+++ b/packages/ag-grid-community/src/entities/colDef.ts
@@ -1059,10 +1059,16 @@ export interface ColDef<TData = any, TValue = any> extends AbstractColDef<TData,
     /**
      * Initial width in pixels for the cell.
      * If no width or flex properties set, cell width will default to 200 pixels.
+     *
+     * This width is owned by the application, so continuous `fitCellContents` auto-sizing leaves it alone.
+     * Use `initialWidth` to seed a width that stays eligible for auto-sizing.
      */
     width?: number;
     /**
      * Same as `width`, except only applied when creating a new column. Not applied when updating column definitions.
+     *
+     * Unlike `width`, this only seeds the width, so the column stays eligible for continuous
+     * `fitCellContents` auto-sizing.
      * @initial
      */
     initialWidth?: number;

--- a/packages/ag-grid-community/src/entities/gridOptions.ts
+++ b/packages/ag-grid-community/src/entities/gridOptions.ts
@@ -550,7 +550,7 @@ export interface GridOptions<TData = any> {
      * @initial
      * @agModule `ColumnAutoSizeModule`
      */
-    autoSizeStrategy?: AutoSizeStrategy;
+    autoSizeStrategy?: AutoSizeStrategy<TData>;
     /**
      * Set to `true` to animate changes to column width when auto-sizing the columns.
      * @default false

--- a/packages/ag-grid-community/src/interfaces/autoSize.ts
+++ b/packages/ag-grid-community/src/interfaces/autoSize.ts
@@ -1,4 +1,5 @@
 import type { Column } from './iColumn';
+import type { AgGridCommon } from './iCommon';
 
 interface WidthLimits {
     /** Defines a minimum width for this column (does not override the column minimum width) */
@@ -46,6 +47,17 @@ export interface SizeColumnsToContentColumnLimits extends WidthLimits {
     colId: string;
 }
 
+/** Params for the `shouldAutoSizeColumns` callback of the continuous `fitCellContents` strategy. */
+export interface AutoSizeColumnsTriggerParams<TData = any, TContext = any> extends AgGridCommon<TData, TContext> {
+    /** What changed in the grid to make it want to re-size columns. */
+    reason: 'dataChanged' | 'columnsChanged' | 'viewportChanged' | 'gridSizeChanged';
+    /**
+     * All eligible columns — those not owned by the developer or user, and not otherwise excluded.
+     * The grid may only be able to measure the subset of these that is currently rendered.
+     */
+    columns: Column[];
+}
+
 /**
  * Auto-size columns to fit their cell contents.
  *
@@ -53,6 +65,25 @@ export interface SizeColumnsToContentColumnLimits extends WidthLimits {
  */
 export interface SizeColumnsToContentStrategy extends ISizeAllColumnsToContentParams {
     type: 'fitCellContents';
+    /**
+     * If `true`, columns are re-sized to fit their cell contents whenever the data, the displayed columns,
+     * the viewport or the grid size changes — not only after the first data render.
+     *
+     * Columns whose width is owned by the developer or the user are left alone: an explicit `colDef.width`,
+     * a header drag resize, a double-click auto-size, or `applyColumnState` with an explicit `width`.
+     * Use `colDef.initialWidth` instead of `colDef.width` to seed a width that stays eligible for re-sizing.
+     *
+     * Only currently rendered cells can be measured, so scrolling may progressively size columns as more
+     * content is rendered. Flex columns are excluded.
+     * @default false
+     */
+    continuous?: boolean;
+    /**
+     * Called before each continuous auto-size, with the columns eligible to be re-sized and the reason the
+     * grid wants to re-size them. Return `false` to skip this one; the columns are neither measured nor
+     * resized. Has no effect unless `continuous` is `true`.
+     */
+    shouldAutoSizeColumns?: (params: AutoSizeColumnsTriggerParams) => boolean;
     /**
      * If `true`, the Column Menu and Context Menu auto-size actions reuse this strategy's options.
      * @default false

--- a/packages/ag-grid-community/src/interfaces/autoSize.ts
+++ b/packages/ag-grid-community/src/interfaces/autoSize.ts
@@ -31,14 +31,14 @@ export interface SizeColumnsToFitGridColumnLimits extends WidthLimits {
 }
 
 /** Auto-size columns to fit the grid width. */
-export interface SizeColumnsToFitGridStrategy extends DefaultWidthLimits {
+export interface SizeColumnsToFitGridStrategy extends DefaultWidthLimits, ContinuousAutoSizeOptions {
     type: 'fitGridWidth';
     /** Provide to limit specific column widths when sizing. */
     columnLimits?: SizeColumnsToFitGridColumnLimits[];
 }
 
 /** Auto-size columns to fit a provided width. */
-export interface SizeColumnsToFitProvidedWidthStrategy {
+export interface SizeColumnsToFitProvidedWidthStrategy extends ContinuousAutoSizeOptions {
     type: 'fitProvidedWidth';
     width: number;
 }
@@ -47,15 +47,36 @@ export interface SizeColumnsToContentColumnLimits extends WidthLimits {
     colId: string;
 }
 
-/** Params for the `shouldAutoSizeColumns` callback of the continuous `fitCellContents` strategy. */
+/** Params for the `shouldAutoSizeColumns` callback of a continuous auto-size strategy. */
 export interface AutoSizeColumnsTriggerParams<TData = any, TContext = any> extends AgGridCommon<TData, TContext> {
     /** What changed in the grid to make it want to re-size columns. */
     reason: 'dataChanged' | 'columnsChanged' | 'viewportChanged' | 'gridSizeChanged';
     /**
      * All eligible columns — those not owned by the developer or user, and not otherwise excluded.
-     * The grid may only be able to measure the subset of these that is currently rendered.
+     * For `fitCellContents`, the grid may only be able to measure the subset that is currently rendered.
      */
     columns: Column[];
+}
+
+/** Opt-in re-running of an auto-size strategy, shared by every strategy type. */
+export interface ContinuousAutoSizeOptions {
+    /**
+     * If `true`, the strategy is re-applied whenever the grid changes in a way that affects column widths,
+     * not only on first render. Which changes count depends on the strategy: every type responds to data and
+     * displayed-column changes and to grid resizes, and `fitCellContents` additionally responds to viewport
+     * changes, because scrolling is what makes new cell content measurable.
+     *
+     * Columns whose width is owned by the developer or the user are left alone and treated as fixed width:
+     * an explicit `colDef.width`, a header drag resize, a double-click auto-size, or `applyColumnState` with
+     * an explicit `width`. Use `colDef.initialWidth` to seed a width that stays eligible for re-sizing.
+     * @default false
+     */
+    continuous?: boolean;
+    /**
+     * Called before each continuous re-size, with the columns eligible to be re-sized and the reason the
+     * grid wants to re-size them. Return `false` to skip this one. Requires `continuous`.
+     */
+    shouldAutoSizeColumns?: (params: AutoSizeColumnsTriggerParams) => boolean;
 }
 
 /**
@@ -63,27 +84,8 @@ export interface AutoSizeColumnsTriggerParams<TData = any, TContext = any> exten
  *
  * Not supported by the Viewport Row Model
  */
-export interface SizeColumnsToContentStrategy extends ISizeAllColumnsToContentParams {
+export interface SizeColumnsToContentStrategy extends ISizeAllColumnsToContentParams, ContinuousAutoSizeOptions {
     type: 'fitCellContents';
-    /**
-     * If `true`, columns are re-sized to fit their cell contents whenever the data, the displayed columns,
-     * the viewport or the grid size changes — not only after the first data render.
-     *
-     * Columns whose width is owned by the developer or the user are left alone: an explicit `colDef.width`,
-     * a header drag resize, a double-click auto-size, or `applyColumnState` with an explicit `width`.
-     * Use `colDef.initialWidth` instead of `colDef.width` to seed a width that stays eligible for re-sizing.
-     *
-     * Only currently rendered cells can be measured, so scrolling may progressively size columns as more
-     * content is rendered. Flex columns are excluded.
-     * @default false
-     */
-    continuous?: boolean;
-    /**
-     * Called before each continuous auto-size, with the columns eligible to be re-sized and the reason the
-     * grid wants to re-size them. Return `false` to skip this one; the columns are neither measured nor
-     * resized. Has no effect unless `continuous` is `true`.
-     */
-    shouldAutoSizeColumns?: (params: AutoSizeColumnsTriggerParams) => boolean;
     /**
      * If `true`, the Column Menu and Context Menu auto-size actions reuse this strategy's options.
      * @default false

--- a/packages/ag-grid-community/src/interfaces/autoSize.ts
+++ b/packages/ag-grid-community/src/interfaces/autoSize.ts
@@ -66,9 +66,10 @@ export interface AutoSizeColumnsTriggerParams<TData = any, TContext = any> exten
 export interface ContinuousAutoSizeOptions<TData = any, TContext = any> {
     /**
      * If `true`, the strategy is re-applied whenever the grid changes in a way that affects column widths,
-     * not only on first render. Which changes count depends on the strategy: every type responds to data and
-     * displayed-column changes and to grid resizes, and `fitCellContents` additionally responds to viewport
-     * changes, because scrolling is what makes new cell content measurable.
+     * not only on first render. Every type responds to displayed-column changes and to grid resizes. Beyond
+     * that, `fitCellContents` responds to any row data change and to viewport changes, because both change
+     * what there is to measure, while the width-distribution strategies respond to new data, a page change
+     * and a scrollbar appearing or disappearing — the changes to the width there is to share out.
      *
      * A column the user has resized themselves is left alone and treated as fixed width — a header drag, a
      * keyboard resize or a double-click auto-size — as is one given an explicit width through

--- a/packages/ag-grid-community/src/interfaces/autoSize.ts
+++ b/packages/ag-grid-community/src/interfaces/autoSize.ts
@@ -31,14 +31,18 @@ export interface SizeColumnsToFitGridColumnLimits extends WidthLimits {
 }
 
 /** Auto-size columns to fit the grid width. */
-export interface SizeColumnsToFitGridStrategy extends DefaultWidthLimits, ContinuousAutoSizeOptions {
+export interface SizeColumnsToFitGridStrategy<TData = any, TContext = any>
+    extends DefaultWidthLimits, ContinuousAutoSizeOptions<TData, TContext> {
     type: 'fitGridWidth';
     /** Provide to limit specific column widths when sizing. */
     columnLimits?: SizeColumnsToFitGridColumnLimits[];
 }
 
 /** Auto-size columns to fit a provided width. */
-export interface SizeColumnsToFitProvidedWidthStrategy extends ContinuousAutoSizeOptions {
+export interface SizeColumnsToFitProvidedWidthStrategy<TData = any, TContext = any> extends ContinuousAutoSizeOptions<
+    TData,
+    TContext
+> {
     type: 'fitProvidedWidth';
     width: number;
 }
@@ -59,7 +63,7 @@ export interface AutoSizeColumnsTriggerParams<TData = any, TContext = any> exten
 }
 
 /** Opt-in re-running of an auto-size strategy, shared by every strategy type. */
-export interface ContinuousAutoSizeOptions {
+export interface ContinuousAutoSizeOptions<TData = any, TContext = any> {
     /**
      * If `true`, the strategy is re-applied whenever the grid changes in a way that affects column widths,
      * not only on first render. Which changes count depends on the strategy: every type responds to data and
@@ -77,7 +81,7 @@ export interface ContinuousAutoSizeOptions {
      * Called before each continuous re-size, with the columns eligible to be re-sized and the reason the
      * grid wants to re-size them. Return `false` to skip this one. Requires `continuous`.
      */
-    shouldAutoSizeColumns?: (params: AutoSizeColumnsTriggerParams) => boolean;
+    shouldAutoSizeColumns?: (params: AutoSizeColumnsTriggerParams<TData, TContext>) => boolean;
 }
 
 /**
@@ -85,7 +89,8 @@ export interface ContinuousAutoSizeOptions {
  *
  * Not supported by the Viewport Row Model
  */
-export interface SizeColumnsToContentStrategy extends ISizeAllColumnsToContentParams, ContinuousAutoSizeOptions {
+export interface SizeColumnsToContentStrategy<TData = any, TContext = any>
+    extends ISizeAllColumnsToContentParams, ContinuousAutoSizeOptions<TData, TContext> {
     type: 'fitCellContents';
     /**
      * If `true`, the Column Menu and Context Menu auto-size actions reuse this strategy's options.
@@ -110,7 +115,7 @@ export interface ISizeColumnsToContentParams extends ISizeAllColumnsToContentPar
     colIds?: string[];
 }
 
-export type AutoSizeStrategy =
-    | SizeColumnsToFitGridStrategy
-    | SizeColumnsToFitProvidedWidthStrategy
-    | SizeColumnsToContentStrategy;
+export type AutoSizeStrategy<TData = any, TContext = any> =
+    | SizeColumnsToFitGridStrategy<TData, TContext>
+    | SizeColumnsToFitProvidedWidthStrategy<TData, TContext>
+    | SizeColumnsToContentStrategy<TData, TContext>;

--- a/packages/ag-grid-community/src/interfaces/autoSize.ts
+++ b/packages/ag-grid-community/src/interfaces/autoSize.ts
@@ -52,7 +52,7 @@ export interface AutoSizeColumnsTriggerParams<TData = any, TContext = any> exten
     /** What changed in the grid to make it want to re-size columns. */
     reason: 'dataChanged' | 'columnsChanged' | 'viewportChanged' | 'gridSizeChanged';
     /**
-     * All eligible columns — those not owned by the developer or user, and not otherwise excluded.
+     * All eligible columns — those the user has not resized, and not otherwise excluded.
      * For `fitCellContents`, the grid may only be able to measure the subset that is currently rendered.
      */
     columns: Column[];
@@ -66,9 +66,10 @@ export interface ContinuousAutoSizeOptions {
      * displayed-column changes and to grid resizes, and `fitCellContents` additionally responds to viewport
      * changes, because scrolling is what makes new cell content measurable.
      *
-     * Columns whose width is owned by the developer or the user are left alone and treated as fixed width:
-     * an explicit `colDef.width`, a header drag resize, a double-click auto-size, or `applyColumnState` with
-     * an explicit `width`. Use `colDef.initialWidth` to seed a width that stays eligible for re-sizing.
+     * A column the user has resized themselves is left alone and treated as fixed width — a header drag, a
+     * keyboard resize or a double-click auto-size — as is one given an explicit width through
+     * `applyColumnState`. `colDef.width` is only a starting width and stays eligible; to hold a column at a
+     * fixed width, set `suppressAutoSize` or `suppressSizeToFit` on it.
      * @default false
      */
     continuous?: boolean;

--- a/packages/ag-grid-community/src/main.ts
+++ b/packages/ag-grid-community/src/main.ts
@@ -11,6 +11,7 @@ export { isColumnGroup } from './entities/agColumnGroup';
 export { isProvidedColumnGroup } from './entities/agProvidedColumnGroup';
 
 export type {
+    AutoSizeColumnsTriggerParams,
     AutoSizeStrategy,
     IColumnLimit,
     ISizeAllColumnsToContentParams,

--- a/packages/ag-grid-community/src/main.ts
+++ b/packages/ag-grid-community/src/main.ts
@@ -13,6 +13,7 @@ export { isProvidedColumnGroup } from './entities/agProvidedColumnGroup';
 export type {
     AutoSizeColumnsTriggerParams,
     AutoSizeStrategy,
+    ContinuousAutoSizeOptions,
     IColumnLimit,
     ISizeAllColumnsToContentParams,
     ISizeColumnsToContentParams,

--- a/packages/ag-grid-community/src/validation/errorMessages/errorText.ts
+++ b/packages/ag-grid-community/src/validation/errorMessages/errorText.ts
@@ -950,6 +950,9 @@ export const AG_GRID_ERRORS = {
         `ignoring \`defaultOption\` \`${defaultOption}\` as it is not one of the filter's \`filterOptions\`` as const,
     327: ({ pattern }: { pattern: string }) =>
         `ignoring \`filterParams.allowedCharPattern\` \`${pattern}\` as it does not compile to a character pattern` as const,
+    328: ({ rowModel }: { rowModel: string }) =>
+        `continuous \`fitCellContents\` auto-sizing is not supported by the '${rowModel}' row model, so it has been ignored` as const,
+    329: ({ error }: { error: unknown }) => ['`shouldAutoSizeColumns` threw, so the auto-size was skipped:', error],
     // When adding a code above this line, raise `MAX_ERROR_ID` below to match.
 };
 
@@ -965,7 +968,7 @@ export type ErrorId = keyof ErrorMap;
  *
  * @knipIgnore Read by the docs site's error-page route
  */
-export const MAX_ERROR_ID = 327;
+export const MAX_ERROR_ID = 329;
 
 type ErrorValue<TId extends ErrorId | null> = TId extends ErrorId ? ErrorMap[TId] : never;
 export type GetErrorParams<TId extends ErrorId> =

--- a/packages/ag-grid-community/src/validation/rules/gridOptionsValidations.ts
+++ b/packages/ag-grid-community/src/validation/rules/gridOptionsValidations.ts
@@ -103,6 +103,9 @@ const GRID_OPTION_DEPRECATIONS = (): Deprecations<GridOptions> => ({
     suppressContentVisibilityAuto: { version: '36.1', message: 'Use `enableContentVisibilityAuto` instead.' },
 });
 
+/** Options that only the `fitCellContents` auto-size strategy supports. */
+const CONTENT_ONLY_STRATEGY_OPTIONS = ['continuous', 'shouldAutoSizeColumns'] as const;
+
 function toConstrainedNum(key: keyof GridOptions, value: any, min: number): string | ValidationWarning | null {
     if (typeof value === 'number' || value == null) {
         if (value == null) {
@@ -802,6 +805,18 @@ const GRID_OPTION_VALIDATIONS: () => Validations<GridOptions> = () => {
                 }
                 if (type === 'fitProvidedWidth' && typeof autoSizeStrategy.width != 'number') {
                     return `When using the 'fitProvidedWidth' auto-size strategy, must provide a numeric \`width\`. You provided ${autoSizeStrategy.width}`;
+                }
+                if (type === 'fitCellContents') {
+                    if (autoSizeStrategy.shouldAutoSizeColumns !== undefined && !autoSizeStrategy.continuous) {
+                        return `The \`shouldAutoSizeColumns\` auto-size option only applies when \`continuous\` is true.`;
+                    }
+                } else {
+                    const unsupported = CONTENT_ONLY_STRATEGY_OPTIONS.filter((key) => key in autoSizeStrategy);
+                    if (unsupported.length) {
+                        const names = unsupported.map((key) => `\`${key}\``).join(' and ');
+                        const verb = unsupported.length > 1 ? 'options are' : 'option is';
+                        return `The ${names} auto-size ${verb} only supported by the 'fitCellContents' strategy, but the '${type}' strategy was configured.`;
+                    }
                 }
                 return null;
             },

--- a/packages/ag-grid-community/src/validation/rules/gridOptionsValidations.ts
+++ b/packages/ag-grid-community/src/validation/rules/gridOptionsValidations.ts
@@ -103,9 +103,6 @@ const GRID_OPTION_DEPRECATIONS = (): Deprecations<GridOptions> => ({
     suppressContentVisibilityAuto: { version: '36.1', message: 'Use `enableContentVisibilityAuto` instead.' },
 });
 
-/** Options that only the `fitCellContents` auto-size strategy supports. */
-const CONTENT_ONLY_STRATEGY_OPTIONS = ['continuous', 'shouldAutoSizeColumns'] as const;
-
 function toConstrainedNum(key: keyof GridOptions, value: any, min: number): string | ValidationWarning | null {
     if (typeof value === 'number' || value == null) {
         if (value == null) {
@@ -806,17 +803,8 @@ const GRID_OPTION_VALIDATIONS: () => Validations<GridOptions> = () => {
                 if (type === 'fitProvidedWidth' && typeof autoSizeStrategy.width != 'number') {
                     return `When using the 'fitProvidedWidth' auto-size strategy, must provide a numeric \`width\`. You provided ${autoSizeStrategy.width}`;
                 }
-                if (type === 'fitCellContents') {
-                    if (autoSizeStrategy.shouldAutoSizeColumns !== undefined && !autoSizeStrategy.continuous) {
-                        return `The \`shouldAutoSizeColumns\` auto-size option only applies when \`continuous\` is true.`;
-                    }
-                } else {
-                    const unsupported = CONTENT_ONLY_STRATEGY_OPTIONS.filter((key) => key in autoSizeStrategy);
-                    if (unsupported.length) {
-                        const names = unsupported.map((key) => `\`${key}\``).join(' and ');
-                        const verb = unsupported.length > 1 ? 'options are' : 'option is';
-                        return `The ${names} auto-size ${verb} only supported by the 'fitCellContents' strategy, but the '${type}' strategy was configured.`;
-                    }
+                if (autoSizeStrategy.shouldAutoSizeColumns !== undefined && !autoSizeStrategy.continuous) {
+                    return `The \`shouldAutoSizeColumns\` auto-size option only applies when \`continuous\` is true.`;
                 }
                 return null;
             },

--- a/testing/behavioural/src/columns/column-autosize-continuous.test.ts
+++ b/testing/behavioural/src/columns/column-autosize-continuous.test.ts
@@ -253,6 +253,73 @@ describe('Continuous Column Autosize', () => {
         });
     });
 
+    describe('all strategy types', () => {
+        test('`fitProvidedWidth` re-distributes the provided width on a data change', async () => {
+            const api = createGrid({
+                columnDefs: [
+                    { colId: 'owned', field: 'owned', width: 200 },
+                    { colId: 'a', field: 'a' },
+                    { colId: 'b', field: 'b' },
+                ],
+                autoSizeStrategy: { type: 'fitProvidedWidth', width: 800, continuous: true },
+            });
+            await waitFor(() => expect(widthOf(api, 'a') + widthOf(api, 'b')).toBe(600));
+
+            // the owned column is held out of the distribution and stays exactly where the colDef put it
+            expect(widthOf(api, 'owned')).toBe(200);
+
+            api.setColumnWidths([
+                { key: 'a', newWidth: 100 },
+                { key: 'b', newWidth: 100 },
+            ]);
+            api.setGridOption('rowData', [{ owned: 'x', a: 'y', b: 'z' }]);
+
+            await waitFor(() => expect(widthOf(api, 'a') + widthOf(api, 'b')).toBe(600));
+            expect(widthOf(api, 'owned')).toBe(200);
+        });
+
+        test('`fitGridWidth` re-runs on a data change and holds owned columns fixed', async () => {
+            const api = createGrid({
+                columnDefs: [
+                    { colId: 'owned', field: 'owned', width: 200 },
+                    { colId: 'a', field: 'a' },
+                    { colId: 'b', field: 'b' },
+                ],
+                autoSizeStrategy: { type: 'fitGridWidth', continuous: true },
+            });
+            await waitFor(() => expect(widthOf(api, 'a')).not.toBe(200));
+
+            const distributed = widthOf(api, 'a') + widthOf(api, 'b');
+            expect(widthOf(api, 'owned')).toBe(200);
+
+            api.setColumnWidths([
+                { key: 'a', newWidth: 50 },
+                { key: 'b', newWidth: 50 },
+            ]);
+            api.setGridOption('rowData', [{ owned: 'x', a: 'y', b: 'z' }]);
+
+            await waitFor(() => expect(widthOf(api, 'a') + widthOf(api, 'b')).toBe(distributed));
+            expect(widthOf(api, 'owned')).toBe(200);
+        });
+
+        test('the width-distribution strategies do not re-run on a horizontal scroll', async () => {
+            const reasons: string[] = [];
+            createGrid({
+                autoSizeStrategy: {
+                    type: 'fitGridWidth',
+                    continuous: true,
+                    shouldAutoSizeColumns: ({ reason }) => {
+                        reasons.push(reason);
+                        return true;
+                    },
+                },
+            });
+            await waitFor(() => expect(reasons.length).toBeGreaterThan(0));
+
+            expect(reasons).not.toContain('viewportChanged');
+        });
+    });
+
     describe('shouldAutoSizeColumns callback', () => {
         test('receives the reason, the eligible columns and the api', async () => {
             const seen: AutoSizeColumnsTriggerParams[] = [];
@@ -392,6 +459,30 @@ describe('Continuous Column Autosize', () => {
             await expectWidth(api, 'listed', MEASURED_WIDTH);
 
             expect(widthOf(api, 'unlisted')).toBe(START_WIDTH);
+        });
+
+        test('`suppressSizeToFit` columns are excluded from the width-distribution strategies', async () => {
+            const seen: string[][] = [];
+            const api = createGrid({
+                columnDefs: [
+                    { colId: 'pinnedWidth', field: 'pinnedWidth', suppressSizeToFit: true },
+                    { colId: 'eligible', field: 'eligible' },
+                ],
+                autoSizeStrategy: {
+                    type: 'fitProvidedWidth',
+                    width: 800,
+                    continuous: true,
+                    shouldAutoSizeColumns: ({ columns }) => {
+                        seen.push(columns.map((col) => col.getColId()));
+                        return true;
+                    },
+                },
+            });
+
+            api.setGridOption('rowData', [{ pinnedWidth: 'a', eligible: 'b' }]);
+            await waitFor(() => expect(seen.length).toBeGreaterThan(0));
+
+            expect(seen[seen.length - 1]).toEqual(['eligible']);
         });
 
         test('an empty grid is safe and leaves widths untouched', async () => {

--- a/testing/behavioural/src/columns/column-autosize-continuous.test.ts
+++ b/testing/behavioural/src/columns/column-autosize-continuous.test.ts
@@ -1,0 +1,396 @@
+/**
+ * Continuous `fitCellContents` auto-sizing: `autoSizeStrategy.continuous`, the width-ownership rules that
+ * decide which columns it may touch, and the `shouldAutoSizeColumns` callback. Kept apart from
+ * `column-autosize.test.ts` because the surface is the continuous strategy rather than the one-shot
+ * auto-size API, and because vitest parallelises across files rather than within one.
+ *
+ * happy-dom measures the fixed-position autosize dummy container as 0 px, so a measured column lands on
+ * `autoSizePadding` (20) clamped up to its own `minWidth`. Every column here therefore carries an explicit
+ * `minWidth` distinct from its starting width, which makes "was this column re-sized?" a plain assertion:
+ * the width becomes `minWidth` if it was eligible, and is left alone if it was not.
+ *
+ * A column that must NOT move has nothing to poll for, so those assertions wait on an eligible column
+ * moving first — proof the sizing pass actually ran — and only then assert the protected width.
+ */
+import { waitFor } from '@testing-library/dom';
+import { DragEventDispatcher, TestGridsManager } from 'ag-test-utils';
+
+import type { AutoSizeColumnsTriggerParams, GridApi, GridOptions } from 'ag-grid-community';
+import { ClientSideRowModelModule, ColumnAutoSizeModule } from 'ag-grid-community';
+
+/** The width every eligible column lands on once measured: `minWidth` beats the 20px happy-dom measurement. */
+const MEASURED_WIDTH = 120;
+const START_WIDTH = 300;
+
+describe('Continuous Column Autosize', () => {
+    const gridsManager = new TestGridsManager({
+        modules: [ClientSideRowModelModule, ColumnAutoSizeModule],
+    });
+
+    afterEach(() => {
+        gridsManager.reset();
+    });
+
+    const widthOf = (api: GridApi, colId: string): number => api.getColumn(colId)!.getActualWidth();
+
+    const expectWidth = (api: GridApi, colId: string, width: number): Promise<void> =>
+        waitFor(() => expect(widthOf(api, colId)).toBe(width));
+
+    /**
+     * `owned` starts at 300 via an explicit `width`, `eligible` starts at 300 via `initialWidth`. Both
+     * have a `minWidth` of 120, so only an eligible column ends up at 120 once measured.
+     */
+    const createGrid = (options: GridOptions = {}): GridApi =>
+        gridsManager.createGrid('myGrid', {
+            columnDefs: [
+                { colId: 'owned', field: 'owned', width: START_WIDTH, minWidth: MEASURED_WIDTH },
+                { colId: 'eligible', field: 'eligible', initialWidth: START_WIDTH, minWidth: MEASURED_WIDTH },
+            ],
+            rowData: [{ owned: 'a', eligible: 'b' }],
+            autoSizeStrategy: { type: 'fitCellContents', continuous: true, skipHeader: true },
+            ...options,
+        });
+
+    /** A grid whose strategy records every reason the callback is invoked with. */
+    const createGridRecordingReasons = (): { api: GridApi; reasons: string[] } => {
+        const reasons: string[] = [];
+        const api = createGrid({
+            autoSizeStrategy: {
+                type: 'fitCellContents',
+                continuous: true,
+                skipHeader: true,
+                shouldAutoSizeColumns: ({ reason }) => {
+                    reasons.push(reason);
+                    return true;
+                },
+            },
+        });
+        return { api, reasons };
+    };
+
+    const LONGER_DATA = [{ owned: 'a much longer value', eligible: 'b much longer value' }];
+
+    describe('ownership', () => {
+        test('`initialWidth` is not owned, so a data change re-sizes the column', async () => {
+            const api = createGrid();
+            await expectWidth(api, 'eligible', MEASURED_WIDTH);
+
+            api.applyColumnState({ state: [{ colId: 'eligible', width: START_WIDTH }] });
+            api.setGridOption('rowData', LONGER_DATA);
+
+            await expectWidth(api, 'eligible', MEASURED_WIDTH);
+        });
+
+        test('an explicit `width` is owned from construction and survives a data change', async () => {
+            const api = createGrid();
+            await expectWidth(api, 'eligible', MEASURED_WIDTH);
+
+            expect(widthOf(api, 'owned')).toBe(START_WIDTH);
+        });
+
+        test('a header drag resize takes ownership, and survives a later data change', async () => {
+            const api = createGrid({
+                columnDefs: [
+                    {
+                        colId: 'dragged',
+                        field: 'dragged',
+                        initialWidth: START_WIDTH,
+                        minWidth: MEASURED_WIDTH,
+                        resizable: true,
+                    },
+                    { colId: 'eligible', field: 'eligible', initialWidth: START_WIDTH, minWidth: MEASURED_WIDTH },
+                ],
+            });
+            await expectWidth(api, 'dragged', MEASURED_WIDTH);
+
+            const eResize = document.querySelector('[col-id="dragged"] .ag-header-cell-resize');
+            expect(eResize).not.toBeNull();
+
+            const dispatcher = new DragEventDispatcher('mouse', null, false);
+            await dispatcher.startDrag(eResize!, 100, 10);
+            await dispatcher.movePointer(eResize!, 200, 10);
+            await dispatcher.finishDrag();
+
+            const draggedWidth = widthOf(api, 'dragged');
+            expect(draggedWidth).toBeGreaterThan(MEASURED_WIDTH);
+
+            // force `eligible` back up so its return to 120 proves the follow-up sizing pass ran
+            api.applyColumnState({ state: [{ colId: 'eligible', width: START_WIDTH }] });
+            api.setGridOption('rowData', [{ dragged: 'a much longer value', eligible: 'b much longer value' }]);
+            await expectWidth(api, 'eligible', MEASURED_WIDTH);
+
+            expect(widthOf(api, 'dragged')).toBe(draggedWidth);
+        });
+
+        test('a reused definition with an updated `width` becomes owned', async () => {
+            const api = createGrid();
+            await expectWidth(api, 'eligible', MEASURED_WIDTH);
+
+            api.setGridOption('columnDefs', [
+                { colId: 'owned', field: 'owned', width: START_WIDTH, minWidth: MEASURED_WIDTH },
+                { colId: 'eligible', field: 'eligible', width: 280, minWidth: MEASURED_WIDTH },
+            ]);
+            api.setGridOption('rowData', LONGER_DATA);
+
+            await waitFor(() => expect(widthOf(api, 'eligible')).toBe(280));
+        });
+
+        test('a reused definition without a `width` preserves prior ownership', async () => {
+            const api = createGrid();
+            await expectWidth(api, 'eligible', MEASURED_WIDTH);
+
+            api.setGridOption('columnDefs', [
+                { colId: 'owned', field: 'owned', minWidth: MEASURED_WIDTH },
+                { colId: 'eligible', field: 'eligible', initialWidth: START_WIDTH, minWidth: MEASURED_WIDTH },
+            ]);
+            await expectWidth(api, 'eligible', MEASURED_WIDTH);
+
+            expect(widthOf(api, 'owned')).toBe(START_WIDTH);
+        });
+
+        test('`applyColumnState` with an explicit width takes ownership', async () => {
+            const api = createGrid();
+            await expectWidth(api, 'eligible', MEASURED_WIDTH);
+
+            api.applyColumnState({ state: [{ colId: 'eligible', width: 260 }] });
+            await waitFor(() => expect(widthOf(api, 'eligible')).toBe(260));
+
+            api.setGridOption('rowData', LONGER_DATA);
+            // nothing is eligible any more, so wait on the callback-free path settling and assert it held
+            await waitFor(() => expect(api.getDisplayedRowCount()).toBe(1));
+            expect(widthOf(api, 'eligible')).toBe(260);
+        });
+
+        test('a state width below the column minimum is ignored and does not take ownership', async () => {
+            const api = createGrid();
+            await expectWidth(api, 'eligible', MEASURED_WIDTH);
+
+            api.applyColumnState({ state: [{ colId: 'eligible', width: 10 }] });
+            api.setGridOption('rowData', LONGER_DATA);
+
+            // the invalid width was dropped, so the column is still eligible and still measures to 120
+            await expectWidth(api, 'eligible', MEASURED_WIDTH);
+        });
+
+        test('resetting column state restores ownership from the colDef', async () => {
+            const api = createGrid();
+            await expectWidth(api, 'eligible', MEASURED_WIDTH);
+
+            api.applyColumnState({ state: [{ colId: 'eligible', width: 260 }] });
+            await waitFor(() => expect(widthOf(api, 'eligible')).toBe(260));
+
+            api.resetColumnState();
+            api.setGridOption('rowData', LONGER_DATA);
+
+            // the colDef declares `initialWidth`, so the column is eligible again
+            await expectWidth(api, 'eligible', MEASURED_WIDTH);
+            expect(widthOf(api, 'owned')).toBe(START_WIDTH);
+        });
+    });
+
+    describe('triggers', () => {
+        test('data replacement re-sizes eligible columns', async () => {
+            const api = createGrid({ rowData: [] });
+            api.setGridOption('rowData', [{ owned: 'a', eligible: 'b' }]);
+
+            await expectWidth(api, 'eligible', MEASURED_WIDTH);
+        });
+
+        test('a transaction update re-sizes eligible columns', async () => {
+            const api = createGrid({ rowData: [] });
+            api.applyTransaction({ add: [{ owned: 'a', eligible: 'b' }] });
+
+            await expectWidth(api, 'eligible', MEASURED_WIDTH);
+        });
+
+        test('sorting alone is not reported as a data change', async () => {
+            const { api, reasons } = createGridRecordingReasons();
+            await expectWidth(api, 'eligible', MEASURED_WIDTH);
+            reasons.length = 0;
+
+            api.applyColumnState({ state: [{ colId: 'eligible', sort: 'asc' }] });
+            await waitFor(() => expect(api.getColumn('eligible')!.getSort()).toBe('asc'));
+
+            expect(reasons).not.toContain('dataChanged');
+        });
+
+        test('a displayed-column change is reported as a column change', async () => {
+            const { api, reasons } = createGridRecordingReasons();
+            await expectWidth(api, 'eligible', MEASURED_WIDTH);
+            reasons.length = 0;
+
+            api.setColumnsVisible(['owned'], false);
+            await waitFor(() => expect(reasons).toContain('columnsChanged'));
+        });
+
+        test('multiple triggers in one frame coalesce into a single evaluation', async () => {
+            const { api, reasons } = createGridRecordingReasons();
+            await expectWidth(api, 'eligible', MEASURED_WIDTH);
+            reasons.length = 0;
+
+            api.setGridOption('rowData', [{ owned: 'a', eligible: 'b' }]);
+            api.setGridOption('rowData', [{ owned: 'c', eligible: 'd' }]);
+            api.setGridOption('rowData', [{ owned: 'e', eligible: 'f' }]);
+
+            await waitFor(() => expect(reasons.length).toBeGreaterThan(0));
+            expect(reasons).toEqual(['dataChanged']);
+        });
+
+        test('the strategy stays one-shot when `continuous` is omitted', async () => {
+            const api = createGrid({
+                autoSizeStrategy: { type: 'fitCellContents', skipHeader: true },
+            });
+            // the one-shot pass runs on first data render and, by design, ignores ownership
+            await expectWidth(api, 'eligible', MEASURED_WIDTH);
+
+            api.applyColumnState({ state: [{ colId: 'eligible', width: START_WIDTH }] });
+            api.setGridOption('rowData', LONGER_DATA);
+            await waitFor(() => expect(api.getDisplayedRowCount()).toBe(1));
+
+            expect(widthOf(api, 'eligible')).toBe(START_WIDTH);
+        });
+    });
+
+    describe('shouldAutoSizeColumns callback', () => {
+        test('receives the reason, the eligible columns and the api', async () => {
+            const seen: AutoSizeColumnsTriggerParams[] = [];
+            const api = createGrid({
+                autoSizeStrategy: {
+                    type: 'fitCellContents',
+                    continuous: true,
+                    skipHeader: true,
+                    shouldAutoSizeColumns: (params) => {
+                        seen.push(params);
+                        return true;
+                    },
+                },
+            });
+
+            api.setGridOption('rowData', [{ owned: 'a', eligible: 'b' }]);
+            await waitFor(() => expect(seen.length).toBeGreaterThan(0));
+
+            const last = seen[seen.length - 1];
+            expect(last.api).toBe(api);
+            // only `eligible` is a candidate — `owned` has an explicit `colDef.width`
+            expect(last.columns.map((col) => col.getColId())).toEqual(['eligible']);
+            expect(['dataChanged', 'columnsChanged', 'viewportChanged', 'gridSizeChanged']).toContain(last.reason);
+        });
+
+        test('returning false suppresses the resize', async () => {
+            let calls = 0;
+            const api = createGrid({
+                autoSizeStrategy: {
+                    type: 'fitCellContents',
+                    continuous: true,
+                    skipHeader: true,
+                    shouldAutoSizeColumns: () => {
+                        calls++;
+                        return false;
+                    },
+                },
+            });
+
+            api.setGridOption('rowData', LONGER_DATA);
+            await waitFor(() => expect(calls).toBeGreaterThan(0));
+
+            expect(widthOf(api, 'eligible')).toBe(START_WIDTH);
+        });
+
+        test('a throwing callback does not leave the service locked', async () => {
+            let shouldThrow = true;
+            const api = createGrid({
+                autoSizeStrategy: {
+                    type: 'fitCellContents',
+                    continuous: true,
+                    skipHeader: true,
+                    shouldAutoSizeColumns: () => {
+                        if (shouldThrow) {
+                            throw new Error('callback failed');
+                        }
+                        return true;
+                    },
+                },
+            });
+
+            await waitFor(() => expect(api.getDisplayedRowCount()).toBe(1));
+            expect(widthOf(api, 'eligible')).toBe(START_WIDTH);
+
+            shouldThrow = false;
+            api.setGridOption('rowData', LONGER_DATA);
+
+            await expectWidth(api, 'eligible', MEASURED_WIDTH);
+        });
+    });
+
+    describe('exclusions', () => {
+        test('`suppressAutoSize` columns are left alone', async () => {
+            const api = createGrid({
+                columnDefs: [
+                    {
+                        colId: 'suppressed',
+                        field: 'suppressed',
+                        initialWidth: START_WIDTH,
+                        minWidth: MEASURED_WIDTH,
+                        suppressAutoSize: true,
+                    },
+                    { colId: 'eligible', field: 'eligible', initialWidth: START_WIDTH, minWidth: MEASURED_WIDTH },
+                ],
+            });
+            await expectWidth(api, 'eligible', MEASURED_WIDTH);
+
+            expect(widthOf(api, 'suppressed')).toBe(START_WIDTH);
+        });
+
+        test('flex columns are excluded from the candidate set', async () => {
+            const seen: string[][] = [];
+            const api = createGrid({
+                columnDefs: [
+                    { colId: 'flexed', field: 'flexed', flex: 1, minWidth: MEASURED_WIDTH },
+                    { colId: 'eligible', field: 'eligible', initialWidth: START_WIDTH, minWidth: MEASURED_WIDTH },
+                ],
+                autoSizeStrategy: {
+                    type: 'fitCellContents',
+                    continuous: true,
+                    skipHeader: true,
+                    shouldAutoSizeColumns: ({ columns }) => {
+                        seen.push(columns.map((col) => col.getColId()));
+                        return true;
+                    },
+                },
+            });
+
+            api.setGridOption('rowData', [{ flexed: 'a', eligible: 'b' }]);
+            await waitFor(() => expect(seen.length).toBeGreaterThan(0));
+
+            expect(seen[seen.length - 1]).toEqual(['eligible']);
+        });
+
+        test('`colIds` restricts sizing to the listed columns', async () => {
+            const api = createGrid({
+                columnDefs: [
+                    { colId: 'listed', field: 'listed', initialWidth: START_WIDTH, minWidth: MEASURED_WIDTH },
+                    { colId: 'unlisted', field: 'unlisted', initialWidth: START_WIDTH, minWidth: MEASURED_WIDTH },
+                ],
+                autoSizeStrategy: {
+                    type: 'fitCellContents',
+                    continuous: true,
+                    skipHeader: true,
+                    colIds: ['listed'],
+                },
+            });
+
+            api.setGridOption('rowData', [{ listed: 'a', unlisted: 'b' }]);
+            await expectWidth(api, 'listed', MEASURED_WIDTH);
+
+            expect(widthOf(api, 'unlisted')).toBe(START_WIDTH);
+        });
+
+        test('an empty grid is safe and leaves widths untouched', async () => {
+            const api = createGrid({ rowData: [] });
+            await waitFor(() => expect(api.getDisplayedRowCount()).toBe(0));
+
+            expect(widthOf(api, 'owned')).toBe(START_WIDTH);
+            expect(widthOf(api, 'eligible')).toBe(START_WIDTH);
+        });
+    });
+});

--- a/testing/behavioural/src/columns/column-autosize-continuous.test.ts
+++ b/testing/behavioural/src/columns/column-autosize-continuous.test.ts
@@ -75,9 +75,11 @@ describe('Continuous Column Autosize', () => {
             const api = createGrid();
             await expectWidth(api, 'eligible', MEASURED_WIDTH);
 
-            api.applyColumnState({ state: [{ colId: 'eligible', width: START_WIDTH }] });
-            api.setGridOption('rowData', LONGER_DATA);
+            // `setColumnWidths` is an api resize, so it widens the column without taking ownership
+            api.setColumnWidths([{ key: 'eligible', newWidth: START_WIDTH }]);
+            expect(widthOf(api, 'eligible')).toBe(START_WIDTH);
 
+            api.setGridOption('rowData', LONGER_DATA);
             await expectWidth(api, 'eligible', MEASURED_WIDTH);
         });
 
@@ -114,8 +116,8 @@ describe('Continuous Column Autosize', () => {
             const draggedWidth = widthOf(api, 'dragged');
             expect(draggedWidth).toBeGreaterThan(MEASURED_WIDTH);
 
-            // force `eligible` back up so its return to 120 proves the follow-up sizing pass ran
-            api.applyColumnState({ state: [{ colId: 'eligible', width: START_WIDTH }] });
+            // widen `eligible` without owning it, so its return to 120 proves the follow-up pass ran
+            api.setColumnWidths([{ key: 'eligible', newWidth: START_WIDTH }]);
             api.setGridOption('rowData', [{ dragged: 'a much longer value', eligible: 'b much longer value' }]);
             await expectWidth(api, 'eligible', MEASURED_WIDTH);
 
@@ -341,11 +343,13 @@ describe('Continuous Column Autosize', () => {
             expect(widthOf(api, 'suppressed')).toBe(START_WIDTH);
         });
 
+        // `colDef.flex` alongside `autoSizeStrategy` is a validated conflict (warning #318), so flex is
+        // applied through column state — the one route that legally produces a flexing column here.
         test('flex columns are excluded from the candidate set', async () => {
             const seen: string[][] = [];
             const api = createGrid({
                 columnDefs: [
-                    { colId: 'flexed', field: 'flexed', flex: 1, minWidth: MEASURED_WIDTH },
+                    { colId: 'flexed', field: 'flexed', initialWidth: START_WIDTH, minWidth: MEASURED_WIDTH },
                     { colId: 'eligible', field: 'eligible', initialWidth: START_WIDTH, minWidth: MEASURED_WIDTH },
                 ],
                 autoSizeStrategy: {
@@ -358,6 +362,11 @@ describe('Continuous Column Autosize', () => {
                     },
                 },
             });
+            await waitFor(() => expect(widthOf(api, 'flexed')).toBe(MEASURED_WIDTH));
+
+            api.applyColumnState({ state: [{ colId: 'flexed', flex: 1 }] });
+            await waitFor(() => expect(api.getColumn('flexed')!.getFlex()).toBe(1));
+            seen.length = 0;
 
             api.setGridOption('rowData', [{ flexed: 'a', eligible: 'b' }]);
             await waitFor(() => expect(seen.length).toBeGreaterThan(0));

--- a/testing/behavioural/src/columns/column-autosize-continuous.test.ts
+++ b/testing/behavioural/src/columns/column-autosize-continuous.test.ts
@@ -13,7 +13,7 @@
  * moving first — proof the sizing pass actually ran — and only then assert the protected width.
  */
 import { waitFor } from '@testing-library/dom';
-import { DragEventDispatcher, TestGridsManager } from 'ag-test-utils';
+import { DragEventDispatcher, TestGridsManager, asyncSetTimeout } from 'ag-test-utils';
 
 import type { AutoSizeColumnsTriggerParams, GridApi, GridOptions } from 'ag-grid-community';
 import { ClientSideRowModelModule, ColumnAutoSizeModule } from 'ag-grid-community';
@@ -32,6 +32,15 @@ describe('Continuous Column Autosize', () => {
     });
 
     const widthOf = (api: GridApi, colId: string): number => api.getColumn(colId)!.getActualWidth();
+
+    /**
+     * Lets a continuous re-size scheduled by the preceding statement run, so that "no re-size happened" is
+     * asserted after the frame rather than ahead of it. Every assertion using this is negative, so there is
+     * nothing to poll for: the scheduler's `setTimeout(0)` plus animation frame is the window being sampled
+     * past (`scheduleContinuousAutoSize` in `columnAutosizeService.ts`).
+     */
+    // eslint-disable-next-line no-restricted-syntax -- samples past the continuous-resize scheduling frame; every assertion that follows it is negative
+    const flushScheduledResize = (): Promise<void> => asyncSetTimeout(50);
 
     const expectWidth = (api: GridApi, colId: string, width: number): Promise<void> =>
         waitFor(() => expect(widthOf(api, colId)).toBe(width));
@@ -89,8 +98,9 @@ describe('Continuous Column Autosize', () => {
             await expectWidth(api, 'eligible', MEASURED_WIDTH);
         });
 
-        test('an explicit `width` is owned from construction and survives a data change', async () => {
+        test('`suppressAutoSize` holds a column at its starting width through a data change', async () => {
             const api = createGrid();
+            // the eligible column moving is proof the pass ran; `pinned` opted out, so it did not move
             await expectWidth(api, 'eligible', MEASURED_WIDTH);
 
             expect(widthOf(api, 'pinned')).toBe(START_WIDTH);
@@ -239,14 +249,47 @@ describe('Continuous Column Autosize', () => {
             await expectWidth(api, 'eligible', MEASURED_WIDTH);
         });
 
-        test('sorting alone is not reported as a data change', async () => {
+        test('sorting is a data change for the content strategy, which re-measures what is rendered', async () => {
             const { api, reasons } = createGridRecordingReasons();
             await expectWidth(api, 'eligible', MEASURED_WIDTH);
             reasons.length = 0;
 
             api.applyColumnState({ state: [{ colId: 'eligible', sort: 'asc' }] });
-            await waitFor(() => expect(api.getColumn('eligible')!.getSort()).toBe('asc'));
 
+            await waitFor(() => expect(reasons).toContain('dataChanged'));
+        });
+
+        test('sorting alone is not a data change for the width-distribution strategies', async () => {
+            const reasons: string[] = [];
+            const api = createGrid({
+                columnDefs: [
+                    { colId: 'a', field: 'a' },
+                    { colId: 'b', field: 'b' },
+                ],
+                autoSizeStrategy: {
+                    type: 'fitGridWidth',
+                    continuous: true,
+                    shouldAutoSizeColumns: ({ reason }) => {
+                        reasons.push(reason);
+                        return true;
+                    },
+                },
+            });
+            await waitFor(() => expect(reasons.length).toBeGreaterThan(0));
+            // startup schedules an initial pass of its own; let it land before clearing, or it turns up
+            // afterwards and looks like a re-size the statement under test caused
+            await flushScheduledResize();
+            reasons.length = 0;
+
+            api.applyColumnState({ state: [{ colId: 'a', sort: 'asc' }] });
+
+            // applying the sort re-creates the displayed columns, so `columnsChanged` is the frame this waits
+            // on. `dataChanged` outranks it, so a sort that had scheduled one would be reported in its place
+            // and this would time out rather than silently pass.
+            await waitFor(() => expect(reasons).toContain('columnsChanged'));
+            await flushScheduledResize();
+
+            // re-ordering rows changes neither the column set nor the width to share out
             expect(reasons).not.toContain('dataChanged');
         });
 
@@ -282,6 +325,7 @@ describe('Continuous Column Autosize', () => {
             api.applyColumnState({ state: [{ colId: 'eligible', width: START_WIDTH }] });
             api.setGridOption('rowData', LONGER_DATA);
             await waitFor(() => expect(api.getDisplayedRowCount()).toBe(1));
+            await flushScheduledResize();
 
             expect(widthOf(api, 'eligible')).toBe(START_WIDTH);
         });
@@ -336,9 +380,19 @@ describe('Continuous Column Autosize', () => {
             expect(widthOf(api, 'pinnedWidth')).toBe(200);
         });
 
-        test('the width-distribution strategies do not re-run on a horizontal scroll', async () => {
+        /**
+         * A real horizontal scroll is not drivable in happy-dom — there is no laid-out body viewport to
+         * scroll — so this covers the registration instead: `virtualColumnsChanged` and `viewportChanged` do
+         * fire during startup and on a column change, and would be reported here if the width-distribution
+         * strategies had been wired to them. The scroll itself is covered by the docs e2e suite.
+         */
+        test('the width-distribution strategies never report a viewport change', async () => {
             const reasons: string[] = [];
-            createGrid({
+            const api = createGrid({
+                columnDefs: [
+                    { colId: 'a', field: 'a' },
+                    { colId: 'b', field: 'b' },
+                ],
                 autoSizeStrategy: {
                     type: 'fitGridWidth',
                     continuous: true,
@@ -349,6 +403,14 @@ describe('Continuous Column Autosize', () => {
                 },
             });
             await waitFor(() => expect(reasons.length).toBeGreaterThan(0));
+            // startup schedules an initial pass of its own; let it land before clearing, or it turns up
+            // afterwards and looks like a re-size the statement under test caused
+            await flushScheduledResize();
+            reasons.length = 0;
+
+            api.setColumnsVisible(['b'], false);
+            await waitFor(() => expect(reasons).toContain('columnsChanged'));
+            await flushScheduledResize();
 
             expect(reasons).not.toContain('viewportChanged');
         });
@@ -374,7 +436,7 @@ describe('Continuous Column Autosize', () => {
 
             const last = seen[seen.length - 1];
             expect(last.api).toBe(api);
-            // only `eligible` is a candidate — `owned` has an explicit `colDef.width`
+            // only `eligible` is a candidate — `pinned` sets `suppressAutoSize`
             expect(last.columns.map((col) => col.getColId())).toEqual(['eligible']);
             expect(['dataChanged', 'columnsChanged', 'viewportChanged', 'gridSizeChanged']).toContain(last.reason);
         });

--- a/testing/behavioural/src/columns/column-autosize-continuous.test.ts
+++ b/testing/behavioural/src/columns/column-autosize-continuous.test.ts
@@ -37,16 +37,22 @@ describe('Continuous Column Autosize', () => {
         waitFor(() => expect(widthOf(api, colId)).toBe(width));
 
     /**
-     * `owned` starts at 300 via an explicit `width`, `eligible` starts at 300 via `initialWidth`. Both
-     * have a `minWidth` of 120, so only an eligible column ends up at 120 once measured.
+     * `pinned` opts out explicitly with `suppressAutoSize`; `eligible` is left for the grid to manage. Both
+     * start at 300 with a `minWidth` of 120, so only an eligible column ends up at 120 once measured.
      */
     const createGrid = (options: GridOptions = {}): GridApi =>
         gridsManager.createGrid('myGrid', {
             columnDefs: [
-                { colId: 'owned', field: 'owned', width: START_WIDTH, minWidth: MEASURED_WIDTH },
+                {
+                    colId: 'pinned',
+                    field: 'pinned',
+                    width: START_WIDTH,
+                    minWidth: MEASURED_WIDTH,
+                    suppressAutoSize: true,
+                },
                 { colId: 'eligible', field: 'eligible', initialWidth: START_WIDTH, minWidth: MEASURED_WIDTH },
             ],
-            rowData: [{ owned: 'a', eligible: 'b' }],
+            rowData: [{ pinned: 'a', eligible: 'b' }],
             autoSizeStrategy: { type: 'fitCellContents', continuous: true, skipHeader: true },
             ...options,
         });
@@ -68,7 +74,7 @@ describe('Continuous Column Autosize', () => {
         return { api, reasons };
     };
 
-    const LONGER_DATA = [{ owned: 'a much longer value', eligible: 'b much longer value' }];
+    const LONGER_DATA = [{ pinned: 'a much longer value', eligible: 'b much longer value' }];
 
     describe('ownership', () => {
         test('`initialWidth` is not owned, so a data change re-sizes the column', async () => {
@@ -87,7 +93,7 @@ describe('Continuous Column Autosize', () => {
             const api = createGrid();
             await expectWidth(api, 'eligible', MEASURED_WIDTH);
 
-            expect(widthOf(api, 'owned')).toBe(START_WIDTH);
+            expect(widthOf(api, 'pinned')).toBe(START_WIDTH);
         });
 
         test('a header drag resize takes ownership, and survives a later data change', async () => {
@@ -124,30 +130,48 @@ describe('Continuous Column Autosize', () => {
             expect(widthOf(api, 'dragged')).toBe(draggedWidth);
         });
 
-        test('a reused definition with an updated `width` becomes owned', async () => {
+        test('a `colDef.width` is only a starting width, so the column is still re-sized', async () => {
+            const api = createGrid({
+                columnDefs: [{ colId: 'eligible', field: 'eligible', width: START_WIDTH, minWidth: MEASURED_WIDTH }],
+            });
+
+            await expectWidth(api, 'eligible', MEASURED_WIDTH);
+        });
+
+        test('a reused definition with an updated `width` is still re-sized', async () => {
             const api = createGrid();
             await expectWidth(api, 'eligible', MEASURED_WIDTH);
 
             api.setGridOption('columnDefs', [
-                { colId: 'owned', field: 'owned', width: START_WIDTH, minWidth: MEASURED_WIDTH },
+                { colId: 'pinned', field: 'pinned', minWidth: MEASURED_WIDTH, suppressAutoSize: true },
                 { colId: 'eligible', field: 'eligible', width: 280, minWidth: MEASURED_WIDTH },
             ]);
             api.setGridOption('rowData', LONGER_DATA);
 
-            await waitFor(() => expect(widthOf(api, 'eligible')).toBe(280));
+            await expectWidth(api, 'eligible', MEASURED_WIDTH);
         });
 
-        test('a reused definition without a `width` preserves prior ownership', async () => {
+        test('a user resize survives a column-definition update', async () => {
             const api = createGrid();
             await expectWidth(api, 'eligible', MEASURED_WIDTH);
 
-            api.setGridOption('columnDefs', [
-                { colId: 'owned', field: 'owned', minWidth: MEASURED_WIDTH },
-                { colId: 'eligible', field: 'eligible', initialWidth: START_WIDTH, minWidth: MEASURED_WIDTH },
-            ]);
-            await expectWidth(api, 'eligible', MEASURED_WIDTH);
+            const eResize = document.querySelector('[col-id="eligible"] .ag-header-cell-resize');
+            const dispatcher = new DragEventDispatcher('mouse', null, false);
+            await dispatcher.startDrag(eResize!, 100, 10);
+            await dispatcher.movePointer(eResize!, 220, 10);
+            await dispatcher.finishDrag();
 
-            expect(widthOf(api, 'owned')).toBe(START_WIDTH);
+            const draggedWidth = widthOf(api, 'eligible');
+            expect(draggedWidth).toBeGreaterThan(MEASURED_WIDTH);
+
+            api.setGridOption('columnDefs', [
+                { colId: 'pinned', field: 'pinned', minWidth: MEASURED_WIDTH, suppressAutoSize: true },
+                { colId: 'eligible', field: 'eligible', minWidth: MEASURED_WIDTH },
+            ]);
+            api.setGridOption('rowData', LONGER_DATA);
+            await waitFor(() => expect(api.getDisplayedRowCount()).toBe(1));
+
+            expect(widthOf(api, 'eligible')).toBe(draggedWidth);
         });
 
         test('`applyColumnState` with an explicit width takes ownership', async () => {
@@ -186,21 +210,21 @@ describe('Continuous Column Autosize', () => {
 
             // the colDef declares `initialWidth`, so the column is eligible again
             await expectWidth(api, 'eligible', MEASURED_WIDTH);
-            expect(widthOf(api, 'owned')).toBe(START_WIDTH);
+            expect(widthOf(api, 'pinned')).toBe(START_WIDTH);
         });
     });
 
     describe('triggers', () => {
         test('data replacement re-sizes eligible columns', async () => {
             const api = createGrid({ rowData: [] });
-            api.setGridOption('rowData', [{ owned: 'a', eligible: 'b' }]);
+            api.setGridOption('rowData', [{ pinned: 'a', eligible: 'b' }]);
 
             await expectWidth(api, 'eligible', MEASURED_WIDTH);
         });
 
         test('a transaction update re-sizes eligible columns', async () => {
             const api = createGrid({ rowData: [] });
-            api.applyTransaction({ add: [{ owned: 'a', eligible: 'b' }] });
+            api.applyTransaction({ add: [{ pinned: 'a', eligible: 'b' }] });
 
             await expectWidth(api, 'eligible', MEASURED_WIDTH);
         });
@@ -221,7 +245,7 @@ describe('Continuous Column Autosize', () => {
             await expectWidth(api, 'eligible', MEASURED_WIDTH);
             reasons.length = 0;
 
-            api.setColumnsVisible(['owned'], false);
+            api.setColumnsVisible(['pinned'], false);
             await waitFor(() => expect(reasons).toContain('columnsChanged'));
         });
 
@@ -230,9 +254,9 @@ describe('Continuous Column Autosize', () => {
             await expectWidth(api, 'eligible', MEASURED_WIDTH);
             reasons.length = 0;
 
-            api.setGridOption('rowData', [{ owned: 'a', eligible: 'b' }]);
-            api.setGridOption('rowData', [{ owned: 'c', eligible: 'd' }]);
-            api.setGridOption('rowData', [{ owned: 'e', eligible: 'f' }]);
+            api.setGridOption('rowData', [{ pinned: 'a', eligible: 'b' }]);
+            api.setGridOption('rowData', [{ pinned: 'c', eligible: 'd' }]);
+            api.setGridOption('rowData', [{ pinned: 'e', eligible: 'f' }]);
 
             await waitFor(() => expect(reasons.length).toBeGreaterThan(0));
             expect(reasons).toEqual(['dataChanged']);
@@ -257,7 +281,7 @@ describe('Continuous Column Autosize', () => {
         test('`fitProvidedWidth` re-distributes the provided width on a data change', async () => {
             const api = createGrid({
                 columnDefs: [
-                    { colId: 'owned', field: 'owned', width: 200 },
+                    { colId: 'pinnedWidth', field: 'pinnedWidth', width: 200, suppressSizeToFit: true },
                     { colId: 'a', field: 'a' },
                     { colId: 'b', field: 'b' },
                 ],
@@ -265,23 +289,23 @@ describe('Continuous Column Autosize', () => {
             });
             await waitFor(() => expect(widthOf(api, 'a') + widthOf(api, 'b')).toBe(600));
 
-            // the owned column is held out of the distribution and stays exactly where the colDef put it
-            expect(widthOf(api, 'owned')).toBe(200);
+            // the opted-out column is held out of the distribution and stays where the colDef put it
+            expect(widthOf(api, 'pinnedWidth')).toBe(200);
 
             api.setColumnWidths([
                 { key: 'a', newWidth: 100 },
                 { key: 'b', newWidth: 100 },
             ]);
-            api.setGridOption('rowData', [{ owned: 'x', a: 'y', b: 'z' }]);
+            api.setGridOption('rowData', [{ pinnedWidth: 'x', a: 'y', b: 'z' }]);
 
             await waitFor(() => expect(widthOf(api, 'a') + widthOf(api, 'b')).toBe(600));
-            expect(widthOf(api, 'owned')).toBe(200);
+            expect(widthOf(api, 'pinnedWidth')).toBe(200);
         });
 
-        test('`fitGridWidth` re-runs on a data change and holds owned columns fixed', async () => {
+        test('`fitGridWidth` re-runs on a data change and holds opted-out columns fixed', async () => {
             const api = createGrid({
                 columnDefs: [
-                    { colId: 'owned', field: 'owned', width: 200 },
+                    { colId: 'pinnedWidth', field: 'pinnedWidth', width: 200, suppressSizeToFit: true },
                     { colId: 'a', field: 'a' },
                     { colId: 'b', field: 'b' },
                 ],
@@ -290,16 +314,16 @@ describe('Continuous Column Autosize', () => {
             await waitFor(() => expect(widthOf(api, 'a')).not.toBe(200));
 
             const distributed = widthOf(api, 'a') + widthOf(api, 'b');
-            expect(widthOf(api, 'owned')).toBe(200);
+            expect(widthOf(api, 'pinnedWidth')).toBe(200);
 
             api.setColumnWidths([
                 { key: 'a', newWidth: 50 },
                 { key: 'b', newWidth: 50 },
             ]);
-            api.setGridOption('rowData', [{ owned: 'x', a: 'y', b: 'z' }]);
+            api.setGridOption('rowData', [{ pinnedWidth: 'x', a: 'y', b: 'z' }]);
 
             await waitFor(() => expect(widthOf(api, 'a') + widthOf(api, 'b')).toBe(distributed));
-            expect(widthOf(api, 'owned')).toBe(200);
+            expect(widthOf(api, 'pinnedWidth')).toBe(200);
         });
 
         test('the width-distribution strategies do not re-run on a horizontal scroll', async () => {
@@ -335,7 +359,7 @@ describe('Continuous Column Autosize', () => {
                 },
             });
 
-            api.setGridOption('rowData', [{ owned: 'a', eligible: 'b' }]);
+            api.setGridOption('rowData', [{ pinned: 'a', eligible: 'b' }]);
             await waitFor(() => expect(seen.length).toBeGreaterThan(0));
 
             const last = seen[seen.length - 1];
@@ -489,7 +513,7 @@ describe('Continuous Column Autosize', () => {
             const api = createGrid({ rowData: [] });
             await waitFor(() => expect(api.getDisplayedRowCount()).toBe(0));
 
-            expect(widthOf(api, 'owned')).toBe(START_WIDTH);
+            expect(widthOf(api, 'pinned')).toBe(START_WIDTH);
             expect(widthOf(api, 'eligible')).toBe(START_WIDTH);
         });
     });

--- a/testing/behavioural/src/columns/column-autosize-continuous.test.ts
+++ b/testing/behavioural/src/columns/column-autosize-continuous.test.ts
@@ -229,6 +229,16 @@ describe('Continuous Column Autosize', () => {
             await expectWidth(api, 'eligible', MEASURED_WIDTH);
         });
 
+        test('`rowNode.setData` re-sizes eligible columns', async () => {
+            const api = createGrid();
+            await expectWidth(api, 'eligible', MEASURED_WIDTH);
+
+            api.setColumnWidths([{ key: 'eligible', newWidth: START_WIDTH }]);
+            api.getDisplayedRowAtIndex(0)!.setData({ pinned: 'x', eligible: 'a much longer value' });
+
+            await expectWidth(api, 'eligible', MEASURED_WIDTH);
+        });
+
         test('sorting alone is not reported as a data change', async () => {
             const { api, reasons } = createGridRecordingReasons();
             await expectWidth(api, 'eligible', MEASURED_WIDTH);


### PR DESCRIPTION
Adds opt-in `autoSizeStrategy.continuous`, which re-applies the configured strategy whenever the grid changes in a way that affects column widths, plus a `shouldAutoSizeColumns(columns, reason)` callback to veto an individual re-size.

Applies to all three strategies (`fitCellContents`, `fitGridWidth`, `fitProvidedWidth`). Columns whose width is owned by a deliberate user resize or an explicit `applyColumnState` width are held out of repeated sizing; `width`/`initialWidth` stay eligible, and `suppressAutoSize`/`suppressSizeToFit` remain the way to pin a column.

Implements the ownership/coalescing approach rather than the `events: []` API sketched on the ticket. Continuous `fitCellContents` is not supported by the Viewport Row Model; there is no runtime re-registration of the strategy.

Fixes [AG-4093](https://ag-grid.atlassian.net/browse/AG-4093)
