### PR TITLE
AG-18316: add a ${baseWWWUrl} substitution so examples resolve site assets in Plunker/CodeSandbox

### DIFF
--- a/documentation/ag-grid-docs/src/components/example-generator/index.ts
+++ b/documentation/ag-grid-docs/src/components/example-generator/index.ts
@@ -1,10 +1,12 @@
+import { SITE_BASE_URL } from '@constants';
 import { getIsDev } from '@utils/env';
 import { getExampleRootFileUrl } from '@utils/pages';
+import { pathJoin } from '@utils/pathJoin';
 import { existsSync } from 'node:fs';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 
-import type { GeneratedContents, InternalFramework } from './types';
+import type { ExampleSubstitutions, GeneratedContents, InternalFramework } from './types';
 
 export type GeneratedExampleParams = ExampleParams & DocsExampleParams;
 
@@ -38,6 +40,32 @@ const getContentJsonPath = (params: GeneratedExampleParams) => {
     return path.join(folderPath, 'contents.json');
 };
 
+// Resolves to the absolute URL of the docs site serving the example, so examples can reference
+// site assets (e.g. fonts) by an absolute URL that also works once opened in Plunker/CodeSandbox.
+const DEFAULT_SUBSTITUTIONS: ExampleSubstitutions = {
+    '${baseWWWUrl}': pathJoin(import.meta.env?.PUBLIC_SITE_URL, SITE_BASE_URL),
+};
+
+const applySubstitutions = (content: GeneratedContents, substitutions: ExampleSubstitutions): GeneratedContents => {
+    Object.keys(substitutions).forEach((key) => {
+        const value = substitutions[key as keyof ExampleSubstitutions];
+
+        Object.keys(content.files).forEach((file) => {
+            let count = 0;
+            while (content.files[file].includes(key)) {
+                count++;
+                content.files[file] = content.files[file].replace(key, value);
+
+                if (count > 1000) {
+                    throw new Error('Substitution limit of 1000 reached, is this a bug?');
+                }
+            }
+        });
+    });
+
+    return content;
+};
+
 const cacheKeys: Record<string, object> = {};
 const cacheValues = new WeakMap<object, GeneratedContents>();
 
@@ -68,7 +96,7 @@ const readContentJson = async (params: GeneratedExampleParams) => {
         cacheValues.set(cacheKey, result);
     }
 
-    return result;
+    return applySubstitutions(result, DEFAULT_SUBSTITUTIONS);
 };
 
 export const hasGeneratedContents = async (params: GeneratedExampleParams) => {

--- a/documentation/ag-grid-docs/src/components/example-generator/types.ts
+++ b/documentation/ag-grid-docs/src/components/example-generator/types.ts
@@ -26,6 +26,11 @@ export interface GeneratedContents {
     excluded?: boolean;
 }
 
+// Make sure to update the Nx plugin copy of this interface when making changes.
+export interface ExampleSubstitutions {
+    '${baseWWWUrl}': string;
+}
+
 export type InternalFramework = 'vanilla' | 'typescript' | 'reactFunctional' | 'reactFunctionalTs' | 'angular' | 'vue3';
 
 export const TYPESCRIPT_INTERNAL_FRAMEWORKS: InternalFramework[] = ['typescript', 'reactFunctionalTs', 'angular'];

--- a/documentation/ag-grid-docs/src/content/docs/pdf-export-languages/_examples/pdf-international-characters/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/pdf-export-languages/_examples/pdf-international-characters/main.ts
@@ -152,8 +152,10 @@ async function loadFonts(): Promise<PdfFontFamilyDefinition[]> {
     ];
 }
 
+const fontBaseUrl = '${baseWWWUrl}/fonts/pdf-export/';
+
 async function loadFont(fileName: string): Promise<ArrayBuffer> {
-    const response = await fetch(`/fonts/pdf-export/${fileName}`);
+    const response = await fetch(fontBaseUrl + fileName);
     if (!response.ok) {
         throw new Error(`Unable to load ${fileName}`);
     }

--- a/documentation/ag-grid-docs/src/content/docs/pdf-export-languages/_examples/pdf-non-latin-language/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/pdf-export-languages/_examples/pdf-non-latin-language/main.ts
@@ -37,8 +37,10 @@ function onBtExport() {
     });
 }
 
+const fontBaseUrl = '${baseWWWUrl}/fonts/pdf-export/';
+
 async function loadFont(fileName: string): Promise<ArrayBuffer> {
-    const response = await fetch(`/fonts/pdf-export/${fileName}`);
+    const response = await fetch(fontBaseUrl + fileName);
     if (!response.ok) {
         throw new Error(`Unable to load ${fileName}`);
     }

--- a/documentation/ag-grid-docs/src/content/docs/pdf-export-languages/_examples/pdf-rtl-languages/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/pdf-export-languages/_examples/pdf-rtl-languages/main.ts
@@ -125,8 +125,10 @@ async function loadFonts(): Promise<PdfFontFamilyDefinition[]> {
     ];
 }
 
+const fontBaseUrl = '${baseWWWUrl}/fonts/pdf-export/';
+
 async function loadFont(fileName: string): Promise<ArrayBuffer> {
-    const response = await fetch(`/fonts/pdf-export/${fileName}`);
+    const response = await fetch(fontBaseUrl + fileName);
     if (!response.ok) {
         throw new Error(`Unable to load ${fileName}`);
     }

--- a/plugins/ag-grid-generate-example-files/src/executors/generate/generator/types.ts
+++ b/plugins/ag-grid-generate-example-files/src/executors/generate/generator/types.ts
@@ -110,6 +110,11 @@ export interface GeneratedContents extends ExampleConfig {
     packageJson: Record<string, any>;
 }
 
+// Make sure to update the Astro copy of this interface when making changes.
+export interface ExampleSubstitutions {
+    '${baseWWWUrl}': string;
+}
+
 export type InternalFramework = 'vanilla' | 'typescript' | 'reactFunctional' | 'reactFunctionalTs' | 'angular' | 'vue3';
 
 export const FRAMEWORKS: InternalFramework[] = [


### PR DESCRIPTION
## Summary
- Ports the `${baseWWWUrl}` example substitution mechanism from ag-charts into ag-grid: any generated example file can reference `${baseWWWUrl}` and have it resolved (at serve time) to the docs site's own absolute URL.
- Updates the three `pdf-export-languages` examples (`pdf-international-characters`, `pdf-rtl-languages`, `pdf-non-latin-language`) to fetch their fonts via `${baseWWWUrl}/fonts/pdf-export/...` instead of a root-relative `/fonts/pdf-export/...` path, so the "Export to PDF" button keeps working once the example is opened in Plunker (previously broken there, since Plunker can't resolve a path relative to the docs site).

Because the substitution resolves to whichever site generated the example (dev/staging/production), this avoids hardcoding a fixed staging or not-yet-published production URL.

## Test plan
- [x] `./checks.sh --projects ag-grid-docs,ag-grid-generate-example-files` (type-check + lint) passes
- [x] Verified `applySubstitutions` resolves `${baseWWWUrl}` correctly for dev/staging/production-style base URLs
- [ ] Manually verify "Export to PDF" works from the Plunker-opened `pdf-export-languages` examples once deployed to staging