### PR TITLE
AG-10819 custom-filter-feat

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/filter-advanced/_examples/custom-filter-options/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/filter-advanced/_examples/custom-filter-options/example.spec.ts
@@ -1,0 +1,110 @@
+import type { Page } from '@playwright/test';
+import {
+    clickHeaderToSort,
+    ensureGridReady,
+    expect,
+    orderedValues,
+    test,
+    waitForGridContent,
+} from '@utils/grid/test-utils';
+
+const filterInput = (page: Page) => page.locator('.ag-advanced-filter input[type=text]');
+
+/** Every rendered age, once the grid has settled on the applied expression. */
+async function expectAges(page: Page, isOutsideFilter: (age: number) => boolean): Promise<void> {
+    await expect(async () => {
+        const cells = await orderedValues(page, 'age');
+        expect(cells.length).toBeGreaterThan(0);
+        // A blank cell would read as `Number('') === 0`, which satisfies the even check it should fail.
+        expect(cells.filter((cell) => !/^\d+$/.test(cell))).toEqual([]);
+        expect(cells.map(Number).filter(isOutsideFilter)).toEqual([]);
+    }).toPass();
+}
+
+/** Types `expression`, closes the suggestion popup covering the buttons, then applies it. */
+async function applyExpression(page: Page, expression: string): Promise<void> {
+    await filterInput(page).fill(expression);
+    await page.keyboard.press('Escape');
+    await expect(page.locator('.ag-autocomplete-list-popup')).toBeHidden();
+    await page.locator('.ag-advanced-filter-buttons').getByText('Apply').click();
+}
+
+test.agExample(import.meta, () => {
+    test.eachFramework('should suggest the custom filter options for a column', async ({ page }) => {
+        await ensureGridReady(page);
+        await waitForGridContent(page);
+
+        await filterInput(page).fill('[Age] ');
+
+        // The whole list, so the narrowing the page describes is covered as well as the two options:
+        // the column's list omits every built-in but `equals`.
+        const autocompleteList = page.locator('.ag-autocomplete-list-popup');
+        await expect(autocompleteList).toBeVisible();
+        await expect(autocompleteList.locator('.ag-autocomplete-row')).toHaveText([
+            '=',
+            'Even Numbers',
+            'Between (Exclusive)',
+        ]);
+    });
+
+    test.eachFramework('should filter rows with zero-input and two-input custom options', async ({ page }) => {
+        await ensureGridReady(page);
+        await waitForGridContent(page);
+
+        await applyExpression(page, '[Age] Even Numbers');
+        await expectAges(page, (age) => age % 2 !== 0);
+
+        await applyExpression(page, '[Age] Between (Exclusive) (25, 30)');
+        await expectAges(page, (age) => age <= 25 || age >= 30);
+
+        // The brackets are optional. A different range, so this cannot hold on the previous result.
+        await applyExpression(page, '[Age] Between (Exclusive) 30, 35');
+        await expectAges(page, (age) => age <= 30 || age >= 35);
+    });
+
+    test.eachFramework('should filter rows with the athlete zero-input and one-input options', async ({ page }) => {
+        await ensureGridReady(page);
+        await waitForGridContent(page);
+
+        await applyExpression(page, '[Athlete] Starts With A');
+        await expect(async () => {
+            const athletes = await orderedValues(page, 'athlete');
+            expect(athletes.length).toBeGreaterThan(0);
+            expect(athletes.filter((athlete) => !athlete.startsWith('A'))).toEqual([]);
+        }).toPass();
+
+        await applyExpression(page, '[Athlete] Does Not Start With "A"');
+        await expect(async () => {
+            const athletes = await orderedValues(page, 'athlete');
+            expect(athletes.length).toBeGreaterThan(0);
+            expect(athletes.filter((athlete) => athlete.toLowerCase().startsWith('a'))).toEqual([]);
+        }).toPass();
+    });
+
+    test.eachFramework('should filter the date column with its custom options', async ({ page }) => {
+        await ensureGridReady(page);
+        await waitForGridContent(page);
+
+        await applyExpression(page, '[Date] Leap Year');
+        await expect(async () => {
+            const years = (await orderedValues(page, 'date')).map((date) => Number(date.split('-')[0]));
+            expect(years.length).toBeGreaterThan(0);
+            expect(years.filter((year) => year % 4 !== 0 || (year % 100 === 0 && year % 400 !== 0))).toEqual([]);
+        }).toPass();
+
+        // 2000 is the data's only century year, and a leap year by the 400 rule the naive `% 100` one drops.
+        // Sorted ascending to bring it into the rendered rows, which are the only ones readable.
+        await clickHeaderToSort(page.locator('.ag-header-cell[col-id="date"]'));
+        await expect(async () => {
+            const years = (await orderedValues(page, 'date')).map((date) => Number(date.split('-')[0]));
+            expect(years[0]).toBe(2000);
+        }).toPass();
+
+        await applyExpression(page, '[Date] Between (Exclusive) ("2008-08-20", "2008-08-25")');
+        await expect(async () => {
+            const dates = await orderedValues(page, 'date');
+            expect(dates.length).toBeGreaterThan(0);
+            expect(dates.filter((date) => date <= '2008-08-20' || date >= '2008-08-25')).toEqual([]);
+        }).toPass();
+    });
+});

--- a/documentation/ag-grid-docs/src/content/docs/filter-advanced/_examples/custom-filter-options/index.html
+++ b/documentation/ag-grid-docs/src/content/docs/filter-advanced/_examples/custom-filter-options/index.html
@@ -1,0 +1,1 @@
+<div id="myGrid" style="height: 100%"></div>

--- a/documentation/ag-grid-docs/src/content/docs/filter-advanced/_examples/custom-filter-options/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/filter-advanced/_examples/custom-filter-options/main.ts
@@ -1,0 +1,140 @@
+import type {
+    GridApi,
+    GridOptions,
+    IDateFilterParams,
+    INumberFilterParams,
+    ITextFilterParams,
+} from 'ag-grid-community';
+import {
+    ClientSideRowModelModule,
+    DateFilterModule,
+    ModuleRegistry,
+    NumberFilterModule,
+    TextFilterModule,
+    createGrid,
+    enableDevValidations,
+} from 'ag-grid-community';
+import { AdvancedFilterModule, ColumnMenuModule, ContextMenuModule } from 'ag-grid-enterprise';
+
+if (process.env.NODE_ENV !== 'production') {
+    // Enable extended validations only for development
+    enableDevValidations();
+}
+
+ModuleRegistry.registerModules([
+    TextFilterModule,
+    NumberFilterModule,
+    DateFilterModule,
+    AdvancedFilterModule,
+    ClientSideRowModelModule,
+    ColumnMenuModule,
+    ContextMenuModule,
+]);
+
+let gridApi: GridApi<IOlympicData>;
+
+const athleteFilterParams: ITextFilterParams = {
+    filterOptions: [
+        'contains',
+        {
+            displayKey: 'startsWithA',
+            displayName: 'Starts With A',
+            numberOfInputs: 0,
+            predicate: (_, cellValue) => cellValue != null && cellValue.startsWith('A'),
+        },
+        {
+            displayKey: 'notStartsWith',
+            displayName: 'Does Not Start With',
+            numberOfInputs: 1,
+            predicate: ([filterValue], cellValue) =>
+                cellValue != null && !cellValue.toLowerCase().startsWith(String(filterValue).toLowerCase()),
+        },
+    ],
+};
+
+const ageFilterParams: INumberFilterParams = {
+    filterOptions: [
+        'equals',
+        {
+            displayKey: 'evenNumbers',
+            displayName: 'Even Numbers',
+            numberOfInputs: 0,
+            predicate: (_, cellValue) => cellValue != null && cellValue % 2 === 0,
+        },
+        {
+            displayKey: 'betweenExclusive',
+            displayName: 'Between (Exclusive)',
+            numberOfInputs: 2,
+            predicate: ([from, to], cellValue) => cellValue != null && cellValue > from && cellValue < to,
+        },
+    ],
+};
+
+const dateFilterParams: IDateFilterParams = {
+    filterOptions: [
+        'equals',
+        {
+            displayKey: 'leapYear',
+            displayName: 'Leap Year',
+            numberOfInputs: 0,
+            predicate: (_, cellValue) => {
+                if (cellValue == null) {
+                    return false;
+                }
+                const year = Number(cellValue.split('-')[0]);
+                return year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+            },
+        },
+        {
+            displayKey: 'betweenExclusive',
+            displayName: 'Between (Exclusive)',
+            numberOfInputs: 2,
+            predicate: ([from, to], cellValue) => {
+                if (cellValue == null) {
+                    return false;
+                }
+                // Built as a local date: the filter's own values are local midnight, and
+                // `new Date('YYYY-MM-DD')` would be UTC midnight, so the two would not line up.
+                const [year, month, day] = cellValue.split('-').map(Number);
+                const cellDate = new Date(year, month - 1, day);
+                return cellDate > from && cellDate < to;
+            },
+        },
+    ],
+};
+
+const gridOptions: GridOptions<IOlympicData> = {
+    columnDefs: [
+        { field: 'athlete', filterParams: athleteFilterParams },
+        { field: 'age', minWidth: 120, filterParams: ageFilterParams },
+        { field: 'date', filter: 'agDateColumnFilter', filterParams: dateFilterParams },
+        { field: 'sport' },
+        { field: 'gold' },
+    ],
+    defaultColDef: {
+        flex: 1,
+        minWidth: 180,
+        filter: true,
+    },
+    enableAdvancedFilter: true,
+};
+
+// setup the grid after the page has finished loading
+document.addEventListener('DOMContentLoaded', () => {
+    const gridDiv = document.querySelector<HTMLElement>('#myGrid')!;
+    gridApi = createGrid(gridDiv, gridOptions);
+
+    fetch('https://www.ag-grid.com/example-assets/olympic-winners.json')
+        .then((response) => response.json())
+        .then((data: IOlympicData[]) =>
+            gridApi!.setGridOption(
+                'rowData',
+                // The supplied dates are `dd/mm/yyyy` strings, which is a text column. Convert them to
+                // `yyyy-mm-dd` so the column is a Date (String) one and its options filter on dates.
+                data.map((rowData) => {
+                    const [day, month, year] = rowData.date.split('/');
+                    return { ...rowData, date: `${year}-${month.padStart(2, '0')}-${day.padStart(2, '0')}` };
+                })
+            )
+        );
+});

--- a/documentation/ag-grid-docs/src/content/docs/filter-advanced/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/filter-advanced/index.mdoc
@@ -150,6 +150,70 @@ For `number`, `date`, `dateString`, `dateTime` and `dateTimeString` Cell Data Ty
 
 These settings only apply when using the Client-Side Row Model. You need to implement support for these in your server-side filtering logic when using the Server-Side Row Model.
 
+### Custom Filter Options
+
+`filterOptions` also accepts [Custom Filter Options](./filter-conditions/#custom-filter-options). The Advanced Filter evaluates the same `predicate` as the column filter, and supports options taking 0, 1 or 2 values. As with the settings above, the `predicate` runs only under the Client-Side Row Model: with the Server-Side Row Model the option reaches the server as its `displayKey` in the filter model, where the server-side filtering logic decides what it means.
+
+```{% frameworkTransform=true %}
+const gridOptions = {
+    columnDefs: [
+        {
+            field: 'age',
+            filterParams: {
+                filterOptions: [
+                    'equals',
+                    {
+                        displayKey: 'evenNumbers',
+                        displayName: 'Even Numbers',
+                        numberOfInputs: 0,
+                        predicate: (_values, cellValue) => cellValue != null && cellValue % 2 === 0,
+                    },
+                    {
+                        displayKey: 'betweenExclusive',
+                        displayName: 'Between (Exclusive)',
+                        numberOfInputs: 2,
+                        predicate: ([from, to], cellValue) => cellValue != null && cellValue > from && cellValue < to,
+                    },
+                ],
+            },
+        },
+    ],
+}
+```
+
+An option is written in an expression under its `displayName`, or its [localised](./localisation/) text where the `displayKey` has an entry, followed by as many values as it takes. An option whose name is blank once resolved is written under its `displayKey` instead, so it stays usable. Two values are separated by a comma, and are conventionally wrapped in brackets, which are optional:
+
+```text
+[Age] Even Numbers
+[Age] Between (Exclusive) (30, 40)
+```
+
+Each value is quoted according to its Cell Data Type, as for the built-in options: `number` and `bigint` values are unquoted, all others are quoted. A value that would otherwise end early — one containing a space or a closing bracket, starting with a quote, or holding the comma that separates a pair — is quoted whatever its type. A `number` or `bigint` value that contains both kinds of quote cannot be wrapped in either, so it is written as the plain number instead.
+
+The filter model stores the `displayKey` in `type`, and the values in `filter` and `filterTo`:
+
+```js
+const advancedFilterModel = {
+    filterType: 'number',
+    colId: 'age',
+    type: 'betweenExclusive',
+    filter: 30,
+    filterTo: 40,
+};
+```
+
+A `displayKey` is resolved against the column being filtered, so different columns can reuse the same key. Reusing an Option Key from the table above replaces that built-in option for the column, the same as it does in the column filter.
+
+A column's list decides what the Advanced Filter suggests for it, not what it can read. An expression naming an option the list leaves out — one saved before the list was narrowed, for example — still applies, so changing `filterOptions` does not discard filters that have already been stored. Where a list names no option the Advanced Filter has, such as the relative date presets, the column keeps the standard options for its Cell Data Type.
+
+The following example demonstrates custom filter options taking different numbers of values:
+
+- The **Athlete** column has `Starts With A` (no values) and `Does Not Start With` (one value).
+- The **Age** column has `Even Numbers` (no values) and `Between (Exclusive)` (two values).
+- The **Date** column has `Leap Year` (no values) and `Between (Exclusive)` (two dates).
+
+{% gridExampleRunner title="Custom Filter Options" name="custom-filter-options" /%}
+
 ## Filter Model / API
 
 The Advanced Filter model describes the current state of the Advanced Filter. This is represented by an `AdvancedFilterModel`, which is either a `ColumnAdvancedFilterModel` for a single condition, or a `JoinAdvancedFilterModel` for multiple conditions:

--- a/documentation/ag-grid-docs/src/content/docs/filter-conditions/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/filter-conditions/index.mdoc
@@ -70,6 +70,8 @@ The number of `filterValues` and corresponding inputs is controlled by the optio
 - If unspecified or set to `1` a single input is displayed, and one-element array of `filterValues` are provided to the `predicate` function.
 - If set to `2` two inputs are displayed, and a two-element array of `filterValues` is provided to the `predicate` function.
 
+Custom Filter Options are also offered by the [Advanced Filter](./filter-advanced/#custom-filter-options), which evaluates them with the same `predicate`.
+
 Custom `FilterOptionDef`s can be supplied alongside the built-in filter option `string` keys as shown below:
 
 ```{% frameworkTransform=true %}

--- a/packages/ag-grid-community/src/filter/filterDataTypeUtils.ts
+++ b/packages/ag-grid-community/src/filter/filterDataTypeUtils.ts
@@ -14,7 +14,7 @@ import type {
 import type { ISetFilterParams } from '../interfaces/iSetFilter';
 import type { IBigIntFilterParams } from './provided/bigInt/iBigIntFilter';
 import type { IDateFilterParams } from './provided/date/iDateFilter';
-import type { ISimpleFilterParams } from './provided/iSimpleFilter';
+import type { IFilterOptionDef, ISimpleFilterParams } from './provided/iSimpleFilter';
 import type { INumberFilterParams } from './provided/number/iNumberFilter';
 import type { ITextFilterParams } from './provided/text/iTextFilter';
 
@@ -101,6 +101,31 @@ type FilterParamsDefMap = CheckDataTypes<{
     object: FilterParamCallback<ITextFilterParams, any>;
 }>;
 
+/** One list shared by every boolean column, so it can be recognised as the grid's rather than the column's. */
+const BOOLEAN_FILTER_OPTIONS: (string | IFilterOptionDef)[] = [
+    'empty',
+    {
+        displayKey: 'true',
+        displayName: 'True',
+        predicate: (_filterValues: any[], cellValue: any) => cellValue,
+        numberOfInputs: 0,
+    },
+    {
+        displayKey: 'false',
+        displayName: 'False',
+        predicate: (_filterValues: any[], cellValue: any) => cellValue === false,
+        numberOfInputs: 0,
+    },
+];
+
+/**
+ * Whether the list is the grid's own for the cell data type, rather than options the column author wrote.
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
+ */
+export function _isGridSuppliedFilterOptions(filterOptions: unknown): boolean {
+    return filterOptions === BOOLEAN_FILTER_OPTIONS;
+}
+
 // using an object here to enforce dev to not forget to implement new types as they are added
 const filterParamsForEachDataType: FilterParamsDefMap = {
     number: () => undefined,
@@ -108,21 +133,7 @@ const filterParamsForEachDataType: FilterParamsDefMap = {
     boolean: () => ({
         maxNumConditions: 1,
         debounceMs: 0,
-        filterOptions: [
-            'empty',
-            {
-                displayKey: 'true',
-                displayName: 'True',
-                predicate: (_filterValues: any[], cellValue: any) => cellValue,
-                numberOfInputs: 0,
-            },
-            {
-                displayKey: 'false',
-                displayName: 'False',
-                predicate: (_filterValues: any[], cellValue: any) => cellValue === false,
-                numberOfInputs: 0,
-            },
-        ],
+        filterOptions: BOOLEAN_FILTER_OPTIONS,
     }),
     date: () => ({ isValidDate }),
     dateString: ({ dataTypeDefinition }) => ({

--- a/packages/ag-grid-community/src/filter/filterDataTypeUtils.ts
+++ b/packages/ag-grid-community/src/filter/filterDataTypeUtils.ts
@@ -101,8 +101,7 @@ type FilterParamsDefMap = CheckDataTypes<{
     object: FilterParamCallback<ITextFilterParams, any>;
 }>;
 
-/** One list shared by every boolean column, so it can be recognised as the grid's rather than the column's. */
-const BOOLEAN_FILTER_OPTIONS: (string | IFilterOptionDef)[] = [
+const BOOLEAN_FILTER_OPTIONS: readonly (string | IFilterOptionDef)[] = [
     'empty',
     {
         displayKey: 'true',
@@ -119,11 +118,20 @@ const BOOLEAN_FILTER_OPTIONS: (string | IFilterOptionDef)[] = [
 ];
 
 /**
- * Whether the list is the grid's own for the cell data type, rather than options the column author wrote.
+ * Whether the list is still exactly what the grid supplied for the cell data type. Content rather than
+ * identity, so a list edited after the fact reads as the column's and both filters go on offering the same.
  * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
  */
 export function _isGridSuppliedFilterOptions(filterOptions: unknown): boolean {
-    return filterOptions === BOOLEAN_FILTER_OPTIONS;
+    if (!Array.isArray(filterOptions) || filterOptions.length !== BOOLEAN_FILTER_OPTIONS.length) {
+        return false;
+    }
+    for (let i = 0, len = BOOLEAN_FILTER_OPTIONS.length; i < len; ++i) {
+        if (filterOptions[i] !== BOOLEAN_FILTER_OPTIONS[i]) {
+            return false;
+        }
+    }
+    return true;
 }
 
 // using an object here to enforce dev to not forget to implement new types as they are added
@@ -133,7 +141,8 @@ const filterParamsForEachDataType: FilterParamsDefMap = {
     boolean: () => ({
         maxNumConditions: 1,
         debounceMs: 0,
-        filterOptions: BOOLEAN_FILTER_OPTIONS,
+        // A copy per column, so editing the list one colDef carries cannot reach the others.
+        filterOptions: [...BOOLEAN_FILTER_OPTIONS],
     }),
     date: () => ({ isValidDate }),
     dateString: ({ dataTypeDefinition }) => ({

--- a/packages/ag-grid-community/src/filter/provided/bigInt/iBigIntFilter.ts
+++ b/packages/ag-grid-community/src/filter/provided/bigInt/iBigIntFilter.ts
@@ -36,7 +36,10 @@ export type BigIntFilterParams<TData = any, TContext = any> = IBigIntFilterParam
  * Parameters used in `colDef.filterParams` to configure a BigInt Filter (`agBigIntColumnFilter`).
  */
 export interface IBigIntFilterParams<TData = any, TContext = any> extends IScalarFilterParams {
-    /** Array of filter options to present to the user. */
+    /**
+     * Array of filter options to present to the user, and the options the Advanced Filter offers for the column.
+     * A key the filter cannot evaluate is reported when a value is tested against it under the built-in matching.
+     */
     filterOptions?: (IFilterOptionDef | ScalarFilterOptionKey)[];
     /** The default filter option to be selected. Must be one of the offered options. */
     defaultOption?: ScalarFilterOptionKey | CustomFilterOptionKey;

--- a/packages/ag-grid-community/src/filter/provided/bigInt/iBigIntFilter.ts
+++ b/packages/ag-grid-community/src/filter/provided/bigInt/iBigIntFilter.ts
@@ -36,10 +36,7 @@ export type BigIntFilterParams<TData = any, TContext = any> = IBigIntFilterParam
  * Parameters used in `colDef.filterParams` to configure a BigInt Filter (`agBigIntColumnFilter`).
  */
 export interface IBigIntFilterParams<TData = any, TContext = any> extends IScalarFilterParams {
-    /**
-     * Array of filter options to present to the user, and the options the Advanced Filter offers for the column.
-     * A key the filter cannot evaluate is reported when a value is tested against it under the built-in matching.
-     */
+    /** Array of filter options to present to the user, and the options the Advanced Filter offers for the column. */
     filterOptions?: (IFilterOptionDef | ScalarFilterOptionKey)[];
     /** The default filter option to be selected. Must be one of the offered options. */
     defaultOption?: ScalarFilterOptionKey | CustomFilterOptionKey;

--- a/packages/ag-grid-community/src/filter/provided/date/iDateFilter.ts
+++ b/packages/ag-grid-community/src/filter/provided/date/iDateFilter.ts
@@ -60,7 +60,10 @@ export type DateFilterParams<TData = any> = IDateFilterParams & IFilterParams<TD
  */
 
 export interface IDateFilterParams extends IScalarFilterParams {
-    /** Array of filter options to present to the user. */
+    /**
+     * Array of filter options to present to the user, and the options the Advanced Filter offers for the column.
+     * A key the filter cannot evaluate is reported when a value is tested against it under the built-in matching.
+     */
     filterOptions?: (IFilterOptionDef | DateFilterOptionKey)[];
     /** The default filter option to be selected. Must be one of the offered options. */
     defaultOption?: DateFilterOptionKey | CustomFilterOptionKey;

--- a/packages/ag-grid-community/src/filter/provided/date/iDateFilter.ts
+++ b/packages/ag-grid-community/src/filter/provided/date/iDateFilter.ts
@@ -60,10 +60,7 @@ export type DateFilterParams<TData = any> = IDateFilterParams & IFilterParams<TD
  */
 
 export interface IDateFilterParams extends IScalarFilterParams {
-    /**
-     * Array of filter options to present to the user, and the options the Advanced Filter offers for the column.
-     * A key the filter cannot evaluate is reported when a value is tested against it under the built-in matching.
-     */
+    /** Array of filter options to present to the user, and the options the Advanced Filter offers for the column. */
     filterOptions?: (IFilterOptionDef | DateFilterOptionKey)[];
     /** The default filter option to be selected. Must be one of the offered options. */
     defaultOption?: DateFilterOptionKey | CustomFilterOptionKey;

--- a/packages/ag-grid-community/src/filter/provided/iSimpleFilter.ts
+++ b/packages/ag-grid-community/src/filter/provided/iSimpleFilter.ts
@@ -11,7 +11,10 @@ export interface IFilterOptionDef {
     displayName: string;
     /** Custom filter logic that returns a boolean based on the `filterValues` and `cellValue`. */
     predicate?: (filterValues: any[], cellValue: any) => boolean;
-    /** Number of inputs to display for this option. Defaults to `1` if unspecified. */
+    /**
+     * Number of inputs to display for this option, and the number of values an Advanced Filter expression
+     * writes for it. Defaults to `1` if unspecified; a value outside the range is clamped into it.
+     */
     numberOfInputs?: 0 | 1 | 2;
 }
 
@@ -49,7 +52,7 @@ export type SimpleFilterParams<TData = any> = ISimpleFilterParams & IFilterParam
  */
 export interface ISimpleFilterParams extends IProvidedFilterParams, IAutoCompleteComponentParams {
     /**
-     * Array of filter options to present to the user.
+     * Array of filter options to present to the user, and the options the Advanced Filter offers for the column.
      * A key the filter cannot evaluate is reported when a value is tested against it under the built-in matching.
      */
     filterOptions?: (IFilterOptionDef | ISimpleFilterModelType)[];

--- a/packages/ag-grid-community/src/filter/provided/iSimpleFilter.ts
+++ b/packages/ag-grid-community/src/filter/provided/iSimpleFilter.ts
@@ -11,10 +11,7 @@ export interface IFilterOptionDef {
     displayName: string;
     /** Custom filter logic that returns a boolean based on the `filterValues` and `cellValue`. */
     predicate?: (filterValues: any[], cellValue: any) => boolean;
-    /**
-     * Number of inputs to display for this option, and the number of values an Advanced Filter expression
-     * writes for it. Defaults to `1` if unspecified; a value outside the range is clamped into it.
-     */
+    /** Number of inputs for this option, and the values an Advanced Filter writes. Defaults to `1`, clamped to 0-2. */
     numberOfInputs?: 0 | 1 | 2;
 }
 
@@ -51,10 +48,7 @@ export type SimpleFilterParams<TData = any> = ISimpleFilterParams & IFilterParam
  * Common parameters in `colDef.filterParams` used by all simple filters. Extended by the specific filter types.
  */
 export interface ISimpleFilterParams extends IProvidedFilterParams, IAutoCompleteComponentParams {
-    /**
-     * Array of filter options to present to the user, and the options the Advanced Filter offers for the column.
-     * A key the filter cannot evaluate is reported when a value is tested against it under the built-in matching.
-     */
+    /** Array of filter options to present to the user, and the options the Advanced Filter offers for the column. */
     filterOptions?: (IFilterOptionDef | ISimpleFilterModelType)[];
     /** The default filter option to be selected. Must be one of the offered options. */
     defaultOption?: ISimpleFilterModelType | CustomFilterOptionKey;

--- a/packages/ag-grid-community/src/filter/provided/number/iNumberFilter.ts
+++ b/packages/ag-grid-community/src/filter/provided/number/iNumberFilter.ts
@@ -36,10 +36,7 @@ export type NumberFilterParams<TData = any, TContext = any> = INumberFilterParam
  */
 
 export interface INumberFilterParams<TData = any, TContext = any> extends IScalarFilterParams {
-    /**
-     * Array of filter options to present to the user, and the options the Advanced Filter offers for the column.
-     * A key the filter cannot evaluate is reported when a value is tested against it under the built-in matching.
-     */
+    /** Array of filter options to present to the user, and the options the Advanced Filter offers for the column. */
     filterOptions?: (IFilterOptionDef | ScalarFilterOptionKey)[];
     /** The default filter option to be selected. Must be one of the offered options. */
     defaultOption?: ScalarFilterOptionKey | CustomFilterOptionKey;

--- a/packages/ag-grid-community/src/filter/provided/number/iNumberFilter.ts
+++ b/packages/ag-grid-community/src/filter/provided/number/iNumberFilter.ts
@@ -36,7 +36,10 @@ export type NumberFilterParams<TData = any, TContext = any> = INumberFilterParam
  */
 
 export interface INumberFilterParams<TData = any, TContext = any> extends IScalarFilterParams {
-    /** Array of filter options to present to the user. */
+    /**
+     * Array of filter options to present to the user, and the options the Advanced Filter offers for the column.
+     * A key the filter cannot evaluate is reported when a value is tested against it under the built-in matching.
+     */
     filterOptions?: (IFilterOptionDef | ScalarFilterOptionKey)[];
     /** The default filter option to be selected. Must be one of the offered options. */
     defaultOption?: ScalarFilterOptionKey | CustomFilterOptionKey;

--- a/packages/ag-grid-community/src/filter/provided/optionsFactory.ts
+++ b/packages/ag-grid-community/src/filter/provided/optionsFactory.ts
@@ -1,8 +1,6 @@
 import type { LogService } from '../../validation/logService';
 import type { IFilterOptionDef, ISimpleFilterParams } from './iSimpleFilter';
-
-/** An entry missing any of these cannot be offered; they are listed so the warning can name the missing one. */
-const REQUIRED_OPTION_PROPERTIES: (keyof IFilterOptionDef)[] = ['displayKey', 'displayName', 'predicate'];
+import { _classifyFilterOptions } from './simpleFilterUtils';
 
 /* Common logic for options, used by both filters and floating filters. */
 export class OptionsFactory {
@@ -40,26 +38,7 @@ export class OptionsFactory {
     }
 
     private collectUsableOptions(log: LogService, configuredOptions: (IFilterOptionDef | string)[]): void {
-        // A `Map` holds a key at the position it was first set in, so it dedupes without reordering the dropdown.
-        const offered = new Map<string, IFilterOptionDef | string>();
-        const customOptions = new Map<string, IFilterOptionDef>();
-        for (let i = 0, len = configuredOptions.length; i < len; ++i) {
-            const option = configuredOptions[i];
-            if (option == null) {
-                continue; // `typeof null` is `'object'`, so a hole would read as an option with no properties
-            } else if (typeof option === 'string') {
-                offered.set(option, offered.get(option) ?? option); // a definition already stored outranks a bare key
-            } else {
-                const missing = REQUIRED_OPTION_PROPERTIES.filter((name) => option[name] == null);
-                if (missing.length) {
-                    log.warn(72, { keys: missing });
-                    continue;
-                }
-                const key = option.displayKey;
-                offered.set(key, option);
-                customOptions.set(key, option);
-            }
-        }
+        const { offered, customOptions } = _classifyFilterOptions(configuredOptions, (keys) => log.warn(72, { keys }));
         this.offeredOptions = offered;
         this.filterOptions = [...offered.values()];
         this.customFilterOptions = customOptions;

--- a/packages/ag-grid-community/src/filter/provided/simpleFilterModelFormatter.ts
+++ b/packages/ag-grid-community/src/filter/provided/simpleFilterModelFormatter.ts
@@ -5,6 +5,7 @@ import { translateForFilter } from '../filterLocaleText';
 import type { ProvidedFilterModel } from './iProvidedFilter';
 import type { FilterOptionKey, ICombinedSimpleModel, ISimpleFilterModel, ISimpleFilterParams } from './iSimpleFilter';
 import type { OptionsFactory } from './optionsFactory';
+import { _getCustomOptionDisplayName, _getCustomOptionNumberOfInputs } from './simpleFilterUtils';
 
 export const SCALAR_FILTER_TYPE_KEYS = {
     equals: 'Equals',
@@ -75,16 +76,16 @@ export abstract class SimpleFilterModelFormatter<
 
             // For custom filter options we display the Name of the filter instead
             // of displaying the `from` value, as it wouldn't be relevant
-            const { displayKey, displayName, numberOfInputs } = customOption || {};
-            if (displayKey && displayName && numberOfInputs === 0) {
-                return translate(displayKey, displayName);
+            const numberOfInputs = customOption ? _getCustomOptionNumberOfInputs(customOption) : undefined;
+            if (customOption && numberOfInputs === 0) {
+                return _getCustomOptionDisplayName(customOption, translate);
             }
             return this.conditionToString(
                 condition,
                 forToolPanel,
                 condition.type === 'inRange' || numberOfInputs === 2,
-                displayKey,
-                displayName
+                customOption?.displayKey,
+                customOption?.displayName
             );
         }
     }

--- a/packages/ag-grid-community/src/filter/provided/simpleFilterUtils.ts
+++ b/packages/ag-grid-community/src/filter/provided/simpleFilterUtils.ts
@@ -118,11 +118,70 @@ const zeroInputTypes: ReadonlySet<string> = new Set<ISimpleFilterModelType>([
     'last24Months',
 ]);
 
+/** An entry missing any of these cannot be offered; they are listed so the warning can name the missing one. */
+const REQUIRED_OPTION_PROPERTIES: (keyof IFilterOptionDef)[] = ['displayKey', 'displayName', 'predicate'];
+
+/**
+ * What a `filterOptions` list offers, keyed in the order it first names them, and the Custom Filter Options
+ * among them. One definition, so the column filter and the Advanced Filter cannot disagree over any one
+ * entry; what each does with a list that keeps nothing is still its own.
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
+ */
+export function _classifyFilterOptions(
+    configuredOptions: (IFilterOptionDef | string)[],
+    warnMissing: (keys: string[]) => void
+): { offered: Map<string, IFilterOptionDef | string>; customOptions: Map<string, IFilterOptionDef> } {
+    // A `Map` holds a key at the position it was first set in, so it dedupes without reordering the dropdown.
+    const offered = new Map<string, IFilterOptionDef | string>();
+    const customOptions = new Map<string, IFilterOptionDef>();
+    for (let i = 0, len = configuredOptions.length; i < len; ++i) {
+        const option = configuredOptions[i];
+        if (option == null) {
+            continue; // `typeof null` is `'object'`, so a hole would read as an option with no properties
+        } else if (typeof option === 'string') {
+            offered.set(option, offered.get(option) ?? option); // a definition already stored outranks a bare key
+        } else {
+            const missing = REQUIRED_OPTION_PROPERTIES.filter((name) => option[name] == null);
+            if (missing.length) {
+                warnMissing(missing);
+                continue;
+            }
+            const key = option.displayKey;
+            offered.set(key, option);
+            customOptions.set(key, option);
+        }
+    }
+    return { offered, customOptions };
+}
+
+/**
+ * The name a Custom Filter Option is shown and written under: its localised text, then its `displayName`,
+ * then its key, as a column falls back from `headerName` to its field. A stray space cannot be spelled in
+ * an expression, hence the trim; a key is not a `string` to a JS caller, hence `String`.
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
+ */
+export function _getCustomOptionDisplayName(
+    option: IFilterOptionDef,
+    translate: (key: string, defaultValue: string) => string
+): string {
+    const displayKey = String(option.displayKey);
+    return translate(displayKey, option.displayName).trim() || displayKey.trim();
+}
+
+/**
+ * How many values a Custom Filter Option takes, so the Advanced Filter cannot disagree with the column
+ * filter about one. The declared `0 | 1 | 2` is no check on a JS caller, hence the clamp.
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
+ */
+export function _getCustomOptionNumberOfInputs(option: IFilterOptionDef): number {
+    const count = Math.trunc(option.numberOfInputs ?? 1);
+    return count > 0 ? Math.min(count, 2) : 0;
+}
+
 export function getNumberOfInputs(type: FilterOptionKey | null | undefined, optionsFactory: OptionsFactory): number {
     const customOpts = optionsFactory.getCustomOption(type);
     if (customOpts) {
-        const { numberOfInputs } = customOpts;
-        return numberOfInputs != null ? numberOfInputs : 1;
+        return _getCustomOptionNumberOfInputs(customOpts);
     }
 
     if (type && zeroInputTypes.has(type)) {

--- a/packages/ag-grid-community/src/filter/provided/simpleFilterUtils.ts
+++ b/packages/ag-grid-community/src/filter/provided/simpleFilterUtils.ts
@@ -122,9 +122,7 @@ const zeroInputTypes: ReadonlySet<string> = new Set<ISimpleFilterModelType>([
 const REQUIRED_OPTION_PROPERTIES: (keyof IFilterOptionDef)[] = ['displayKey', 'displayName', 'predicate'];
 
 /**
- * What a `filterOptions` list offers, keyed in the order it first names them, and the Custom Filter Options
- * among them. One definition, so the column filter and the Advanced Filter cannot disagree over any one
- * entry; what each does with a list that keeps nothing is still its own.
+ * One definition of what a `filterOptions` list offers, so the column filter and the Advanced Filter cannot disagree.
  * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
  */
 export function _classifyFilterOptions(
@@ -155,9 +153,7 @@ export function _classifyFilterOptions(
 }
 
 /**
- * The name a Custom Filter Option is shown and written under: its localised text, then its `displayName`,
- * then its key, as a column falls back from `headerName` to its field. A stray space cannot be spelled in
- * an expression, hence the trim; a key is not a `string` to a JS caller, hence `String`.
+ * The name an option is shown and written under: localised text, then `displayName`, then its key.
  * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
  */
 export function _getCustomOptionDisplayName(
@@ -169,8 +165,7 @@ export function _getCustomOptionDisplayName(
 }
 
 /**
- * How many values a Custom Filter Option takes, so the Advanced Filter cannot disagree with the column
- * filter about one. The declared `0 | 1 | 2` is no check on a JS caller, hence the clamp.
+ * How many values an option takes; the declared `0 | 1 | 2` is no check on a JS caller, hence the clamp.
  * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
  */
 export function _getCustomOptionNumberOfInputs(option: IFilterOptionDef): number {

--- a/packages/ag-grid-community/src/filter/provided/text/iTextFilter.ts
+++ b/packages/ag-grid-community/src/filter/provided/text/iTextFilter.ts
@@ -67,10 +67,7 @@ export type TextFilterParams<TData = any> = ITextFilterParams & IFilterParams<TD
  */
 
 export interface ITextFilterParams extends ISimpleFilterParams {
-    /**
-     * Array of filter options to present to the user, and the options the Advanced Filter offers for the column.
-     * A key the filter cannot evaluate is reported when a value is tested against it under the built-in matching.
-     */
+    /** Array of filter options to present to the user, and the options the Advanced Filter offers for the column. */
     filterOptions?: (IFilterOptionDef | TextFilterOptionKey)[];
     /** The default filter option to be selected. Must be one of the offered options. */
     defaultOption?: TextFilterOptionKey | CustomFilterOptionKey;

--- a/packages/ag-grid-community/src/filter/provided/text/iTextFilter.ts
+++ b/packages/ag-grid-community/src/filter/provided/text/iTextFilter.ts
@@ -67,7 +67,10 @@ export type TextFilterParams<TData = any> = ITextFilterParams & IFilterParams<TD
  */
 
 export interface ITextFilterParams extends ISimpleFilterParams {
-    /** Array of filter options to present to the user. */
+    /**
+     * Array of filter options to present to the user, and the options the Advanced Filter offers for the column.
+     * A key the filter cannot evaluate is reported when a value is tested against it under the built-in matching.
+     */
     filterOptions?: (IFilterOptionDef | TextFilterOptionKey)[];
     /** The default filter option to be selected. Must be one of the offered options. */
     defaultOption?: TextFilterOptionKey | CustomFilterOptionKey;

--- a/packages/ag-grid-community/src/interfaces/advancedFilterModel.ts
+++ b/packages/ag-grid-community/src/interfaces/advancedFilterModel.ts
@@ -1,4 +1,5 @@
 import type { CheckDataTypes } from '../entities/dataType';
+import type { CustomFilterOptionKey } from '../filter/provided/iSimpleFilter';
 
 export type AdvancedFilterModel = JoinAdvancedFilterModel | ColumnAdvancedFilterModel;
 
@@ -39,9 +40,11 @@ export interface TextAdvancedFilterModel {
     /** The ID of the column being filtered. */
     colId: string;
     /** The filter option that is being applied. */
-    type: TextAdvancedFilterModelType;
+    type: TextAdvancedFilterModelType | CustomFilterOptionKey;
     /** The value to filter on. This is the same value as displayed in the input. */
     filter?: string;
+    /** The second value to filter on, where the filter option takes two. */
+    filterTo?: string;
 }
 
 /** Represents a single filter condition for a number column */
@@ -50,9 +53,11 @@ export interface NumberAdvancedFilterModel {
     /** The ID of the column being filtered. */
     colId: string;
     /** The filter option that is being applied. */
-    type: ScalarAdvancedFilterModelType;
+    type: ScalarAdvancedFilterModelType | CustomFilterOptionKey;
     /** The value to filter on. */
     filter?: number;
+    /** The second value to filter on, where the filter option takes two. */
+    filterTo?: number;
 }
 
 /** Represents a single filter condition for a bigint column */
@@ -61,9 +66,11 @@ interface BigIntAdvancedFilterModel {
     /** The ID of the column being filtered. */
     colId: string;
     /** The filter option that is being applied. */
-    type: ScalarAdvancedFilterModelType;
+    type: ScalarAdvancedFilterModelType | CustomFilterOptionKey;
     /** The value to filter on. */
     filter?: string;
+    /** The second value to filter on, where the filter option takes two. */
+    filterTo?: string;
 }
 
 /** Represents a single filter condition for a date column */
@@ -72,9 +79,11 @@ export interface DateAdvancedFilterModel {
     /** The ID of the column being filtered. */
     colId: string;
     /** The filter option that is being applied. */
-    type: ScalarAdvancedFilterModelType;
+    type: ScalarAdvancedFilterModelType | CustomFilterOptionKey;
     /** The value to filter on. This is in format `YYYY-MM-DD`. */
     filter?: string;
+    /** The second value to filter on, where the filter option takes two. */
+    filterTo?: string;
 }
 
 /** Represents a single filter condition for a date string column */
@@ -83,9 +92,11 @@ export interface DateStringAdvancedFilterModel {
     /** The ID of the column being filtered. */
     colId: string;
     /** The filter option that is being applied. */
-    type: ScalarAdvancedFilterModelType;
+    type: ScalarAdvancedFilterModelType | CustomFilterOptionKey;
     /** The value to filter on. This is in format `YYYY-MM-DD`. */
     filter?: string;
+    /** The second value to filter on, where the filter option takes two. */
+    filterTo?: string;
 }
 
 /** Represents a single filter condition for a boolean column */
@@ -94,7 +105,11 @@ export interface BooleanAdvancedFilterModel {
     /** The ID of the column being filtered. */
     colId: string;
     /** The filter option that is being applied. */
-    type: BooleanAdvancedFilterModelType;
+    type: BooleanAdvancedFilterModelType | CustomFilterOptionKey;
+    /** The value to filter on. Only used by Custom Filter Options, as the built-in options take none. */
+    filter?: string;
+    /** The second value to filter on, where the filter option takes two. */
+    filterTo?: string;
 }
 
 /** Represents a single filter condition for an object column */
@@ -104,8 +119,10 @@ export interface ObjectAdvancedFilterModel {
     colId: string;
     /** The value to filter on. This is the same value as displayed in the input. */
     filter?: string;
+    /** The second value to filter on, where the filter option takes two. */
+    filterTo?: string;
     /** The filter option that is being applied. */
-    type: TextAdvancedFilterModelType;
+    type: TextAdvancedFilterModelType | CustomFilterOptionKey;
 }
 
 export interface DateTimeAdvancedFilterModel {
@@ -113,9 +130,11 @@ export interface DateTimeAdvancedFilterModel {
     /** The ID of the column being filtered. */
     colId: string;
     /** The filter option that is being applied. */
-    type: ScalarAdvancedFilterModelType;
+    type: ScalarAdvancedFilterModelType | CustomFilterOptionKey;
     /** The value to filter on. This is in format `YYYY-MM-DDTHH:mm:ss`. */
     filter?: string;
+    /** The second value to filter on, where the filter option takes two. */
+    filterTo?: string;
 }
 
 export interface DateTimeStringAdvancedFilterModel {
@@ -123,9 +142,11 @@ export interface DateTimeStringAdvancedFilterModel {
     /** The ID of the column being filtered. */
     colId: string;
     /** The filter option that is being applied. */
-    type: ScalarAdvancedFilterModelType;
+    type: ScalarAdvancedFilterModelType | CustomFilterOptionKey;
     /** The value to filter on. This is in format `YYYY-MM-DD HH:mm:ss`. */
     filter?: string;
+    /** The second value to filter on, where the filter option takes two. */
+    filterTo?: string;
 }
 
 /** Represents a single filter condition on a column */

--- a/packages/ag-grid-community/src/main-internal.ts
+++ b/packages/ag-grid-community/src/main-internal.ts
@@ -136,14 +136,25 @@ export {
 export { AgFilterButtonSelector, FilterButtonComp } from './filter/filterButtonComp';
 export type { FilterButton, FilterButtonEvent } from './filter/filterButtonComp';
 export { FilterComp } from './filter/filterComp';
-export { _getDefaultSimpleFilter, _getFilterParamsForDataType } from './filter/filterDataTypeUtils';
+export {
+    _getDefaultSimpleFilter,
+    _getFilterParamsForDataType,
+    _isGridSuppliedFilterOptions,
+} from './filter/filterDataTypeUtils';
 export { translateForFilter as _translateForFilter } from './filter/filterLocaleText';
 export type { FilterManager } from './filter/filterManager';
 export type { FilterValueService } from './filter/filterValueService';
 export { FilterWrapperComp } from './filter/filterWrapperComp';
 export { _getDefaultFloatingFilterType } from './filter/floating/floatingFilterMapper';
 export { _isUseApplyButton } from './filter/provided/providedFilterUtils';
-export { _bindFilterCallback, _isBlank, _hasValue } from './filter/provided/simpleFilterUtils';
+export {
+    _bindFilterCallback,
+    _classifyFilterOptions,
+    _getCustomOptionDisplayName,
+    _getCustomOptionNumberOfInputs,
+    _hasValue,
+    _isBlank,
+} from './filter/provided/simpleFilterUtils';
 export type { FocusService } from './focusService';
 export { _getGlobalGridOption } from './globalGridOptions';
 export { GridCoreCreator } from './grid';

--- a/packages/ag-grid-enterprise/src/advancedFilter/advancedFilterExpressionService.ts
+++ b/packages/ag-grid-enterprise/src/advancedFilter/advancedFilterExpressionService.ts
@@ -1,10 +1,9 @@
-import { _hasOwn, _parseBigIntOrNull, _parseDateTimeFromString, _serialiseDate, _toStringOrNull } from 'ag-stack';
+import { _getOwn, _parseBigIntOrNull, _parseDateTimeFromString, _serialiseDate, _toStringOrNull } from 'ag-stack';
 
 import type {
     AgColumn,
     BaseCellDataType,
     BeanCollection,
-    BooleanAdvancedFilterModel,
     ColumnAdvancedFilterModel,
     ColumnModel,
     ColumnNameService,
@@ -13,11 +12,12 @@ import type {
     NamedBean,
     ValueService,
 } from 'ag-grid-community';
-import { BeanStub, _toFiniteNumber } from 'ag-grid-community';
+import { BeanStub, _classifyFilterOptions, _toFiniteNumber } from 'ag-grid-community';
 
 import { ADVANCED_FILTER_LOCALE_TEXT } from './advancedFilterLocaleText';
 import type { AutocompleteEntry, AutocompleteListParams } from './autocomplete/autocompleteParams';
 import { COL_FILTER_EXPRESSION_END_CHAR, COL_FILTER_EXPRESSION_START_CHAR } from './colFilterExpressionParser';
+import { createCustomOptionOperators, getColumnFilterOptions } from './customFilterOptions';
 import type {
     DataTypeFilterExpressionOperators,
     FilterExpressionEvaluatorParams,
@@ -29,6 +29,7 @@ import {
     ScalarFilterExpressionOperators,
     TextFilterExpressionOperators,
 } from './filterExpressionOperators';
+import type { ColumnFilterModelOperands } from './filterExpressionUtils';
 import {
     getBigIntFormatter,
     getBigIntParser,
@@ -37,9 +38,18 @@ import {
     hasCustomNumberOperands,
 } from './filterExpressionUtils';
 
-/** What an unquoted operand cannot carry: a space or `)` ends it, and a leading quote opens one. */
-function needsQuotes(operand: string): boolean {
-    return operand.includes(' ') || operand.includes(')') || operand.startsWith(`'`) || operand.startsWith('"');
+/**
+ * What an unquoted operand cannot carry: a space or `)` ends it, a leading quote opens one, and inside a
+ * comma-separated pair a `,` ends it too.
+ */
+function needsQuotes(operand: string, inPair?: boolean): boolean {
+    return (
+        operand.includes(' ') ||
+        operand.includes(')') ||
+        operand.startsWith(`'`) ||
+        operand.startsWith('"') ||
+        (!!inPair && operand.includes(','))
+    );
 }
 
 /** The quote a value can be wrapped in, or null when it holds both kinds: either one would end it early. */
@@ -59,6 +69,12 @@ const COPIED_FILTER_PARAMS: (keyof FilterExpressionEvaluatorParams<any>)[] = [
     'includeBlanksInGreaterThan',
 ];
 
+/** A column's operators and the keys it narrows them to, classified together from its one `filterOptions`. */
+interface ColumnOperators {
+    readonly operators: DataTypeFilterExpressionOperators<any>;
+    readonly activeOperators: string[] | undefined;
+}
+
 export class AdvancedFilterExpressionService extends BeanStub implements NamedBean {
     beanName = 'advFilterExpSvc' as const;
 
@@ -74,7 +90,7 @@ export class AdvancedFilterExpressionService extends BeanStub implements NamedBe
         // Written in the column's own syntax exactly where `getNumberParser` reads that syntax back.
         number: (model) => {
             const column = this.colModel.getNonPivotCol(model.colId);
-            return this.formatOperand(
+            return this.applyOperandFormatter(
                 model.filter,
                 getNumberFormatter(column, this.gos),
                 _toFiniteNumber,
@@ -83,7 +99,7 @@ export class AdvancedFilterExpressionService extends BeanStub implements NamedBe
         },
         bigint: (model) => {
             const column = this.colModel.getNonPivotCol(model.colId);
-            return this.formatOperand(
+            return this.applyOperandFormatter(
                 model.filter,
                 getBigIntFormatter(column, this.gos),
                 _parseBigIntOrNull,
@@ -166,10 +182,23 @@ export class AdvancedFilterExpressionService extends BeanStub implements NamedBe
     private expressionOperators: FilterExpressionOperators;
     private expressionJoinOperators: { AND: string; OR: string };
     private expressionEvaluatorParams: { [colId: string]: FilterExpressionEvaluatorParams<any> } = Object.create(null);
+    /** Keyed by data type as well as column: a model's `filterType` need not be the column's current one. */
+    private columnExpressionOperators: { [dataType: string]: WeakMap<AgColumn, ColumnOperators> } = Object.create(null);
 
     public postConstruct(): void {
         this.expressionJoinOperators = this.generateExpressionJoinOperators();
         this.expressionOperators = this.generateExpressionOperators();
+        // Everything cached here is keyed on a column's name, visibility or definition, and each of these
+        // changes one of them without going through `newColumnsLoaded`.
+        const resetColumnCaches = this.resetColumnCaches.bind(this);
+        this.addManagedEventListeners({
+            newColumnsLoaded: resetColumnCaches,
+            columnVisible: resetColumnCaches,
+            columnRowGroupChanged: resetColumnCaches,
+            columnPivotModeChanged: resetColumnCaches,
+            columnPivotChanged: resetColumnCaches,
+            columnHeaderNameChanged: resetColumnCaches,
+        });
     }
 
     public parseJoinOperator(model: JoinAdvancedFilterModel): string {
@@ -198,7 +227,7 @@ export class AdvancedFilterExpressionService extends BeanStub implements NamedBe
      * is used: the expression is what the operand is parsed back out of, so one that does not round-trip
      * would quietly rewrite the stored value.
      */
-    private formatOperand<V>(
+    private applyOperandFormatter<V>(
         filter: string | number | undefined,
         formatter: ((value: V) => string | null) | null | undefined,
         parse: (rawValue: string) => V | null,
@@ -223,7 +252,11 @@ export class AdvancedFilterExpressionService extends BeanStub implements NamedBe
     }
 
     public getOperatorDisplayValue(model: ColumnAdvancedFilterModel): string | undefined {
-        return this.getExpressionOperator(model.filterType, model.type)?.displayValue ?? model.type;
+        return this.getModelOperator(model)?.displayValue ?? model.type;
+    }
+
+    private getModelOperator(model: ColumnAdvancedFilterModel): FilterExpressionOperator<any> | undefined {
+        return this.getExpressionOperator(model.filterType, model.type, this.colModel.getNonPivotColById(model.colId));
     }
 
     public getOperandModelValue(
@@ -249,32 +282,48 @@ export class AdvancedFilterExpressionService extends BeanStub implements NamedBe
         return baseCellDataType !== 'bigint';
     }
 
-    public getOperandDisplayValue(model: ColumnAdvancedFilterModel, skipFormatting?: boolean): string {
-        const { filter, filterType } = model as Exclude<ColumnAdvancedFilterModel, BooleanAdvancedFilterModel>;
-
-        if (filter == null) {
+    /** The whole operand region: one value, or the comma-separated bracketed pair an option taking two writes. */
+    private getOperandDisplayValue(model: ColumnAdvancedFilterModel): string {
+        const { filter, filterTo } = model as ColumnFilterModelOperands;
+        const numOperands = this.getModelOperator(model)?.numOperands;
+        // A slot the option does not take is not its value, and writing it spells an expression nothing parses.
+        if (numOperands === 0) {
             return '';
         }
-        const canonical = _toStringOrNull(filter) ?? '';
-        let operand1 =
-            this.filterOperandGetters[filterType](
-                model as Exclude<ColumnAdvancedFilterModel, BooleanAdvancedFilterModel>
-            ) ?? canonical;
+        if (numOperands !== 2) {
+            return filter == null ? '' : ` ${this.formatOperand(model, filter)}`;
+        }
+        return ` (${this.formatOperand(model, filter, false, true)}, ${this.formatOperand(model, filterTo, false, true)})`;
+    }
+
+    /** One operand of a model, quoted for the expression unless the caller shows it on its own. */
+    public formatOperand(
+        model: ColumnAdvancedFilterModel,
+        value: string | number | undefined,
+        skipFormatting?: boolean,
+        inPair?: boolean
+    ): string {
+        if (value == null) {
+            return '';
+        }
+        const { filterType, colId } = model;
+        const canonical = _toStringOrNull(value) ?? '';
+        let operand = _getOwn(this.filterOperandGetters, filterType)?.({ filter: value, colId }) ?? canonical;
         const isNumeric = filterType === 'number' || filterType === 'bigint';
         // A numeric operand is written bare, so quotes are added only for a format that could not be read
         // back without them. Text is always quoted, empty included.
-        if (!skipFormatting && (!isNumeric || needsQuotes(operand1))) {
-            const quote = quoteChar(operand1);
+        if (!skipFormatting && (!isNumeric || needsQuotes(operand, inPair))) {
+            const quote = quoteChar(operand);
             if (quote) {
-                operand1 = `${quote}${operand1}${quote}`;
+                operand = `${quote}${operand}${quote}`;
             } else if (isNumeric) {
                 // No quote can wrap this format, so it cannot be read back: write the canonical number instead.
-                operand1 = canonical;
+                operand = canonical;
             } else {
-                operand1 = `"${operand1}"`; // text is the value itself, so there is nothing to fall back to
+                operand = `"${operand}"`; // text is the value itself, so there is nothing to fall back to
             }
         }
-        return skipFormatting ? operand1 : ` ${operand1}`;
+        return operand;
     }
 
     public parseColumnFilterModel(model: ColumnAdvancedFilterModel): string {
@@ -340,6 +389,7 @@ export class AdvancedFilterExpressionService extends BeanStub implements NamedBe
             }
             return 0;
         });
+        this.columnAutocompleteEntries = entries;
         return entries;
     }
 
@@ -348,11 +398,8 @@ export class AdvancedFilterExpressionService extends BeanStub implements NamedBe
         column: AgColumn | null | undefined,
         baseCellDataType?: BaseCellDataType
     ): AutocompleteEntry[] {
-        const operatorForType = this.getDataTypeExpressionOperator(baseCellDataType);
-        if (!operatorForType) {
-            return [];
-        }
-        return operatorForType.getEntries(column ? this.getActiveOperators(column) : undefined);
+        const columnOperators = this.getColumnOperators(baseCellDataType, column);
+        return columnOperators ? columnOperators.operators.getEntries(columnOperators.activeOperators) : [];
     }
 
     public getJoinOperatorAutocompleteEntries(): AutocompleteEntry[] {
@@ -364,19 +411,78 @@ export class AdvancedFilterExpressionService extends BeanStub implements NamedBe
         return this.generateAutocompleteListParams(this.getColumnAutocompleteEntries(), 'column', searchString);
     }
 
-    public getDataTypeExpressionOperator(
-        baseCellDataType?: BaseCellDataType
-    ): DataTypeFilterExpressionOperators<any> | undefined {
-        return this.expressionOperators[baseCellDataType!];
-    }
-
     public getExpressionOperator(
         baseCellDataType?: BaseCellDataType,
-        operator?: string
+        operator?: string,
+        column?: AgColumn | null
     ): FilterExpressionOperator<any> | undefined {
-        const operators = this.getDataTypeExpressionOperator(baseCellDataType)?.operators;
         // A model `type` such as `toString` must not resolve to an inherited member.
-        return operators && _hasOwn(operators, operator!) ? operators[operator!] : undefined;
+        return _getOwn(this.getColumnOperators(baseCellDataType, column)?.operators.operators, operator!);
+    }
+
+    /**
+     * Whether the column's dropdown lists this operator - offered, not merely resolvable. Only a pill the
+     * user is retargeting asks: an expression already written is read against everything the column resolves.
+     */
+    public isOperatorOffered(
+        baseCellDataType: BaseCellDataType | undefined,
+        operator: string | undefined,
+        column: AgColumn | null | undefined
+    ): boolean {
+        const columnOperators = this.getColumnOperators(baseCellDataType, column);
+        if (!operator || !_getOwn(columnOperators?.operators.operators, operator)) {
+            return false;
+        }
+        const activeOperators = columnOperators!.activeOperators;
+        return !activeOperators || activeOperators.includes(operator);
+    }
+
+    /**
+     * A data type's built-ins with the column's own options over them, so a `displayKey` is per column, and
+     * the keys the column narrows its suggestions to — everything it can resolve, and what it offers of that.
+     */
+    public getColumnOperators(
+        baseCellDataType: BaseCellDataType | undefined,
+        column: AgColumn | null | undefined
+    ): ColumnOperators | undefined {
+        const dataTypeOperators = this.expressionOperators[baseCellDataType!];
+        if (!dataTypeOperators) {
+            return undefined;
+        }
+        if (!column) {
+            return { operators: dataTypeOperators, activeOperators: undefined };
+        }
+        const byDataType = this.columnExpressionOperators;
+        let forDataType = byDataType[baseCellDataType!];
+        if (!forDataType) {
+            forDataType = new WeakMap();
+            byDataType[baseCellDataType!] = forDataType;
+        }
+        let columnOperators = forDataType.get(column);
+        if (!columnOperators) {
+            columnOperators = this.createColumnOperators(dataTypeOperators, column);
+            forDataType.set(column, columnOperators);
+        }
+        return columnOperators;
+    }
+
+    private createColumnOperators(
+        dataTypeOperators: DataTypeFilterExpressionOperators<any>,
+        column: AgColumn
+    ): ColumnOperators {
+        const filterOptions = getColumnFilterOptions(column);
+        if (!filterOptions) {
+            return { operators: dataTypeOperators, activeOperators: undefined };
+        }
+        // Reported here as well as by `OptionsFactory`, because a column filtered only through the Advanced
+        // Filter never builds one.
+        const { offered, customOptions } = _classifyFilterOptions(filterOptions, (keys) => this.warn(72, { keys }));
+        const localeTextFunc = this.getLocaleTextFunc();
+        const operators = customOptions.size
+            ? createCustomOptionOperators(dataTypeOperators, customOptions, localeTextFunc)
+            : dataTypeOperators;
+        const activeOperators = [...offered.keys()].filter((key) => _getOwn(operators.operators, key));
+        return { operators, activeOperators: activeOperators.length ? activeOperators : undefined };
     }
 
     public getExpressionJoinOperators(): { AND: string; OR: string } {
@@ -502,18 +608,10 @@ export class AdvancedFilterExpressionService extends BeanStub implements NamedBe
         };
     }
 
-    private getActiveOperators(column: AgColumn): string[] | undefined {
-        const filterOptions = column.colDef.filterParams?.filterOptions;
-        if (!filterOptions) {
-            return undefined;
-        }
-        const isValid = filterOptions.every((filterOption: any) => typeof filterOption === 'string');
-        return isValid ? filterOptions : undefined;
-    }
-
     public resetColumnCaches(): void {
         this.columnAutocompleteEntries = null;
         this.columnNameToIdMap = Object.create(null);
         this.expressionEvaluatorParams = Object.create(null);
+        this.columnExpressionOperators = Object.create(null);
     }
 }

--- a/packages/ag-grid-enterprise/src/advancedFilter/advancedFilterExpressionService.ts
+++ b/packages/ag-grid-enterprise/src/advancedFilter/advancedFilterExpressionService.ts
@@ -38,10 +38,7 @@ import {
     hasCustomNumberOperands,
 } from './filterExpressionUtils';
 
-/**
- * What an unquoted operand cannot carry: a space or `)` ends it, a leading quote opens one, and inside a
- * comma-separated pair a `,` ends it too.
- */
+/** What an unquoted operand cannot carry: a space or `)` ends it, a quote opens one, a `,` ends it in a pair. */
 function needsQuotes(operand: string, inPair?: boolean): boolean {
     return (
         operand.includes(' ') ||
@@ -188,8 +185,7 @@ export class AdvancedFilterExpressionService extends BeanStub implements NamedBe
     public postConstruct(): void {
         this.expressionJoinOperators = this.generateExpressionJoinOperators();
         this.expressionOperators = this.generateExpressionOperators();
-        // Everything cached here is keyed on a column's name, visibility or definition, and each of these
-        // changes one of them without going through `newColumnsLoaded`.
+        // Each of these changes a column's name, visibility or definition without a `newColumnsLoaded`.
         const resetColumnCaches = this.resetColumnCaches.bind(this);
         this.addManagedEventListeners({
             newColumnsLoaded: resetColumnCaches,
@@ -420,10 +416,7 @@ export class AdvancedFilterExpressionService extends BeanStub implements NamedBe
         return _getOwn(this.getColumnOperators(baseCellDataType, column)?.operators.operators, operator!);
     }
 
-    /**
-     * Whether the column's dropdown lists this operator - offered, not merely resolvable. Only a pill the
-     * user is retargeting asks: an expression already written is read against everything the column resolves.
-     */
+    /** Offered, not merely resolvable: only a pill being retargeted asks, an expression reads against all. */
     public isOperatorOffered(
         baseCellDataType: BaseCellDataType | undefined,
         operator: string | undefined,
@@ -437,10 +430,7 @@ export class AdvancedFilterExpressionService extends BeanStub implements NamedBe
         return !activeOperators || activeOperators.includes(operator);
     }
 
-    /**
-     * A data type's built-ins with the column's own options over them, so a `displayKey` is per column, and
-     * the keys the column narrows its suggestions to — everything it can resolve, and what it offers of that.
-     */
+    /** A data type's built-ins with the column's own options over them, plus the keys it narrows suggestions to. */
     public getColumnOperators(
         baseCellDataType: BaseCellDataType | undefined,
         column: AgColumn | null | undefined
@@ -474,8 +464,7 @@ export class AdvancedFilterExpressionService extends BeanStub implements NamedBe
         if (!filterOptions) {
             return { operators: dataTypeOperators, activeOperators: undefined };
         }
-        // Reported here as well as by `OptionsFactory`, because a column filtered only through the Advanced
-        // Filter never builds one.
+        // Reported here too: a column filtered only through the Advanced Filter never builds an `OptionsFactory`.
         const { offered, customOptions } = _classifyFilterOptions(filterOptions, (keys) => this.warn(72, { keys }));
         const localeTextFunc = this.getLocaleTextFunc();
         const operators = customOptions.size

--- a/packages/ag-grid-enterprise/src/advancedFilter/builder/advancedFilterBuilderComp.ts
+++ b/packages/ag-grid-enterprise/src/advancedFilter/builder/advancedFilterBuilderComp.ts
@@ -20,6 +20,7 @@ import type { AdvancedFilterExpressionService } from '../advancedFilterExpressio
 import type { ADVANCED_FILTER_LOCALE_TEXT } from '../advancedFilterLocaleText';
 import type { AdvancedFilterService } from '../advancedFilterService';
 import type { PartialColumnFilterModel } from '../filterExpressionUtils';
+import { hasEveryOperand } from '../filterExpressionUtils';
 import { AdvancedFilterBuilderDragFeature } from './advancedFilterBuilderDragFeature';
 import { AdvancedFilterBuilderItemAddComp } from './advancedFilterBuilderItemAddComp';
 import { AdvancedFilterBuilderItemComp } from './advancedFilterBuilderItemComp';
@@ -572,22 +573,29 @@ export class AdvancedFilterBuilderComp extends Component<AdvancedFilterBuilderEv
         this.eButtons?.updateValidity(isValid, validationMessage);
     }
 
+    /** The only pass every item gets: a row the virtual list has not mounted has no component to validate it. */
     private validateItems(): void {
+        const advFilterExpSvc = this.advFilterExpSvc;
         for (const item of this.items) {
             if (!item.valid || !item.filterModel || item.filterModel.filterType === 'join') {
                 continue;
             }
             const { filterModel } = item;
             const { colId } = filterModel;
-            const hasColumn = this.advFilterExpSvc.getColumnAutocompleteEntries().find(({ key }) => key === colId);
-            const { column, baseCellDataType } = this.advFilterExpSvc.getColumnDetails(colId);
+            const hasColumn = advFilterExpSvc.getColumnAutocompleteEntries().find(({ key }) => key === colId);
+            const { column, baseCellDataType } = advFilterExpSvc.getColumnDetails(colId);
             if (!hasColumn || !column) {
                 item.valid = false;
                 delete (filterModel as PartialColumnFilterModel).colId;
                 clearCondition(filterModel);
-            } else if (!this.advFilterExpSvc.getExpressionOperator(baseCellDataType, filterModel.type, column)) {
+                continue;
+            }
+            const operator = advFilterExpSvc.getExpressionOperator(baseCellDataType, filterModel.type, column);
+            if (!operator) {
                 item.valid = false;
                 clearCondition(filterModel);
+            } else if (!hasEveryOperand(advFilterExpSvc, filterModel, operator.numOperands)) {
+                item.valid = false;
             }
         }
     }

--- a/packages/ag-grid-enterprise/src/advancedFilter/builder/advancedFilterBuilderComp.ts
+++ b/packages/ag-grid-enterprise/src/advancedFilter/builder/advancedFilterBuilderComp.ts
@@ -1,4 +1,4 @@
-import { RefPlaceholder, _exists, _removeFromParent } from 'ag-stack';
+import { RefPlaceholder, _removeFromParent } from 'ag-stack';
 
 import type {
     AdvancedFilterModel,
@@ -19,6 +19,7 @@ import { VirtualList } from '../../widgets/virtualList';
 import type { AdvancedFilterExpressionService } from '../advancedFilterExpressionService';
 import type { ADVANCED_FILTER_LOCALE_TEXT } from '../advancedFilterLocaleText';
 import type { AdvancedFilterService } from '../advancedFilterService';
+import type { PartialColumnFilterModel } from '../filterExpressionUtils';
 import { AdvancedFilterBuilderDragFeature } from './advancedFilterBuilderDragFeature';
 import { AdvancedFilterBuilderItemAddComp } from './advancedFilterBuilderItemAddComp';
 import { AdvancedFilterBuilderItemComp } from './advancedFilterBuilderItemComp';
@@ -572,12 +573,6 @@ export class AdvancedFilterBuilderComp extends Component<AdvancedFilterBuilderEv
     }
 
     private validateItems(): void {
-        const clearOperator = (filterModel: ColumnAdvancedFilterModel) => {
-            filterModel.type = undefined as any;
-        };
-        const clearOperand = (filterModel: ColumnAdvancedFilterModel) => {
-            delete (filterModel as any).filter;
-        };
         for (const item of this.items) {
             if (!item.valid || !item.filterModel || item.filterModel.filterType === 'join') {
                 continue;
@@ -585,25 +580,21 @@ export class AdvancedFilterBuilderComp extends Component<AdvancedFilterBuilderEv
             const { filterModel } = item;
             const { colId } = filterModel;
             const hasColumn = this.advFilterExpSvc.getColumnAutocompleteEntries().find(({ key }) => key === colId);
-            const columnDetails = this.advFilterExpSvc.getColumnDetails(filterModel.colId);
-            if (!hasColumn || !columnDetails.column) {
+            const { column, baseCellDataType } = this.advFilterExpSvc.getColumnDetails(colId);
+            if (!hasColumn || !column) {
                 item.valid = false;
-                filterModel.colId = undefined as any;
-                clearOperator(filterModel);
-                clearOperand(filterModel);
-                continue;
-            }
-            const operatorForType = this.advFilterExpSvc.getDataTypeExpressionOperator(columnDetails.baseCellDataType)!;
-            const operator = operatorForType.operators[filterModel.type];
-            if (!operator) {
+                delete (filterModel as PartialColumnFilterModel).colId;
+                clearCondition(filterModel);
+            } else if (!this.advFilterExpSvc.getExpressionOperator(baseCellDataType, filterModel.type, column)) {
                 item.valid = false;
-                clearOperator(filterModel);
-                clearOperand(filterModel);
-                continue;
-            }
-            if (operator.numOperands > 0 && !_exists((filterModel as any).filter)) {
-                item.valid = false;
+                clearCondition(filterModel);
             }
         }
     }
 }
+
+const clearCondition = (filterModel: PartialColumnFilterModel) => {
+    delete filterModel.type;
+    delete filterModel.filter;
+    delete filterModel.filterTo;
+};

--- a/packages/ag-grid-enterprise/src/advancedFilter/builder/conditionPillWrapperComp.ts
+++ b/packages/ag-grid-enterprise/src/advancedFilter/builder/conditionPillWrapperComp.ts
@@ -1,16 +1,11 @@
-import { _exists, _removeFromParent, _toStringOrNull } from 'ag-stack';
+import { _removeFromParent, _toStringOrNull } from 'ag-stack';
 
-import type {
-    AgColumn,
-    BaseCellDataType,
-    BeanCollection,
-    BooleanAdvancedFilterModel,
-    ColumnAdvancedFilterModel,
-} from 'ag-grid-community';
+import type { AgColumn, BaseCellDataType, BeanCollection, ColumnAdvancedFilterModel } from 'ag-grid-community';
 import { Component } from 'ag-grid-community';
 
 import type { AdvancedFilterExpressionService } from '../advancedFilterExpressionService';
 import type { AutocompleteEntry } from '../autocomplete/autocompleteParams';
+import type { ColumnFilterModelOperands, PartialColumnFilterModel } from '../filterExpressionUtils';
 import { getNumberParser } from '../filterExpressionUtils';
 import type {
     AdvancedFilterBuilderEvents,
@@ -19,6 +14,9 @@ import type {
 } from './iAdvancedFilterBuilder';
 import type { InputPillComp } from './inputPillComp';
 import type { SelectPillComp } from './selectPillComp';
+
+/** The model names its two operands rather than listing them, so an operand index maps to a key. */
+const OPERAND_KEYS = ['filter', 'filterTo'] as const;
 
 export class ConditionPillWrapperComp extends Component<AdvancedFilterBuilderEvents> {
     private advFilterExpSvc: AdvancedFilterExpressionService;
@@ -35,7 +33,7 @@ export class ConditionPillWrapperComp extends Component<AdvancedFilterBuilderEve
     private numOperands: number;
     private eColumnPill: SelectPillComp | InputPillComp;
     private eOperatorPill: SelectPillComp | InputPillComp | undefined;
-    private eOperandPill: SelectPillComp | InputPillComp | undefined;
+    private readonly eOperandPills: (SelectPillComp | InputPillComp)[] = [];
     private validationMessage: string | null = null;
 
     constructor() {
@@ -53,7 +51,7 @@ export class ConditionPillWrapperComp extends Component<AdvancedFilterBuilderEve
         this.setupColumnCondition(this.filterModel);
         this.validate();
 
-        this.addDestroyFunc(() => this.destroyBeans([this.eColumnPill, this.eOperatorPill, this.eOperandPill]));
+        this.addDestroyFunc(() => this.destroyBeans([this.eColumnPill, this.eOperatorPill, ...this.eOperandPills]));
     }
 
     public getDragName(): string {
@@ -78,11 +76,12 @@ export class ConditionPillWrapperComp extends Component<AdvancedFilterBuilderEve
         const columnDetails = this.advFilterExpSvc.getColumnDetails(filterModel.colId);
         this.baseCellDataType = columnDetails.baseCellDataType;
         this.column = columnDetails.column;
-        this.numOperands = this.getNumOperands(this.getOperatorKey());
+        this.numOperands = this.getNumOperands(filterModel.type);
 
         this.eColumnPill = this.createPill({
-            key: this.getColumnKey(),
-            displayValue: this.getColumnDisplayValue() ?? this.getDefaultColumnDisplayValue(),
+            key: filterModel.colId,
+            displayValue:
+                this.advFilterExpSvc.getColumnDisplayValue(filterModel) ?? this.getDefaultColumnDisplayValue(),
             cssClass: 'ag-advanced-filter-builder-column-pill',
             isSelect: true,
             getEditorParams: () => ({ values: this.advFilterExpSvc.getColumnAutocompleteEntries() }),
@@ -93,18 +92,18 @@ export class ConditionPillWrapperComp extends Component<AdvancedFilterBuilderEve
         });
         this.getGui().appendChild(this.eColumnPill.getGui());
 
-        if (_exists(this.getColumnKey())) {
+        if (filterModel.colId) {
             this.createOperatorPill();
-            if (this.hasOperand()) {
-                this.createOperandPill();
-            }
+            this.syncOperandPills();
         }
     }
 
     private createOperatorPill(): void {
         this.eOperatorPill = this.createPill({
-            key: this.getOperatorKey(),
-            displayValue: this.getOperatorDisplayValue() ?? this.getDefaultOptionSelectValue(),
+            key: this.filterModel.type,
+            displayValue:
+                this.advFilterExpSvc.getOperatorDisplayValue(this.filterModel) ??
+                this.advFilterExpSvc.translate('advancedFilterBuilderSelectOption'),
             cssClass: 'ag-advanced-filter-builder-option-pill',
             isSelect: true,
             getEditorParams: () => ({ values: this.getOperatorAutocompleteEntries() }),
@@ -116,14 +115,15 @@ export class ConditionPillWrapperComp extends Component<AdvancedFilterBuilderEve
         this.eColumnPill.getGui().insertAdjacentElement('afterend', this.eOperatorPill.getGui());
     }
 
-    private createOperandPill(): void {
+    private createOperandPill(index: number): void {
         // Date inputs want iso string, so read straight from model. For numbers, convert to string
-        const { filter } = this.filterModel as Exclude<ColumnAdvancedFilterModel, BooleanAdvancedFilterModel>;
-        const key = (typeof filter === 'number' || typeof filter === 'bigint' ? _toStringOrNull(filter) : filter) ?? '';
+        const value = this.getOperandModelValue(index);
+        const key = (typeof value === 'number' || typeof value === 'bigint' ? _toStringOrNull(value) : value) ?? '';
         // Read from the model, not from the text handed in: an edit is stored through the column's own
         // parser, and the display is produced by the default one, which need not read the same syntax.
-        const valueFormatter = () => this.getOperandDisplayValue();
-        this.eOperandPill = this.createPill({
+        const valueFormatter = () =>
+            this.advFilterExpSvc.formatOperand(this.filterModel, this.getOperandModelValue(index), true);
+        const eOperandPill = this.createPill({
             key,
             // Convert from the input format to display format.
             // Input format matches model format except for numbers, but these get stringified anyway
@@ -136,34 +136,64 @@ export class ConditionPillWrapperComp extends Component<AdvancedFilterBuilderEve
             baseCellDataType: this.baseCellDataType,
             cssClass: 'ag-advanced-filter-builder-value-pill',
             isSelect: false,
-            update: (key) => this.setOperand(key),
-            ariaLabel: this.advFilterExpSvc.translate('ariaAdvancedFilterBuilderValue'),
+            update: (key) => this.setOperand(key, index),
+            ariaLabel: this.getOperandAriaLabel(index),
         });
-        this.getGui().appendChild(this.eOperandPill.getGui());
+        this.eOperandPills.push(eOperandPill);
+        this.getGui().appendChild(eOperandPill.getGui());
     }
 
-    private getColumnKey(): string {
-        return this.filterModel.colId;
+    /** Two pills both called "Value" are indistinguishable to a screen reader, so the pair takes the column
+     * filter's own from/to labels rather than composing one, which no locale could reorder. */
+    private getOperandAriaLabel(index: number): string {
+        if (this.numOperands < 2) {
+            return this.advFilterExpSvc.translate('ariaAdvancedFilterBuilderValue');
+        }
+        const translate = this.getLocaleTextFunc();
+        return index === 0
+            ? translate('ariaFilterFromValue', 'Filter from value')
+            : translate('ariaFilterToValue', 'Filter to value');
     }
 
-    private getColumnDisplayValue(): string | undefined {
-        return this.advFilterExpSvc.getColumnDisplayValue(this.filterModel);
+    private destroyOperandPills(): void {
+        const eOperandPills = this.eOperandPills;
+        for (let i = 0, len = eOperandPills.length; i < len; ++i) {
+            const eOperandPill = eOperandPills[i];
+            _removeFromParent(eOperandPill.getGui());
+            this.destroyBean(eOperandPill);
+        }
+        eOperandPills.length = 0;
     }
 
-    private getOperatorKey(): string {
-        return this.filterModel.type;
+    /** Call after every change to the count: the first pill is named From only while there is a second. */
+    private syncOperandPills(): void {
+        const { eOperandPills, numOperands } = this;
+        for (let i = numOperands, len = OPERAND_KEYS.length; i < len; ++i) {
+            this.setOperandModelValue(i, undefined);
+        }
+        if (eOperandPills.length === numOperands) {
+            return;
+        }
+        this.destroyOperandPills();
+        for (let i = 0; i < numOperands; ++i) {
+            this.createOperandPill(i);
+        }
     }
 
-    private getOperatorDisplayValue(): string | undefined {
-        return this.advFilterExpSvc.getOperatorDisplayValue(this.filterModel);
+    private getOperandModelValue(index: number): string | number | undefined {
+        const model: ColumnFilterModelOperands = this.filterModel;
+        return model[OPERAND_KEYS[index]];
     }
 
-    private getOperandDisplayValue(): string {
-        return this.advFilterExpSvc.getOperandDisplayValue(this.filterModel, true);
-    }
-
-    private hasOperand(): boolean {
-        return this.numOperands > 0;
+    /** Undefined removes the slot, so the model this builds carries no key the chosen option does not use. */
+    private setOperandModelValue(index: number, value: string | number | undefined): void {
+        const model: ColumnFilterModelOperands = this.filterModel;
+        const key = OPERAND_KEYS[index];
+        if (value === undefined) {
+            delete model[key];
+        } else {
+            model[key] = value;
+        }
     }
 
     private getOperatorAutocompleteEntries(): AutocompleteEntry[] {
@@ -177,80 +207,77 @@ export class ConditionPillWrapperComp extends Component<AdvancedFilterBuilderEve
             this.createOperatorPill();
         }
 
-        const newColumnDetails = this.advFilterExpSvc.getColumnDetails(colId);
+        const { column, baseCellDataType } = this.advFilterExpSvc.getColumnDetails(colId);
         const previousColumn = this.column;
-        this.column = newColumnDetails.column;
-        const newBaseCellDataType = newColumnDetails.baseCellDataType;
-        if (this.baseCellDataType !== newBaseCellDataType) {
-            this.baseCellDataType = newBaseCellDataType;
-
-            this.setOperatorKey(undefined as any);
-            if (this.eOperatorPill) {
-                _removeFromParent(this.eOperatorPill.getGui());
-                this.destroyBean(this.eOperatorPill);
-                this.createOperatorPill();
-            }
-            this.validate();
-        }
+        const dataTypeChanged = this.baseCellDataType !== baseCellDataType;
+        // Both the key and the name it resolves to, since a column can offer the same operator under another.
+        const previousOperatorKey = this.filterModel.type;
+        const previousOperatorDisplayValue = this.advFilterExpSvc.getOperatorDisplayValue(this.filterModel);
+        this.column = column;
+        this.baseCellDataType = baseCellDataType;
         this.filterModel.colId = colId;
-        this.filterModel.filterType = this.baseCellDataType;
-        // The operand editor is chosen from the column's own parser, so it outlives a same-type column.
-        if (this.eOperandPill && previousColumn !== this.column) {
-            _removeFromParent(this.eOperandPill.getGui());
-            this.destroyBean(this.eOperandPill);
-            this.createOperandPill();
-            // The new column's formatter decides what the operand displays as, and an empty display is
-            // what makes the condition incomplete.
-            this.validate();
+        this.filterModel.filterType = baseCellDataType;
+
+        // A data type change takes the operator with it; within one data type the column's own options decide,
+        // as an operator can be unavailable on another column of the same type, or offered under another name.
+        const keepOperator =
+            !dataTypeChanged && this.advFilterExpSvc.isOperatorOffered(baseCellDataType, this.filterModel.type, column);
+        if (!keepOperator) {
+            delete (this.filterModel as PartialColumnFilterModel).type;
         }
+        if (
+            this.filterModel.type !== previousOperatorKey ||
+            this.advFilterExpSvc.getOperatorDisplayValue(this.filterModel) !== previousOperatorDisplayValue
+        ) {
+            _removeFromParent(this.eOperatorPill!.getGui());
+            this.destroyBean(this.eOperatorPill);
+            this.createOperatorPill();
+        }
+        // A pill's editor and display come from the column's own parser and formatter. A data type change
+        // has already dropped the operator, so `syncOperandPills` clears the values it took.
+        if (previousColumn !== column) {
+            this.destroyOperandPills();
+        }
+        this.numOperands = this.getNumOperands(this.filterModel.type);
+        this.syncOperandPills();
+        this.validate();
     }
 
     private setOperatorKey(operator: string): void {
         const newNumOperands = this.getNumOperands(operator);
         if (newNumOperands !== this.numOperands) {
             this.numOperands = newNumOperands;
-            if (newNumOperands === 0) {
-                this.destroyOperandPill();
-            } else {
-                this.createOperandPill();
-                if (this.baseCellDataType !== 'number') {
-                    this.setOperand('');
-                }
-            }
+            this.syncOperandPills();
         }
-        this.filterModel.type = operator as any;
+        (this.filterModel as PartialColumnFilterModel).type = operator;
         this.validate();
     }
 
-    private setOperand(operand: string): void {
-        let parsedOperand: string | number = operand;
-        // Number comes back as string from input, so convert. Dates are already in iso string format
-        if (this.baseCellDataType === 'number') {
-            parsedOperand =
-                operand != null && operand !== '' ? (getNumberParser(this.column, this.gos)(operand) ?? '') : '';
-        }
-        (this.filterModel as any).filter = parsedOperand;
+    private setOperand(operand: string, index: number): void {
+        // Number comes back as string from input, so convert. Dates are already in iso string format.
+        // An emptied pill holds nothing to filter on, so the slot goes rather than keeping an empty string.
+        const value =
+            this.baseCellDataType === 'number' && operand
+                ? (getNumberParser(this.column, this.gos)(operand) ?? '')
+                : operand;
+        this.setOperandModelValue(index, value === '' ? undefined : value);
         this.validate();
     }
 
     private getNumOperands(operator: string): number {
-        return this.advFilterExpSvc.getExpressionOperator(this.baseCellDataType, operator)?.numOperands ?? 0;
-    }
-
-    private destroyOperandPill(): void {
-        delete (this.filterModel as any).filter;
-        this.eOperandPill?.getGui().remove();
-        this.destroyBean(this.eOperandPill);
-        this.eOperandPill = undefined;
+        return (
+            this.advFilterExpSvc.getExpressionOperator(this.baseCellDataType, operator, this.column)?.numOperands ?? 0
+        );
     }
 
     private validate(): void {
-        let validationMessage = null;
-        if (!_exists(this.getColumnKey())) {
+        const filterModel = this.filterModel;
+        let validationMessage: string | null = null;
+        if (!filterModel.colId) {
             validationMessage = this.advFilterExpSvc.translate('advancedFilterBuilderValidationSelectColumn');
-        } else if (!_exists(this.getOperatorKey())) {
+        } else if (!filterModel.type) {
             validationMessage = this.advFilterExpSvc.translate('advancedFilterBuilderValidationSelectOption');
-        } else if (this.numOperands > 0 && !_exists(this.getOperandDisplayValue())) {
+        } else if (!this.hasEveryOperand()) {
             validationMessage = this.advFilterExpSvc.translate('advancedFilterBuilderValidationEnterValue');
         }
 
@@ -263,11 +290,22 @@ export class ConditionPillWrapperComp extends Component<AdvancedFilterBuilderEve
         }
     }
 
-    private getDefaultColumnDisplayValue(): string {
-        return this.advFilterExpSvc.translate('advancedFilterBuilderSelectColumn');
+    /** Judged on the display, not the model: what the column's formatter cannot write is not a value it holds. */
+    private hasEveryOperand(): boolean {
+        for (let i = 0, len = this.numOperands; i < len; ++i) {
+            const displayValue = this.advFilterExpSvc.formatOperand(
+                this.filterModel,
+                this.getOperandModelValue(i),
+                true
+            );
+            if (!displayValue) {
+                return false;
+            }
+        }
+        return true;
     }
 
-    private getDefaultOptionSelectValue(): string {
-        return this.advFilterExpSvc.translate('advancedFilterBuilderSelectOption');
+    private getDefaultColumnDisplayValue(): string {
+        return this.advFilterExpSvc.translate('advancedFilterBuilderSelectColumn');
     }
 }

--- a/packages/ag-grid-enterprise/src/advancedFilter/builder/conditionPillWrapperComp.ts
+++ b/packages/ag-grid-enterprise/src/advancedFilter/builder/conditionPillWrapperComp.ts
@@ -6,7 +6,7 @@ import { Component } from 'ag-grid-community';
 import type { AdvancedFilterExpressionService } from '../advancedFilterExpressionService';
 import type { AutocompleteEntry } from '../autocomplete/autocompleteParams';
 import type { ColumnFilterModelOperands, PartialColumnFilterModel } from '../filterExpressionUtils';
-import { getNumberParser } from '../filterExpressionUtils';
+import { OPERAND_KEYS, getNumberParser, hasEveryOperand } from '../filterExpressionUtils';
 import type {
     AdvancedFilterBuilderEvents,
     AdvancedFilterBuilderItem,
@@ -14,9 +14,6 @@ import type {
 } from './iAdvancedFilterBuilder';
 import type { InputPillComp } from './inputPillComp';
 import type { SelectPillComp } from './selectPillComp';
-
-/** The model names its two operands rather than listing them, so an operand index maps to a key. */
-const OPERAND_KEYS = ['filter', 'filterTo'] as const;
 
 export class ConditionPillWrapperComp extends Component<AdvancedFilterBuilderEvents> {
     private advFilterExpSvc: AdvancedFilterExpressionService;
@@ -143,8 +140,7 @@ export class ConditionPillWrapperComp extends Component<AdvancedFilterBuilderEve
         this.getGui().appendChild(eOperandPill.getGui());
     }
 
-    /** Two pills both called "Value" are indistinguishable to a screen reader, so the pair takes the column
-     * filter's own from/to labels rather than composing one, which no locale could reorder. */
+    /** Two pills both called "Value" are indistinguishable to a screen reader, hence the from/to labels. */
     private getOperandAriaLabel(index: number): string {
         if (this.numOperands < 2) {
             return this.advFilterExpSvc.translate('ariaAdvancedFilterBuilderValue');
@@ -218,8 +214,7 @@ export class ConditionPillWrapperComp extends Component<AdvancedFilterBuilderEve
         this.filterModel.colId = colId;
         this.filterModel.filterType = baseCellDataType;
 
-        // A data type change takes the operator with it; within one data type the column's own options decide,
-        // as an operator can be unavailable on another column of the same type, or offered under another name.
+        // A data type change takes the operator with it; within one type the column's own options decide.
         const keepOperator =
             !dataTypeChanged && this.advFilterExpSvc.isOperatorOffered(baseCellDataType, this.filterModel.type, column);
         if (!keepOperator) {
@@ -233,8 +228,7 @@ export class ConditionPillWrapperComp extends Component<AdvancedFilterBuilderEve
             this.destroyBean(this.eOperatorPill);
             this.createOperatorPill();
         }
-        // A pill's editor and display come from the column's own parser and formatter. A data type change
-        // has already dropped the operator, so `syncOperandPills` clears the values it took.
+        // A pill's editor and display come from the column's own parser and formatter.
         if (previousColumn !== column) {
             this.destroyOperandPills();
         }
@@ -277,7 +271,7 @@ export class ConditionPillWrapperComp extends Component<AdvancedFilterBuilderEve
             validationMessage = this.advFilterExpSvc.translate('advancedFilterBuilderValidationSelectColumn');
         } else if (!filterModel.type) {
             validationMessage = this.advFilterExpSvc.translate('advancedFilterBuilderValidationSelectOption');
-        } else if (!this.hasEveryOperand()) {
+        } else if (!hasEveryOperand(this.advFilterExpSvc, filterModel, this.numOperands)) {
             validationMessage = this.advFilterExpSvc.translate('advancedFilterBuilderValidationEnterValue');
         }
 
@@ -288,21 +282,6 @@ export class ConditionPillWrapperComp extends Component<AdvancedFilterBuilderEve
                 type: 'advancedFilterBuilderValidChanged',
             });
         }
-    }
-
-    /** Judged on the display, not the model: what the column's formatter cannot write is not a value it holds. */
-    private hasEveryOperand(): boolean {
-        for (let i = 0, len = this.numOperands; i < len; ++i) {
-            const displayValue = this.advFilterExpSvc.formatOperand(
-                this.filterModel,
-                this.getOperandModelValue(i),
-                true
-            );
-            if (!displayValue) {
-                return false;
-            }
-        }
-        return true;
     }
 
     private getDefaultColumnDisplayValue(): string {

--- a/packages/ag-grid-enterprise/src/advancedFilter/colFilterExpressionParser.ts
+++ b/packages/ag-grid-enterprise/src/advancedFilter/colFilterExpressionParser.ts
@@ -190,12 +190,7 @@ class OperatorParser implements Parser {
         return { key, length, isPartialMatch };
     }
 
-    /**
-     * The longest name written here wins, so one that another name starts with - or one containing a
-     * terminator - resolves. What the column offers is searched first; the rest it can resolve is a
-     * fallback that may only lengthen the match, so an option left out of `filterOptions` stays spellable
-     * and an offered name whose end another name runs past cannot cut it short.
-     */
+    /** Longest match wins, offered names first, so a name another starts with or contains still resolves. */
     private parseOperator(fromComplete: boolean, endPosition: number): boolean {
         const { params, startPosition } = this;
         const expression = params.expression;
@@ -466,7 +461,6 @@ class OperandsParser implements Parser {
             return undefined;
         }
 
-        // Inside quotes every character is content, spaces and brackets included.
         if (parser && !this.expectSeparator && parser.isInsideQuotes()) {
             return this.delegate(char, position);
         }
@@ -492,7 +486,6 @@ class OperandsParser implements Parser {
                 this.finishOperand(position - 1);
             }
             if (this.isComplete() && !this.hasOpenBracket) {
-                // Past the last value an unbracketed region is over, exactly as it is at a space.
                 return true;
             }
             this.parser = undefined;
@@ -505,8 +498,7 @@ class OperandsParser implements Parser {
                 this.finishOperand(position - 1);
             }
             if (!this.hasOpenBracket) {
-                // The enclosing group's bracket, so the region ended on the previous char. `complete` is not
-                // reached once the region has ended, so a value still outstanding has to be reported here.
+                // The enclosing group's bracket ended the region, so `complete` never runs to report a gap.
                 if (!this.isComplete()) {
                     this.reject('advancedFilterValidationMissingValue');
                 }
@@ -750,8 +742,7 @@ export class ColFilterExpressionParser {
         const numOperands = this.getNumOperandsFor(baseCellDataType, updateEntry.key);
         const hasOperand = numOperands > 0;
         const operatorParser = this.operatorParser;
-        // The default span is a point insert, for a caret in between multiple spaces; only a caret at or
-        // past the operator replaces text.
+        // A point insert by default, for a caret between spaces; only one at or past the operator replaces.
         let startPosition = position;
         let endPosition = position;
         let empty = false;

--- a/packages/ag-grid-enterprise/src/advancedFilter/colFilterExpressionParser.ts
+++ b/packages/ag-grid-enterprise/src/advancedFilter/colFilterExpressionParser.ts
@@ -6,6 +6,7 @@ import type { ADVANCED_FILTER_LOCALE_TEXT } from './advancedFilterLocaleText';
 import type { AutocompleteEntry, AutocompleteListParams } from './autocomplete/autocompleteParams';
 import type {
     AutocompleteUpdate,
+    ColumnFilterModelOperands,
     FilterExpressionFunction,
     FilterExpressionFunctionParams,
     FilterExpressionParserParams,
@@ -22,15 +23,12 @@ import {
 } from './filterExpressionUtils';
 
 interface Parser {
-    type: string;
     parse(char: string, position: number): boolean | undefined;
     complete(position: number): void;
     getValidationError(): FilterExpressionValidationError | null;
 }
 
 class ColumnParser implements Parser {
-    public readonly type = 'column';
-
     public valid = true;
     public endPosition: number | undefined;
     public baseCellDataType: BaseCellDataType;
@@ -110,8 +108,6 @@ class ColumnParser implements Parser {
 }
 
 class OperatorParser implements Parser {
-    public readonly type = 'operator';
-
     public valid = true;
     public endPosition: number | undefined;
     public expectedNumOperands: number = 0;
@@ -163,21 +159,16 @@ class OperatorParser implements Parser {
         return this.parsedOperator;
     }
 
-    /**
-     * Greedy, over the options the column offers: the longest name spelled here wins, so one that another name
-     * starts with - or one containing a terminator - resolves.
-     */
-    private parseOperator(fromComplete: boolean, endPosition: number): boolean {
+    /** The longest name in `entries` written at the start position, and whether one is still being typed. */
+    private matchOperatorName(
+        entries: AutocompleteEntry[],
+        minLength: number,
+        partialSearchValue: string
+    ): { key: string | undefined; length: number; isPartialMatch: boolean } {
         const { params, startPosition } = this;
         const expression = params.expression;
-        const advFilterExpSvc = params.advFilterExpSvc;
-        const entries = advFilterExpSvc.getOperatorAutocompleteEntries(this.column, this.baseCellDataType);
-        this.endPosition = endPosition;
-
-        const minLength = endPosition - startPosition + 1;
-        const partialSearchValue = expression.slice(startPosition, endPosition + 1).toLocaleLowerCase() + ' ';
-        let matchedOperator: string | undefined;
-        let matchedLength = 0;
+        let key: string | undefined;
+        let length = 0;
         let isPartialMatch = false;
         for (let i = 0, len = entries.length; i < len; ++i) {
             const entry = entries[i];
@@ -185,24 +176,63 @@ class OperatorParser implements Parser {
             // Lengths come from the name as written: lower-casing can change them, `İ` becoming two units.
             const lowerCaseDisplayValue = displayValue.toLocaleLowerCase();
             if (
-                displayValue.length > matchedLength &&
+                displayValue.length > length &&
                 displayValue.length >= minLength &&
                 isNameAt(expression, startPosition, displayValue, lowerCaseDisplayValue)
             ) {
-                matchedOperator = entry.key;
-                matchedLength = displayValue.length;
+                key = entry.key;
+                length = displayValue.length;
             }
             if (lowerCaseDisplayValue.startsWith(partialSearchValue)) {
                 isPartialMatch = true;
             }
         }
+        return { key, length, isPartialMatch };
+    }
+
+    /**
+     * The longest name written here wins, so one that another name starts with - or one containing a
+     * terminator - resolves. What the column offers is searched first; the rest it can resolve is a
+     * fallback that may only lengthen the match, so an option left out of `filterOptions` stays spellable
+     * and an offered name whose end another name runs past cannot cut it short.
+     */
+    private parseOperator(fromComplete: boolean, endPosition: number): boolean {
+        const { params, startPosition } = this;
+        const expression = params.expression;
+        const columnOperators = params.advFilterExpSvc.getColumnOperators(this.baseCellDataType, this.column);
+        this.endPosition = endPosition;
+
+        const minLength = endPosition - startPosition + 1;
+        const partialSearchValue = expression.slice(startPosition, endPosition + 1).toLocaleLowerCase() + ' ';
+        const activeOperators = columnOperators?.activeOperators;
+        let match = this.matchOperatorName(
+            columnOperators?.operators.getEntries(activeOperators) ?? [],
+            minLength,
+            partialSearchValue
+        );
+        // Only a narrowing column has a second list; without one the two are the same scan.
+        if (activeOperators) {
+            const resolvable = this.matchOperatorName(
+                columnOperators!.operators.getEntries(),
+                minLength,
+                partialSearchValue
+            );
+            if (resolvable.length > match.length || (!match.key && resolvable.isPartialMatch)) {
+                match = resolvable;
+            }
+        }
+        const { key: matchedOperator, isPartialMatch } = match;
 
         if (matchedOperator) {
-            const matchEndPosition = startPosition + matchedLength - 1;
+            const matchEndPosition = startPosition + match.length - 1;
             this.parsedOperator = matchedOperator;
             this.endPosition = matchEndPosition;
             this.matchEndPosition = matchEndPosition;
-            const operator = advFilterExpSvc.getExpressionOperator(this.baseCellDataType, matchedOperator)!;
+            const operator = params.advFilterExpSvc.getExpressionOperator(
+                this.baseCellDataType,
+                matchedOperator,
+                this.column
+            )!;
             this.expectedNumOperands = operator.numOperands;
             const operatorDisplayValue = operator.displayValue;
             const userValue = expression.slice(startPosition, matchEndPosition + 1);
@@ -236,9 +266,6 @@ function isNameAt(
 }
 
 class OperandParser implements Parser {
-    public readonly type = 'operand';
-
-    public valid = true;
     public endPosition: number | undefined;
     private quotes: `'` | `"` | undefined;
     private operand = '';
@@ -253,19 +280,16 @@ class OperandParser implements Parser {
         number: (modelValue) => {
             // A column's own `numberParser` reports unreadable input as null, where `Number` gives NaN.
             if (modelValue == null || isNaN(modelValue as number)) {
-                this.valid = false;
                 this.validationMessage = this.params.advFilterExpSvc.translate('advancedFilterValidationNotANumber');
             }
         },
         bigint: () => {
             if (_parseBigIntOrNull(this.modelValue) === null) {
-                this.valid = false;
                 this.validationMessage = this.params.advFilterExpSvc.translate('advancedFilterValidationNotABigInt');
             }
         },
         date: (modelValue) => {
             if (modelValue == null) {
-                this.valid = false;
                 this.validationMessage = this.params.advFilterExpSvc.translate('advancedFilterValidationInvalidDate');
             }
         },
@@ -303,6 +327,7 @@ class OperandParser implements Parser {
             this.quotes = char;
         } else if (this.quotes && char === this.quotes) {
             this.parseOperand(false, position);
+            this.quotes = undefined;
             return false;
         } else {
             this.operand += char;
@@ -322,6 +347,10 @@ class OperandParser implements Parser {
                   endPosition: this.endPosition ?? this.params.expression.length - 1,
               }
             : null;
+    }
+
+    public isInsideQuotes(): boolean {
+        return this.quotes != null;
     }
 
     public getRawValue(): string {
@@ -348,10 +377,8 @@ class OperandParser implements Parser {
         this.modelValue = this.operand;
         if (fromComplete && this.quotes) {
             // missing end quote
-            this.valid = false;
             this.validationMessage = advFilterExpSvc.translate('advancedFilterValidationMissingQuote');
         } else if (this.modelValue === '') {
-            this.valid = false;
             this.validationMessage = advFilterExpSvc.translate('advancedFilterValidationMissingValue');
         } else {
             const modelValue = advFilterExpSvc.getOperandModelValue(this.operand, this.baseCellDataType, this.column!);
@@ -360,6 +387,176 @@ class OperandParser implements Parser {
             }
             this.filterValidationSetters[this.baseCellDataType](modelValue);
         }
+    }
+}
+
+/** One value is the operand alone, with no syntax of its own; two are a comma-separated pair in optional brackets. */
+class OperandsParser implements Parser {
+    private readonly parsers: OperandParser[] = [];
+    private parser: OperandParser | undefined;
+    private expectSeparator = false;
+    private hasOpenBracket = false;
+    private validationMessage: string | null = null;
+    /** Also marks the region as rejected: the rest of the text belongs to the error reported at this position. */
+    private validationEndPosition: number | undefined;
+
+    constructor(
+        private readonly params: FilterExpressionParserParams,
+        public readonly startPosition: number,
+        private readonly baseCellDataType: BaseCellDataType,
+        private readonly column: AgColumn | null | undefined,
+        private readonly expectedNumOperands: number
+    ) {}
+
+    public parse(char: string, position: number): boolean | undefined {
+        if (this.expectedNumOperands > 1) {
+            return this.parseSeveral(char, position);
+        }
+        this.startOperand(position); // one value, so no separator syntax of its own
+        return this.parser!.parse(char, position);
+    }
+
+    public complete(position: number): void {
+        if (this.parser && !this.expectSeparator) {
+            this.finishOperand(position);
+        }
+        if (this.expectedNumOperands < 2) {
+            return;
+        }
+        if (this.parsers.length < this.expectedNumOperands) {
+            this.reject('advancedFilterValidationMissingValue');
+        } else if (this.hasOpenBracket) {
+            this.reject('advancedFilterValidationMissingEndBracket');
+        }
+    }
+
+    public getValidationError(): FilterExpressionValidationError | null {
+        // An operand's own fault has a span and names the character at issue, so it beats the region's.
+        const { validationMessage, validationEndPosition, parsers } = this;
+        for (let i = 0, len = parsers.length; i < len; ++i) {
+            const error = parsers[i].getValidationError();
+            if (error) {
+                return error;
+            }
+        }
+        if (validationMessage) {
+            // With no span of its own the fault is that the expression stopped, not that something in it is wrong.
+            const atEnd = this.params.expression.length;
+            return {
+                message: validationMessage,
+                startPosition: validationEndPosition == null ? atEnd : this.startPosition,
+                endPosition: validationEndPosition ?? atEnd,
+            };
+        }
+        return null;
+    }
+
+    public isComplete(): boolean {
+        return this.parsers.length >= this.expectedNumOperands;
+    }
+
+    public getParsers(): OperandParser[] {
+        return this.parsers;
+    }
+
+    private parseSeveral(char: string, position: number): boolean | undefined {
+        // Read live throughout: `finishOperand` sets `expectSeparator`, and the reads below straddle it.
+        const parser = this.parser;
+        if (this.validationEndPosition != null) {
+            return undefined;
+        }
+
+        // Inside quotes every character is content, spaces and brackets included.
+        if (parser && !this.expectSeparator && parser.isInsideQuotes()) {
+            return this.delegate(char, position);
+        }
+
+        if (char === ' ') {
+            if (parser && !this.expectSeparator) {
+                this.finishOperand(position - 1);
+            }
+            // Spacing between the values; past the last one an unbracketed region is over.
+            return this.expectSeparator && this.isComplete() && !this.hasOpenBracket ? true : undefined;
+        }
+
+        if (char === '(' && !parser && !this.hasOpenBracket && !this.parsers.length) {
+            this.hasOpenBracket = true;
+            return undefined;
+        }
+
+        if (char === ',') {
+            if (!parser) {
+                return this.reject('advancedFilterValidationMissingValue', position);
+            }
+            if (!this.expectSeparator) {
+                this.finishOperand(position - 1);
+            }
+            if (this.isComplete() && !this.hasOpenBracket) {
+                // Past the last value an unbracketed region is over, exactly as it is at a space.
+                return true;
+            }
+            this.parser = undefined;
+            this.expectSeparator = false;
+            return this.isComplete() ? this.reject('advancedFilterValidationMissingEndBracket', position) : undefined;
+        }
+
+        if (char === ')') {
+            if (parser && !this.expectSeparator) {
+                this.finishOperand(position - 1);
+            }
+            if (!this.hasOpenBracket) {
+                // The enclosing group's bracket, so the region ended on the previous char. `complete` is not
+                // reached once the region has ended, so a value still outstanding has to be reported here.
+                if (!this.isComplete()) {
+                    this.reject('advancedFilterValidationMissingValue');
+                }
+                return true;
+            }
+            return this.isComplete() ? false : this.reject('advancedFilterValidationMissingValue', position);
+        }
+
+        if (this.expectSeparator) {
+            // Past the last value the fault is the bracket left open; before it, the missing separator.
+            return this.reject(
+                this.isComplete()
+                    ? 'advancedFilterValidationMissingEndBracket'
+                    : 'advancedFilterValidationMissingValue',
+                position
+            );
+        }
+
+        this.startOperand(position);
+        return this.delegate(char, position);
+    }
+
+    private delegate(char: string, position: number): boolean | undefined {
+        // The inner parser only reports back on a closing quote, which ends the operand but not the region.
+        if (this.parser!.parse(char, position) != null) {
+            this.expectSeparator = true;
+        }
+        return undefined;
+    }
+
+    private startOperand(position: number): void {
+        if (this.parser) {
+            return;
+        }
+        this.parser = new OperandParser(this.params, position, this.baseCellDataType, this.column);
+        this.parsers.push(this.parser);
+    }
+
+    private finishOperand(position: number): void {
+        this.parser!.complete(position);
+        this.expectSeparator = true;
+    }
+
+    /** Returns undefined, so the region keeps the rest of the text rather than being abandoned and restarted. */
+    private reject(key: keyof typeof ADVANCED_FILTER_LOCALE_TEXT, position?: number): undefined {
+        this.validationMessage ??= this.params.advFilterExpSvc.translate(key);
+        if (position != null) {
+            this.validationEndPosition ??= position;
+        }
+        return undefined;
     }
 }
 
@@ -372,7 +569,7 @@ export class ColFilterExpressionParser {
     private parser: Parser | undefined;
     private columnParser: ColumnParser | undefined;
     private operatorParser: OperatorParser | undefined;
-    private operandParser: OperandParser | undefined;
+    private operandsParser: OperandsParser | undefined;
 
     private readonly operandValueGetters: {
         number: (a: string) => number;
@@ -425,13 +622,15 @@ export class ColFilterExpressionParser {
                         );
                         parser = this.operatorParser;
                     } else {
-                        this.operandParser = new OperandParser(
+                        // One region for the whole operand list, so a resumed parse keeps what it already read.
+                        this.operandsParser ??= new OperandsParser(
                             this.params,
                             i,
                             this.columnParser.baseCellDataType,
-                            this.columnParser.column
+                            this.columnParser.column,
+                            this.operatorParser.expectedNumOperands
                         );
-                        parser = this.operandParser;
+                        parser = this.operandsParser;
                     }
                     this.parser = parser;
                 }
@@ -451,19 +650,15 @@ export class ColFilterExpressionParser {
     }
 
     public isValid(): boolean {
-        return (
-            this.isComplete() &&
-            this.columnParser!.valid &&
-            this.operatorParser!.valid &&
-            (!this.operandParser || this.operandParser.valid)
-        );
+        // Every parser that can be invalid reports a message when it is, so the one error source decides.
+        return this.isComplete() && this.getValidationError() == null;
     }
 
     public getValidationError(): FilterExpressionValidationError | null {
         const validationError =
             this.columnParser?.getValidationError() ??
             this.operatorParser?.getValidationError() ??
-            this.operandParser?.getValidationError();
+            this.operandsParser?.getValidationError();
         if (validationError) {
             return validationError;
         }
@@ -473,7 +668,7 @@ export class ColFilterExpressionParser {
             translateKey = 'advancedFilterValidationMissingColumn';
         } else if (!this.operatorParser) {
             translateKey = 'advancedFilterValidationMissingOption';
-        } else if (this.operatorParser.expectedNumOperands && !this.operandParser) {
+        } else if (this.operatorParser.expectedNumOperands && !this.operandsParser) {
             translateKey = 'advancedFilterValidationMissingValue';
         }
         if (translateKey) {
@@ -487,15 +682,33 @@ export class ColFilterExpressionParser {
     }
 
     public getFunction(params: FilterExpressionFunctionParams): FilterExpressionFunction {
-        return this.getFunctionCommon(params, (operandIndex, operatorIndex, colId, evaluatorParamsIndex) => {
-            return (expressionProxy, node, p) =>
-                p.operators[operatorIndex].evaluator(
-                    expressionProxy.getValue(colId, node),
-                    node,
-                    p.evaluatorParams[evaluatorParamsIndex],
-                    operandIndex == null ? undefined : p.operands[operandIndex]
-                );
-        });
+        const columnParser = this.columnParser!;
+        const colId = columnParser.getColId();
+        const { operators, evaluatorParams, operands } = params;
+        const advFilterExpSvc = this.params.advFilterExpSvc;
+        const operatorIndex = addToListAndGetIndex(
+            operators,
+            advFilterExpSvc.getExpressionOperator(
+                columnParser.baseCellDataType,
+                this.operatorParser?.getOperatorKey(),
+                columnParser.column
+            )
+        );
+        const evaluatorParamsIndex = addToListAndGetIndex(
+            evaluatorParams,
+            advFilterExpSvc.getExpressionEvaluatorParams(colId)
+        );
+        const [from, to] = this.getOperandParsers();
+        const fromIndex = from ? addToListAndGetIndex(operands, this.getOperandValue(from)) : -1;
+        const toIndex = to ? addToListAndGetIndex(operands, this.getOperandValue(to)) : -1;
+        return (expressionProxy, node, p) =>
+            p.operators[operatorIndex].evaluator(
+                expressionProxy.getValue(colId, node),
+                node,
+                p.evaluatorParams[evaluatorParamsIndex],
+                fromIndex < 0 ? undefined : p.operands[fromIndex],
+                toIndex < 0 ? undefined : p.operands[toIndex]
+            );
     }
 
     public getAutocompleteListParams(position: number): AutocompleteListParams | undefined {
@@ -517,116 +730,89 @@ export class ColFilterExpressionParser {
         type?: string
     ): AutocompleteUpdate | null {
         const { expression } = this.params;
+        const columnParser = this.columnParser;
         if (this.isColumnPosition(position)) {
             return updateExpression(
-                this.params.expression,
+                expression,
                 this.startPosition,
-                this.columnParser?.getColId()
-                    ? this.columnParser.endPosition!
+                columnParser?.getColId()
+                    ? columnParser.endPosition!
                     : findEndPosition(expression, position).endPosition,
                 this.params.advFilterExpSvc.getColumnValue(updateEntry),
                 true
             );
-        } else if (this.isOperatorPosition(position)) {
-            const baseCellDataType = this.getBaseCellDataTypeFromOperatorAutocompleteType(type);
-            const hasOperand = this.hasOperand(baseCellDataType, updateEntry.key);
-            const doesOperandNeedQuotes = hasOperand && this.doesOperandNeedQuotes(baseCellDataType);
-            let update: AutocompleteUpdate;
-            if (this.operatorParser?.startPosition != null && position < this.operatorParser.startPosition) {
-                // in between multiple spaces, just insert direct
-                update = updateExpression(
-                    expression,
-                    position,
-                    position,
-                    updateEntry.displayValue ?? updateEntry.key,
-                    hasOperand,
-                    doesOperandNeedQuotes
-                );
-            } else {
-                let endPosition: number;
-                let empty = false;
-                if (this.operatorParser?.getOperatorKey()) {
-                    endPosition = this.operatorParser.endPosition!;
-                } else {
-                    const { endPosition: calculatedEndPosition, isEmpty } = findEndPosition(
-                        expression,
-                        position,
-                        true,
-                        true
-                    );
-                    endPosition = calculatedEndPosition;
-                    empty = isEmpty;
-                }
-                update = updateExpression(
-                    expression,
-                    findStartPosition(expression, this.columnParser!.endPosition! + 1, endPosition),
-                    endPosition,
-                    updateEntry.displayValue ?? updateEntry.key,
-                    hasOperand,
-                    doesOperandNeedQuotes,
-                    empty
-                );
-            }
-            return { ...update, hideAutocomplete: !hasOperand };
         }
-        return null;
+        if (!this.isOperatorPosition(position)) {
+            return null;
+        }
+
+        const baseCellDataType = this.getBaseCellDataTypeFromOperatorAutocompleteType(type);
+        const numOperands = this.getNumOperandsFor(baseCellDataType, updateEntry.key);
+        const hasOperand = numOperands > 0;
+        const operatorParser = this.operatorParser;
+        // The default span is a point insert, for a caret in between multiple spaces; only a caret at or
+        // past the operator replaces text.
+        let startPosition = position;
+        let endPosition = position;
+        let empty = false;
+        if (operatorParser?.startPosition == null || position >= operatorParser.startPosition) {
+            if (operatorParser?.getOperatorKey()) {
+                endPosition = operatorParser.endPosition!;
+            } else {
+                const found = findEndPosition(expression, position, true, true);
+                endPosition = found.endPosition;
+                empty = found.isEmpty;
+            }
+            startPosition = findStartPosition(expression, columnParser!.endPosition! + 1, endPosition);
+        }
+        const update = updateExpression(
+            expression,
+            startPosition,
+            endPosition,
+            updateEntry.displayValue ?? updateEntry.key,
+            hasOperand,
+            hasOperand && this.doesOperandNeedQuotes(baseCellDataType),
+            empty,
+            numOperands > 1
+        );
+        return { ...update, hideAutocomplete: !hasOperand };
     }
 
     public getModel(forBuilder?: boolean): AdvancedFilterModel {
-        const colId = this.columnParser!.getColId();
-        const model = {
-            filterType: this.columnParser!.baseCellDataType,
-            colId,
-            type: this.operatorParser!.getOperatorKey(),
-        };
-        if (this.operatorParser!.expectedNumOperands) {
-            const operandParser = this.operandParser!;
-            (model as any).filter = forBuilder ? operandParser.getBuilderValue() : operandParser.getModelValue();
+        const columnParser = this.columnParser!;
+        const [from, to] = this.getOperandParsers();
+        const operands: ColumnFilterModelOperands = {};
+        if (from) {
+            operands.filter = forBuilder ? from.getBuilderValue() : from.getModelValue();
         }
-        return model as AdvancedFilterModel;
+        if (to) {
+            operands.filterTo = forBuilder ? to.getBuilderValue() : to.getModelValue();
+        }
+        // The parse decides the member by `filterType`, which the union itself cannot express.
+        return {
+            filterType: columnParser.baseCellDataType,
+            colId: columnParser.getColId(),
+            type: this.operatorParser!.getOperatorKey(),
+            ...operands,
+        } as AdvancedFilterModel;
     }
 
-    private getFunctionCommon<T>(
-        params: FilterExpressionFunctionParams,
-        processFunc: (
-            operandIndex: number | undefined,
-            operatorIndex: number,
-            colId: string,
-            evaluatorParamsIndex: number
-        ) => T
-    ) {
-        const colId = this.columnParser!.getColId();
-        const operator = this.operatorParser?.getOperatorKey();
-        const { operators, evaluatorParams, operands } = params;
-        const operatorForColumn = this.params.advFilterExpSvc.getExpressionOperator(
-            this.columnParser!.baseCellDataType,
-            operator
-        );
-        const operatorIndex = this.addToListAndGetIndex(operators, operatorForColumn);
-        const evaluatorParamsForColumn = this.params.advFilterExpSvc.getExpressionEvaluatorParams(colId);
-        const evaluatorParamsIndex = this.addToListAndGetIndex(evaluatorParams, evaluatorParamsForColumn);
-        const operandIndex =
-            this.operatorParser?.expectedNumOperands === 0
-                ? undefined
-                : this.addToListAndGetIndex(operands, this.getOperandValue());
-        return processFunc(operandIndex, operatorIndex, colId, evaluatorParamsIndex);
-    }
-
-    private getOperandValue(): any {
+    private getOperandValue(operandParser: OperandParser): any {
         const { baseCellDataType, column } = this.columnParser!;
-        const operand = this.operandValueGetters[baseCellDataType](this.operandParser!.getRawValue());
+        const operand = this.operandValueGetters[baseCellDataType](operandParser.getRawValue());
         if (baseCellDataType === 'dateString' || baseCellDataType === 'dateTimeString') {
             return this.params.dataTypeSvc?.getDateParserFunction(column)(operand as string) ?? operand;
         }
         return operand;
     }
 
+    private getOperandParsers(): OperandParser[] {
+        return this.operandsParser?.getParsers() ?? [];
+    }
+
     private isComplete(): boolean {
-        return !!(
-            this.operatorParser &&
-            (!this.operatorParser.expectedNumOperands ||
-                (this.operatorParser.expectedNumOperands && this.operandParser))
-        );
+        const operatorParser = this.operatorParser;
+        return !!operatorParser && (!operatorParser.expectedNumOperands || !!this.operandsParser?.isComplete());
     }
 
     private isColumnPosition(position: number): boolean {
@@ -702,21 +888,19 @@ export class ColFilterExpressionParser {
         return type?.replace('operator-', '') as BaseCellDataType;
     }
 
-    private hasOperand(baseCellDataType?: BaseCellDataType, operator?: string): boolean {
-        return (
-            !baseCellDataType ||
-            !operator ||
-            (this.params.advFilterExpSvc.getExpressionOperator(baseCellDataType, operator)?.numOperands ?? 0) > 0
-        );
+    private getNumOperandsFor(baseCellDataType: BaseCellDataType | undefined, operator: string): number {
+        if (!baseCellDataType || !operator) {
+            return 1;
+        }
+        const column = this.columnParser?.column;
+        return this.params.advFilterExpSvc.getExpressionOperator(baseCellDataType, operator, column)?.numOperands ?? 0;
     }
 
     private doesOperandNeedQuotes(baseCellDataType?: BaseCellDataType): boolean {
         return baseCellDataType !== 'number' && baseCellDataType !== 'bigint';
     }
+}
 
-    private addToListAndGetIndex<T>(list: T[], value: T): number {
-        const index = list.length;
-        list.push(value);
-        return index;
-    }
+function addToListAndGetIndex<T>(list: T[], value: T): number {
+    return list.push(value) - 1;
 }

--- a/packages/ag-grid-enterprise/src/advancedFilter/customFilterOptions.ts
+++ b/packages/ag-grid-enterprise/src/advancedFilter/customFilterOptions.ts
@@ -10,10 +10,7 @@ import {
 import type { DataTypeFilterExpressionOperators, FilterExpressionOperator } from './filterExpressionOperators';
 import { getEntries } from './filterExpressionOperators';
 
-/**
- * A list the column author wrote, as opposed to the one a data type supplies for every column of its kind.
- * An empty list narrows to nothing, so it is not a list this column offers anything from.
- */
+/** A list the column author wrote, as opposed to the one its data type supplies; an empty list narrows nothing. */
 function getAuthoredFilterOptions(filterParams: any): (string | IFilterOptionDef)[] | undefined {
     const filterOptions = filterParams?.filterOptions;
     return !filterOptions?.length || _isGridSuppliedFilterOptions(filterOptions) ? undefined : filterOptions;
@@ -22,8 +19,7 @@ function getAuthoredFilterOptions(filterParams: any): (string | IFilterOptionDef
 /** The options a column narrows itself to, or `undefined` where it narrows nothing of its own. */
 export function getColumnFilterOptions(column: AgColumn): (string | IFilterOptionDef)[] | undefined {
     const filterParams = column.colDef.filterParams;
-    // A Multi Filter's own params carry its children, and `filterOptions` is written on a child rather than
-    // on them. Its own level is read after the children, for a list written there.
+    // A Multi Filter writes `filterOptions` on a child, so its own level is read only after them.
     const filters: { filterParams?: any }[] | undefined = filterParams?.filters;
     for (let i = 0, len = filters?.length ?? 0; i < len; ++i) {
         const childOptions = getAuthoredFilterOptions(filters![i]?.filterParams);
@@ -56,8 +52,7 @@ function createCustomOptionOperator(
 ): FilterExpressionOperator<any> {
     const predicate = option.predicate!;
     const numOperands = _getCustomOptionNumberOfInputs(option);
-    // Arity bound here rather than branched on per row; the predicate gets the raw cell value, as it does
-    // in the column filter.
+    // Arity bound here rather than branched on per row; the predicate gets the raw cell value.
     let evaluator: FilterExpressionOperator<any>['evaluator'];
     if (numOperands === 0) {
         evaluator = (value) => predicate([], value);

--- a/packages/ag-grid-enterprise/src/advancedFilter/customFilterOptions.ts
+++ b/packages/ag-grid-enterprise/src/advancedFilter/customFilterOptions.ts
@@ -1,0 +1,70 @@
+import type { LocaleTextFunc } from 'ag-stack';
+
+import type { AgColumn, IFilterOptionDef } from 'ag-grid-community';
+import {
+    _getCustomOptionDisplayName,
+    _getCustomOptionNumberOfInputs,
+    _isGridSuppliedFilterOptions,
+} from 'ag-grid-community';
+
+import type { DataTypeFilterExpressionOperators, FilterExpressionOperator } from './filterExpressionOperators';
+import { getEntries } from './filterExpressionOperators';
+
+/**
+ * A list the column author wrote, as opposed to the one a data type supplies for every column of its kind.
+ * An empty list narrows to nothing, so it is not a list this column offers anything from.
+ */
+function getAuthoredFilterOptions(filterParams: any): (string | IFilterOptionDef)[] | undefined {
+    const filterOptions = filterParams?.filterOptions;
+    return !filterOptions?.length || _isGridSuppliedFilterOptions(filterOptions) ? undefined : filterOptions;
+}
+
+/** The options a column narrows itself to, or `undefined` where it narrows nothing of its own. */
+export function getColumnFilterOptions(column: AgColumn): (string | IFilterOptionDef)[] | undefined {
+    const filterParams = column.colDef.filterParams;
+    // A Multi Filter's own params carry its children, and `filterOptions` is written on a child rather than
+    // on them. Its own level is read after the children, for a list written there.
+    const filters: { filterParams?: any }[] | undefined = filterParams?.filters;
+    for (let i = 0, len = filters?.length ?? 0; i < len; ++i) {
+        const childOptions = getAuthoredFilterOptions(filters![i]?.filterParams);
+        if (childOptions) {
+            return childOptions;
+        }
+    }
+    return getAuthoredFilterOptions(filterParams);
+}
+
+/** Overlays a column's Custom Filter Options on its data type's operators, replacing a built-in of the same key. */
+export function createCustomOptionOperators(
+    dataTypeOperators: DataTypeFilterExpressionOperators<any>,
+    customOptions: Map<string, IFilterOptionDef>,
+    localeTextFunc: LocaleTextFunc
+): DataTypeFilterExpressionOperators<any> {
+    const operators: { [operator: string]: FilterExpressionOperator<any> } = Object.assign(
+        Object.create(null),
+        dataTypeOperators.operators
+    );
+    customOptions.forEach((option, key) => {
+        operators[key] = createCustomOptionOperator(option, localeTextFunc);
+    });
+    return { operators, getEntries: (activeOperators) => getEntries(operators, activeOperators) };
+}
+
+function createCustomOptionOperator(
+    option: IFilterOptionDef,
+    localeTextFunc: LocaleTextFunc
+): FilterExpressionOperator<any> {
+    const predicate = option.predicate!;
+    const numOperands = _getCustomOptionNumberOfInputs(option);
+    // Arity bound here rather than branched on per row; the predicate gets the raw cell value, as it does
+    // in the column filter.
+    let evaluator: FilterExpressionOperator<any>['evaluator'];
+    if (numOperands === 0) {
+        evaluator = (value) => predicate([], value);
+    } else if (numOperands === 1) {
+        evaluator = (value, _node, _params, operand1) => predicate([operand1], value);
+    } else {
+        evaluator = (value, _node, _params, operand1, operand2) => predicate([operand1, operand2], value);
+    }
+    return { displayValue: _getCustomOptionDisplayName(option, localeTextFunc), evaluator, numOperands };
+}

--- a/packages/ag-grid-enterprise/src/advancedFilter/filterExpressionOperators.ts
+++ b/packages/ag-grid-enterprise/src/advancedFilter/filterExpressionOperators.ts
@@ -1,4 +1,4 @@
-import { _hasOwn } from 'ag-stack';
+import { _getOwn } from 'ag-stack';
 
 import { _hasValue, _isBlank } from 'ag-grid-community';
 import type { BaseCellDataType, IRowNode } from 'ag-grid-community';
@@ -77,7 +77,7 @@ export function findMatch<T>(
     }
 }
 
-function getEntries<ConvertedTValue, TValue = ConvertedTValue>(
+export function getEntries<ConvertedTValue, TValue = ConvertedTValue>(
     operators: { [operator: string]: FilterExpressionOperator<ConvertedTValue, TValue> },
     activeOperatorKeys?: string[]
 ): AutocompleteEntry[] {
@@ -87,7 +87,7 @@ function getEntries<ConvertedTValue, TValue = ConvertedTValue>(
     let count = 0;
     for (let i = 0; i < len; ++i) {
         const key = keys[i];
-        const operator = _hasOwn(operators, key) ? operators[key] : undefined;
+        const operator = _getOwn(operators, key);
         if (operator) {
             entries[count++] = { key, displayValue: operator.displayValue };
         }

--- a/packages/ag-grid-enterprise/src/advancedFilter/filterExpressionUtils.ts
+++ b/packages/ag-grid-enterprise/src/advancedFilter/filterExpressionUtils.ts
@@ -3,6 +3,7 @@ import { _parseBigIntOrNull } from 'ag-stack';
 import { _bindFilterCallback } from 'ag-grid-community';
 import type {
     AgColumn,
+    ColumnAdvancedFilterModel,
     ColumnModel,
     DataTypeService,
     GridOptionsService,
@@ -19,6 +20,23 @@ import type { FilterExpressionEvaluatorParams, FilterExpressionOperator } from '
 export interface ColumnFilterModelOperands {
     filter?: string | number;
     filterTo?: string | number;
+}
+
+/** The model names its two operands rather than listing them, so an operand index maps to a key. */
+export const OPERAND_KEYS = ['filter', 'filterTo'] as const;
+
+/** Judged on the display: what the column's formatter cannot write is not a value the model holds. */
+export function hasEveryOperand(
+    advFilterExpSvc: AdvancedFilterExpressionService,
+    model: ColumnAdvancedFilterModel,
+    numOperands: number
+): boolean {
+    for (let i = 0; i < numOperands; ++i) {
+        if (!advFilterExpSvc.formatOperand(model, (model as ColumnFilterModelOperands)[OPERAND_KEYS[i]], true)) {
+            return false;
+        }
+    }
+    return true;
 }
 
 /** A condition the Builder is still assembling: each slot is absent until the user has chosen it. */
@@ -133,8 +151,7 @@ export function updateExpression(
             positionOffset = 1;
         } else {
             updatedValuePart += ' ';
-            // An option taking two values opens their bracketed list, then the first value's quote. These
-            // have to be written past the space, so an existing one is rewritten rather than kept.
+            // A two-value option opens its bracket then the first quote, both past the space, so one there is rewritten.
             if (appendBracket) {
                 updatedValuePart += '(';
             }

--- a/packages/ag-grid-enterprise/src/advancedFilter/filterExpressionUtils.ts
+++ b/packages/ag-grid-enterprise/src/advancedFilter/filterExpressionUtils.ts
@@ -15,6 +15,18 @@ import type {
 import type { AdvancedFilterExpressionService } from './advancedFilterExpressionService';
 import type { FilterExpressionEvaluatorParams, FilterExpressionOperator } from './filterExpressionOperators';
 
+/** The operand slots every `ColumnAdvancedFilterModel` member shares, which the union itself cannot express. */
+export interface ColumnFilterModelOperands {
+    filter?: string | number;
+    filterTo?: string | number;
+}
+
+/** A condition the Builder is still assembling: each slot is absent until the user has chosen it. */
+export interface PartialColumnFilterModel extends ColumnFilterModelOperands {
+    colId?: string;
+    type?: string;
+}
+
 export interface FilterExpressionParserParams {
     expression: string;
     gos: GridOptionsService;
@@ -109,18 +121,28 @@ export function updateExpression(
     updatedValuePart: string,
     appendSpace?: boolean,
     appendQuote?: boolean,
-    empty?: boolean
+    empty?: boolean,
+    appendBracket?: boolean
 ): AutocompleteUpdate {
-    const secondPartStartPosition = endPosition + (!expression.length || empty ? 0 : 1);
+    let secondPartStartPosition = endPosition + (!expression.length || empty ? 0 : 1);
     let positionOffset = 0;
     if (appendSpace) {
-        if (expression[secondPartStartPosition] === ' ') {
-            // already a space, just move the position
+        const hasSpace = expression[secondPartStartPosition] === ' ';
+        if (hasSpace && !appendBracket && !appendQuote) {
+            // already a space and nothing to open after it, so just move the position
             positionOffset = 1;
         } else {
             updatedValuePart += ' ';
+            // An option taking two values opens their bracketed list, then the first value's quote. These
+            // have to be written past the space, so an existing one is rewritten rather than kept.
+            if (appendBracket) {
+                updatedValuePart += '(';
+            }
             if (appendQuote) {
                 updatedValuePart += `"`;
+            }
+            if (hasSpace) {
+                secondPartStartPosition++;
             }
         }
     }

--- a/packages/ag-grid-enterprise/src/aiToolkit/features/advancedFilterFeatureSchema.ts
+++ b/packages/ag-grid-enterprise/src/aiToolkit/features/advancedFilterFeatureSchema.ts
@@ -7,36 +7,38 @@ import type { SchemaBuilder } from '../schemaBuilder';
 import { s } from '../schemaBuilder';
 import type { JSONSchema } from '../schemaTypes';
 
-/** Columns sharing a data type and the same operators, which a column's `filterOptions` can narrow or extend. */
+/** Columns sharing a data type, an arity and the same operators of that arity. */
 interface OperatorGroup {
     readonly dataType: BaseCellDataType;
     readonly colIds: string[];
     readonly operatorKeys: string[];
-    readonly maxOperands: number;
+    readonly numOperands: number;
 }
 
 /**
  * Read from the expression service rather than listed here, so a column's Custom Filter Options are offered
- * to a caller under the same keys, and the same arity, that an expression would accept.
+ * to a caller under the same keys, and the same arity, that an expression would accept. Split by arity: the
+ * operands a model must carry are the chosen operator's, and one schema spanning several cannot say that.
  */
-function getColumnOperatorGroup(
+function getColumnOperatorKeysByArity(
     advFilterExpSvc: AdvancedFilterExpressionService,
     column: AgColumn,
     dataType: BaseCellDataType
-): Omit<OperatorGroup, 'colIds'> {
+): Map<number, string[]> {
     const columnOperators = advFilterExpSvc.getColumnOperators(dataType, column);
     const entries = columnOperators?.operators.getEntries(columnOperators.activeOperators) ?? [];
-    const operatorKeys: string[] = [];
-    let maxOperands = 0;
+    const byArity = new Map<number, string[]>();
     for (let i = 0, len = entries.length; i < len; ++i) {
         const key = entries[i].key;
-        operatorKeys.push(key);
         const numOperands = _getOwn(columnOperators!.operators.operators, key)?.numOperands ?? 0;
-        if (numOperands > maxOperands) {
-            maxOperands = numOperands;
+        const keys = byArity.get(numOperands);
+        if (keys) {
+            keys.push(key);
+        } else {
+            byArity.set(numOperands, [key]);
         }
     }
-    return { dataType, operatorKeys, maxOperands };
+    return byArity;
 }
 
 export const buildAdvancedFilterFeatureSchema = ({ colModel, dataTypeSvc, advFilterExpSvc }: BeanCollection) => {
@@ -54,15 +56,17 @@ export const buildAdvancedFilterFeatureSchema = ({ colModel, dataTypeSvc, advFil
         if (!dataType) {
             continue;
         }
-        const group = getColumnOperatorGroup(expSvc, col, dataType);
-        // JSON rather than a join: a `displayKey` is author-written and may hold the separator itself.
-        const groupKey = `${dataType} ${group.maxOperands} ${JSON.stringify(group.operatorKeys)}`;
-        const existing = groups.get(groupKey);
-        if (existing) {
-            existing.colIds.push(col.colId);
-        } else {
-            groups.set(groupKey, { ...group, colIds: [col.colId] });
-        }
+        const byArity = getColumnOperatorKeysByArity(expSvc, col, dataType);
+        byArity.forEach((operatorKeys, numOperands) => {
+            // JSON rather than a join: a `displayKey` is author-written and may hold the separator itself.
+            const groupKey = `${dataType} ${numOperands} ${JSON.stringify(operatorKeys)}`;
+            const existing = groups.get(groupKey);
+            if (existing) {
+                existing.colIds.push(col.colId);
+            } else {
+                groups.set(groupKey, { dataType, operatorKeys, numOperands, colIds: [col.colId] });
+            }
+        });
     }
 
     const columnFilterModels: JSONSchema[] = [];
@@ -166,7 +170,7 @@ const DataTypeSchemas: Record<BaseCellDataType, DataTypeSchema> = {
     text: { filterType: 'text', noun: 'text', titleNoun: 'Text', value: () => s.string('Text value to filter by') },
 };
 
-/** The second value only exists where an option takes one, which today means a Custom Filter Option. */
+/** One arity per schema, so the value slots it declares are exactly the ones its operators require. */
 function buildFilterSchema(group: OperatorGroup): SchemaBuilder {
     const { filterType, noun, titleNoun, value } = DataTypeSchemas[group.dataType];
     const props: Record<string, SchemaBuilder> = {
@@ -174,14 +178,14 @@ function buildFilterSchema(group: OperatorGroup): SchemaBuilder {
         colId: s.enum(group.colIds, `Column identifier for the ${noun} column to filter`),
         type: s.enum(group.operatorKeys, `${titleNoun} filter operation type`),
     };
-    // Optional, not merely nullable: the operators in one group need not share an arity, so `blank` beside
-    // `equals` must be writable without its operands, exactly as the model declares them.
-    const { maxOperands } = group;
-    if (maxOperands > 0) {
-        props.filter = value().nullable().optional();
+    // Required, because every operator in this group takes them: a condition short of its operands is not a
+    // narrower filter, it is one the parser rejects, and rejecting one discards the whole model.
+    const { numOperands } = group;
+    if (numOperands > 0) {
+        props.filter = value().nullable();
     }
-    if (maxOperands > 1) {
-        props.filterTo = value().nullable().optional();
+    if (numOperands > 1) {
+        props.filterTo = value().nullable();
     }
     return s.object(props);
 }

--- a/packages/ag-grid-enterprise/src/aiToolkit/features/advancedFilterFeatureSchema.ts
+++ b/packages/ag-grid-enterprise/src/aiToolkit/features/advancedFilterFeatureSchema.ts
@@ -15,11 +15,7 @@ interface OperatorGroup {
     readonly numOperands: number;
 }
 
-/**
- * Read from the expression service rather than listed here, so a column's Custom Filter Options are offered
- * to a caller under the same keys, and the same arity, that an expression would accept. Split by arity: the
- * operands a model must carry are the chosen operator's, and one schema spanning several cannot say that.
- */
+/** Read from the expression service, so a caller is offered the keys and arity an expression would accept. */
 function getColumnOperatorKeysByArity(
     advFilterExpSvc: AdvancedFilterExpressionService,
     column: AgColumn,
@@ -178,8 +174,7 @@ function buildFilterSchema(group: OperatorGroup): SchemaBuilder {
         colId: s.enum(group.colIds, `Column identifier for the ${noun} column to filter`),
         type: s.enum(group.operatorKeys, `${titleNoun} filter operation type`),
     };
-    // Required, because every operator in this group takes them: a condition short of its operands is not a
-    // narrower filter, it is one the parser rejects, and rejecting one discards the whole model.
+    // Required: the parser rejects a condition short of its operands, and that discards the whole model.
     const { numOperands } = group;
     if (numOperands > 0) {
         props.filter = value().nullable();

--- a/packages/ag-grid-enterprise/src/aiToolkit/features/advancedFilterFeatureSchema.ts
+++ b/packages/ag-grid-enterprise/src/aiToolkit/features/advancedFilterFeatureSchema.ts
@@ -1,31 +1,67 @@
-import type { BaseCellDataType, BeanCollection } from 'ag-grid-community';
+import { _getOwn } from 'ag-stack';
 
+import type { AgColumn, BaseCellDataType, BeanCollection } from 'ag-grid-community';
+
+import type { AdvancedFilterExpressionService } from '../../advancedFilter/advancedFilterExpressionService';
+import type { SchemaBuilder } from '../schemaBuilder';
 import { s } from '../schemaBuilder';
 import type { JSONSchema } from '../schemaTypes';
 
-export const buildAdvancedFilterFeatureSchema = ({ colModel, dataTypeSvc }: BeanCollection) => {
-    if (!dataTypeSvc) {
+/** Columns sharing a data type and the same operators, which a column's `filterOptions` can narrow or extend. */
+interface OperatorGroup {
+    readonly dataType: BaseCellDataType;
+    readonly colIds: string[];
+    readonly operatorKeys: string[];
+    readonly maxOperands: number;
+}
+
+/**
+ * Read from the expression service rather than listed here, so a column's Custom Filter Options are offered
+ * to a caller under the same keys, and the same arity, that an expression would accept.
+ */
+function getColumnOperatorGroup(
+    advFilterExpSvc: AdvancedFilterExpressionService,
+    column: AgColumn,
+    dataType: BaseCellDataType
+): Omit<OperatorGroup, 'colIds'> {
+    const columnOperators = advFilterExpSvc.getColumnOperators(dataType, column);
+    const entries = columnOperators?.operators.getEntries(columnOperators.activeOperators) ?? [];
+    const operatorKeys: string[] = [];
+    let maxOperands = 0;
+    for (let i = 0, len = entries.length; i < len; ++i) {
+        const key = entries[i].key;
+        operatorKeys.push(key);
+        const numOperands = _getOwn(columnOperators!.operators.operators, key)?.numOperands ?? 0;
+        if (numOperands > maxOperands) {
+            maxOperands = numOperands;
+        }
+    }
+    return { dataType, operatorKeys, maxOperands };
+}
+
+export const buildAdvancedFilterFeatureSchema = ({ colModel, dataTypeSvc, advFilterExpSvc }: BeanCollection) => {
+    if (!dataTypeSvc || !advFilterExpSvc) {
         return;
     }
+    const expSvc = advFilterExpSvc as AdvancedFilterExpressionService;
 
     const columns = colModel.getCols();
 
-    const dataTypes: Record<BaseCellDataType, string[]> = {
-        boolean: [],
-        object: [],
-        date: [],
-        dateString: [],
-        dateTime: [],
-        dateTimeString: [],
-        number: [],
-        bigint: [],
-        text: [],
-    };
-
+    // Keyed on the operators as well as the data type, so one column's options never reach a sibling's schema.
+    const groups = new Map<string, OperatorGroup>();
     for (const col of columns) {
         const dataType = dataTypeSvc.getBaseDataType(col);
-        if (dataType) {
-            dataTypes[dataType].push(col.colId);
+        if (!dataType) {
+            continue;
+        }
+        const group = getColumnOperatorGroup(expSvc, col, dataType);
+        // JSON rather than a join: a `displayKey` is author-written and may hold the separator itself.
+        const groupKey = `${dataType} ${group.maxOperands} ${JSON.stringify(group.operatorKeys)}`;
+        const existing = groups.get(groupKey);
+        if (existing) {
+            existing.colIds.push(col.colId);
+        } else {
+            groups.set(groupKey, { ...group, colIds: [col.colId] });
         }
     }
 
@@ -33,13 +69,15 @@ export const buildAdvancedFilterFeatureSchema = ({ colModel, dataTypeSvc }: Bean
 
     const defs: Record<string, JSONSchema> = {};
 
-    for (const key of Object.keys(dataTypes) as BaseCellDataType[]) {
-        if (dataTypes[key].length > 0) {
-            const ref = `${key}AdvancedFilterModel`;
-            const builder = DataTypeSchemaBuilders[key];
-            defs[ref] = builder(dataTypes[key]);
-            columnFilterModels.push({ $ref: `#/$defs/${ref}` });
-        }
+    const refCounts: Partial<Record<BaseCellDataType, number>> = {};
+    for (const group of groups.values()) {
+        const { dataType } = group;
+        // The first group of a data type keeps the unsuffixed name, which is the only one most grids have.
+        const count = (refCounts[dataType] ?? 0) + 1;
+        refCounts[dataType] = count;
+        const ref = `${dataType}AdvancedFilterModel${count > 1 ? count : ''}`;
+        defs[ref] = buildFilterSchema(group).toJSON();
+        columnFilterModels.push({ $ref: `#/$defs/${ref}` });
     }
 
     defs.joinAdvancedFilterModel = s.object({
@@ -68,191 +106,82 @@ export const buildAdvancedFilterFeatureSchema = ({ colModel, dataTypeSvc }: Bean
     return schema;
 };
 
-const buildBooleanFilterSchema = (colIds: string[]) => {
-    return s.object({
-        filterType: s.literal('boolean', 'Filter type identifier for boolean column filters'),
-        colId: s.enum(colIds, 'Column identifier for the boolean column to filter'),
-        type: s.enum(['true', 'false'], 'Boolean value to filter by'),
-    });
-};
+/** What a data type contributes: the literal its model writes, the nouns its text reads in, and its value. */
+interface DataTypeSchema {
+    readonly filterType: string;
+    readonly noun: string;
+    readonly titleNoun: string;
+    readonly value: () => SchemaBuilder;
+}
 
-const buildObjectFilterSchema = (colIds: string[]) => {
-    return s.object({
-        filterType: s.literal('object', 'Filter type identifier for object column filters'),
-        colId: s.enum(colIds, 'Column identifier for the object column to filter'),
-        filter: s.string('Filter value to compare against object column values').nullable(),
-        type: s.enum(
-            ['equals', 'notEqual', 'contains', 'notContains', 'startsWith', 'endsWith', 'blank', 'notBlank'],
-            'Object filter operation type'
-        ),
-    });
-};
+const dateValue = () => s.string({ pattern: '^\\d{4}-\\d{2}-\\d{2}$', description: 'Date value in YYYY-MM-DD format' });
 
-const buildDateFilterSchema = (colIds: string[]) => {
-    return s.object({
-        filterType: s.literal('date', 'Filter type identifier for date column filters'),
-        colId: s.enum(colIds, 'Column identifier for the date column to filter'),
-        filter: s
-            .string({ pattern: '^\\d{4}-\\d{2}-\\d{2}$', description: 'Date value in YYYY-MM-DD format' })
-            .nullable(),
-        type: s.enum(
-            [
-                'equals',
-                'notEqual',
-                'lessThan',
-                'lessThanOrEqual',
-                'greaterThan',
-                'greaterThanOrEqual',
-                'blank',
-                'notBlank',
-            ],
-            'Date filter operation type'
-        ),
-    });
-};
-
-const buildDateStringFilterSchema = (colIds: string[]) => {
-    return s.object({
-        filterType: s.literal('date', 'Filter type identifier for date string column filters'),
-        colId: s.enum(colIds, 'Column identifier for the date string column to filter'),
-        filter: s
-            .string({ pattern: '^\\d{4}-\\d{2}-\\d{2}$', description: 'Date value in YYYY-MM-DD format' })
-            .nullable(),
-        type: s.enum(
-            [
-                'equals',
-                'notEqual',
-                'lessThan',
-                'lessThanOrEqual',
-                'greaterThan',
-                'greaterThanOrEqual',
-                'blank',
-                'notBlank',
-            ],
-            'Date string filter operation type'
-        ),
-    });
-};
-
-const buildDateTimeFilterSchema = (colIds: string[]) => {
-    return s.object({
-        filterType: s.literal('dateTime', 'Filter type identifier for datetime column filters'),
-        colId: s.enum(colIds, 'Column identifier for the datetime column to filter'),
-        filter: s
-            .string({
+const DataTypeSchemas: Record<BaseCellDataType, DataTypeSchema> = {
+    boolean: {
+        filterType: 'boolean',
+        noun: 'boolean',
+        titleNoun: 'Boolean',
+        value: () => s.string('Filter value to compare against boolean column values'),
+    },
+    object: {
+        filterType: 'object',
+        noun: 'object',
+        titleNoun: 'Object',
+        value: () => s.string('Filter value to compare against object column values'),
+    },
+    date: { filterType: 'date', noun: 'date', titleNoun: 'Date', value: dateValue },
+    dateString: { filterType: 'dateString', noun: 'date string', titleNoun: 'Date string', value: dateValue },
+    dateTime: {
+        filterType: 'dateTime',
+        noun: 'datetime',
+        titleNoun: 'DateTime',
+        value: () =>
+            s.string({
                 pattern: '^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}$',
                 description: 'DateTime value in YYYY-MM-DDTHH:mm:ss format',
-            })
-            .nullable(),
-        type: s.enum(
-            [
-                'equals',
-                'notEqual',
-                'lessThan',
-                'lessThanOrEqual',
-                'greaterThan',
-                'greaterThanOrEqual',
-                'blank',
-                'notBlank',
-            ],
-            'DateTime filter operation type'
-        ),
-    });
-};
-
-const buildDateTimeStringFilterSchema = (colIds: string[]) => {
-    return s.object({
-        filterType: s.literal('dateTimeString', 'Filter type identifier for datetime string column filters'),
-        colId: s.enum(colIds, 'Column identifier for the datetime string column to filter'),
-        filter: s
-            .string({
+            }),
+    },
+    dateTimeString: {
+        filterType: 'dateTimeString',
+        noun: 'datetime string',
+        titleNoun: 'DateTime string',
+        value: () =>
+            s.string({
                 pattern: '^\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}$',
                 description: 'DateTime value in YYYY-MM-DD HH:mm:ss format',
-            })
-            .nullable(),
-        type: s.enum(
-            [
-                'equals',
-                'notEqual',
-                'lessThan',
-                'lessThanOrEqual',
-                'greaterThan',
-                'greaterThanOrEqual',
-                'blank',
-                'notBlank',
-            ],
-            'DateTime string filter operation type'
-        ),
-    });
+            }),
+    },
+    number: {
+        filterType: 'number',
+        noun: 'number',
+        titleNoun: 'Number',
+        value: () => s.number('Numeric value to filter by'),
+    },
+    bigint: {
+        filterType: 'bigint',
+        noun: 'bigint',
+        titleNoun: 'BigInt',
+        value: () => s.string({ pattern: '^-?\\d+$', description: 'BigInt value to filter by' }),
+    },
+    text: { filterType: 'text', noun: 'text', titleNoun: 'Text', value: () => s.string('Text value to filter by') },
 };
 
-const buildNumberFilterSchema = (colIds: string[]) => {
-    return s.object({
-        filterType: s.literal('number', 'Filter type identifier for number column filters'),
-        colId: s.enum(colIds, 'Column identifier for the number column to filter'),
-        filter: s.number('Numeric value to filter by').nullable(),
-        type: s.enum(
-            [
-                'equals',
-                'notEqual',
-                'lessThan',
-                'lessThanOrEqual',
-                'greaterThan',
-                'greaterThanOrEqual',
-                'blank',
-                'notBlank',
-            ],
-            'Number filter operation type'
-        ),
-    });
-};
-
-const buildBigIntFilterSchema = (colIds: string[]) => {
-    return s.object({
-        filterType: s.literal('bigint', 'Filter type identifier for bigint column filters'),
-        colId: s.enum(colIds, 'Column identifier for the bigint column to filter'),
-        filter: s
-            .string({
-                pattern: '^-?\\d+$',
-                description: 'BigInt value to filter by',
-            })
-            .nullable(),
-        type: s.enum(
-            [
-                'equals',
-                'notEqual',
-                'lessThan',
-                'lessThanOrEqual',
-                'greaterThan',
-                'greaterThanOrEqual',
-                'blank',
-                'notBlank',
-            ],
-            'BigInt filter operation type'
-        ),
-    });
-};
-
-const buildTextFilterSchema = (colIds: string[]) => {
-    return s.object({
-        filterType: s.literal('text', 'Filter type identifier for text column filters'),
-        colId: s.enum(colIds, 'Column identifier for the text column to filter'),
-        filter: s.string('Text value to filter by').nullable(),
-        type: s.enum(
-            ['equals', 'notEqual', 'contains', 'notContains', 'startsWith', 'endsWith', 'blank', 'notBlank'],
-            'Text filter operation type'
-        ),
-    });
-};
-
-const DataTypeSchemaBuilders: Record<BaseCellDataType, (colIds: string[]) => any> = {
-    boolean: buildBooleanFilterSchema,
-    object: buildObjectFilterSchema,
-    date: buildDateFilterSchema,
-    dateString: buildDateStringFilterSchema,
-    dateTime: buildDateTimeFilterSchema,
-    dateTimeString: buildDateTimeStringFilterSchema,
-    number: buildNumberFilterSchema,
-    bigint: buildBigIntFilterSchema,
-    text: buildTextFilterSchema,
-};
+/** The second value only exists where an option takes one, which today means a Custom Filter Option. */
+function buildFilterSchema(group: OperatorGroup): SchemaBuilder {
+    const { filterType, noun, titleNoun, value } = DataTypeSchemas[group.dataType];
+    const props: Record<string, SchemaBuilder> = {
+        filterType: s.literal(filterType, `Filter type identifier for ${noun} column filters`),
+        colId: s.enum(group.colIds, `Column identifier for the ${noun} column to filter`),
+        type: s.enum(group.operatorKeys, `${titleNoun} filter operation type`),
+    };
+    // Optional, not merely nullable: the operators in one group need not share an arity, so `blank` beside
+    // `equals` must be writable without its operands, exactly as the model declares them.
+    const { maxOperands } = group;
+    if (maxOperands > 0) {
+        props.filter = value().nullable().optional();
+    }
+    if (maxOperands > 1) {
+        props.filterTo = value().nullable().optional();
+    }
+    return s.object(props);
+}

--- a/packages/ag-grid-enterprise/src/aiToolkit/features/filterFeatureSchema.ts
+++ b/packages/ag-grid-enterprise/src/aiToolkit/features/filterFeatureSchema.ts
@@ -1,4 +1,5 @@
 import type { BeanCollection, StructuredSchemaParams } from 'ag-grid-community';
+import { _classifyFilterOptions } from 'ag-grid-community';
 
 import type { MultiFilterHandler } from '../../multiFilter/multiFilterHandler';
 import { getMultiFilterDefs } from '../../multiFilter/multiFilterUtil';
@@ -110,18 +111,10 @@ function buildColumnFilterSchema(
 
     if (SimpleFilterKeys.includes(filterKey)) {
         const maxConditions = filterParams?.maxNumConditions;
+        // The filter's own definition of a usable entry, so the schema cannot offer a `type` it drops.
+        // Read-only, so an entry it drops is not warned about again here.
         const filterOptions = filterParams?.filterOptions
-            ? filterParams.filterOptions
-                  .map((option: any) => {
-                      if (typeof option === 'string') {
-                          return option;
-                      }
-                      if (typeof option === 'object' && option.displayKey) {
-                          return option.displayKey;
-                      }
-                      return null;
-                  })
-                  .filter(Boolean)
+            ? [..._classifyFilterOptions(filterParams.filterOptions, () => {}).offered.keys()]
             : undefined;
         const useIsoSeparator = filterParams?.useIsoSeparator || false;
 

--- a/packages/ag-grid-enterprise/src/aiToolkit/schemaBuilder.ts
+++ b/packages/ag-grid-enterprise/src/aiToolkit/schemaBuilder.ts
@@ -15,9 +15,6 @@ import type {
 export interface SchemaBuilder {
     toJSON(): JSONSchema;
     nullable(): SchemaBuilder;
-    /** Kept out of the owning object's `required`, for a property the model itself declares optional. */
-    optional(): SchemaBuilder;
-    _optional?: boolean;
 }
 
 abstract class BaseSchemaBuilder<TType extends JSONSchemaType> {
@@ -26,7 +23,6 @@ abstract class BaseSchemaBuilder<TType extends JSONSchemaType> {
 
     _defs: Record<string, JSONSchema> = {};
     _nullable: boolean = false;
-    _optional: boolean = false;
 
     constructor(description?: string) {
         this.description = description;
@@ -61,11 +57,6 @@ abstract class BaseSchemaBuilder<TType extends JSONSchemaType> {
 
     nullable(): this {
         this._nullable = true;
-        return this;
-    }
-
-    optional(): this {
-        this._optional = true;
         return this;
     }
 
@@ -272,7 +263,7 @@ class ObjectSchemaBuilder extends BaseSchemaBuilder<'object'> {
         this._defs = allDefs;
 
         return this._toJSON({
-            required: Object.keys(this.properties).filter((key) => !this.properties[key]._optional),
+            required: Object.keys(this.properties),
             additionalProperties: false,
             properties: propertySchemas,
         });
@@ -281,7 +272,6 @@ class ObjectSchemaBuilder extends BaseSchemaBuilder<'object'> {
 
 class UnionSchemaBuilder {
     private _nullable: boolean = false;
-    public _optional: boolean = false;
     private _defs: Record<string, JSONSchema> = {};
 
     constructor(
@@ -295,11 +285,6 @@ class UnionSchemaBuilder {
 
     nullable(): this {
         this._nullable = true;
-        return this;
-    }
-
-    optional(): this {
-        this._optional = true;
         return this;
     }
 
@@ -343,16 +328,9 @@ class UnionSchemaBuilder {
 }
 
 class ReferenceSchemaBuilder {
-    public _optional: boolean = false;
-
     constructor(private readonly id: string) {}
 
     nullable(): this {
-        return this;
-    }
-
-    optional(): this {
-        this._optional = true;
         return this;
     }
 

--- a/packages/ag-grid-enterprise/src/aiToolkit/schemaBuilder.ts
+++ b/packages/ag-grid-enterprise/src/aiToolkit/schemaBuilder.ts
@@ -15,6 +15,9 @@ import type {
 export interface SchemaBuilder {
     toJSON(): JSONSchema;
     nullable(): SchemaBuilder;
+    /** Kept out of the owning object's `required`, for a property the model itself declares optional. */
+    optional(): SchemaBuilder;
+    _optional?: boolean;
 }
 
 abstract class BaseSchemaBuilder<TType extends JSONSchemaType> {
@@ -23,6 +26,7 @@ abstract class BaseSchemaBuilder<TType extends JSONSchemaType> {
 
     _defs: Record<string, JSONSchema> = {};
     _nullable: boolean = false;
+    _optional: boolean = false;
 
     constructor(description?: string) {
         this.description = description;
@@ -57,6 +61,11 @@ abstract class BaseSchemaBuilder<TType extends JSONSchemaType> {
 
     nullable(): this {
         this._nullable = true;
+        return this;
+    }
+
+    optional(): this {
+        this._optional = true;
         return this;
     }
 
@@ -263,7 +272,7 @@ class ObjectSchemaBuilder extends BaseSchemaBuilder<'object'> {
         this._defs = allDefs;
 
         return this._toJSON({
-            required: Object.keys(this.properties),
+            required: Object.keys(this.properties).filter((key) => !this.properties[key]._optional),
             additionalProperties: false,
             properties: propertySchemas,
         });
@@ -272,6 +281,7 @@ class ObjectSchemaBuilder extends BaseSchemaBuilder<'object'> {
 
 class UnionSchemaBuilder {
     private _nullable: boolean = false;
+    public _optional: boolean = false;
     private _defs: Record<string, JSONSchema> = {};
 
     constructor(
@@ -285,6 +295,11 @@ class UnionSchemaBuilder {
 
     nullable(): this {
         this._nullable = true;
+        return this;
+    }
+
+    optional(): this {
+        this._optional = true;
         return this;
     }
 
@@ -328,9 +343,16 @@ class UnionSchemaBuilder {
 }
 
 class ReferenceSchemaBuilder {
+    public _optional: boolean = false;
+
     constructor(private readonly id: string) {}
 
     nullable(): this {
+        return this;
+    }
+
+    optional(): this {
+        this._optional = true;
         return this;
     }
 

--- a/packages/ag-stack/src/main-internal.ts
+++ b/packages/ag-stack/src/main-internal.ts
@@ -252,6 +252,7 @@ export { _fuzzySuggestions } from './utils/fuzzyMatch';
 export {
     _defaultComparator,
     _exists,
+    _getOwn,
     _hasOwn,
     _jsonEquals,
     _makeNull,

--- a/packages/ag-stack/src/utils/generic.test.ts
+++ b/packages/ag-stack/src/utils/generic.test.ts
@@ -1,4 +1,30 @@
-import { _defaultComparator, _makeNull } from './generic';
+import { _defaultComparator, _getOwn, _hasOwn, _makeNull } from './generic';
+
+describe('own-property lookup', () => {
+    it('resolves a table entry and not an inherited one', () => {
+        const table = { contains: 'a value' };
+
+        expect(_hasOwn(table, 'contains')).toBe(true);
+        expect(_getOwn(table, 'contains')).toBe('a value');
+        expect(_hasOwn(table, 'toString')).toBe(false);
+        expect(_getOwn(table, 'toString')).toBeUndefined();
+    });
+
+    it('refuses `__proto__`, even where a parsed payload planted it as an own property', () => {
+        const planted = JSON.parse('{"__proto__": "attacker value", "contains": "a value"}');
+        // The premise the refusal rests on: it really is an own data property here.
+        expect(Object.prototype.hasOwnProperty.call(planted, '__proto__')).toBe(true);
+
+        expect(_hasOwn(planted, '__proto__')).toBe(false);
+        expect(_getOwn(planted, '__proto__')).toBeUndefined();
+        expect(_getOwn(planted, 'contains')).toBe('a value');
+    });
+
+    it('reads nothing from an absent table', () => {
+        expect(_getOwn(null, 'contains')).toBeUndefined();
+        expect(_getOwn(undefined, 'contains')).toBeUndefined();
+    });
+});
 
 describe('_makeNull', () => {
     it.each([4, 'string', new Date()])('returns value if not null: %s', (value) => {

--- a/packages/ag-stack/src/utils/generic.ts
+++ b/packages/ag-stack/src/utils/generic.ts
@@ -2,11 +2,20 @@ const hasOwnProperty = Object.prototype.hasOwnProperty;
 
 /**
  * Own properties only: a lookup table keyed by a user-supplied string otherwise resolves `toString` and friends
- * off `Object.prototype` and hands back a function where a value was expected.
+ * off `Object.prototype` and hands back a function where a value was expected. `__proto__` is refused outright
+ * rather than tested, as no table means it as a key and a parsed payload can plant it as an own property.
  * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
  */
 export function _hasOwn(obj: object, key: PropertyKey): boolean {
-    return hasOwnProperty.call(obj, key);
+    return key !== '__proto__' && hasOwnProperty.call(obj, key);
+}
+
+/**
+ * The value a lookup table holds under a user-supplied key, or `undefined` where it holds none.
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
+ */
+export function _getOwn<T>(table: { [key: string]: T } | null | undefined, key: string): T | undefined {
+    return table != null && _hasOwn(table, key) ? table[key] : undefined;
 }
 
 /**

--- a/packages/ag-stack/src/utils/generic.ts
+++ b/packages/ag-stack/src/utils/generic.ts
@@ -1,9 +1,7 @@
 const hasOwnProperty = Object.prototype.hasOwnProperty;
 
 /**
- * Own properties only: a lookup table keyed by a user-supplied string otherwise resolves `toString` and friends
- * off `Object.prototype` and hands back a function where a value was expected. `__proto__` is refused outright
- * rather than tested, as no table means it as a key and a parsed payload can plant it as an own property.
+ * Own properties only, `__proto__` refused outright: a user-supplied key otherwise resolves off `Object.prototype`.
  * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
  */
 export function _hasOwn(obj: object, key: PropertyKey): boolean {

--- a/testing/ag-test-utils/src/filters/advancedFilterBuilderHarness.ts
+++ b/testing/ag-test-utils/src/filters/advancedFilterBuilderHarness.ts
@@ -248,6 +248,17 @@ export class AdvancedFilterBuilderHarness {
 
     /** Clicks the builder Apply button, committing the staged edits to the grid (and closing the dialog). */
     public async apply(): Promise<this> {
+        await firePointerLikeClick(this.applyButton());
+        await asyncSetTimeout(0);
+        return this;
+    }
+
+    /** Whether Apply is shut — the whole list's verdict, including rows the virtual list has not mounted. */
+    public applyDisabled(): boolean {
+        return this.applyButton().disabled;
+    }
+
+    private applyButton(): HTMLButtonElement {
         const panel = document.querySelector(`${BUILDER} .ag-filter-apply-panel`);
         const button = Array.from(panel?.querySelectorAll<HTMLButtonElement>('button') ?? []).find(
             (b) => b.textContent?.trim() === 'Apply'
@@ -255,9 +266,7 @@ export class AdvancedFilterBuilderHarness {
         if (!button) {
             throw new Error('Builder Apply button not found');
         }
-        await firePointerLikeClick(button);
-        await asyncSetTimeout(0);
-        return this;
+        return button;
     }
 
     /**

--- a/testing/behavioural/src/ai-toolkit/structured-schema.test.ts
+++ b/testing/behavioural/src/ai-toolkit/structured-schema.test.ts
@@ -703,8 +703,7 @@ describe('getStructuredSchema - filter feature', () => {
             );
         });
 
-        // The filter's own definition of a usable entry decides, so the schema cannot offer a `type` the
-        // filter drops: `customEquals` has no `displayName` or `predicate`, `startsA` has both.
+        // The filter decides what is usable, so the schema cannot offer a `type` it drops.
         test('extracts displayKey from object-style filterOptions, and drops an entry the filter would', async () => {
             const api = gridsManager.createGrid('myGrid', {
                 columnDefs: [
@@ -1395,8 +1394,7 @@ describe('getStructuredSchema - advanced filter', () => {
         `);
     });
 
-    // The operators come from the expression service, so a Custom Filter Option is offered under the same
-    // key an expression would accept, and only to the column that declares it.
+    // From the expression service, so an option is offered under the key an expression would accept.
     test('a column custom option reaches the schema, and a sibling of the same type keeps the built-ins', async () => {
         const api = gridsManager.createGrid('myGrid', {
             columnDefs: [
@@ -1424,8 +1422,7 @@ describe('getStructuredSchema - advanced filter', () => {
 
         const schema = toJSON(api.getStructuredSchema());
 
-        // A def per column AND arity: the operands a model must carry are the chosen operator's, so operators
-        // taking different counts cannot share one schema. Found by what each def names rather than by suffix.
+        // A def per column AND arity: operators taking different counts cannot share one schema.
         const defsFor = (colId: string) =>
             (Object.values(schema.$defs) as any[]).filter((def: any) => def?.properties?.colId?.enum?.includes(colId));
         const defFor = (colId: string, ...operatorKeys: string[]) =>

--- a/testing/behavioural/src/ai-toolkit/structured-schema.test.ts
+++ b/testing/behavioural/src/ai-toolkit/structured-schema.test.ts
@@ -1424,40 +1424,38 @@ describe('getStructuredSchema - advanced filter', () => {
 
         const schema = toJSON(api.getStructuredSchema());
 
-        // Found by the column each def names, not by the suffix: the suffix follows column order, so
-        // reading it positionally would swap the two silently if the columnDefs were reordered.
-        const defFor = (colId: string) =>
-            Object.values(schema.$defs).find((def: any) => def?.properties?.colId?.enum?.includes(colId)) as any;
+        // A def per column AND arity: the operands a model must carry are the chosen operator's, so operators
+        // taking different counts cannot share one schema. Found by what each def names rather than by suffix.
+        const defsFor = (colId: string) =>
+            (Object.values(schema.$defs) as any[]).filter((def: any) => def?.properties?.colId?.enum?.includes(colId));
+        const defFor = (colId: string, ...operatorKeys: string[]) =>
+            defsFor(colId).find((def: any) => def.properties.type.enum.join() === operatorKeys.join());
 
-        // The suffix scheme is then a claim of its own: the first group of a data type keeps the bare name.
-        expect(Object.keys(schema.$defs).filter((key) => key.startsWith('numberAdvancedFilterModel'))).toEqual([
-            'numberAdvancedFilterModel',
-            'numberAdvancedFilterModel2',
-        ]);
+        const ageOneValue = defFor('age', 'equals');
+        expect(ageOneValue.properties.filterTo).toBeUndefined();
+        expect(ageOneValue.required).toEqual(['filterType', 'colId', 'type', 'filter']);
 
-        const narrowed = defFor('age');
-        expect(narrowed.properties.colId.enum).toEqual(['age']);
-        expect(narrowed.properties.type.enum).toEqual(['equals', 'betweenExclusive']);
-        expect(narrowed.properties.filterTo).toBeDefined();
-        // The operators in one group need not share an arity, so a model naming the one-value `equals` must
-        // validate without `filterTo`, and `blank` below without either. The model declares both optional.
-        expect(narrowed.required).toEqual(['filterType', 'colId', 'type']);
+        const ageTwoValue = defFor('age', 'betweenExclusive');
+        expect(ageTwoValue.properties.filterTo).toBeDefined();
+        expect(ageTwoValue.required).toEqual(['filterType', 'colId', 'type', 'filter', 'filterTo']);
 
-        const builtIns = defFor('score');
-        expect(builtIns.properties.colId.enum).toEqual(['score']);
-        expect(builtIns.properties.type.enum).toEqual([
+        // The built-in sibling splits the same way: its blanks take no value, the rest take one.
+        const scoreNoValue = defFor('score', 'blank', 'notBlank');
+        expect(scoreNoValue.properties.filter).toBeUndefined();
+        expect(scoreNoValue.required).toEqual(['filterType', 'colId', 'type']);
+
+        const scoreOneValue = defFor(
+            'score',
             'equals',
             'notEqual',
             'greaterThan',
             'greaterThanOrEqual',
             'lessThan',
-            'lessThanOrEqual',
-            'blank',
-            'notBlank',
-        ]);
-        expect(builtIns.properties.filterTo).toBeUndefined();
-        // `blank` and `notBlank` take no value, so `filter` cannot be required here either.
-        expect(builtIns.required).toEqual(['filterType', 'colId', 'type']);
+            'lessThanOrEqual'
+        );
+        expect(scoreOneValue.properties.colId.enum).toEqual(['score']);
+        expect(scoreOneValue.required).toEqual(['filterType', 'colId', 'type', 'filter']);
+        expect(scoreOneValue.properties.filterTo).toBeUndefined();
     });
 
     test('a boolean column carries no value slot, since none of its operators takes one', async () => {

--- a/testing/behavioural/src/ai-toolkit/structured-schema.test.ts
+++ b/testing/behavioural/src/ai-toolkit/structured-schema.test.ts
@@ -703,14 +703,24 @@ describe('getStructuredSchema - filter feature', () => {
             );
         });
 
-        test('extracts displayKey from object-style filterOptions', async () => {
+        // The filter's own definition of a usable entry decides, so the schema cannot offer a `type` the
+        // filter drops: `customEquals` has no `displayName` or `predicate`, `startsA` has both.
+        test('extracts displayKey from object-style filterOptions, and drops an entry the filter would', async () => {
             const api = gridsManager.createGrid('myGrid', {
                 columnDefs: [
                     {
                         field: 'name',
                         filter: 'agTextColumnFilter',
                         filterParams: {
-                            filterOptions: ['contains', { displayKey: 'customEquals' }],
+                            filterOptions: [
+                                'contains',
+                                { displayKey: 'customEquals' },
+                                {
+                                    displayKey: 'startsA',
+                                    displayName: 'Starts With A',
+                                    predicate: (_v: any[], cellValue: any) => cellValue?.startsWith('A'),
+                                },
+                            ],
                         },
                     },
                 ],
@@ -728,7 +738,7 @@ describe('getStructuredSchema - filter feature', () => {
             const schema = toJSON(api.getStructuredSchema());
             const nameFilter = resolveNullable(schema.properties.filter.properties.filterModel.properties.name);
             const conditionType = nameFilter.properties.conditions.items.properties.type;
-            expect(conditionType.enum).toEqual(['contains', 'customEquals']);
+            expect(conditionType.enum).toEqual(['contains', 'startsA']);
             await new GridRows(api, `extracts displayKey from object-style filterOptions final state`).check(`
                 ROOT id:ROOT_NODE_ID
                 └── LEAF id:0 name:"Alice"
@@ -1383,6 +1393,86 @@ describe('getStructuredSchema - advanced filter', () => {
             ROOT id:ROOT_NODE_ID
             └── LEAF id:0 name:"Alice"
         `);
+    });
+
+    // The operators come from the expression service, so a Custom Filter Option is offered under the same
+    // key an expression would accept, and only to the column that declares it.
+    test('a column custom option reaches the schema, and a sibling of the same type keeps the built-ins', async () => {
+        const api = gridsManager.createGrid('myGrid', {
+            columnDefs: [
+                {
+                    field: 'age',
+                    cellDataType: 'number',
+                    filterParams: {
+                        filterOptions: [
+                            'equals',
+                            {
+                                displayKey: 'betweenExclusive',
+                                displayName: 'Between (Exclusive)',
+                                numberOfInputs: 2,
+                                predicate: ([from, to]: any[], cellValue: any) =>
+                                    cellValue != null && cellValue > from && cellValue < to,
+                            },
+                        ],
+                    },
+                },
+                { field: 'score', cellDataType: 'number' },
+            ],
+            rowData: [{ age: 25, score: 10 }],
+            enableAdvancedFilter: true,
+        });
+
+        const schema = toJSON(api.getStructuredSchema());
+
+        // Found by the column each def names, not by the suffix: the suffix follows column order, so
+        // reading it positionally would swap the two silently if the columnDefs were reordered.
+        const defFor = (colId: string) =>
+            Object.values(schema.$defs).find((def: any) => def?.properties?.colId?.enum?.includes(colId)) as any;
+
+        // The suffix scheme is then a claim of its own: the first group of a data type keeps the bare name.
+        expect(Object.keys(schema.$defs).filter((key) => key.startsWith('numberAdvancedFilterModel'))).toEqual([
+            'numberAdvancedFilterModel',
+            'numberAdvancedFilterModel2',
+        ]);
+
+        const narrowed = defFor('age');
+        expect(narrowed.properties.colId.enum).toEqual(['age']);
+        expect(narrowed.properties.type.enum).toEqual(['equals', 'betweenExclusive']);
+        expect(narrowed.properties.filterTo).toBeDefined();
+        // The operators in one group need not share an arity, so a model naming the one-value `equals` must
+        // validate without `filterTo`, and `blank` below without either. The model declares both optional.
+        expect(narrowed.required).toEqual(['filterType', 'colId', 'type']);
+
+        const builtIns = defFor('score');
+        expect(builtIns.properties.colId.enum).toEqual(['score']);
+        expect(builtIns.properties.type.enum).toEqual([
+            'equals',
+            'notEqual',
+            'greaterThan',
+            'greaterThanOrEqual',
+            'lessThan',
+            'lessThanOrEqual',
+            'blank',
+            'notBlank',
+        ]);
+        expect(builtIns.properties.filterTo).toBeUndefined();
+        // `blank` and `notBlank` take no value, so `filter` cannot be required here either.
+        expect(builtIns.required).toEqual(['filterType', 'colId', 'type']);
+    });
+
+    test('a boolean column carries no value slot, since none of its operators takes one', async () => {
+        const api = gridsManager.createGrid('myGrid', {
+            columnDefs: [{ field: 'active', cellDataType: 'boolean' }],
+            rowData: [{ active: true }],
+            enableAdvancedFilter: true,
+        });
+
+        const schema = toJSON(api.getStructuredSchema());
+
+        const model = schema.$defs.booleanAdvancedFilterModel;
+        expect(model.properties.type.enum).toEqual(['true', 'false', 'blank', 'notBlank']);
+        expect(model.properties.filter).toBeUndefined();
+        expect(model.properties.filterTo).toBeUndefined();
     });
 });
 

--- a/testing/behavioural/src/filters/advanced-filter-regression/af-builder-keyboard-nav.test.ts
+++ b/testing/behavioural/src/filters/advanced-filter-regression/af-builder-keyboard-nav.test.ts
@@ -16,9 +16,10 @@ import { AdvancedFilterModule } from 'ag-grid-enterprise';
 /**
  * Regression baseline for the Advanced Filter Builder keyboard surface: the item-navigation feature
  * (Enter to focus into a row's pills, Escape to return focus to the row, focus highlight) and the
- * keyboard-accessible reorder via the Move Up/Down buttons (shown by `showMoveButtons`). Reordering
- * AND siblings does not change the result, so the observable behaviour is the model's condition order
- * and the builder tree — both asserted, alongside a GridRows check that the filter still applies.
+ * keyboard-accessible reorder via the Move Up/Down buttons (shown by
+ * `showMoveButtons`). Reordering AND siblings does not change the result, so the observable behaviour is
+ * the model's condition order and the builder tree — both asserted, alongside a GridRows check that the
+ * filter still applies.
  */
 interface Row {
     athlete: string;

--- a/testing/behavioural/src/filters/advanced-filter-regression/af-builder-keyboard-nav.test.ts
+++ b/testing/behavioural/src/filters/advanced-filter-regression/af-builder-keyboard-nav.test.ts
@@ -13,14 +13,7 @@ import type { AdvancedFilterModel, GridOptions } from 'ag-grid-community';
 import { ClientSideRowModelModule, NumberFilterModule, TextFilterModule, setupAgTestIds } from 'ag-grid-community';
 import { AdvancedFilterModule } from 'ag-grid-enterprise';
 
-/**
- * Regression baseline for the Advanced Filter Builder keyboard surface: the item-navigation feature
- * (Enter to focus into a row's pills, Escape to return focus to the row, focus highlight) and the
- * keyboard-accessible reorder via the Move Up/Down buttons (shown by
- * `showMoveButtons`). Reordering AND siblings does not change the result, so the observable behaviour is
- * the model's condition order and the builder tree — both asserted, alongside a GridRows check that the
- * filter still applies.
- */
+/** Regression baseline for the Builder keyboard surface: item navigation and Move Up/Down reorder. */
 interface Row {
     athlete: string;
     age: number;

--- a/testing/behavioural/src/filters/advanced-filter-regression/af-options.test.ts
+++ b/testing/behavioural/src/filters/advanced-filter-regression/af-options.test.ts
@@ -5,11 +5,14 @@ import {
     GridRows,
     TestGridsManager,
     asyncSetTimeout,
+    installFilterLayoutMock,
+    uninstallFilterLayoutMock,
 } from 'ag-test-utils';
 
 import type { GridApi, GridOptions, IFilterOptionDef } from 'ag-grid-community';
 import {
     ClientSideRowModelModule,
+    ColumnApiModule,
     DateFilterModule,
     LocaleModule,
     NumberFilterModule,
@@ -22,9 +25,14 @@ import { AdvancedFilterModule, SetFilterModule } from 'ag-grid-enterprise';
 /**
  * Regression baseline for Advanced Filter grid options and current operator behaviour: display-name/colId
  * resolution, `includeHiddenColumnsInAdvancedFilter`, `suppressAdvancedFilterEval`, `advancedFilterParent`;
- * operators the tickets will ADD but don't offer today (AG-10029 presets, AG-10029/10819 inRange, AG-10819
- * custom filterOptions); and Set Filter columns treated as text (AG-8950). Locks each so tickets are visible diffs.
+ * operators not offered today (the relative date presets, `inRange`); Set Filter columns treated as text;
+ * and a Custom Filter Option's `displayKey` being rejected as a name. Locks each so a change is a visible diff.
  */
+
+// The suggestion list is virtualised, so without a layout it renders a single row and every assertion on
+// its contents reads that truncation rather than what the column offers.
+beforeAll(() => installFilterLayoutMock());
+afterAll(() => uninstallFilterLayoutMock());
 
 describe('Advanced Filter — grid options', () => {
     interface Row {
@@ -39,7 +47,13 @@ describe('Advanced Filter — grid options', () => {
     ];
 
     const gridsManager = new TestGridsManager({
-        modules: [TextFilterModule, NumberFilterModule, AdvancedFilterModule, ClientSideRowModelModule],
+        modules: [
+            TextFilterModule,
+            NumberFilterModule,
+            AdvancedFilterModule,
+            ColumnApiModule,
+            ClientSideRowModelModule,
+        ],
     });
 
     afterEach(() => gridsManager.reset());
@@ -83,6 +97,39 @@ describe('Advanced Filter — grid options', () => {
                 valid: false — Expression has an error. Column not found - [Athlete] equals "Bolt".
                 buttons: Apply ⊘ | Builder
                 model: null
+            `);
+        });
+
+        test('a header renamed after the grid is built swaps which name the expression takes', async () => {
+            const api = await gridsManager.createGridAndWait('grid1', OPTS);
+            const af = AdvancedFilterHarness.get(api);
+
+            await af.applyExpression('[Competitor] equals "Bolt"');
+            await asyncSetTimeout(0);
+            expect(api.getDisplayedRowCount()).toBe(1);
+
+            // Cleared first: an invalid expression leaves the previous filter applied, which would read as
+            // the old name still resolving.
+            await af.applyExpression('');
+            await asyncSetTimeout(0);
+            api.applyColumnState({ state: [{ colId: 'athlete', headerName: 'Runner' }] });
+            await asyncSetTimeout(0);
+
+            await af.applyExpression('[Competitor] equals "Bolt"');
+            await asyncSetTimeout(0);
+            expect(api.getAdvancedFilterModel()).toBeNull();
+
+            await af.applyExpression('[Runner] equals "Bolt"');
+            await asyncSetTimeout(0);
+            expect(api.getAdvancedFilterModel()).toEqual({
+                filterType: 'text',
+                colId: 'athlete',
+                type: 'equals',
+                filter: 'Bolt',
+            });
+            await new GridRows(api, 'renamed header applied under its new name').check(`
+                ROOT id:ROOT_NODE_ID
+                └── LEAF id:0 athlete:"Bolt" age:25
             `);
         });
 
@@ -308,19 +355,28 @@ describe('Advanced Filter — currently-unsupported operators (baseline)', () =>
             `);
         });
 
-        // A preset key names no AF option, so it can make none available: the list leaves only `equals`.
-        test('an operator absent from the preset list is not offered', async () => {
+        // A preset key names no AF option, so the list leaves only `equals` to suggest. The grammar is the
+        // data type's either way, so an operator typed rather than picked still reads.
+        test('an operator absent from the preset list is not suggested, but still reads', async () => {
             const api: GridApi = await gridsManager.createGridAndWait('grid1', OPTS);
+            const af = AdvancedFilterHarness.get(api);
 
-            await AdvancedFilterHarness.get(api).applyExpression('[Date] > "2024-03-01"');
+            await af.type('[Date] ');
+            expect(af.autocompleteEntries()).toEqual(['=']);
+
+            await af.applyExpression('[Date] > "2024-03-01"');
             await asyncSetTimeout(0);
 
-            await new FilterDom(api, 'preset column greaterThan not offered').checkFilterDom(`
+            await new FilterDom(api, 'preset column greaterThan typed').checkFilterDom(`
                 ADVANCED FILTER
                 input: "[Date] > "2024-03-01""
-                valid: false — Expression has an error. Option not found - > "2024-03-01".
+                valid: true
                 buttons: Apply ⊘ | Builder
-                model: null
+                model:
+                  filterType: "dateString"
+                  colId: "date"
+                  type: "greaterThan"
+                  filter: "2024-03-01"
             `);
         });
     });
@@ -353,51 +409,60 @@ describe('Advanced Filter — currently-unsupported operators (baseline)', () =>
             `);
         });
     });
+});
 
-    describe('custom (object) filterOptions are ignored today', () => {
-        const EVEN: IFilterOptionDef = {
-            displayKey: 'even',
-            displayName: 'Is even',
-            numberOfInputs: 0,
-            predicate: (_v, cellValue) => typeof cellValue === 'number' && cellValue % 2 === 0,
-        };
-        const OPTS: GridOptions = {
-            columnDefs: [
-                { field: 'age', filter: 'agNumberColumnFilter', filterParams: { filterOptions: ['equals', EVEN] } },
-            ],
-            rowData: [{ age: 10 }, { age: 15 }, { age: 20 }],
-            enableAdvancedFilter: true,
-        };
+/**
+ * `filterOptions` naming a Custom Filter Option: where the option has a `displayName`, its `displayKey` is
+ * not a name an expression can use.
+ */
+describe('Advanced Filter — custom filterOptions entries', () => {
+    const gridsManager = new TestGridsManager({
+        modules: [TextFilterModule, NumberFilterModule, AdvancedFilterModule, ClientSideRowModelModule],
+    });
 
-        test('the custom option key is not an AF operator, but standard operators still work', async () => {
-            const api: GridApi = await gridsManager.createGridAndWait('grid1', OPTS);
+    afterEach(() => gridsManager.reset());
 
-            // The object option makes the whole list "not all strings", so AF falls back to its default
-            // operators — the custom key is unknown.
-            await AdvancedFilterHarness.get(api).applyExpression('[Age] even');
-            await asyncSetTimeout(0);
-            expect(api.getAdvancedFilterModel()).toBeNull();
-            await new FilterDom(api, 'custom option rejected').checkFilterDom(`
-                ADVANCED FILTER
-                input: "[Age] even"
-                valid: false — Expression has an error. Option not found - even.
-                buttons: Apply ⊘ | Builder
-                model: null
-            `);
+    const EVEN: IFilterOptionDef = {
+        displayKey: 'even',
+        displayName: 'Is even',
+        numberOfInputs: 0,
+        predicate: (_v, cellValue) => typeof cellValue === 'number' && cellValue % 2 === 0,
+    };
+    const OPTS: GridOptions = {
+        columnDefs: [
+            { field: 'age', filter: 'agNumberColumnFilter', filterParams: { filterOptions: ['equals', EVEN] } },
+        ],
+        rowData: [{ age: 10 }, { age: 15 }, { age: 20 }],
+        enableAdvancedFilter: true,
+    };
 
-            await AdvancedFilterHarness.get(api).applyExpression('[Age] = 20');
-            await asyncSetTimeout(0);
-            expect(api.getAdvancedFilterModel()).toEqual({
-                filterType: 'number',
-                colId: 'age',
-                type: 'equals',
-                filter: 20,
-            });
-            await new GridRows(api, 'custom column standard operator applied').check(`
-                ROOT id:ROOT_NODE_ID
-                └── LEAF id:2 age:20
-            `);
+    test('the displayKey is not an operator name, and the built-ins the list keeps still work', async () => {
+        const api: GridApi = await gridsManager.createGridAndWait('grid1', OPTS);
+
+        // `Is even` is what the option is called in an expression; `even` only identifies it in the model.
+        await AdvancedFilterHarness.get(api).applyExpression('[Age] even');
+        await asyncSetTimeout(0);
+        expect(api.getAdvancedFilterModel()).toBeNull();
+        await new FilterDom(api, 'custom option rejected').checkFilterDom(`
+            ADVANCED FILTER
+            input: "[Age] even"
+            valid: false — Expression has an error. Option not found - even.
+            buttons: Apply ⊘ | Builder
+            model: null
+        `);
+
+        await AdvancedFilterHarness.get(api).applyExpression('[Age] = 20');
+        await asyncSetTimeout(0);
+        expect(api.getAdvancedFilterModel()).toEqual({
+            filterType: 'number',
+            colId: 'age',
+            type: 'equals',
+            filter: 20,
         });
+        await new GridRows(api, 'custom column standard operator applied').check(`
+            ROOT id:ROOT_NODE_ID
+            └── LEAF id:2 age:20
+        `);
     });
 });
 
@@ -443,55 +508,61 @@ describe('Advanced Filter — string filterOptions restrict the options', () => 
         `);
     });
 
-    test('an option the list omits is not a known option', async () => {
+    // The list decides what is suggested; the data type decides what can be written. An option left out is
+    // absent from the suggestions and still read where an expression names it.
+    test('an option the list omits is not suggested, but an expression naming it applies', async () => {
         const api: GridApi = await gridsManager.createGridAndWait('grid1', optionsWithNotContainsNamed());
+        const af = AdvancedFilterHarness.get(api);
 
-        await AdvancedFilterHarness.get(api).applyExpression('[Name] contains "o"');
+        await af.type('[Name] ');
+        expect(af.autocompleteEntries()).toEqual(['equals']);
+
+        await af.applyExpression('[Name] contains "o"');
         await asyncSetTimeout(0);
 
         await new FilterDom(api, 'an omitted option').checkFilterDom(`
             ADVANCED FILTER
             input: "[Name] contains "o""
-            valid: false — Expression has an error. Option not found - contains "o".
+            valid: true
             buttons: Apply ⊘ | Builder
-            model: null
+            model:
+              filterType: "text"
+              colId: "name"
+              type: "contains"
+              filter: "o"
+        `);
+        // The model is what the editor holds; the rows are what the row model did with it.
+        await new GridRows(api, 'an omitted option filters').check(`
+            ROOT id:ROOT_NODE_ID
+            └── LEAF id:0 name:"Bolt"
         `);
     });
 
-    test('a model naming an option the list omits does not apply', async () => {
-        const api: GridApi = await gridsManager.createGridAndWait('grid1', optionsWithNotContainsNamed());
-
-        api.setAdvancedFilterModel({ filterType: 'text', colId: 'name', type: 'contains', filter: 'o' });
-        await asyncSetTimeout(0);
-
-        await new FilterDom(api, 'a model naming an omitted option').checkFilterDom(`
-            ADVANCED FILTER
-            input: "[Name] contains "o""
-            valid: false — Expression has an error. Option not found - contains "o".
-            buttons: Apply ⊘ | Builder
-            model: null
-        `);
-    });
-
-    test('an omitted longer name does not beat the shorter one it starts with', async () => {
+    test('an omitted longer name beats the shorter offered one it starts with', async () => {
         const api: GridApi = await gridsManager.createGridAndWait('grid1', optionsWithNotContainsNamed('equals not'));
 
-        // `equals not` names the omitted `notContains`, so only `equals` is in the running: `not` becomes its
-        // operand and `"Bolt"` is left where a join operator belongs.
+        // `equals not` names the omitted `notContains`. The offered `equals` matches first, and the wider
+        // set then lengthens the match rather than being consulted only when nothing matched at all.
         await AdvancedFilterHarness.get(api).applyExpression('[Name] equals not "Bolt"');
         await asyncSetTimeout(0);
 
         await new FilterDom(api, 'an omitted longer name').checkFilterDom(`
             ADVANCED FILTER
             input: "[Name] equals not "Bolt""
-            valid: false — Expression has an error. Join operator not found - "Bolt".
+            valid: true
             buttons: Apply ⊘ | Builder
-            model: null
+            model:
+              filterType: "text"
+              colId: "name"
+              type: "notContains"
+              filter: "Bolt"
         `);
     });
 
-    // Presets have no expression form yet, so a list of only presets names nothing the parser can offer.
-    test('a list naming no Advanced Filter option leaves the column unfilterable', async () => {
+    // Presets have no expression form here, so a list of only presets names nothing this filter can offer:
+    // narrowing to nothing would leave the column unusable, so the built-ins stand as they do for a list
+    // whose every entry was dropped.
+    test('a list naming no Advanced Filter option leaves the built-ins standing', async () => {
         const api: GridApi = await gridsManager.createGridAndWait('grid1', {
             columnDefs: [
                 {
@@ -505,15 +576,25 @@ describe('Advanced Filter — string filterOptions restrict the options', () => 
             enableAdvancedFilter: true,
         });
 
-        await AdvancedFilterHarness.get(api).applyExpression('[Date] = "2024-01-01"');
+        const af = AdvancedFilterHarness.get(api);
+        await af.type('[Date] ');
+        await asyncSetTimeout(0);
+        // Every built-in, since "standing" is the whole list rather than a survivor from it.
+        expect(af.autocompleteEntries()).toEqual(['=', '!=', '>', '>=', '<', '<=', 'is blank', 'is not blank']);
+
+        await af.applyExpression('[Date] = "2024-01-01"');
         await asyncSetTimeout(0);
 
         await new FilterDom(api, 'a list naming no AF option').checkFilterDom(`
             ADVANCED FILTER
             input: "[Date] = "2024-01-01""
-            valid: false — Expression has an error. Option not found - = "2024-01-01".
+            valid: true
             buttons: Apply ⊘ | Builder
-            model: null
+            model:
+              filterType: "dateString"
+              colId: "date"
+              type: "equals"
+              filter: "2024-01-01"
         `);
     });
 });

--- a/testing/behavioural/src/filters/advanced-filter-regression/af-options.test.ts
+++ b/testing/behavioural/src/filters/advanced-filter-regression/af-options.test.ts
@@ -22,15 +22,9 @@ import {
 } from 'ag-grid-community';
 import { AdvancedFilterModule, SetFilterModule } from 'ag-grid-enterprise';
 
-/**
- * Regression baseline for Advanced Filter grid options and current operator behaviour: display-name/colId
- * resolution, `includeHiddenColumnsInAdvancedFilter`, `suppressAdvancedFilterEval`, `advancedFilterParent`;
- * operators not offered today (the relative date presets, `inRange`); Set Filter columns treated as text;
- * and a Custom Filter Option's `displayKey` being rejected as a name. Locks each so a change is a visible diff.
- */
+/** Regression baseline for Advanced Filter grid options and the operators not offered today. */
 
-// The suggestion list is virtualised, so without a layout it renders a single row and every assertion on
-// its contents reads that truncation rather than what the column offers.
+// The suggestion list virtualises, so without a layout it renders one row and assertions read that truncation.
 beforeAll(() => installFilterLayoutMock());
 afterAll(() => uninstallFilterLayoutMock());
 
@@ -108,8 +102,7 @@ describe('Advanced Filter — grid options', () => {
             await asyncSetTimeout(0);
             expect(api.getDisplayedRowCount()).toBe(1);
 
-            // Cleared first: an invalid expression leaves the previous filter applied, which would read as
-            // the old name still resolving.
+            // Cleared first: an invalid expression leaves the previous filter applied, reading as the old name.
             await af.applyExpression('');
             await asyncSetTimeout(0);
             api.applyColumnState({ state: [{ colId: 'athlete', headerName: 'Runner' }] });
@@ -355,8 +348,7 @@ describe('Advanced Filter — currently-unsupported operators (baseline)', () =>
             `);
         });
 
-        // A preset key names no AF option, so the list leaves only `equals` to suggest. The grammar is the
-        // data type's either way, so an operator typed rather than picked still reads.
+        // A preset names no AF option, so only `equals` is suggested; the grammar is the data type's either way.
         test('an operator absent from the preset list is not suggested, but still reads', async () => {
             const api: GridApi = await gridsManager.createGridAndWait('grid1', OPTS);
             const af = AdvancedFilterHarness.get(api);
@@ -411,10 +403,7 @@ describe('Advanced Filter — currently-unsupported operators (baseline)', () =>
     });
 });
 
-/**
- * `filterOptions` naming a Custom Filter Option: where the option has a `displayName`, its `displayKey` is
- * not a name an expression can use.
- */
+/** Where a Custom Filter Option has a `displayName`, its `displayKey` is not a name an expression can use. */
 describe('Advanced Filter — custom filterOptions entries', () => {
     const gridsManager = new TestGridsManager({
         modules: [TextFilterModule, NumberFilterModule, AdvancedFilterModule, ClientSideRowModelModule],
@@ -508,8 +497,7 @@ describe('Advanced Filter — string filterOptions restrict the options', () => 
         `);
     });
 
-    // The list decides what is suggested; the data type decides what can be written. An option left out is
-    // absent from the suggestions and still read where an expression names it.
+    // The list decides what is suggested; the data type decides what can be written.
     test('an option the list omits is not suggested, but an expression naming it applies', async () => {
         const api: GridApi = await gridsManager.createGridAndWait('grid1', optionsWithNotContainsNamed());
         const af = AdvancedFilterHarness.get(api);
@@ -541,8 +529,7 @@ describe('Advanced Filter — string filterOptions restrict the options', () => 
     test('an omitted longer name beats the shorter offered one it starts with', async () => {
         const api: GridApi = await gridsManager.createGridAndWait('grid1', optionsWithNotContainsNamed('equals not'));
 
-        // `equals not` names the omitted `notContains`. The offered `equals` matches first, and the wider
-        // set then lengthens the match rather than being consulted only when nothing matched at all.
+        // The offered `equals` matches first, and the wider set then lengthens it into the omitted `notContains`.
         await AdvancedFilterHarness.get(api).applyExpression('[Name] equals not "Bolt"');
         await asyncSetTimeout(0);
 
@@ -559,9 +546,7 @@ describe('Advanced Filter — string filterOptions restrict the options', () => 
         `);
     });
 
-    // Presets have no expression form here, so a list of only presets names nothing this filter can offer:
-    // narrowing to nothing would leave the column unusable, so the built-ins stand as they do for a list
-    // whose every entry was dropped.
+    // A list of only presets names nothing this filter offers, so the built-ins stand rather than nothing.
     test('a list naming no Advanced Filter option leaves the built-ins standing', async () => {
         const api: GridApi = await gridsManager.createGridAndWait('grid1', {
             columnDefs: [

--- a/testing/behavioural/src/filters/advanced-filter/advanced-filter-custom-options.test.ts
+++ b/testing/behavioural/src/filters/advanced-filter/advanced-filter-custom-options.test.ts
@@ -11,7 +11,7 @@ import {
     uninstallFilterLayoutMock,
 } from 'ag-test-utils';
 
-import type { AdvancedFilterModel, GridApi, GridOptions, IFilterOptionDef } from 'ag-grid-community';
+import type { AdvancedFilterModel, ColDef, GridApi, GridOptions, IFilterOptionDef } from 'ag-grid-community';
 import {
     BigIntFilterModule,
     ClientSideRowModelModule,
@@ -24,11 +24,7 @@ import {
 } from 'ag-grid-community';
 import { AdvancedFilterModule, MultiFilterModule, SetFilterModule } from 'ag-grid-enterprise';
 
-/**
- * Custom Filter Options from `colDef.filterParams.filterOptions` in the Advanced Filter: which options a
- * column offers, the 0/1/2-value expression grammar, the model round-trip, the Builder, and evaluation
- * running the same `predicate` as the column filter.
- */
+/** Custom Filter Options in the Advanced Filter: what a column offers, the grammar, the model, the Builder. */
 interface TestRow {
     athlete: string;
     age: number | null;
@@ -167,8 +163,7 @@ describe('Advanced Filter - custom filter options', () => {
             expect(af.autocompleteEntries()).toEqual(['is true', 'is false', 'is blank', 'is not blank']);
         });
 
-        // `inRange` is a column-filter option this filter has no operator for, so narrowing to it would
-        // narrow to nothing: no suggestions, an unpickable Builder row and an unsatisfiable AI schema.
+        // This filter has no `inRange` operator, so narrowing to it alone would narrow to nothing.
         test('a list naming only options this filter cannot resolve leaves the built-ins standing', async () => {
             const api = gridsManager.createGrid('grid1', {
                 columnDefs: [
@@ -196,8 +191,7 @@ describe('Advanced Filter - custom filter options', () => {
             `);
         });
 
-        // A boolean column takes its `filterOptions` from the grid, and identity is what tells that list
-        // apart from an authored one — so a colDef copied through the API must carry the same array.
+        // Identity tells the grid's list from an authored one, so a copied colDef must carry the same array.
         test('the grid-supplied boolean list survives a columnDefs round trip', async () => {
             const api = gridsManager.createGrid('grid1', {
                 columnDefs: [{ field: 'won', filter: 'agTextColumnFilter' }],
@@ -250,8 +244,7 @@ describe('Advanced Filter - custom filter options', () => {
             expect(af.value).toBe('[Athlete] Starts With "A"');
         });
 
-        // What a column narrows away is missing from the suggestions, not from the grammar: an expression
-        // written before the list narrowed is still one the column can read.
+        // Narrowing removes a name from the suggestions, not from the grammar.
         test('a built-in the column omits is not offered, but an expression naming it still applies', async () => {
             const api = gridsManager.createGrid('grid1', opts());
             await asyncSetTimeout(0);
@@ -303,9 +296,7 @@ describe('Advanced Filter - custom filter options', () => {
             expect(api.getAdvancedFilterModel()).toEqual(savedModel);
         });
 
-        // Three names running into one another: `contain`, the longer `contain both` beside it, and the
-        // built-in `contains` the list leaves out. A name is only matched where it ends at a space, a
-        // bracket or the expression, so the offered pair neither swallows the omitted one nor loses to it.
+        // A name only matches where it ends at a space, a bracket or the expression, hence these three.
         test('an option name another name starts with resolves each of the three', async () => {
             const CONTAIN: IFilterOptionDef = {
                 displayKey: 'contain',
@@ -371,8 +362,7 @@ describe('Advanced Filter - custom filter options', () => {
             });
         });
 
-        // An offered name ending where a longer omitted one continues: `is` terminates at the space that
-        // `is blank` runs through, so the offered match has to be lengthened rather than taken as final.
+        // `is` terminates at the space `is blank` runs through, so the offered match must be lengthened.
         test('an offered name does not cut short a longer option the list leaves out', async () => {
             const IS: IFilterOptionDef = {
                 displayKey: 'isValue',
@@ -417,8 +407,7 @@ describe('Advanced Filter - custom filter options', () => {
             });
         });
 
-        // The Builder lists what the column offers, so a restored condition naming something else has to
-        // survive the pass that clears one the column cannot resolve at all.
+        // A restored condition naming an unlisted option must survive the pass that clears unresolvable ones.
         test('the Builder keeps a restored condition whose option the column no longer offers', async () => {
             const api = gridsManager.createGrid('grid1', opts());
             await asyncSetTimeout(0);
@@ -575,8 +564,7 @@ describe('Advanced Filter - custom filter options', () => {
             });
         }
 
-        // The child is where `filterOptions` belongs: the parent's own params are `IMultiFilterParams`, which
-        // carries `filters` and nothing about options.
+        // `filterOptions` belongs on the child; `IMultiFilterParams` carries `filters` and nothing about options.
         test('takes the options its child filter declares, as the column filter does', async () => {
             const params = {
                 filters: [
@@ -613,15 +601,13 @@ describe('Advanced Filter - custom filter options', () => {
             expect(af.autocompleteEntries()).toEqual(['contains', 'Starts With A']);
         });
 
-        // Which list wins, where more than one is written: the first child that declares one, over a
-        // second child and over the parent's own params.
+        // The first child that declares a list wins, over a second child and over the parent's own params.
         test('the first child that declares a list is the one read', async () => {
             const advanced = multiFilterGrid(
                 {
                     ...STARTS_A_ONLY,
                     filters: [
-                        // An empty list is not a list this child offers anything from, so it is passed over
-                        // rather than being the first one found.
+                        // An empty list offers nothing, so it is passed over rather than being the first found.
                         { filter: 'agTextColumnFilter', filterParams: { filterOptions: [] } },
                         { filter: 'agTextColumnFilter', filterParams: { filterOptions: [REGULAR_EXPRESSION] } },
                         { filter: 'agTextColumnFilter', filterParams: STARTS_A_ONLY },
@@ -764,8 +750,7 @@ describe('Advanced Filter - custom filter options', () => {
                 └── LEAF id:2 athlete:"Ada" age:28 won:true
             `);
 
-            // Cleared first: a rejected expression leaves the previous filter applied, so re-asserting the
-            // bracketed form's own model would pass whether or not the unbracketed one parsed.
+            // Cleared first: a rejected expression leaves the previous filter applied, so this would pass either way.
             await af.applyExpression('');
             await asyncSetTimeout(0);
             expect(api.getAdvancedFilterModel()).toBeNull();
@@ -1075,8 +1060,7 @@ describe('Advanced Filter - custom filter options', () => {
             `);
         });
 
-        // Every cell data type the expression format names as quoted: text and dateString have their own
-        // tests above, so this covers the two `Date`-valued ones.
+        // Text and dateString have their own tests above, so this covers the two `Date`-valued types.
         test('two dates and two date-times are quoted, and round-trip through the model', async () => {
             const api = gridsManager.createGrid('grid1', {
                 columnDefs: [
@@ -1408,8 +1392,7 @@ describe('Advanced Filter - custom filter options', () => {
             const applyBoth = async (colId: 'athlete' | 'age', model: any, expected: string[]) => {
                 advanced.setAdvancedFilterModel({ ...model, colId });
                 advanced.onFilterChanged();
-                // An advanced model replaces the previous one; column filters are per column and would
-                // otherwise stack, so the other column is cleared before each pair.
+                // Column filters are per column and would otherwise stack, so the other is cleared each time.
                 await column.setColumnFilterModel(colId === 'athlete' ? 'age' : 'athlete', null);
                 await column.setColumnFilterModel(colId, model);
                 column.onFilterChanged();
@@ -1425,9 +1408,7 @@ describe('Advanced Filter - custom filter options', () => {
             ]);
         });
 
-        // The operand list is built per call, so a predicate that keeps or edits what it is handed cannot
-        // reach the next call. Driven through ONE option used twice: two options would each have their own
-        // operator object, and a list hoisted onto the operator would still look clean.
+        // One option used twice: with two, a list hoisted onto the operator would still look clean.
         test('a predicate that mutates its operands does not reach the next call', async () => {
             const seen: any[][] = [];
             const api = gridsManager.createGrid('grid1', {
@@ -1464,8 +1445,7 @@ describe('Advanced Filter - custom filter options', () => {
         });
     });
 
-    // What survives classification, and what the survivors are called: two functions, but both are about
-    // an option the grid has to make sense of rather than one written the way the docs describe.
+    // What survives classification, and what the survivors are called.
     describe('malformed options and name resolution', () => {
         test('an entry missing a required property is dropped and reported', async () => {
             // Deliberate: the option is missing `displayName`/`predicate`, which triggers warning #72.
@@ -1493,8 +1473,7 @@ describe('Advanced Filter - custom filter options', () => {
             expect(message).toContain('predicate');
         });
 
-        // The name is a locale lookup on the `displayKey`, so a translation replaces the `displayName`
-        // rather than sitting beside it: the expression is written in whichever wins.
+        // A locale lookup on the `displayKey` replaces the `displayName` rather than sitting beside it.
         test('a localised name is the one the expression is written in', async () => {
             const api = gridsManager.createGrid('grid1', {
                 columnDefs: [
@@ -1522,8 +1501,7 @@ describe('Advanced Filter - custom filter options', () => {
                 └── LEAF id:2 athlete:"Ada"
             `);
 
-            // Cleared first: an invalid expression leaves the previous filter applied, which would read as
-            // the untranslated name still resolving.
+            // Cleared first: an invalid expression leaves the previous filter applied, reading as the old name.
             await af.applyExpression('');
             await asyncSetTimeout(0);
             await af.applyExpression('[Athlete] Starts With A');
@@ -1592,8 +1570,7 @@ describe('Advanced Filter - custom filter options', () => {
             expect(af.value).toBe('[Athlete] startsA');
         });
 
-        // A key is written by whoever wrote the option, so standing in as a name it faces the grammar the
-        // display names already do.
+        // A key stands in as a name, so it faces the grammar the display names already do.
         test('a displayKey standing in as the name carries a space, and round-trips', async () => {
             const api = gridsManager.createGrid('grid1', {
                 columnDefs: [
@@ -1869,8 +1846,7 @@ describe('Advanced Filter - custom filter options', () => {
                 'Filter to value',
             ]);
             expect(pills.map((pill, index) => builder.valuePillText(condition, index))).toEqual(['24', '30']);
-            // Tab order is the browser's own, which happy-dom does not walk, so what is asserted is the thing
-            // that decides it: zero or above, since absent reads as `-1` and so does a skipped pill.
+            // happy-dom does not walk tab order, so assert what decides it: absent reads `-1`, as a skip does.
             expect(pills.map((pill) => pill.tabIndex)).toEqual([0, 0]);
 
             // One value, so there is no pair to tell apart, and the pill left behind is still in the tab order.
@@ -1960,8 +1936,6 @@ describe('Advanced Filter - custom filter options', () => {
             expect(builder.valuePills(condition)).toHaveLength(0);
         });
 
-        // `validateItems` no longer checks the operands, so what holds Apply shut for an emptied pill is the
-        // invalidity `refreshList` carries across a rebuild rather than a re-derivation.
         test('an emptied value keeps Apply shut across an external model change', async () => {
             const api = gridsManager.createGrid('grid1', opts());
             await asyncSetTimeout(0);
@@ -2022,8 +1996,84 @@ describe('Advanced Filter - custom filter options', () => {
                   type: "evenNumbers"
             `);
         });
+
+        // Only a mounted row validates itself, so the all-items pass must catch a scrolled-out incomplete one.
+        test('an option that gains a second input shuts Apply for a condition the list has not mounted', async () => {
+            const api = gridsManager.createGrid('grid1', { ...opts(), columnDefs: ageColumnDefs(1) });
+            await asyncSetTimeout(0);
+            api.setAdvancedFilterModel(longModelEndingInNearly());
+            api.onFilterChanged();
+            await asyncSetTimeout(0);
+
+            const builder = await AdvancedFilterBuilderHarness.open(api);
+            // The `Nearly` row must not be among them, or its own component would validate it.
+            expect((await builder.conditionItems()).length).toBeLessThan(TAIL_CONDITIONS + 1);
+
+            api.setGridOption('columnDefs', ageColumnDefs(2));
+            await rebuildBuilderList(api);
+
+            expect(builder.applyDisabled()).toBe(true);
+        });
+
+        // The control: the same rebuild with the arity left alone, so Apply is proven to enable at all.
+        test('a condition the list has not mounted leaves Apply open while its option still takes one value', async () => {
+            const api = gridsManager.createGrid('grid1', { ...opts(), columnDefs: ageColumnDefs(1) });
+            await asyncSetTimeout(0);
+            api.setAdvancedFilterModel(longModelEndingInNearly());
+            api.onFilterChanged();
+            await asyncSetTimeout(0);
+
+            const builder = await AdvancedFilterBuilderHarness.open(api);
+            expect((await builder.conditionItems()).length).toBeLessThan(TAIL_CONDITIONS + 1);
+
+            api.setGridOption('columnDefs', ageColumnDefs(1));
+            await rebuildBuilderList(api);
+
+            expect(builder.applyDisabled()).toBe(false);
+        });
     });
 });
+
+/** Enough leading conditions that the last one sits outside the builder's rendered window. */
+const TAIL_CONDITIONS = 30;
+
+/** Its arity is what a colDef refresh changes; `evenNumbers` takes none, so only `Nearly` can go incomplete. */
+const nearlyOption = (numberOfInputs: 1 | 2): IFilterOptionDef => ({
+    displayKey: 'nearly',
+    displayName: 'Nearly',
+    numberOfInputs,
+    predicate: ([from, to], cellValue) => cellValue != null && cellValue >= from && (to == null || cellValue <= to),
+});
+
+const ageColumnDefs = (numberOfInputs: 1 | 2): ColDef<TestRow>[] => [
+    {
+        field: 'age',
+        filter: 'agNumberColumnFilter',
+        filterParams: { filterOptions: [EVEN_NUMBERS, nearlyOption(numberOfInputs)] },
+    },
+];
+
+/** Reseeds every row valid and makes the builder's model differ from the applied one, so Apply turns on validity. */
+async function rebuildBuilderList(api: GridApi<TestRow>): Promise<void> {
+    api.setAdvancedFilterModel({ filterType: 'number', colId: 'age', type: 'evenNumbers' });
+    api.onFilterChanged();
+    await asyncSetTimeout(0);
+}
+
+/** Every visible row valid whatever the arity, and one single-valued `Nearly` below the fold. */
+function longModelEndingInNearly(): AdvancedFilterModel {
+    return {
+        filterType: 'join',
+        type: 'AND',
+        conditions: [
+            ...Array.from(
+                { length: TAIL_CONDITIONS },
+                () => ({ filterType: 'number', colId: 'age', type: 'evenNumbers' }) as const
+            ),
+            { filterType: 'number', colId: 'age', type: 'nearly', filter: 20 },
+        ],
+    };
+}
 
 /** The expected list is named, so two grids that both filtered nothing cannot pass for agreement. */
 function expectSameAthletes(advanced: GridApi<TestRow>, column: GridApi<TestRow>, expected: string[]): void {

--- a/testing/behavioural/src/filters/advanced-filter/advanced-filter-custom-options.test.ts
+++ b/testing/behavioural/src/filters/advanced-filter/advanced-filter-custom-options.test.ts
@@ -1,0 +1,2038 @@
+import { waitFor } from '@testing-library/dom';
+import {
+    ALL_SEVERITIES,
+    AdvancedFilterBuilderHarness,
+    AdvancedFilterHarness,
+    FilterDom,
+    GridRows,
+    TestGridsManager,
+    asyncSetTimeout,
+    installFilterLayoutMock,
+    uninstallFilterLayoutMock,
+} from 'ag-test-utils';
+
+import type { AdvancedFilterModel, GridApi, GridOptions, IFilterOptionDef } from 'ag-grid-community';
+import {
+    BigIntFilterModule,
+    ClientSideRowModelModule,
+    DateFilterModule,
+    LocaleModule,
+    NumberFilterModule,
+    TextFilterModule,
+    ValidationModule,
+    enableDevValidations,
+} from 'ag-grid-community';
+import { AdvancedFilterModule, MultiFilterModule, SetFilterModule } from 'ag-grid-enterprise';
+
+/**
+ * Custom Filter Options from `colDef.filterParams.filterOptions` in the Advanced Filter: which options a
+ * column offers, the 0/1/2-value expression grammar, the model round-trip, the Builder, and evaluation
+ * running the same `predicate` as the column filter.
+ */
+interface TestRow {
+    athlete: string;
+    age: number | null;
+    won: boolean;
+}
+
+const ROW_DATA: TestRow[] = [
+    { athlete: 'Bolt', age: 25, won: true },
+    { athlete: 'Ng', age: 40, won: false },
+    { athlete: 'Ada', age: 28, won: true },
+    { athlete: 'Wei', age: null, won: false },
+];
+
+const STARTS_A: IFilterOptionDef = {
+    displayKey: 'startsA',
+    displayName: 'Starts With A',
+    numberOfInputs: 0,
+    predicate: (_values, cellValue) => typeof cellValue === 'string' && cellValue.startsWith('A'),
+};
+
+const REGULAR_EXPRESSION: IFilterOptionDef = {
+    displayKey: 'regexp',
+    displayName: 'Regular Expression',
+    numberOfInputs: 1,
+    predicate: ([filterValue], cellValue) => cellValue != null && new RegExp(filterValue, 'i').test(cellValue),
+};
+
+const ODD_NUMBERS: IFilterOptionDef = {
+    displayKey: 'oddNumbers',
+    displayName: 'Odd Numbers',
+    numberOfInputs: 0,
+    predicate: (_values, cellValue) => cellValue != null && cellValue % 2 === 1,
+};
+
+const EVEN_NUMBERS: IFilterOptionDef = {
+    displayKey: 'evenNumbers',
+    displayName: 'Even Numbers',
+    numberOfInputs: 0,
+    predicate: (_values, cellValue) => cellValue != null && cellValue % 2 === 0,
+};
+
+/** Comparison-based, so it serves the text and the number column alike. */
+const BETWEEN_EXCLUSIVE: IFilterOptionDef = {
+    displayKey: 'betweenExclusive',
+    displayName: 'Between (Exclusive)',
+    numberOfInputs: 2,
+    predicate: ([from, to], cellValue) => cellValue != null && cellValue > from && cellValue < to,
+};
+
+/** The operands reach the predicate as `Date`s, as they do in the column filter. */
+const DATE_BETWEEN_EXCLUSIVE: IFilterOptionDef = {
+    displayKey: 'betweenExclusive',
+    displayName: 'Between (Exclusive)',
+    numberOfInputs: 2,
+    predicate: ([from, to], cellValue) => {
+        if (cellValue == null) {
+            return false;
+        }
+        const [year, month, day] = cellValue.split('-').map(Number);
+        const cellDate = new Date(year, month - 1, day);
+        return cellDate > from && cellDate < to;
+    },
+};
+
+/** Reuses a built-in key, so it replaces `contains` for the column that declares it. */
+const CONTAINS_BACKWARDS: IFilterOptionDef = {
+    displayKey: 'contains',
+    displayName: 'contains backwards',
+    numberOfInputs: 1,
+    predicate: ([filterValue], cellValue) =>
+        typeof cellValue === 'string' && cellValue.split('').reverse().join('').includes(filterValue),
+};
+
+const ATHLETE_OPTIONS = ['contains', STARTS_A, REGULAR_EXPRESSION, BETWEEN_EXCLUSIVE];
+const AGE_OPTIONS = ['equals', EVEN_NUMBERS, BETWEEN_EXCLUSIVE];
+
+/** Built per grid: the grid writes the merged `filterParams` back onto the colDef it was handed. */
+const opts = (): GridOptions<TestRow> => ({
+    columnDefs: [
+        { field: 'athlete', filter: 'agTextColumnFilter', filterParams: { filterOptions: ATHLETE_OPTIONS } },
+        { field: 'age', filter: 'agNumberColumnFilter', filterParams: { filterOptions: AGE_OPTIONS } },
+        { field: 'won', filter: true },
+    ],
+    rowData: ROW_DATA,
+    enableAdvancedFilter: true,
+});
+
+describe('Advanced Filter - custom filter options', () => {
+    const gridsManager = new TestGridsManager({
+        modules: [
+            TextFilterModule,
+            NumberFilterModule,
+            BigIntFilterModule,
+            DateFilterModule,
+            LocaleModule,
+            ValidationModule,
+            AdvancedFilterModule,
+            MultiFilterModule,
+            SetFilterModule,
+            ClientSideRowModelModule,
+        ],
+    });
+
+    beforeAll(() => installFilterLayoutMock());
+    afterAll(() => uninstallFilterLayoutMock());
+    afterEach(() => {
+        gridsManager.reset();
+        vi.restoreAllMocks();
+        enableDevValidations({ throwOn: ALL_SEVERITIES });
+    });
+
+    describe('the options a column offers', () => {
+        test('the configured options are offered by display name, in the order they are listed', async () => {
+            const api = gridsManager.createGrid('grid1', opts());
+            await asyncSetTimeout(0);
+            const af = AdvancedFilterHarness.get(api);
+
+            await af.type('[Athlete] ');
+            expect(af.autocompleteEntries()).toEqual([
+                'contains',
+                'Starts With A',
+                'Regular Expression',
+                'Between (Exclusive)',
+            ]);
+
+            await af.type('[Age] ');
+            expect(af.autocompleteEntries()).toEqual(['=', 'Even Numbers', 'Between (Exclusive)']);
+        });
+
+        test('a column with no options of its own still offers every built-in for its data type', async () => {
+            const api = gridsManager.createGrid('grid1', opts());
+            await asyncSetTimeout(0);
+            const af = AdvancedFilterHarness.get(api);
+
+            await af.type('[Won] ');
+            expect(af.autocompleteEntries()).toEqual(['is true', 'is false', 'is blank', 'is not blank']);
+        });
+
+        // `inRange` is a column-filter option this filter has no operator for, so narrowing to it would
+        // narrow to nothing: no suggestions, an unpickable Builder row and an unsatisfiable AI schema.
+        test('a list naming only options this filter cannot resolve leaves the built-ins standing', async () => {
+            const api = gridsManager.createGrid('grid1', {
+                columnDefs: [
+                    {
+                        field: 'age',
+                        filter: 'agNumberColumnFilter',
+                        filterParams: { filterOptions: ['inRange'] },
+                    },
+                ],
+                rowData: ROW_DATA,
+                enableAdvancedFilter: true,
+            });
+            await asyncSetTimeout(0);
+            const af = AdvancedFilterHarness.get(api);
+
+            await af.type('[Age] ');
+            // Every built-in, not just one of them: "standing" is the whole list, not a survivor from it.
+            expect(af.autocompleteEntries()).toEqual(['=', '!=', '>', '>=', '<', '<=', 'is blank', 'is not blank']);
+
+            await af.applyExpression('[Age] = 25');
+            await asyncSetTimeout(0);
+            await new GridRows(api, 'the built-ins filter the column').check(`
+                ROOT id:ROOT_NODE_ID
+                └── LEAF id:0 age:25
+            `);
+        });
+
+        // A boolean column takes its `filterOptions` from the grid, and identity is what tells that list
+        // apart from an authored one — so a colDef copied through the API must carry the same array.
+        test('the grid-supplied boolean list survives a columnDefs round trip', async () => {
+            const api = gridsManager.createGrid('grid1', {
+                columnDefs: [{ field: 'won', filter: 'agTextColumnFilter' }],
+                rowData: ROW_DATA,
+                enableAdvancedFilter: true,
+            });
+            await asyncSetTimeout(0);
+            const af = AdvancedFilterHarness.get(api);
+
+            await af.type('[Won] ');
+            expect(af.autocompleteEntries()).toEqual(['is true', 'is false', 'is blank', 'is not blank']);
+
+            api.setGridOption('columnDefs', api.getColumnDefs()!);
+            await asyncSetTimeout(0);
+
+            await af.type('');
+            await af.type('[Won] ');
+            expect(af.autocompleteEntries()).toEqual(['is true', 'is false', 'is blank', 'is not blank']);
+        });
+
+        // The quote that delimits an operand can also appear inside an option name.
+        test('an option whose name contains a quote is offered, parses and round-trips', async () => {
+            const api = gridsManager.createGrid('grid1', {
+                columnDefs: [
+                    {
+                        field: 'athlete',
+                        filter: 'agTextColumnFilter',
+                        filterParams: { filterOptions: ['contains', { ...STARTS_A, displayName: 'Starts With "A"' }] },
+                    },
+                ],
+                rowData: ROW_DATA,
+                enableAdvancedFilter: true,
+            });
+            await asyncSetTimeout(0);
+            const af = AdvancedFilterHarness.get(api);
+
+            await af.type('[Athlete] ');
+            expect(af.autocompleteEntries()).toEqual(['contains', 'Starts With "A"']);
+
+            await af.applyExpression('[Athlete] Starts With "A"');
+            await asyncSetTimeout(0);
+            expect(api.getAdvancedFilterModel()).toEqual({
+                filterType: 'text',
+                colId: 'athlete',
+                type: 'startsA',
+            });
+
+            api.setAdvancedFilterModel(api.getAdvancedFilterModel());
+            await asyncSetTimeout(0);
+            expect(af.value).toBe('[Athlete] Starts With "A"');
+        });
+
+        // What a column narrows away is missing from the suggestions, not from the grammar: an expression
+        // written before the list narrowed is still one the column can read.
+        test('a built-in the column omits is not offered, but an expression naming it still applies', async () => {
+            const api = gridsManager.createGrid('grid1', opts());
+            await asyncSetTimeout(0);
+            const af = AdvancedFilterHarness.get(api);
+
+            await af.type('[Athlete] ');
+            // The whole list, so a popup that never opened cannot pass for `ends with` being absent from it.
+            expect(af.autocompleteEntries()).toEqual([
+                'contains',
+                'Starts With A',
+                'Regular Expression',
+                'Between (Exclusive)',
+            ]);
+
+            await af.applyExpression('[Athlete] ends with "a"');
+            await asyncSetTimeout(0);
+            await new FilterDom(api, 'omitted built-in accepted').checkFilterDom(`
+                ADVANCED FILTER
+                input: "[Athlete] ends with "a""
+                valid: true
+                buttons: Apply ⊘ | Builder
+                model:
+                  filterType: "text"
+                  colId: "athlete"
+                  type: "endsWith"
+                  filter: "a"
+            `);
+        });
+
+        test('a saved model naming an omitted built-in restores whole, with the conditions beside it', async () => {
+            const api = gridsManager.createGrid('grid1', opts());
+            await asyncSetTimeout(0);
+
+            const savedModel: AdvancedFilterModel = {
+                filterType: 'join',
+                type: 'AND',
+                conditions: [
+                    { filterType: 'text', colId: 'athlete', type: 'endsWith', filter: 'a' },
+                    { filterType: 'number', colId: 'age', type: 'evenNumbers' },
+                ],
+            };
+            api.setAdvancedFilterModel(savedModel);
+            await asyncSetTimeout(0);
+
+            await new GridRows(api, 'both conditions filter').check(`
+                ROOT id:ROOT_NODE_ID
+                └── LEAF id:2 athlete:"Ada" age:28 won:true
+            `);
+            expect(api.getAdvancedFilterModel()).toEqual(savedModel);
+        });
+
+        // Three names running into one another: `contain`, the longer `contain both` beside it, and the
+        // built-in `contains` the list leaves out. A name is only matched where it ends at a space, a
+        // bracket or the expression, so the offered pair neither swallows the omitted one nor loses to it.
+        test('an option name another name starts with resolves each of the three', async () => {
+            const CONTAIN: IFilterOptionDef = {
+                displayKey: 'contain',
+                displayName: 'contain',
+                numberOfInputs: 1,
+                predicate: ([value], cellValue) => typeof cellValue === 'string' && cellValue.includes(value),
+            };
+            const CONTAIN_BOTH: IFilterOptionDef = {
+                displayKey: 'containBoth',
+                displayName: 'contain both',
+                numberOfInputs: 2,
+                predicate: ([first, second], cellValue) =>
+                    typeof cellValue === 'string' && cellValue.includes(first) && cellValue.includes(second),
+            };
+            const api = gridsManager.createGrid('grid1', {
+                columnDefs: [
+                    {
+                        field: 'athlete',
+                        filter: 'agTextColumnFilter',
+                        filterParams: { filterOptions: [CONTAIN, CONTAIN_BOTH] },
+                    },
+                ],
+                rowData: ROW_DATA,
+                enableAdvancedFilter: true,
+            });
+            await asyncSetTimeout(0);
+            const af = AdvancedFilterHarness.get(api);
+
+            await af.type('[Athlete] ');
+            expect(af.autocompleteEntries()).toEqual(['contain', 'contain both']);
+
+            await af.applyExpression('[Athlete] contain "o"');
+            await asyncSetTimeout(0);
+            expect(api.getAdvancedFilterModel()).toEqual({
+                filterType: 'text',
+                colId: 'athlete',
+                type: 'contain',
+                filter: 'o',
+            });
+
+            await af.applyExpression('[Athlete] contain both ("A", "d")');
+            await asyncSetTimeout(0);
+            expect(api.getAdvancedFilterModel()).toEqual({
+                filterType: 'text',
+                colId: 'athlete',
+                type: 'containBoth',
+                filter: 'A',
+                filterTo: 'd',
+            });
+            await new GridRows(api, 'the longer name takes both values').check(`
+                ROOT id:ROOT_NODE_ID
+                └── LEAF id:2 athlete:"Ada"
+            `);
+
+            // Neither offered name ends here, so the omitted built-in is reached.
+            await af.applyExpression('[Athlete] contains "o"');
+            await asyncSetTimeout(0);
+            expect(api.getAdvancedFilterModel()).toEqual({
+                filterType: 'text',
+                colId: 'athlete',
+                type: 'contains',
+                filter: 'o',
+            });
+        });
+
+        // An offered name ending where a longer omitted one continues: `is` terminates at the space that
+        // `is blank` runs through, so the offered match has to be lengthened rather than taken as final.
+        test('an offered name does not cut short a longer option the list leaves out', async () => {
+            const IS: IFilterOptionDef = {
+                displayKey: 'isValue',
+                displayName: 'is',
+                numberOfInputs: 1,
+                predicate: ([value], cellValue) => cellValue === value,
+            };
+            const api = gridsManager.createGrid('grid1', {
+                columnDefs: [
+                    {
+                        field: 'athlete',
+                        filter: 'agTextColumnFilter',
+                        filterParams: { filterOptions: ['contains', IS] },
+                    },
+                ],
+                rowData: [...ROW_DATA, { athlete: '', age: 1, won: false }],
+                enableAdvancedFilter: true,
+            });
+            await asyncSetTimeout(0);
+            const af = AdvancedFilterHarness.get(api);
+
+            await af.type('[Athlete] ');
+            expect(af.autocompleteEntries()).toEqual(['contains', 'is']);
+
+            // `is blank` is not offered, and still names the built-in rather than `is` with operand `blank`.
+            await af.applyExpression('[Athlete] is blank');
+            await asyncSetTimeout(0);
+            expect(api.getAdvancedFilterModel()).toEqual({ filterType: 'text', colId: 'athlete', type: 'blank' });
+            await new GridRows(api, 'the longer omitted name wins').check(`
+                ROOT id:ROOT_NODE_ID
+                └── LEAF id:4 athlete:""
+            `);
+
+            // The offered name still wins where nothing longer is written here.
+            await af.applyExpression('[Athlete] is "Ada"');
+            await asyncSetTimeout(0);
+            expect(api.getAdvancedFilterModel()).toEqual({
+                filterType: 'text',
+                colId: 'athlete',
+                type: 'isValue',
+                filter: 'Ada',
+            });
+        });
+
+        // The Builder lists what the column offers, so a restored condition naming something else has to
+        // survive the pass that clears one the column cannot resolve at all.
+        test('the Builder keeps a restored condition whose option the column no longer offers', async () => {
+            const api = gridsManager.createGrid('grid1', opts());
+            await asyncSetTimeout(0);
+            api.setAdvancedFilterModel({ filterType: 'text', colId: 'athlete', type: 'endsWith', filter: 'a' });
+            api.onFilterChanged();
+            await asyncSetTimeout(0);
+
+            const builder = await AdvancedFilterBuilderHarness.open(api);
+            const [condition] = await builder.conditionItems();
+
+            await new FilterDom(api, 'the restored condition survives', { mode: 'builder' }).checkFilterDom(`
+                BUILDER
+                AND
+                  Athlete ends with "a"
+                  + add
+                buttons: Apply | Cancel
+                model:
+                  filterType: "text"
+                  colId: "athlete"
+                  type: "endsWith"
+                  filter: "a"
+            `);
+            // Kept, but still not one the dropdown lists.
+            expect(await builder.operatorOptions(condition)).toEqual([
+                'contains',
+                'Starts With A',
+                'Regular Expression',
+                'Between (Exclusive)',
+            ]);
+        });
+
+        test('a list replaced after the grid is built is the one offered', async () => {
+            const api = gridsManager.createGrid('grid1', opts());
+            await asyncSetTimeout(0);
+            const af = AdvancedFilterHarness.get(api);
+
+            await af.type('[Age] ');
+            expect(af.autocompleteEntries()).toEqual(['=', 'Even Numbers', 'Between (Exclusive)']);
+
+            api.setGridOption('columnDefs', [
+                { field: 'athlete', filter: 'agTextColumnFilter' },
+                {
+                    field: 'age',
+                    filter: 'agNumberColumnFilter',
+                    filterParams: { filterOptions: ['equals', ODD_NUMBERS] },
+                },
+                { field: 'won', filter: true },
+            ]);
+            await asyncSetTimeout(0);
+
+            await af.type('');
+            await af.type('[Age] ');
+            expect(af.autocompleteEntries()).toEqual(['=', 'Odd Numbers']);
+
+            await af.applyExpression('[Age] Odd Numbers');
+            await asyncSetTimeout(0);
+            await new GridRows(api, 'the replaced option filters').check(`
+                ROOT id:ROOT_NODE_ID
+                └── LEAF id:0 athlete:"Bolt" age:25 won:true
+            `);
+        });
+
+        test('a list replaced while the Advanced Filter is off is the one offered when it comes back', async () => {
+            const api = gridsManager.createGrid('grid1', opts());
+            await asyncSetTimeout(0);
+
+            await AdvancedFilterHarness.get(api).type('[Age] ');
+
+            api.setGridOption('enableAdvancedFilter', false);
+            api.setGridOption('columnDefs', [
+                { field: 'athlete', filter: 'agTextColumnFilter' },
+                {
+                    field: 'age',
+                    filter: 'agNumberColumnFilter',
+                    filterParams: { filterOptions: ['equals', ODD_NUMBERS] },
+                },
+                { field: 'won', filter: true },
+            ]);
+            await asyncSetTimeout(0);
+            api.setGridOption('enableAdvancedFilter', true);
+            await waitFor(() => expect(document.querySelector('.ag-advanced-filter-header')).not.toBeNull());
+            await asyncSetTimeout(0);
+
+            const af = AdvancedFilterHarness.get(api);
+            await af.applyExpression('[Age] Odd Numbers');
+            await asyncSetTimeout(0);
+            await new FilterDom(api, 'the list replaced while off').checkFilterDom(`
+                ADVANCED FILTER
+                input: "[Age] Odd Numbers"
+                valid: true
+                buttons: Apply ⊘ | Builder
+                model:
+                  filterType: "number"
+                  colId: "age"
+                  type: "oddNumbers"
+            `);
+            await new GridRows(api, 'the replaced option filters after the toggle').check(`
+                ROOT id:ROOT_NODE_ID
+                └── LEAF id:0 athlete:"Bolt" age:25 won:true
+            `);
+        });
+
+        test('a boolean column can take an option with a value of its own', async () => {
+            const api = gridsManager.createGrid('grid1', {
+                columnDefs: [
+                    { field: 'athlete' },
+                    {
+                        field: 'won',
+                        filter: true,
+                        filterParams: {
+                            filterOptions: [
+                                {
+                                    displayKey: 'isValue',
+                                    displayName: 'Is Value',
+                                    numberOfInputs: 1,
+                                    predicate: ([filterValue]: any[], cellValue: any) =>
+                                        String(cellValue) === filterValue,
+                                },
+                            ],
+                        },
+                    },
+                ],
+                rowData: ROW_DATA,
+                enableAdvancedFilter: true,
+            });
+            await asyncSetTimeout(0);
+            const af = AdvancedFilterHarness.get(api);
+
+            await af.applyExpression('[Won] Is Value "true"');
+            await asyncSetTimeout(0);
+
+            expect(api.getAdvancedFilterModel()).toEqual({
+                filterType: 'boolean',
+                colId: 'won',
+                type: 'isValue',
+                filter: 'true',
+            });
+            await new GridRows(api, 'boolean custom option with a value').check(`
+                ROOT id:ROOT_NODE_ID
+                ├── LEAF id:0 athlete:"Bolt" won:true
+                └── LEAF id:2 athlete:"Ada" won:true
+            `);
+        });
+    });
+
+    describe('a Multi Filter column', () => {
+        const STARTS_A_ONLY = { filterOptions: ['contains', STARTS_A] };
+
+        function multiFilterGrid(filterParams: any, id: string, advanced: boolean) {
+            return gridsManager.createGrid<TestRow>(id, {
+                columnDefs: [{ field: 'athlete', filter: 'agMultiColumnFilter', filterParams }],
+                rowData: ROW_DATA,
+                enableAdvancedFilter: advanced,
+            });
+        }
+
+        // The child is where `filterOptions` belongs: the parent's own params are `IMultiFilterParams`, which
+        // carries `filters` and nothing about options.
+        test('takes the options its child filter declares, as the column filter does', async () => {
+            const params = {
+                filters: [
+                    { filter: 'agTextColumnFilter', filterParams: STARTS_A_ONLY },
+                    { filter: 'agSetColumnFilter' },
+                ],
+            };
+            const advanced = multiFilterGrid(params, 'grid1', true);
+            const column = multiFilterGrid(params, 'grid2', false);
+            await asyncSetTimeout(0);
+
+            const af = AdvancedFilterHarness.get(advanced);
+            await af.type('[Athlete] ');
+            expect(af.autocompleteEntries()).toEqual(['contains', 'Starts With A']);
+
+            await af.applyExpression('[Athlete] Starts With A');
+            await column.setColumnFilterModel('athlete', {
+                filterType: 'multi',
+                filterModels: [{ filterType: 'text', type: 'startsA' }, null],
+            });
+            column.onFilterChanged();
+            await asyncSetTimeout(0);
+
+            expect(filteredAthletes(advanced)).toEqual(['Ada']);
+            expect(filteredAthletes(column)).toEqual(filteredAthletes(advanced));
+        });
+
+        test('still reads a list written on its own params', async () => {
+            const advanced = multiFilterGrid(STARTS_A_ONLY, 'grid1', true);
+            await asyncSetTimeout(0);
+
+            const af = AdvancedFilterHarness.get(advanced);
+            await af.type('[Athlete] ');
+            expect(af.autocompleteEntries()).toEqual(['contains', 'Starts With A']);
+        });
+
+        // Which list wins, where more than one is written: the first child that declares one, over a
+        // second child and over the parent's own params.
+        test('the first child that declares a list is the one read', async () => {
+            const advanced = multiFilterGrid(
+                {
+                    ...STARTS_A_ONLY,
+                    filters: [
+                        // An empty list is not a list this child offers anything from, so it is passed over
+                        // rather than being the first one found.
+                        { filter: 'agTextColumnFilter', filterParams: { filterOptions: [] } },
+                        { filter: 'agTextColumnFilter', filterParams: { filterOptions: [REGULAR_EXPRESSION] } },
+                        { filter: 'agTextColumnFilter', filterParams: STARTS_A_ONLY },
+                    ],
+                },
+                'grid1',
+                true
+            );
+            await asyncSetTimeout(0);
+
+            const af = AdvancedFilterHarness.get(advanced);
+            await af.type('[Athlete] ');
+            expect(af.autocompleteEntries()).toEqual(['Regular Expression']);
+        });
+    });
+
+    describe('an option taking no value', () => {
+        test('it parses, round-trips through the model and runs its predicate', async () => {
+            const api = gridsManager.createGrid('grid1', opts());
+            await asyncSetTimeout(0);
+            const af = AdvancedFilterHarness.get(api);
+
+            await af.applyExpression('[Athlete] Starts With A');
+            await asyncSetTimeout(0);
+
+            expect(api.getAdvancedFilterModel()).toEqual({
+                filterType: 'text',
+                colId: 'athlete',
+                type: 'startsA',
+            });
+            await new GridRows(api, 'startsA').check(`
+                ROOT id:ROOT_NODE_ID
+                └── LEAF id:2 athlete:"Ada" age:28 won:true
+            `);
+        });
+
+        test('a value left in the model by another option is dropped, not written out', async () => {
+            const api = gridsManager.createGrid('grid1', opts());
+            await asyncSetTimeout(0);
+
+            api.setAdvancedFilterModel({ filterType: 'text', colId: 'athlete', type: 'startsA', filter: 'zzz' });
+            api.onFilterChanged();
+            await asyncSetTimeout(0);
+
+            expect(AdvancedFilterHarness.get(api).value).toBe('[Athlete] Starts With A');
+            expect(api.getAdvancedFilterModel()).toEqual({
+                filterType: 'text',
+                colId: 'athlete',
+                type: 'startsA',
+            });
+            await new GridRows(api, 'stale operand slot ignored').check(`
+                ROOT id:ROOT_NODE_ID
+                └── LEAF id:2 athlete:"Ada" age:28 won:true
+            `);
+        });
+
+        test('a model naming it is written back as the expression it came from', async () => {
+            const api = gridsManager.createGrid('grid1', opts());
+            await asyncSetTimeout(0);
+
+            api.setAdvancedFilterModel({ filterType: 'number', colId: 'age', type: 'evenNumbers' });
+            api.onFilterChanged();
+            await asyncSetTimeout(0);
+
+            expect(AdvancedFilterHarness.get(api).value).toBe('[Age] Even Numbers');
+            await new GridRows(api, 'evenNumbers').check(`
+                ROOT id:ROOT_NODE_ID
+                ├── LEAF id:1 athlete:"Ng" age:40 won:false
+                └── LEAF id:2 athlete:"Ada" age:28 won:true
+            `);
+        });
+    });
+
+    describe('an option taking one value', () => {
+        test('a quoted text value parses, round-trips and runs its predicate', async () => {
+            const api = gridsManager.createGrid('grid1', opts());
+            await asyncSetTimeout(0);
+            const af = AdvancedFilterHarness.get(api);
+
+            await af.applyExpression('[Athlete] Regular Expression "^(bolt|ada)$"');
+            await asyncSetTimeout(0);
+
+            expect(api.getAdvancedFilterModel()).toEqual({
+                filterType: 'text',
+                colId: 'athlete',
+                type: 'regexp',
+                filter: '^(bolt|ada)$',
+            });
+            await new GridRows(api, 'regexp').check(`
+                ROOT id:ROOT_NODE_ID
+                ├── LEAF id:0 athlete:"Bolt" age:25 won:true
+                └── LEAF id:2 athlete:"Ada" age:28 won:true
+            `);
+        });
+
+        test('a value the option needs and has not got is reported', async () => {
+            const api = gridsManager.createGrid('grid1', opts());
+            await asyncSetTimeout(0);
+
+            await AdvancedFilterHarness.get(api).applyExpression('[Athlete] Regular Expression');
+            await asyncSetTimeout(0);
+
+            await new FilterDom(api, 'incomplete one-value option').checkFilterDom(`
+                ADVANCED FILTER
+                input: "[Athlete] Regular Expression"
+                valid: false — Expression has an error. Value is missing at end of expression.
+                buttons: Apply ⊘ | Builder
+                model: null
+            `);
+            await new GridRows(api, 'incomplete one-value option filters nothing').check(`
+                ROOT id:ROOT_NODE_ID
+                ├── LEAF id:0 athlete:"Bolt" age:25 won:true
+                ├── LEAF id:1 athlete:"Ng" age:40 won:false
+                ├── LEAF id:2 athlete:"Ada" age:28 won:true
+                └── LEAF id:3 athlete:"Wei" age:null won:false
+            `);
+        });
+    });
+
+    describe('an option taking two values', () => {
+        test('unquoted numbers parse, round-trip and run the predicate, with or without the brackets', async () => {
+            const api = gridsManager.createGrid('grid1', opts());
+            await asyncSetTimeout(0);
+            const af = AdvancedFilterHarness.get(api);
+
+            const expected = {
+                filterType: 'number',
+                colId: 'age',
+                type: 'betweenExclusive',
+                filter: 24,
+                filterTo: 30,
+            };
+
+            await af.applyExpression('[Age] Between (Exclusive) (24, 30)');
+            await asyncSetTimeout(0);
+            expect(api.getAdvancedFilterModel()).toEqual(expected);
+            await new GridRows(api, 'betweenExclusive numbers').check(`
+                ROOT id:ROOT_NODE_ID
+                ├── LEAF id:0 athlete:"Bolt" age:25 won:true
+                └── LEAF id:2 athlete:"Ada" age:28 won:true
+            `);
+
+            // Cleared first: a rejected expression leaves the previous filter applied, so re-asserting the
+            // bracketed form's own model would pass whether or not the unbracketed one parsed.
+            await af.applyExpression('');
+            await asyncSetTimeout(0);
+            expect(api.getAdvancedFilterModel()).toBeNull();
+
+            await af.applyExpression('[Age] Between (Exclusive) 24, 30');
+            await asyncSetTimeout(0);
+            expect(api.getAdvancedFilterModel()).toEqual(expected);
+            await new GridRows(api, 'betweenExclusive unbracketed').check(`
+                ROOT id:ROOT_NODE_ID
+                ├── LEAF id:0 athlete:"Bolt" age:25 won:true
+                └── LEAF id:2 athlete:"Ada" age:28 won:true
+            `);
+        });
+
+        test('quoted text values in brackets parse, round-trip and run the predicate', async () => {
+            const api = gridsManager.createGrid('grid1', opts());
+            await asyncSetTimeout(0);
+            const af = AdvancedFilterHarness.get(api);
+
+            await af.applyExpression('[Athlete] Between (Exclusive) ("Ada", "Ng")');
+            await asyncSetTimeout(0);
+
+            expect(api.getAdvancedFilterModel()).toEqual({
+                filterType: 'text',
+                colId: 'athlete',
+                type: 'betweenExclusive',
+                filter: 'Ada',
+                filterTo: 'Ng',
+            });
+            await new GridRows(api, 'betweenExclusive text').check(`
+                ROOT id:ROOT_NODE_ID
+                └── LEAF id:0 athlete:"Bolt" age:25 won:true
+            `);
+        });
+
+        test('a model naming it is written back as a bracketed pair', async () => {
+            const api = gridsManager.createGrid('grid1', opts());
+            await asyncSetTimeout(0);
+
+            api.setAdvancedFilterModel({
+                filterType: 'number',
+                colId: 'age',
+                type: 'betweenExclusive',
+                filter: 24,
+                filterTo: 30,
+            });
+            api.onFilterChanged();
+            await asyncSetTimeout(0);
+
+            expect(AdvancedFilterHarness.get(api).value).toBe('[Age] Between (Exclusive) (24, 30)');
+        });
+
+        test('it joins with other conditions, and a surrounding group keeps its own brackets', async () => {
+            const api = gridsManager.createGrid('grid1', opts());
+            await asyncSetTimeout(0);
+
+            await AdvancedFilterHarness.get(api).applyExpression(
+                '([Age] Between (Exclusive) (24, 30) OR [Athlete] Starts With A) AND [Athlete] contains "d"'
+            );
+            await asyncSetTimeout(0);
+
+            expect(api.getAdvancedFilterModel()).toEqual({
+                filterType: 'join',
+                type: 'AND',
+                conditions: [
+                    {
+                        filterType: 'join',
+                        type: 'OR',
+                        conditions: [
+                            { filterType: 'number', colId: 'age', type: 'betweenExclusive', filter: 24, filterTo: 30 },
+                            { filterType: 'text', colId: 'athlete', type: 'startsA' },
+                        ],
+                    },
+                    { filterType: 'text', colId: 'athlete', type: 'contains', filter: 'd' },
+                ],
+            });
+            await new GridRows(api, 'two-value option inside a group').check(`
+                ROOT id:ROOT_NODE_ID
+                └── LEAF id:2 athlete:"Ada" age:28 won:true
+            `);
+        });
+
+        test('completing it opens the bracket, and the quote too where the values are quoted', async () => {
+            const api = gridsManager.createGrid('grid1', opts());
+            await asyncSetTimeout(0);
+            const af = AdvancedFilterHarness.get(api);
+
+            await af.type('[Age] Betw');
+            await af.tabComplete();
+            expect(af.value).toBe('[Age] Between (Exclusive) (');
+
+            await af.type('[Athlete] Betw');
+            await af.tabComplete();
+            expect(af.value).toBe('[Athlete] Between (Exclusive) ("');
+        });
+
+        test('two dates are quoted, and round-trip through the model', async () => {
+            const api = gridsManager.createGrid('grid1', {
+                columnDefs: [
+                    {
+                        field: 'when',
+                        cellDataType: 'dateString',
+                        filter: 'agDateColumnFilter',
+                        filterParams: { filterOptions: ['equals', DATE_BETWEEN_EXCLUSIVE] },
+                    },
+                ],
+                rowData: [{ when: '2012-08-11' }, { when: '2012-08-20' }, { when: '2012-09-01' }],
+                enableAdvancedFilter: true,
+            });
+            await asyncSetTimeout(0);
+
+            const af = AdvancedFilterHarness.get(api);
+            await af.applyExpression('[When] Between (Exclusive) ("2012-08-12", "2012-08-30")');
+            await asyncSetTimeout(0);
+
+            expect(api.getAdvancedFilterModel()).toEqual({
+                filterType: 'dateString',
+                colId: 'when',
+                type: 'betweenExclusive',
+                filter: '2012-08-12',
+                filterTo: '2012-08-30',
+            });
+            await new GridRows(api, 'date betweenExclusive').check(`
+                ROOT id:ROOT_NODE_ID
+                └── LEAF id:1 when:"2012-08-20"
+            `);
+
+            // Written back out of the model in the same syntax it was read from.
+            api.setAdvancedFilterModel(api.getAdvancedFilterModel());
+            await asyncSetTimeout(0);
+            expect(af.value).toBe('[When] Between (Exclusive) ("2012-08-12", "2012-08-30")');
+        });
+
+        test('only one value given is reported as a missing value', async () => {
+            const api = gridsManager.createGrid('grid1', opts());
+            await asyncSetTimeout(0);
+
+            await AdvancedFilterHarness.get(api).applyExpression('[Age] Between (Exclusive) (24)');
+            await asyncSetTimeout(0);
+
+            await new FilterDom(api, 'one value of two').checkFilterDom(`
+                ADVANCED FILTER
+                input: "[Age] Between (Exclusive) (24)"
+                valid: false — Expression has an error. Value is missing - (24).
+                buttons: Apply ⊘ | Builder
+                model: null
+            `);
+            expect(api.getDisplayedRowCount()).toBe(4);
+        });
+
+        test('an unbracketed pair cut short by the group bracket is rejected, and the group still ends', async () => {
+            const api = gridsManager.createGrid('grid1', opts());
+            await asyncSetTimeout(0);
+
+            await AdvancedFilterHarness.get(api).applyExpression(
+                '([Age] Between (Exclusive) 24 OR [Athlete] Starts With A)'
+            );
+            await asyncSetTimeout(0);
+
+            await new FilterDom(api, 'unbracketed pair cut short in a group').checkFilterDom(`
+                ADVANCED FILTER
+                input: "([Age] Between (Exclusive) 24 OR [Athlete] Starts With A)"
+                valid: false — Expression has an error. Value is missing - 24 O.
+                buttons: Apply ⊘ | Builder
+                model: null
+            `);
+            expect(api.getDisplayedRowCount()).toBe(4);
+        });
+
+        test('a second value missing after the comma is reported as a missing value', async () => {
+            const api = gridsManager.createGrid('grid1', opts());
+            await asyncSetTimeout(0);
+
+            await AdvancedFilterHarness.get(api).applyExpression('[Age] Between (Exclusive) (24, )');
+            await asyncSetTimeout(0);
+
+            await new FilterDom(api, 'second value missing').checkFilterDom(`
+                ADVANCED FILTER
+                input: "[Age] Between (Exclusive) (24, )"
+                valid: false — Expression has an error. Value is missing - (24, ).
+                buttons: Apply ⊘ | Builder
+                model: null
+            `);
+            expect(api.getDisplayedRowCount()).toBe(4);
+        });
+
+        test('an unclosed bracket is reported as a missing end bracket, whatever follows it', async () => {
+            const api = gridsManager.createGrid('grid1', opts());
+            await asyncSetTimeout(0);
+            const af = AdvancedFilterHarness.get(api);
+
+            await af.applyExpression('[Age] Between (Exclusive) (24, 30');
+            await asyncSetTimeout(0);
+            await new FilterDom(api, 'end bracket missing at the end').checkFilterDom(`
+                ADVANCED FILTER
+                input: "[Age] Between (Exclusive) (24, 30"
+                valid: false — Expression has an error. Missing end bracket at end of expression.
+                buttons: Apply ⊘ | Builder
+                model: null
+            `);
+
+            // The same fault, reported the same way, when the expression carries on past it.
+            await af.applyExpression('[Age] Between (Exclusive) (24, 30 AND [Athlete] contains "d"');
+            await asyncSetTimeout(0);
+            await new FilterDom(api, 'end bracket missing mid-expression').checkFilterDom(`
+                ADVANCED FILTER
+                input: "[Age] Between (Exclusive) (24, 30 AND [Athlete] contains "d""
+                valid: false — Expression has an error. Missing end bracket - (24, 30 A.
+                buttons: Apply ⊘ | Builder
+                model: null
+            `);
+        });
+
+        test('a separator before the first value is reported as a missing value', async () => {
+            const api = gridsManager.createGrid('grid1', opts());
+            await asyncSetTimeout(0);
+
+            await AdvancedFilterHarness.get(api).applyExpression('[Age] Between (Exclusive) (, 30)');
+            await asyncSetTimeout(0);
+
+            await new FilterDom(api, 'separator before the first value').checkFilterDom(`
+                ADVANCED FILTER
+                input: "[Age] Between (Exclusive) (, 30)"
+                valid: false — Expression has an error. Value is missing - (,.
+                buttons: Apply ⊘ | Builder
+                model: null
+            `);
+            expect(api.getDisplayedRowCount()).toBe(4);
+        });
+
+        test('two values with no separator are reported as a missing value', async () => {
+            const api = gridsManager.createGrid('grid1', opts());
+            await asyncSetTimeout(0);
+
+            await AdvancedFilterHarness.get(api).applyExpression('[Age] Between (Exclusive) (24 30)');
+            await asyncSetTimeout(0);
+
+            await new FilterDom(api, 'no separator').checkFilterDom(`
+                ADVANCED FILTER
+                input: "[Age] Between (Exclusive) (24 30)"
+                valid: false — Expression has an error. Value is missing - (24 3.
+                buttons: Apply ⊘ | Builder
+                model: null
+            `);
+            expect(api.getDisplayedRowCount()).toBe(4);
+        });
+
+        test('more values than the option takes are rejected', async () => {
+            const api = gridsManager.createGrid('grid1', opts());
+            await asyncSetTimeout(0);
+
+            await AdvancedFilterHarness.get(api).applyExpression('[Age] Between (Exclusive) (24, 30, 50)');
+            await asyncSetTimeout(0);
+
+            await new FilterDom(api, 'three values').checkFilterDom(`
+                ADVANCED FILTER
+                input: "[Age] Between (Exclusive) (24, 30, 50)"
+                valid: false — Expression has an error. Missing end bracket - (24, 30,.
+                buttons: Apply ⊘ | Builder
+                model: null
+            `);
+            expect(api.getDisplayedRowCount()).toBe(4);
+        });
+
+        test('a quoted value carries the separators the region reads', async () => {
+            const api = gridsManager.createGrid('grid1', opts());
+            await asyncSetTimeout(0);
+            const af = AdvancedFilterHarness.get(api);
+
+            await af.applyExpression('[Athlete] Between (Exclusive) ("a, b", "c (d)")');
+            await asyncSetTimeout(0);
+
+            expect(api.getAdvancedFilterModel()).toEqual({
+                filterType: 'text',
+                colId: 'athlete',
+                type: 'betweenExclusive',
+                filter: 'a, b',
+                filterTo: 'c (d)',
+            });
+
+            api.setAdvancedFilterModel(api.getAdvancedFilterModel());
+            await asyncSetTimeout(0);
+            expect(af.value).toBe('[Athlete] Between (Exclusive) ("a, b", "c (d)")');
+        });
+
+        test('the brackets stay optional inside a group', async () => {
+            const api = gridsManager.createGrid('grid1', opts());
+            await asyncSetTimeout(0);
+
+            await AdvancedFilterHarness.get(api).applyExpression(
+                '([Age] Between (Exclusive) 24, 30 OR [Athlete] Starts With A)'
+            );
+            await asyncSetTimeout(0);
+
+            expect(api.getAdvancedFilterModel()).toEqual({
+                filterType: 'join',
+                type: 'OR',
+                conditions: [
+                    { filterType: 'number', colId: 'age', type: 'betweenExclusive', filter: 24, filterTo: 30 },
+                    { filterType: 'text', colId: 'athlete', type: 'startsA' },
+                ],
+            });
+            await new GridRows(api, 'unbracketed pair inside a group').check(`
+                ROOT id:ROOT_NODE_ID
+                ├── LEAF id:0 athlete:"Bolt" age:25 won:true
+                └── LEAF id:2 athlete:"Ada" age:28 won:true
+            `);
+        });
+
+        // Every cell data type the expression format names as quoted: text and dateString have their own
+        // tests above, so this covers the two `Date`-valued ones.
+        test('two dates and two date-times are quoted, and round-trip through the model', async () => {
+            const api = gridsManager.createGrid('grid1', {
+                columnDefs: [
+                    {
+                        field: 'day',
+                        cellDataType: 'date',
+                        filter: 'agDateColumnFilter',
+                        filterParams: { filterOptions: [BETWEEN_EXCLUSIVE] },
+                    },
+                    {
+                        field: 'moment',
+                        cellDataType: 'dateTime',
+                        filter: 'agDateColumnFilter',
+                        filterParams: { filterOptions: [BETWEEN_EXCLUSIVE] },
+                    },
+                ],
+                rowData: [
+                    { day: new Date(2012, 7, 5), moment: new Date(2012, 7, 5, 9, 30, 0) },
+                    { day: new Date(2012, 7, 20), moment: new Date(2012, 7, 20, 9, 30, 0) },
+                ],
+                enableAdvancedFilter: true,
+            });
+            await asyncSetTimeout(0);
+            const af = AdvancedFilterHarness.get(api);
+
+            await af.applyExpression('[Day] Between (Exclusive) ("2012-08-10", "2012-08-25")');
+            await asyncSetTimeout(0);
+            expect(api.getAdvancedFilterModel()).toEqual({
+                filterType: 'date',
+                colId: 'day',
+                type: 'betweenExclusive',
+                filter: '2012-08-10',
+                filterTo: '2012-08-25',
+            });
+            // Which row, not how many: an inverted comparison also leaves one of the two standing.
+            await new GridRows(api, 'the date pair filters').check(`
+                ROOT id:ROOT_NODE_ID
+                └── LEAF id:1 day:"2012-08-20" moment:"2012-08-20T09:30:00"
+            `);
+            api.setAdvancedFilterModel(api.getAdvancedFilterModel());
+            await asyncSetTimeout(0);
+            expect(af.value).toBe('[Day] Between (Exclusive) ("2012-08-10", "2012-08-25")');
+
+            await af.applyExpression('[Moment] Between (Exclusive) ("2012-08-10T00:00:00", "2012-08-25T00:00:00")');
+            await asyncSetTimeout(0);
+            expect(api.getAdvancedFilterModel()).toEqual({
+                filterType: 'dateTime',
+                colId: 'moment',
+                type: 'betweenExclusive',
+                filter: '2012-08-10T00:00:00',
+                filterTo: '2012-08-25T00:00:00',
+            });
+            await new GridRows(api, 'the date-time pair filters').check(`
+                ROOT id:ROOT_NODE_ID
+                └── LEAF id:1 day:"2012-08-20" moment:"2012-08-20T09:30:00"
+            `);
+        });
+
+        // The model member is a decimal string while the predicate is handed a `bigint`.
+        test('two bigints round-trip through the model and reach the predicate as bigints', async () => {
+            const seen: unknown[][] = [];
+            const api = gridsManager.createGrid('grid1', {
+                columnDefs: [
+                    {
+                        field: 'count',
+                        cellDataType: 'bigint',
+                        filter: 'agBigIntColumnFilter',
+                        filterParams: {
+                            filterOptions: [
+                                {
+                                    ...BETWEEN_EXCLUSIVE,
+                                    predicate: ([from, to]: any[], cellValue: any) => {
+                                        seen.push([typeof from, typeof to, typeof cellValue]);
+                                        return cellValue != null && cellValue > from && cellValue < to;
+                                    },
+                                },
+                            ],
+                        },
+                    },
+                ],
+                rowData: [{ count: 10n }, { count: 20n }, { count: 30n }],
+                enableAdvancedFilter: true,
+            });
+            await asyncSetTimeout(0);
+            const af = AdvancedFilterHarness.get(api);
+
+            await af.applyExpression('[Count] Between (Exclusive) (15, 25)');
+            await asyncSetTimeout(0);
+            expect(api.getAdvancedFilterModel()).toEqual({
+                filterType: 'bigint',
+                colId: 'count',
+                type: 'betweenExclusive',
+                filter: '15',
+                filterTo: '25',
+            });
+            expect(seen[0]).toEqual(['bigint', 'bigint', 'bigint']);
+            await new GridRows(api, 'betweenExclusive bigint').check(`
+                ROOT id:ROOT_NODE_ID
+                └── LEAF id:1 count:"20n"
+            `);
+
+            api.setAdvancedFilterModel(api.getAdvancedFilterModel());
+            await asyncSetTimeout(0);
+            expect(af.value).toBe('[Count] Between (Exclusive) (15, 25)');
+        });
+
+        test('two date-time strings are quoted and round-trip through the model', async () => {
+            const seen: unknown[] = [];
+            const api = gridsManager.createGrid('grid1', {
+                columnDefs: [
+                    {
+                        field: 'stamp',
+                        cellDataType: 'dateTimeString',
+                        filter: 'agDateColumnFilter',
+                        filterParams: {
+                            filterOptions: [
+                                {
+                                    ...DATE_BETWEEN_EXCLUSIVE,
+                                    // The cell is the raw string; the operands arrive parsed, as for a date column.
+                                    predicate: ([from, to]: any[], cellValue: any) => {
+                                        seen.push([from instanceof Date, to instanceof Date, typeof cellValue]);
+                                        return (
+                                            cellValue != null &&
+                                            new Date(cellValue.replace(' ', 'T')) > from &&
+                                            new Date(cellValue.replace(' ', 'T')) < to
+                                        );
+                                    },
+                                },
+                            ],
+                        },
+                    },
+                ],
+                rowData: [{ stamp: '2012-08-05 10:30:00' }, { stamp: '2012-08-20 10:30:00' }],
+                enableAdvancedFilter: true,
+            });
+            await asyncSetTimeout(0);
+            const af = AdvancedFilterHarness.get(api);
+
+            await af.applyExpression('[Stamp] Between (Exclusive) ("2012-08-10 00:00:00", "2012-08-25 00:00:00")');
+            await asyncSetTimeout(0);
+            expect(api.getAdvancedFilterModel()).toEqual({
+                filterType: 'dateTimeString',
+                colId: 'stamp',
+                type: 'betweenExclusive',
+                filter: '2012-08-10T00:00:00',
+                filterTo: '2012-08-25T00:00:00',
+            });
+            expect(seen[0]).toEqual([true, true, 'string']);
+            await new GridRows(api, 'betweenExclusive dateTimeString').check(`
+                ROOT id:ROOT_NODE_ID
+                └── LEAF id:1 stamp:"2012-08-20 10:30:00"
+            `);
+
+            // Both separators parse, and a model is written back in the one the model itself stores.
+            api.setAdvancedFilterModel(api.getAdvancedFilterModel());
+            await asyncSetTimeout(0);
+            expect(af.value).toBe('[Stamp] Between (Exclusive) ("2012-08-10T00:00:00", "2012-08-25T00:00:00")');
+
+            await af.applyExpression(af.value);
+            await asyncSetTimeout(0);
+            expect(api.getAdvancedFilterModel()).toEqual({
+                filterType: 'dateTimeString',
+                colId: 'stamp',
+                type: 'betweenExclusive',
+                filter: '2012-08-10T00:00:00',
+                filterTo: '2012-08-25T00:00:00',
+            });
+        });
+
+        test('two object values are quoted and round-trip through the model', async () => {
+            const api = gridsManager.createGrid('grid1', {
+                columnDefs: [
+                    {
+                        field: 'tag',
+                        cellDataType: 'object',
+                        valueFormatter: ({ value }: { value: { name: string } | null }) => value?.name ?? '',
+                        filter: 'agTextColumnFilter',
+                        filterParams: { filterOptions: [BETWEEN_EXCLUSIVE] },
+                    },
+                ],
+                rowData: [{ tag: { name: 'Ada' } }, { tag: { name: 'Bolt' } }, { tag: { name: 'Wei' } }],
+                enableAdvancedFilter: true,
+            });
+            await asyncSetTimeout(0);
+            const af = AdvancedFilterHarness.get(api);
+
+            await af.applyExpression('[Tag] Between (Exclusive) ("Ada", "Wei")');
+            await asyncSetTimeout(0);
+            expect(api.getAdvancedFilterModel()).toEqual({
+                filterType: 'object',
+                colId: 'tag',
+                type: 'betweenExclusive',
+                filter: 'Ada',
+                filterTo: 'Wei',
+            });
+            await new GridRows(api, 'betweenExclusive object').check(`
+                ROOT id:ROOT_NODE_ID
+                └── LEAF id:1 tag:"Bolt"
+            `);
+
+            api.setAdvancedFilterModel(api.getAdvancedFilterModel());
+            await asyncSetTimeout(0);
+            expect(af.value).toBe('[Tag] Between (Exclusive) ("Ada", "Wei")');
+        });
+
+        test('a model short of its second value is written out and rejected, not silently halved', async () => {
+            const api = gridsManager.createGrid('grid1', opts());
+            await asyncSetTimeout(0);
+
+            api.setAdvancedFilterModel({
+                filterType: 'number',
+                colId: 'age',
+                type: 'betweenExclusive',
+                filter: 24,
+            });
+            api.onFilterChanged();
+            await asyncSetTimeout(0);
+
+            await new FilterDom(api, 'model missing filterTo').checkFilterDom(`
+                ADVANCED FILTER
+                input: "[Age] Between (Exclusive) (24, )"
+                valid: false — Expression has an error. Value is missing - (24, ).
+                buttons: Apply ⊘ | Builder
+                model: null
+            `);
+            expect(api.getDisplayedRowCount()).toBe(4);
+        });
+
+        // A `,` ends a value in this region, so an operand that contains one has to be written quoted.
+        test('a numberFormatter writing a separator has both values quoted, and reads back', async () => {
+            const api = gridsManager.createGrid('grid1', {
+                columnDefs: [
+                    {
+                        field: 'age',
+                        filter: 'agNumberColumnFilter',
+                        filterParams: {
+                            filterOptions: AGE_OPTIONS,
+                            numberFormatter: (value: number | null) =>
+                                value == null ? null : value.toLocaleString('en-US'),
+                            numberParser: (text: string | null) => {
+                                const digits = text?.replace(/[^\d]/g, '');
+                                return digits ? Number(digits) : null;
+                            },
+                        },
+                    },
+                ],
+                rowData: [{ age: 1234 }, { age: 5678 }, { age: 999999 }],
+                enableAdvancedFilter: true,
+            });
+            await asyncSetTimeout(0);
+
+            api.setAdvancedFilterModel({
+                filterType: 'number',
+                colId: 'age',
+                type: 'betweenExclusive',
+                filter: 1000,
+                filterTo: 9999,
+            });
+            api.onFilterChanged();
+            await asyncSetTimeout(0);
+
+            const af = AdvancedFilterHarness.get(api);
+            expect(af.value).toBe('[Age] Between (Exclusive) ("1,000", "9,999")');
+            await new GridRows(api, 'grouped two-value operands').check(`
+                ROOT id:ROOT_NODE_ID
+                ├── LEAF id:0 age:1234
+                └── LEAF id:1 age:5678
+            `);
+
+            await af.applyExpression('');
+            await asyncSetTimeout(0);
+            await af.applyExpression('[Age] Between (Exclusive) ("1,000", "9,999")');
+            await asyncSetTimeout(0);
+            expect(api.getAdvancedFilterModel()).toEqual({
+                filterType: 'number',
+                colId: 'age',
+                type: 'betweenExclusive',
+                filter: 1000,
+                filterTo: 9999,
+            });
+        });
+    });
+
+    describe('replacing a built-in option', () => {
+        test('the column filter and the Advanced Filter both run the replacement', async () => {
+            const columnDefs: GridOptions<TestRow>['columnDefs'] = [
+                {
+                    field: 'athlete',
+                    filter: 'agTextColumnFilter',
+                    filterParams: { filterOptions: [CONTAINS_BACKWARDS, 'equals'] },
+                },
+            ];
+            const advanced = gridsManager.createGrid('grid1', {
+                columnDefs,
+                rowData: ROW_DATA,
+                enableAdvancedFilter: true,
+            });
+            const column = gridsManager.createGrid('grid2', { columnDefs, rowData: ROW_DATA });
+            await asyncSetTimeout(0);
+
+            const af = AdvancedFilterHarness.get(advanced);
+            await af.type('[Athlete] ');
+            expect(af.autocompleteEntries()).toEqual(['contains backwards', 'equals']);
+
+            // 'tloB' contains 'lo'; 'Bolt' does not.
+            await af.applyExpression('[Athlete] contains backwards "lo"');
+            await column.setColumnFilterModel('athlete', { filterType: 'text', type: 'contains', filter: 'lo' });
+            column.onFilterChanged();
+            await asyncSetTimeout(0);
+
+            expect(filteredAthletes(advanced)).toEqual(['Bolt']);
+            expect(filteredAthletes(column)).toEqual(filteredAthletes(advanced));
+        });
+    });
+
+    describe('predicate parity with the column filter', () => {
+        async function createParityGrids(): Promise<{ advanced: GridApi<TestRow>; column: GridApi<TestRow> }> {
+            const advanced = gridsManager.createGrid<TestRow>('grid1', opts());
+            const column = gridsManager.createGrid<TestRow>('grid2', {
+                columnDefs: opts().columnDefs,
+                rowData: ROW_DATA,
+            });
+            await asyncSetTimeout(0);
+            return { advanced, column };
+        }
+
+        test('an option filters the same rows as the column filter, whatever number of values it takes', async () => {
+            const { advanced, column } = await createParityGrids();
+            const applyBoth = async (colId: 'athlete' | 'age', model: any, expected: string[]) => {
+                advanced.setAdvancedFilterModel({ ...model, colId });
+                advanced.onFilterChanged();
+                // An advanced model replaces the previous one; column filters are per column and would
+                // otherwise stack, so the other column is cleared before each pair.
+                await column.setColumnFilterModel(colId === 'athlete' ? 'age' : 'athlete', null);
+                await column.setColumnFilterModel(colId, model);
+                column.onFilterChanged();
+                await asyncSetTimeout(0);
+                expectSameAthletes(advanced, column, expected);
+            };
+
+            await applyBoth('athlete', { filterType: 'text', type: 'startsA' }, ['Ada']);
+            await applyBoth('athlete', { filterType: 'text', type: 'regexp', filter: 'a' }, ['Ada']);
+            await applyBoth('age', { filterType: 'number', type: 'betweenExclusive', filter: 24, filterTo: 30 }, [
+                'Bolt',
+                'Ada',
+            ]);
+        });
+
+        // The operand list is built per call, so a predicate that keeps or edits what it is handed cannot
+        // reach the next call. Driven through ONE option used twice: two options would each have their own
+        // operator object, and a list hoisted onto the operator would still look clean.
+        test('a predicate that mutates its operands does not reach the next call', async () => {
+            const seen: any[][] = [];
+            const api = gridsManager.createGrid('grid1', {
+                columnDefs: [
+                    {
+                        field: 'athlete',
+                        filter: 'agTextColumnFilter',
+                        filterParams: {
+                            filterOptions: [
+                                {
+                                    displayKey: 'records',
+                                    displayName: 'Records',
+                                    numberOfInputs: 1,
+                                    predicate: (values: any[]) => {
+                                        seen.push([...values]);
+                                        values.push('polluted');
+                                        return true;
+                                    },
+                                },
+                            ],
+                        },
+                    },
+                ],
+                rowData: ROW_DATA,
+                enableAdvancedFilter: true,
+            });
+            await asyncSetTimeout(0);
+
+            await AdvancedFilterHarness.get(api).applyExpression('[Athlete] Records "x" AND [Athlete] Records "y"');
+            await asyncSetTimeout(0);
+
+            // Two conditions over four rows, each call handed its own operand and nothing else.
+            expect(seen).toEqual([['x'], ['y'], ['x'], ['y'], ['x'], ['y'], ['x'], ['y']]);
+        });
+    });
+
+    // What survives classification, and what the survivors are called: two functions, but both are about
+    // an option the grid has to make sense of rather than one written the way the docs describe.
+    describe('malformed options and name resolution', () => {
+        test('an entry missing a required property is dropped and reported', async () => {
+            // Deliberate: the option is missing `displayName`/`predicate`, which triggers warning #72.
+            enableDevValidations({ throwOn: ALL_SEVERITIES, suppress: [72] });
+            const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+            const api = gridsManager.createGrid('grid1', {
+                columnDefs: [
+                    {
+                        field: 'athlete',
+                        filter: 'agTextColumnFilter',
+                        filterParams: { filterOptions: ['contains', { displayKey: 'broken' } as IFilterOptionDef] },
+                    },
+                ],
+                rowData: ROW_DATA,
+                enableAdvancedFilter: true,
+            });
+            await asyncSetTimeout(0);
+            const af = AdvancedFilterHarness.get(api);
+
+            await af.type('[Athlete] ');
+            expect(af.autocompleteEntries()).toEqual(['contains']);
+            const message = warn.mock.calls.flat().join(' ');
+            expect(message).toContain('warning #72');
+            expect(message).toContain('displayName');
+            expect(message).toContain('predicate');
+        });
+
+        // The name is a locale lookup on the `displayKey`, so a translation replaces the `displayName`
+        // rather than sitting beside it: the expression is written in whichever wins.
+        test('a localised name is the one the expression is written in', async () => {
+            const api = gridsManager.createGrid('grid1', {
+                columnDefs: [
+                    {
+                        field: 'athlete',
+                        filter: 'agTextColumnFilter',
+                        filterParams: { filterOptions: ['contains', STARTS_A] },
+                    },
+                ],
+                rowData: ROW_DATA,
+                enableAdvancedFilter: true,
+                localeText: { startsA: 'Commence par A' },
+            });
+            await asyncSetTimeout(0);
+            const af = AdvancedFilterHarness.get(api);
+
+            await af.type('[Athlete] ');
+            expect(af.autocompleteEntries()).toEqual(['contains', 'Commence par A']);
+
+            await af.applyExpression('[Athlete] Commence par A');
+            await asyncSetTimeout(0);
+            expect(api.getAdvancedFilterModel()).toEqual({ filterType: 'text', colId: 'athlete', type: 'startsA' });
+            await new GridRows(api, 'the localised name filters').check(`
+                ROOT id:ROOT_NODE_ID
+                └── LEAF id:2 athlete:"Ada"
+            `);
+
+            // Cleared first: an invalid expression leaves the previous filter applied, which would read as
+            // the untranslated name still resolving.
+            await af.applyExpression('');
+            await asyncSetTimeout(0);
+            await af.applyExpression('[Athlete] Starts With A');
+            await asyncSetTimeout(0);
+            expect(api.getAdvancedFilterModel()).toBeNull();
+        });
+
+        // An expression is written in the name, so an option that resolves to none takes its key as one.
+        test('an entry whose displayName is empty, or nothing but space, is offered under its displayKey', async () => {
+            const api = gridsManager.createGrid('grid1', {
+                columnDefs: [
+                    {
+                        field: 'athlete',
+                        filter: 'agTextColumnFilter',
+                        filterParams: {
+                            filterOptions: [
+                                'contains',
+                                {
+                                    displayKey: 'startsA',
+                                    displayName: '',
+                                    numberOfInputs: 0,
+                                    predicate: (_values: any[], cellValue: any) =>
+                                        typeof cellValue === 'string' && cellValue.startsWith('A'),
+                                },
+                            ],
+                        },
+                    },
+                ],
+                rowData: ROW_DATA,
+                enableAdvancedFilter: true,
+            });
+            await asyncSetTimeout(0);
+
+            const af = AdvancedFilterHarness.get(api);
+            await af.type('[Athlete] ');
+            expect(af.autocompleteEntries()).toEqual(['contains', 'startsA']);
+
+            // A name that is nothing but space resolves to blank too, so it takes the key the same way.
+            api.setGridOption('columnDefs', [
+                {
+                    field: 'athlete',
+                    filter: 'agTextColumnFilter',
+                    filterParams: { filterOptions: ['contains', { ...STARTS_A, displayName: '   ' }] },
+                },
+            ]);
+            await asyncSetTimeout(0);
+            await af.type('');
+            await af.type('[Athlete] ');
+            expect(af.autocompleteEntries()).toEqual(['contains', 'startsA']);
+
+            await af.applyExpression('[Athlete] startsA');
+            await asyncSetTimeout(0);
+            await new GridRows(api, 'the key spells the option').check(`
+                ROOT id:ROOT_NODE_ID
+                └── LEAF id:2 athlete:"Ada"
+            `);
+
+            expect(api.getAdvancedFilterModel()).toEqual({
+                filterType: 'text',
+                colId: 'athlete',
+                type: 'startsA',
+            });
+
+            api.setAdvancedFilterModel(api.getAdvancedFilterModel());
+            await asyncSetTimeout(0);
+            expect(af.value).toBe('[Athlete] startsA');
+        });
+
+        // A key is written by whoever wrote the option, so standing in as a name it faces the grammar the
+        // display names already do.
+        test('a displayKey standing in as the name carries a space, and round-trips', async () => {
+            const api = gridsManager.createGrid('grid1', {
+                columnDefs: [
+                    {
+                        field: 'athlete',
+                        filter: 'agTextColumnFilter',
+                        filterParams: {
+                            filterOptions: ['contains', { ...STARTS_A, displayKey: 'starts a', displayName: '' }],
+                        },
+                    },
+                ],
+                rowData: ROW_DATA,
+                enableAdvancedFilter: true,
+            });
+            await asyncSetTimeout(0);
+            const af = AdvancedFilterHarness.get(api);
+
+            await af.type('[Athlete] ');
+            expect(af.autocompleteEntries()).toEqual(['contains', 'starts a']);
+
+            await af.applyExpression('[Athlete] starts a');
+            await asyncSetTimeout(0);
+            await new GridRows(api, 'a key of two words filters').check(`
+                ROOT id:ROOT_NODE_ID
+                └── LEAF id:2 athlete:"Ada"
+            `);
+            expect(api.getAdvancedFilterModel()).toEqual({
+                filterType: 'text',
+                colId: 'athlete',
+                type: 'starts a',
+            });
+
+            api.setAdvancedFilterModel(api.getAdvancedFilterModel());
+            await asyncSetTimeout(0);
+            expect(af.value).toBe('[Athlete] starts a');
+        });
+
+        // The name is trimmed to what can be spelled; the model goes on holding the key as configured.
+        test('a padded displayKey is spelled trimmed and stored as written', async () => {
+            const api = gridsManager.createGrid('grid1', {
+                columnDefs: [
+                    {
+                        field: 'athlete',
+                        filter: 'agTextColumnFilter',
+                        filterParams: { filterOptions: [{ ...STARTS_A, displayKey: '  startsA  ', displayName: '' }] },
+                    },
+                ],
+                rowData: ROW_DATA,
+                enableAdvancedFilter: true,
+            });
+            await asyncSetTimeout(0);
+            const af = AdvancedFilterHarness.get(api);
+
+            await af.type('[Athlete] ');
+            expect(af.autocompleteEntries()).toEqual(['startsA']);
+
+            await af.applyExpression('[Athlete] startsA');
+            await asyncSetTimeout(0);
+            expect(api.getAdvancedFilterModel()).toEqual({
+                filterType: 'text',
+                colId: 'athlete',
+                type: '  startsA  ',
+            });
+
+            api.setAdvancedFilterModel(api.getAdvancedFilterModel());
+            await asyncSetTimeout(0);
+            expect(af.value).toBe('[Athlete] startsA');
+        });
+
+        test('a list that keeps nothing leaves the built-ins standing, as it does for the column filter', async () => {
+            enableDevValidations({ throwOn: ALL_SEVERITIES, suppress: [72] });
+            const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+            const api = gridsManager.createGrid('grid1', {
+                columnDefs: [
+                    {
+                        field: 'athlete',
+                        filter: 'agTextColumnFilter',
+                        filterParams: { filterOptions: [{ displayKey: 'broken' } as IFilterOptionDef] },
+                    },
+                ],
+                rowData: ROW_DATA,
+                enableAdvancedFilter: true,
+            });
+            await asyncSetTimeout(0);
+
+            const af = AdvancedFilterHarness.get(api);
+            await af.type('[Athlete] ');
+            expect(af.autocompleteEntries()).toContain('ends with');
+            expect(warn.mock.calls.flat().join(' ')).toContain('warning #72');
+        });
+
+        test('a name with space around it is offered and written without it', async () => {
+            const api = gridsManager.createGrid('grid1', {
+                columnDefs: [
+                    {
+                        field: 'athlete',
+                        filter: 'agTextColumnFilter',
+                        filterParams: { filterOptions: [{ ...STARTS_A, displayName: ' Starts With A ' }] },
+                    },
+                ],
+                rowData: ROW_DATA,
+                enableAdvancedFilter: true,
+            });
+            await asyncSetTimeout(0);
+            const af = AdvancedFilterHarness.get(api);
+
+            await af.type('[Athlete] ');
+            expect(af.autocompleteEntries()).toEqual(['Starts With A']);
+
+            await af.applyExpression('[Athlete] Starts With A');
+            await asyncSetTimeout(0);
+            await new GridRows(api, 'a name trimmed to what the grammar can spell').check(`
+                ROOT id:ROOT_NODE_ID
+                └── LEAF id:2 athlete:"Ada"
+            `);
+        });
+
+        // Named by its key, it is an option like any other, so the list narrows to it as any list does.
+        test('an option declaring more inputs than the grammar has takes two', async () => {
+            const api = gridsManager.createGrid('grid1', {
+                columnDefs: [
+                    {
+                        field: 'age',
+                        filter: 'agNumberColumnFilter',
+                        filterParams: {
+                            // `numberOfInputs` is declared `0 | 1 | 2`, which is no check on a JS caller.
+                            filterOptions: [{ ...BETWEEN_EXCLUSIVE, numberOfInputs: 3 as unknown as 2 }],
+                        },
+                    },
+                ],
+                rowData: ROW_DATA,
+                enableAdvancedFilter: true,
+            });
+            await asyncSetTimeout(0);
+
+            await AdvancedFilterHarness.get(api).applyExpression('[Age] Between (Exclusive) (24, 30)');
+            await asyncSetTimeout(0);
+
+            expect(api.getAdvancedFilterModel()).toEqual({
+                filterType: 'number',
+                colId: 'age',
+                type: 'betweenExclusive',
+                filter: 24,
+                filterTo: 30,
+            });
+        });
+    });
+
+    describe('the Builder', () => {
+        test('the option dropdown offers the column custom options', async () => {
+            const api = gridsManager.createGrid('grid1', opts());
+            await asyncSetTimeout(0);
+            api.setAdvancedFilterModel({ filterType: 'text', colId: 'athlete', type: 'startsA' });
+            api.onFilterChanged();
+            await asyncSetTimeout(0);
+
+            const builder = await AdvancedFilterBuilderHarness.open(api);
+            const [condition] = await builder.conditionItems();
+
+            expect(await builder.operatorOptions(condition)).toEqual([
+                'contains',
+                'Starts With A',
+                'Regular Expression',
+                'Between (Exclusive)',
+            ]);
+            expect(builder.valuePills(condition)).toHaveLength(0);
+        });
+
+        test('an option taking two values gets a pill each, and applying them sets both', async () => {
+            const api = gridsManager.createGrid('grid1', opts());
+            await asyncSetTimeout(0);
+            api.setAdvancedFilterModel({ filterType: 'number', colId: 'age', type: 'evenNumbers' });
+            api.onFilterChanged();
+            await asyncSetTimeout(0);
+
+            const builder = await AdvancedFilterBuilderHarness.open(api);
+            const [condition] = await builder.conditionItems();
+            expect(builder.valuePills(condition)).toHaveLength(0);
+
+            await builder.selectOperator(condition, 'Between (Exclusive)');
+            expect(builder.valuePills(condition)).toHaveLength(2);
+
+            await builder.setValue(condition, '24', 0);
+            await builder.setValue(condition, '30', 1);
+            await builder.apply();
+            await asyncSetTimeout(0);
+
+            expect(api.getAdvancedFilterModel()).toEqual({
+                filterType: 'number',
+                colId: 'age',
+                type: 'betweenExclusive',
+                filter: 24,
+                filterTo: 30,
+            });
+            await new GridRows(api, 'builder two-value option').check(`
+                ROOT id:ROOT_NODE_ID
+                ├── LEAF id:0 athlete:"Bolt" age:25 won:true
+                └── LEAF id:2 athlete:"Ada" age:28 won:true
+            `);
+        });
+
+        test('a loaded two-value model shows both values, and dropping to one value drops the second', async () => {
+            const api = gridsManager.createGrid('grid1', opts());
+            await asyncSetTimeout(0);
+            api.setAdvancedFilterModel({
+                filterType: 'text',
+                colId: 'athlete',
+                type: 'betweenExclusive',
+                filter: 'Ada',
+                filterTo: 'Ng',
+            });
+            api.onFilterChanged();
+            await asyncSetTimeout(0);
+
+            const builder = await AdvancedFilterBuilderHarness.open(api);
+            const [condition] = await builder.conditionItems();
+            // The input pill quotes a text value itself.
+            expect(builder.valuePillText(condition, 0)).toBe('"Ada"');
+            expect(builder.valuePillText(condition, 1)).toBe('"Ng"');
+
+            await builder.selectOperator(condition, 'Regular Expression');
+            expect(builder.valuePills(condition)).toHaveLength(1);
+
+            await builder.setValue(condition, 'a');
+            await builder.apply();
+            await asyncSetTimeout(0);
+
+            expect(api.getAdvancedFilterModel()).toEqual({
+                filterType: 'text',
+                colId: 'athlete',
+                type: 'regexp',
+                filter: 'a',
+            });
+        });
+
+        test('a typed expression restores as pills, whatever number of values the option takes', async () => {
+            const api = gridsManager.createGrid('grid1', opts());
+            await asyncSetTimeout(0);
+            await AdvancedFilterHarness.get(api).applyExpression(
+                '[Athlete] Starts With A OR [Age] Between (Exclusive) (24, 30)'
+            );
+            await asyncSetTimeout(0);
+
+            const builder = await AdvancedFilterBuilderHarness.open(api);
+            const [startsWithA, between] = await builder.conditionItems();
+
+            expect(builder.valuePills(startsWithA)).toHaveLength(0);
+            expect(builder.valuePills(between)).toHaveLength(2);
+            expect(builder.valuePillText(between, 0)).toBe('24');
+            expect(builder.valuePillText(between, 1)).toBe('30');
+        });
+
+        test('the two value pills are named From and To for a screen reader', async () => {
+            const api = gridsManager.createGrid('grid1', opts());
+            await asyncSetTimeout(0);
+            api.setAdvancedFilterModel({
+                filterType: 'number',
+                colId: 'age',
+                type: 'betweenExclusive',
+                filter: 24,
+                filterTo: 30,
+            });
+            api.onFilterChanged();
+            await asyncSetTimeout(0);
+
+            const builder = await AdvancedFilterBuilderHarness.open(api);
+            const [condition] = await builder.conditionItems();
+
+            // The column filter's own from/to labels, so the pair reads the same wherever the user meets it.
+            const pills = builder.valuePills(condition);
+            expect(pills.map((pill) => pill.getAttribute('aria-label'))).toEqual([
+                'Filter from value',
+                'Filter to value',
+            ]);
+            expect(pills.map((pill, index) => builder.valuePillText(condition, index))).toEqual(['24', '30']);
+            // Tab order is the browser's own, which happy-dom does not walk, so what is asserted is the thing
+            // that decides it: zero or above, since absent reads as `-1` and so does a skipped pill.
+            expect(pills.map((pill) => pill.tabIndex)).toEqual([0, 0]);
+
+            // One value, so there is no pair to tell apart, and the pill left behind is still in the tab order.
+            await builder.selectOperator(condition, '=');
+            const remaining = builder.valuePills(condition);
+            expect(remaining.map((pill) => pill.getAttribute('aria-label'))).toEqual(['Value']);
+            expect(remaining.map((pill) => pill.tabIndex)).toEqual([0]);
+        });
+
+        test('switching to a column that offers the option under another name relabels it', async () => {
+            const api = gridsManager.createGrid('grid1', {
+                ...opts(),
+                columnDefs: [
+                    { field: 'athlete', filter: 'agTextColumnFilter' },
+                    {
+                        field: 'other',
+                        filter: 'agTextColumnFilter',
+                        filterParams: { filterOptions: [CONTAINS_BACKWARDS] },
+                    },
+                ],
+                rowData: ROW_DATA.map((row) => ({ ...row, other: row.athlete })),
+            });
+            await asyncSetTimeout(0);
+            api.setAdvancedFilterModel({ filterType: 'text', colId: 'athlete', type: 'contains', filter: 'a' });
+            api.onFilterChanged();
+            await asyncSetTimeout(0);
+
+            const builder = await AdvancedFilterBuilderHarness.open(api);
+            const [condition] = await builder.conditionItems();
+            await builder.selectColumn(condition, 'Other');
+
+            expect(await builder.operatorOptions(condition)).toEqual(['contains backwards']);
+            await builder.apply();
+            await asyncSetTimeout(0);
+            expect(AdvancedFilterHarness.get(api).value).toBe('[Other] contains backwards "a"');
+        });
+
+        test('switching to a column that narrows away a built-in clears it', async () => {
+            const api = gridsManager.createGrid('grid1', {
+                ...opts(),
+                columnDefs: [
+                    { field: 'athlete', filter: 'agTextColumnFilter' },
+                    {
+                        field: 'other',
+                        filter: 'agTextColumnFilter',
+                        filterParams: { filterOptions: ['equals'] },
+                    },
+                ],
+                rowData: ROW_DATA.map((row) => ({ ...row, other: row.athlete })),
+            });
+            await asyncSetTimeout(0);
+            api.setAdvancedFilterModel({ filterType: 'text', colId: 'athlete', type: 'contains', filter: 'a' });
+            api.onFilterChanged();
+            await asyncSetTimeout(0);
+
+            const builder = await AdvancedFilterBuilderHarness.open(api);
+            const [condition] = await builder.conditionItems();
+            await builder.selectColumn(condition, 'Other');
+
+            expect(await builder.operatorOptions(condition)).toEqual(['equals']);
+            expect(builder.valuePills(condition)).toHaveLength(0);
+        });
+
+        test('switching to a column that does not offer the option clears it', async () => {
+            const api = gridsManager.createGrid('grid1', {
+                ...opts(),
+                columnDefs: [
+                    {
+                        field: 'athlete',
+                        filter: 'agTextColumnFilter',
+                        filterParams: { filterOptions: ATHLETE_OPTIONS },
+                    },
+                    { field: 'other', filter: 'agTextColumnFilter', filterParams: { filterOptions: ['contains'] } },
+                ],
+                rowData: ROW_DATA.map((row) => ({ ...row, other: row.athlete })),
+            });
+            await asyncSetTimeout(0);
+            api.setAdvancedFilterModel({ filterType: 'text', colId: 'athlete', type: 'startsA' });
+            api.onFilterChanged();
+            await asyncSetTimeout(0);
+
+            const builder = await AdvancedFilterBuilderHarness.open(api);
+            const [condition] = await builder.conditionItems();
+            await builder.selectColumn(condition, 'Other');
+
+            expect(await builder.operatorOptions(condition)).toEqual(['contains']);
+            expect(builder.valuePills(condition)).toHaveLength(0);
+        });
+
+        // `validateItems` no longer checks the operands, so what holds Apply shut for an emptied pill is the
+        // invalidity `refreshList` carries across a rebuild rather than a re-derivation.
+        test('an emptied value keeps Apply shut across an external model change', async () => {
+            const api = gridsManager.createGrid('grid1', opts());
+            await asyncSetTimeout(0);
+            api.setAdvancedFilterModel({
+                filterType: 'number',
+                colId: 'age',
+                type: 'betweenExclusive',
+                filter: 24,
+                filterTo: 30,
+            });
+            api.onFilterChanged();
+            await asyncSetTimeout(0);
+
+            const builder = await AdvancedFilterBuilderHarness.open(api);
+            const [condition] = await builder.conditionItems();
+            await builder.setValue(condition, '', 1);
+            await new FilterDom(api, 'the second value emptied', { mode: 'builder' }).checkFilterDom(`
+                BUILDER
+                AND
+                  Age Between (Exclusive) 24 Enter a value... ✗
+                  + add
+                buttons: Apply ⊘ | Cancel
+                model:
+                  filterType: "number"
+                  colId: "age"
+                  type: "betweenExclusive"
+                  filter: 24
+                  filterTo: 30
+            `);
+
+            // Rebuilds the item list, which seeds every row valid again.
+            api.setAdvancedFilterModel({ filterType: 'number', colId: 'age', type: 'evenNumbers' });
+            api.onFilterChanged();
+            await asyncSetTimeout(0);
+            await new FilterDom(api, 'still shut after the rebuild', { mode: 'builder' }).checkFilterDom(`
+                BUILDER
+                AND
+                  Age Between (Exclusive) 24 Enter a value... ✗
+                  + add
+                buttons: Apply ⊘ | Cancel
+                model:
+                  filterType: "number"
+                  colId: "age"
+                  type: "evenNumbers"
+            `);
+
+            // The control, so the two assertions above are not passing on a snapshot that never says Apply.
+            await builder.setValue(condition, '30', 1);
+            await new FilterDom(api, 'both values back', { mode: 'builder' }).checkFilterDom(`
+                BUILDER
+                AND
+                  Age Between (Exclusive) 24 30
+                  + add
+                buttons: Apply | Cancel
+                model:
+                  filterType: "number"
+                  colId: "age"
+                  type: "evenNumbers"
+            `);
+        });
+    });
+});
+
+/** The expected list is named, so two grids that both filtered nothing cannot pass for agreement. */
+function expectSameAthletes(advanced: GridApi<TestRow>, column: GridApi<TestRow>, expected: string[]): void {
+    expect(filteredAthletes(advanced)).toEqual(expected);
+    expect(filteredAthletes(column)).toEqual(expected);
+}
+
+function filteredAthletes(api: GridApi<{ athlete: string }>): (string | undefined)[] {
+    const athletes: (string | undefined)[] = [];
+    api.forEachNodeAfterFilter((node) => athletes.push(node.data?.athlete));
+    return athletes;
+}

--- a/testing/behavioural/src/filters/filter-options-validation.test.ts
+++ b/testing/behavioural/src/filters/filter-options-validation.test.ts
@@ -3,6 +3,7 @@ import {
     ALL_SEVERITIES,
     ColumnFilterHarness,
     FilterDom,
+    FloatingFilterHarness,
     GridRows,
     TestGridsManager,
     asyncSetTimeout,
@@ -982,6 +983,59 @@ describe('Column filter — a malformed `filterOptions` list', () => {
         `);
     });
 
+    // The summary reads the same count the inputs did, so it names both values rather than only the first.
+    test('a numeric string `numberOfInputs` counts for the summary too', async () => {
+        const api: GridApi<AgeRow> = await gridsManager.createGridAndWait('grid1', {
+            columnDefs: [
+                {
+                    field: 'age',
+                    filter: 'agNumberColumnFilter',
+                    floatingFilter: true,
+                    filterParams: { filterOptions: [{ ...ANY_OF_TWO, numberOfInputs: '2' }] as any, debounceMs: 0 },
+                },
+            ],
+            rowData: [{ age: 25 }, { age: 40 }],
+        });
+
+        await api.setColumnFilterModel('age', { filterType: 'number', type: 'anyOfTwo', filter: 25, filterTo: 40 });
+        api.onFilterChanged();
+        await asyncSetTimeout(0);
+
+        expect(FloatingFilterHarness.get(api, 'age').input().value).toBe('25-40');
+    });
+
+    // The declared `0 | 1 | 2` is no check on a JS caller, so a count outside it is clamped into the range
+    // rather than believed: the inputs, the model and the summary then cannot disagree about the arity.
+    test('a count above the range is taken as two, and one below it as none', async () => {
+        const api: GridApi<AgeRow> = await gridsManager.createGridAndWait('grid1', {
+            columnDefs: [
+                {
+                    field: 'age',
+                    filter: 'agNumberColumnFilter',
+                    floatingFilter: true,
+                    filterParams: { filterOptions: [{ ...ANY_OF_TWO, numberOfInputs: 3 }] as any, debounceMs: 0 },
+                },
+                {
+                    field: 'age',
+                    colId: 'below',
+                    filter: 'agNumberColumnFilter',
+                    floatingFilter: true,
+                    filterParams: { filterOptions: [{ ...ANY_OF_TWO, numberOfInputs: -1 }] as any, debounceMs: 0 },
+                },
+            ],
+            rowData: [{ age: 25 }, { age: 40 }],
+        });
+
+        await api.setColumnFilterModel('age', { filterType: 'number', type: 'anyOfTwo', filter: 25, filterTo: 40 });
+        await api.setColumnFilterModel('below', { filterType: 'number', type: 'anyOfTwo', filter: 25, filterTo: 40 });
+        api.onFilterChanged();
+        await asyncSetTimeout(0);
+
+        expect(FloatingFilterHarness.get(api, 'age').input().value).toBe('25-40');
+        // No values, so the summary is the option's name and neither value is shown.
+        expect(FloatingFilterHarness.get(api, 'below').input().value).toBe('Any Of Two');
+    });
+
     test('`filterPlaceholder` is given the custom option, not an unresolved key', async () => {
         const seen: { filterOptionKey: string; filterOption: string }[] = [];
         const api = await gridsManager.createGridAndWait('grid1', {
@@ -1551,6 +1605,36 @@ describe('Column filter — the date summary for an option the grid does not def
         await new FilterDom(api, 'a zero-input custom option', { colId: 'date' }).checkFilterDom(`
             FLOATING FILTER date
             input: "Is weekend" ⊘
+            active: true
+            model:
+              filterType: "date"
+              type: "isWeekend"
+              dateFrom: null
+              dateTo: null
+        `);
+    });
+
+    test('a zero-input custom option whose `displayName` is blank is named by its key', async () => {
+        const filterParams = {
+            filterOptions: [
+                'equals',
+                { displayKey: 'isWeekend', displayName: '', numberOfInputs: 0, predicate: () => true },
+            ],
+            readOnly: true,
+            debounceMs: 0,
+        };
+        const api: GridApi = await gridsManager.createGridAndWait('grid1', {
+            columnDefs: [{ field: 'date', filter: 'agDateColumnFilter', floatingFilter: true, filterParams }],
+            rowData: [{ date: '2024-01-01' }],
+        } as GridOptions);
+
+        await api.setColumnFilterModel('date', { filterType: 'date', type: 'isWeekend', dateFrom: null, dateTo: null });
+        await api.onFilterChanged();
+        await asyncSetTimeout(0);
+
+        await new FilterDom(api, 'a zero-input custom option with a blank name', { colId: 'date' }).checkFilterDom(`
+            FLOATING FILTER date
+            input: "isWeekend" ⊘
             active: true
             model:
               filterType: "date"

--- a/testing/behavioural/src/filters/filter-options-validation.test.ts
+++ b/testing/behavioural/src/filters/filter-options-validation.test.ts
@@ -1,6 +1,7 @@
 import { waitFor } from '@testing-library/dom';
 import {
     ALL_SEVERITIES,
+    AdvancedFilterHarness,
     ColumnFilterHarness,
     FilterDom,
     FloatingFilterHarness,
@@ -22,12 +23,9 @@ import {
     enableDevValidations,
     setupAgTestIds,
 } from 'ag-grid-community';
-import { ColumnMenuModule } from 'ag-grid-enterprise';
+import { AdvancedFilterModule, ColumnMenuModule } from 'ag-grid-enterprise';
 
-/**
- * What a `filterOptions` list offers, and what is reported when it cannot: a malformed entry, a `defaultOption`
- * the list does not contain, a key one filter cannot evaluate, and a `displayKey` colliding with a built-in one.
- */
+/** What a `filterOptions` list offers, and what is reported when it cannot. */
 interface AgeRow {
     age: number;
 }
@@ -399,8 +397,7 @@ describe('Column filter — a built-in option the filter cannot evaluate', () =>
         `);
     });
 
-    // The option is offered as configured: only a `textMatcher` or a `predicate` can say what it means,
-    // and either may supply one, so it is the evaluation with neither that reports.
+    // Either a `textMatcher` or a `predicate` can say what it means, so only evaluation with neither reports.
     test('an option belonging to another filter type is offered, and reported when it is evaluated', async () => {
         enableDevValidations({ throwOn: ALL_SEVERITIES, suppress: [76] });
         const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
@@ -1004,8 +1001,7 @@ describe('Column filter — a malformed `filterOptions` list', () => {
         expect(FloatingFilterHarness.get(api, 'age').input().value).toBe('25-40');
     });
 
-    // The declared `0 | 1 | 2` is no check on a JS caller, so a count outside it is clamped into the range
-    // rather than believed: the inputs, the model and the summary then cannot disagree about the arity.
+    // Clamped rather than believed, so the inputs, the model and the summary cannot disagree about the arity.
     test('a count above the range is taken as two, and one below it as none', async () => {
         const api: GridApi<AgeRow> = await gridsManager.createGridAndWait('grid1', {
             columnDefs: [
@@ -1290,8 +1286,7 @@ describe('Column filter — the offered list survives a colDef refresh', () => {
         `);
     });
 
-    // A `colDef` is replaced, never edited, so editing the list it was given is not a change the grid acts on:
-    // the applied model survives an option disappearing from under it.
+    // A `colDef` is replaced, never edited, so the applied model survives an option disappearing from under it.
     test('a list mutated in place is not a refresh at all', async () => {
         const options: (string | IFilterOptionDef)[] = ['equals', EVEN];
         const api: GridApi<AgeRow> = await gridsManager.createGridAndWait('grid1', {
@@ -1642,5 +1637,79 @@ describe('Column filter — the date summary for an option the grid does not def
               dateFrom: null
               dateTo: null
         `);
+    });
+});
+
+describe('Column filter — the list a data type supplies', () => {
+    const gridsManager = new TestGridsManager({
+        modules: [TextFilterModule, ColumnMenuModule, AdvancedFilterModule, ClientSideRowModelModule],
+    });
+
+    beforeAll(() => {
+        setupAgTestIds();
+        installFilterLayoutMock();
+    });
+    afterAll(() => uninstallFilterLayoutMock());
+    afterEach(() => gridsManager.reset());
+
+    const SHOUT: IFilterOptionDef = {
+        displayKey: 'shout',
+        displayName: 'Shout',
+        numberOfInputs: 0,
+        predicate: () => true,
+    };
+
+    const booleanColumns: ColDef[] = [
+        { field: 'won', filter: 'agTextColumnFilter' },
+        { field: 'lost', filter: 'agTextColumnFilter' },
+    ];
+
+    test('a list edited on one boolean column does not reach another', async () => {
+        const api: GridApi = gridsManager.createGrid('grid1', {
+            columnDefs: booleanColumns,
+            rowData: [{ won: true, lost: false }],
+        });
+        await asyncSetTimeout(0);
+
+        const [won] = api.getColumnDefs()! as ColDef[];
+        won.filterParams.filterOptions.push(SHOUT);
+
+        expect(await (await ColumnFilterHarness.open(api, 'lost')).operatorOptions()).toEqual([
+            'Choose one',
+            'True',
+            'False',
+        ]);
+    });
+
+    // The grid knows its own list by content, so an edited one is the column's: both filters then offer it,
+    // where recognising the list by where it came from would have left the Advanced Filter ignoring the edit.
+    test('an edited list is offered by the Advanced Filter as well as the column filter', async () => {
+        const api: GridApi = gridsManager.createGrid('grid1', {
+            columnDefs: booleanColumns,
+            rowData: [{ won: true, lost: false }],
+            enableAdvancedFilter: true,
+        });
+        await asyncSetTimeout(0);
+
+        const af = AdvancedFilterHarness.get(api);
+        // The control: an untouched column is still the grid's, so it offers the Advanced Filter's own operators.
+        await af.type('[Lost] ');
+        expect(af.autocompleteEntries()).toEqual(['is true', 'is false', 'is blank', 'is not blank']);
+
+        const [won] = api.getColumnDefs()! as ColDef[];
+        won.filterParams.filterOptions.push(SHOUT);
+
+        await af.type('');
+        await af.type('[Won] ');
+        expect(af.autocompleteEntries()).toEqual(['True', 'False', 'Shout']);
+
+        api.setGridOption('enableAdvancedFilter', false);
+        await asyncSetTimeout(0);
+        expect(await (await ColumnFilterHarness.open(api, 'won')).operatorOptions()).toEqual([
+            'Choose one',
+            'True',
+            'False',
+            'Shout',
+        ]);
     });
 });


### PR DESCRIPTION
<!-- base: latest -->

# AG-10819: Custom Filter Options in the Advanced Filter

FIX AG-10819

A column's `filterParams.filterOptions` reached the Advanced Filter only as a list of built-in keys: a list containing a `FilterOptionDef` was discarded whole, so the column offered every default option and none of its own. It now offers a column's Custom Filter Options and evaluates them with the same `predicate` as the column filter, for options taking 0, 1 or 2 values.

| scope  | net lines |     lines changed | hunks |      files changed |
| ------ | --------: | ----------------: | ----: | -----------------: |
| source |      +391 |  1605 (+998 -607) |   179 | 22 (+1, 21 edited) |
| tests  |     +2370 | 2576 (+2473 -103) |    46 |   7 (+1, 6 edited) |
| docs   |      +317 |         317 added |     5 |   5 (+3, 2 edited) |

## A mixed `filterOptions` list narrows what a column offers

`getActiveOperators` handed back the configured array as the key list, so it bailed on any entry that was not a string: a list mixing built-in keys with `FilterOptionDef` objects narrowed nothing, and the column offered every option for its data type while offering none of its own. Each entry now maps to its key (the string itself, or the definition's `displayKey`), which is what the column configured in the first place.

Narrowing decides what is suggested, not what can be read. What the column offers is matched first, and the rest it can resolve may then lengthen that match, so an expression naming an option the list omits still applies, whether typed or restored from a saved model, and the Builder keeps it rather than clearing the condition. A column whose list was all strings rejected such an expression before; accepting it widens what parses, so nothing that worked stops working. `isOperatorOffered` is left with the Builder's column switch, where the user is choosing rather than restoring.

A key that names no operator here cannot narrow to anything, so a list of only those (the `filterOptions` the column filter understands and this one does not, such as the relative date presets or `inRange`) leaves the built-ins standing, as a list whose every entry was dropped does.

## Options are resolved per column

`AdvancedFilterExpressionService` overlays a column's Custom Filter Options on its data type's built-ins, cached per column, so `getExpressionOperator` and its siblings take the column being filtered. A `displayKey` reusing a built-in key replaces that built-in for that column alone, as it does in the column filter. A Multi Filter reads the list from the first child that declares one.

An entry missing `displayKey`, `displayName` or `predicate` is dropped and reported as warning 72, and where a list keeps nothing usable the built-ins stand. A name is the localised text, then the `displayName`, then the `displayKey`, as a column falls back from `headerName` to its field: an expression is written in that name, so an option that resolves to none is spelled by its key rather than lost. Renaming a header through `applyColumnState` now takes the old display name out of the expression vocabulary.

Shared with the column filter, so the two cannot disagree about one entry: `_classifyFilterOptions` decides what a usable entry is, `_getCustomOptionDisplayName` decides what it is called, and `_getCustomOptionNumberOfInputs` clamps `numberOfInputs` to the declared `0 | 1 | 2`, so `numberOfInputs: -1` hands the predicate no values where it previously handed it one. `_getOwn(table, key)` joins `_hasOwn` in `ag-stack`; both refuse `__proto__`, as `_mergeDeep` and `fieldAccess` already do.

The name fallback reaches the column filter too. A zero-input option whose name resolves to blank is summarised by its `displayKey` in a read-only floating filter and in the Filter Tool Panel, where the summary was previously the empty string.

## An operand region of one or two values

`ColFilterExpressionParser` gains an `OperandsParser` owning the whole operand region. One value parses as before; two are comma-separated, conventionally in brackets, which are optional:

```text
[Age] Even Numbers
[Age] Between (Exclusive) (30, 40)
[Date] Between (Exclusive) ("2012-08-12", "2012-08-30")
```

Each value is quoted by its cell data type on the rules the built-in options already use, and additionally where it contains the `,` separating the pair. Completing a two-value option from the suggestion list opens the bracket, and the first value's quote where that type is quoted; both are now written where a space already follows the caret, which previously suppressed the quote as well.

## `filterTo` on the column filter model

Every `ColumnAdvancedFilterModel` member gains `filterTo`, and `type` widens to accept a `displayKey`. `BooleanAdvancedFilterModel` gains `filter` too.

```js
const advancedFilterModel = { filterType: 'number', colId: 'age', type: 'betweenExclusive', filter: 30, filterTo: 40 };
```

## The AI toolkit schema is generated from the offered operators

`getStructuredSchema` listed each data type's operators by hand, so a Custom Filter Option was not expressible and neither was `filterTo`. The `type` enum now comes from the operators the column offers and the value slots from their arity, which also drops two mirrors that had drifted: a boolean column's enum was missing `blank` / `notBlank`, and a `dateString` column wrote `filterType: 'date'` where its model member is `'dateString'`. Models are keyed on the operator set as well as the data type, so two number columns offering different operators produce `numberAdvancedFilterModel` and `numberAdvancedFilterModel2` rather than one enum naming operators half of them do not offer.

The column filter's own schema, built when the Advanced Filter is off, takes its `type` enum from `_classifyFilterOptions` as well, so an entry the filter drops is no longer offered to a model as a legal option.

## The Builder renders a pill per value

`ConditionPillWrapperComp` holds a list of operand pills, rebuilt when the chosen option's arity changes; a pair takes the column filter's `ariaFilterFromValue` / `ariaFilterToValue` labels. Choosing a different column re-resolves the operator against what that column offers: one it does not offer is cleared, one it offers under another name is relabelled.

A condition short of an operand now holds Apply shut whether or not its row is rendered, and for either value rather than only the first: the check the mounted pill runs is the one the Builder's all-items pass runs, so a two-value option left without its second value cannot be applied from a row scrolled out of view.
