### PR TITLE
AG-18315: Fix on-this-page anchor links using stale pathname after SPA navigation

### DIFF
--- a/documentation/ag-grid-docs/src/components/pages-navigation/components/SideNavigation.tsx
+++ b/documentation/ag-grid-docs/src/components/pages-navigation/components/SideNavigation.tsx
@@ -1,5 +1,6 @@
 import { Icon } from '@ag-website-shared/components/icon/Icon';
-import { navigate, scrollIntoViewById } from '@ag-website-shared/utils/navigation';
+import { replaceHistoryUrl } from '@ag-website-shared/utils/historyUrl';
+import { scrollIntoViewById } from '@ag-website-shared/utils/navigation';
 import { useScrollSpy } from '@components/pages-navigation/hooks/useScrollSpy';
 import { addNonBreakingSpaceBetweenLastWords } from '@utils/addNonBreakingSpaceBetweenLastWords';
 import type { MarkdownHeading } from 'astro';
@@ -33,11 +34,7 @@ export function SideNavigation({ headings, delayedScrollSpy }: Props) {
                                     onClick={(event) => {
                                         event.preventDefault();
                                         scrollIntoViewById(slug);
-                                        navigate({
-                                            pathname: window.location.pathname,
-                                            search: window.location.search,
-                                            hash: slug,
-                                        });
+                                        replaceHistoryUrl(`#${slug}`);
                                     }}
                                 >
                                     {addNonBreakingSpaceBetweenLastWords(displayText)}
@@ -53,11 +50,7 @@ export function SideNavigation({ headings, delayedScrollSpy }: Props) {
                         onClick={(event) => {
                             event.preventDefault();
                             scrollIntoViewById('top');
-                            navigate({
-                                pathname: window.location.pathname,
-                                search: window.location.search,
-                                hash: 'top',
-                            });
+                            replaceHistoryUrl('#top');
                         }}
                     >
                         <Icon name="backToTop" svgClasses={styles.backToTopIcon} />

--- a/documentation/ag-grid-docs/src/components/pages-navigation/components/SideNavigation.tsx
+++ b/documentation/ag-grid-docs/src/components/pages-navigation/components/SideNavigation.tsx
@@ -33,7 +33,11 @@ export function SideNavigation({ headings, delayedScrollSpy }: Props) {
                                     onClick={(event) => {
                                         event.preventDefault();
                                         scrollIntoViewById(slug);
-                                        navigate({ search: window.location.search, hash: slug });
+                                        navigate({
+                                            pathname: window.location.pathname,
+                                            search: window.location.search,
+                                            hash: slug,
+                                        });
                                     }}
                                 >
                                     {addNonBreakingSpaceBetweenLastWords(displayText)}
@@ -49,7 +53,11 @@ export function SideNavigation({ headings, delayedScrollSpy }: Props) {
                         onClick={(event) => {
                             event.preventDefault();
                             scrollIntoViewById('top');
-                            navigate({ search: window.location.search, hash: 'top' });
+                            navigate({
+                                pathname: window.location.pathname,
+                                search: window.location.search,
+                                hash: 'top',
+                            });
                         }}
                     >
                         <Icon name="backToTop" svgClasses={styles.backToTopIcon} />


### PR DESCRIPTION
## Summary
- On the docs site, clicking a right-hand "On this page" anchor link (or "Back to top") after navigating client-side via the left menu kept the URL's pathname pinned to whatever page was first loaded in the session, instead of the current page.
- Root cause: `SideNavigation.tsx` used the shared `navigate()` helper, which wraps the `history` npm package's `browserHistory` singleton. Its cached `location.pathname` is only refreshed on `popstate`, which Astro's `<ClientRouter />` view-transition navigations never fire (they use their own `pushState` calls) - so a partial `navigate({ search, hash })` call fell back to a stale pathname.
- Beyond the reported bug, `browserHistory.push()`/`.replace()` also rebuild `history.state` as `{usr, key, idx}` on every call, unconditionally overwriting Astro's own `<ClientRouter />` session-history bookkeeping stored in that same `history.state` - which can break the page's back/forward handling. It also pushes a new back-stack entry per anchor click, which isn't desirable for scroll-to-section links.
- Fix: switch to `replaceHistoryUrl` (already used for the same "same-page hash update" pattern in `LinkIcon.tsx`'s copy-link button). It resolves the URL against the live `window.location` (no stale singleton involved) and merges `history.state` instead of overwriting it, so Astro's transition bookkeeping survives.

## Test plan
- [x] `./checks.sh` (type-check + lint) passes
- [ ] Manually verify: navigate via left-hand menu to a new page (e.g. Columns → Configuration), then click an "On this page" anchor link - confirm the URL updates to the current page's path + the anchor hash, not the first page loaded in the session
- [ ] Manually verify browser back/forward still works correctly after clicking an anchor link post-navigation
