### PR TITLE
AG-17851: remove the October 2026 date from the Beyond the Prompt page

### DIFF
--- a/documentation/ag-grid-docs/src/pages/community/beyond-the-prompt.astro
+++ b/documentation/ag-grid-docs/src/pages/community/beyond-the-prompt.astro
@@ -145,8 +145,6 @@ const markdownUrl = DISABLE_MARKDOWN_DOCS ? undefined : urlWithBaseUrl('/communi
 
                         <ul class={styles.heroMeta}>
                             <li>
-                                <Icon name="alarm" />
-                                <span>October 2026</span>
                                 <Icon name="mapPin" />
                                 <span>New York City</span>
                                 <span class={styles.heroMetaNewBadge}>New!</span>

--- a/documentation/ag-grid-docs/src/utils/beyondThePromptSessions.ts
+++ b/documentation/ag-grid-docs/src/utils/beyondThePromptSessions.ts
@@ -18,9 +18,9 @@ export const PAGE_CONTENT = {
             'Engineers and experts from AG Grid, Bryntum, and beyond who spoke about what it takes to build applications that hold up in production.',
     },
     notify: {
-        location: 'New York · October 2026',
+        location: 'New York',
         heading: 'Get notified',
-        lead: "The series continues in New York this October. Leave your email and we'll let you know as soon as registration opens.",
+        lead: "The series continues in New York. Leave your email and we'll let you know as soon as registration opens.",
     },
 };
 

--- a/documentation/ag-grid-docs/src/utils/markdown-pages/buildCommunityBeyondThePromptMarkdown.test.ts
+++ b/documentation/ag-grid-docs/src/utils/markdown-pages/buildCommunityBeyondThePromptMarkdown.test.ts
@@ -32,8 +32,7 @@ describe('buildCommunityBeyondThePromptMarkdown', () => {
     });
 
     it('links to the signup section rather than reproducing the form', () => {
-        expect(output).toContain('## Get notified');
-        expect(output).toContain('New York · October 2026');
+        expect(output).toContain('## Get notified\n\nNew York');
         expect(output).toContain('[Sign up for updates](https://www.ag-grid.com/community/beyond-the-prompt/#notify)');
     });
 


### PR DESCRIPTION
Follows up [AG-17851](https://ag-grid.atlassian.net/browse/AG-17851) comment [133589](https://ag-grid.atlassian.net/browse/AG-17851?focusedCommentId=133589): the New York event isn't happening in the form it was announced, so the Beyond the Prompt page drops the specific timing while keeping the signup form.

## Changes

- **Hero meta** — removed the alarm icon and `October 2026`, leaving `📍 New York City` and the `New!` badge.
- **Get notified location** — `New York · October 2026` → `New York`.
- **Get notified lead** — "The series continues in New York **this October**." → "The series continues in New York."

The location and lead live in `beyondThePromptSessions.ts`, which the page, its markdown twin and the `/session/<slug>` routes all read, so all three stay in sync.

The markdown twin's test assertion for the notify location was retargeted to `'## Get notified\n\nNew York'` — a bare `'New York'` would have passed on the lead sentence alone and no longer guarded the location line.

## Not changed

The intro copy still ends *"The series continues later this year in New York."* (`beyondThePromptSessions.ts:12`). That's also specific timing and will read as stale, but the comment names only "October 2026" and the notify lead, so it's left for a separate call.

## Testing

`./behave.sh --project ag-grid-docs src/utils/markdown-pages/buildCommunityBeyondThePromptMarkdown.test.ts` — 6/6 passing.
