### PR TITLE
AG-18342: set explicit tabindex on docs links Safari skips

### DIFF
--- a/documentation/ag-grid-docs/src/components/SiteLogo.tsx
+++ b/documentation/ag-grid-docs/src/components/SiteLogo.tsx
@@ -13,6 +13,7 @@ export const SiteLogo: FunctionComponent = () => {
         <a
             href={SITE_BASE_URL}
             aria-label="Home"
+            tabIndex={0}
             className={siteHeaderStyles.headerLogo}
             onMouseEnter={() => {
                 setIsLogoHover(true);

--- a/documentation/ag-grid-docs/src/components/example-runner/components/ExampleRunner.tsx
+++ b/documentation/ag-grid-docs/src/components/example-runner/components/ExampleRunner.tsx
@@ -94,6 +94,7 @@ export const ExampleRunner: FunctionComponent<Props> = ({
                     {showExampleDevToolbar && <ExampleDevToolbar framework={framework} exampleName={exampleName} />}
                     <button
                         className={classnames(styles.previewCodeToggle, 'button-secondary')}
+                        tabIndex={0}
                         onClick={() => {
                             setShowCode(!showCode);
                         }}

--- a/documentation/ag-grid-docs/src/components/pages-navigation/components/SideNavigation.tsx
+++ b/documentation/ag-grid-docs/src/components/pages-navigation/components/SideNavigation.tsx
@@ -30,6 +30,7 @@ export function SideNavigation({ headings, delayedScrollSpy }: Props) {
                                 <a
                                     href={`#${slug}`}
                                     className="nav-link"
+                                    tabIndex={0}
                                     onClick={(event) => {
                                         event.preventDefault();
                                         scrollIntoViewById(slug);
@@ -46,6 +47,7 @@ export function SideNavigation({ headings, delayedScrollSpy }: Props) {
                     <a
                         href="#top"
                         className="nav-link"
+                        tabIndex={0}
                         onClick={(event) => {
                             event.preventDefault();
                             scrollIntoViewById('top');

--- a/external/ag-website-shared/src/components/docs-navigation/DocsNav.tsx
+++ b/external/ag-website-shared/src/components/docs-navigation/DocsNav.tsx
@@ -61,7 +61,7 @@ function Item({ itemData, framework, pageName }: { itemData?: any; framework?: F
     return (
         isCorrectFramework && (
             <>
-                <a href={linkUrl} className={className} {...(isExternalURL && { target: '_blank' })}>
+                <a href={linkUrl} tabIndex={0} className={className} {...(isExternalURL && { target: '_blank' })}>
                     {itemData.icon && <Icon name={itemData.icon} svgClasses={styles.itemIcon} />}
 
                     <span>
@@ -167,7 +167,7 @@ function Group({
 
     return (
         <div ref={groupRef} className={classnames(styles.group, isOpen ? styles.isOpen : '')}>
-            <button className={classnames('button-style-none', styles.groupTitle)} onClick={handleClick}>
+            <button tabIndex={0} className={classnames('button-style-none', styles.groupTitle)} onClick={handleClick}>
                 <Icon name="chevronRight" svgClasses={styles.groupChevron} />
 
                 <span>{groupData.title}</span>
@@ -266,7 +266,9 @@ export function DocsNav({
                 <div className={styles.docsNavInner}>
                     {showWhatsNew && (
                         <div className={styles.whatsNewLink}>
-                            <a href={urlWithBaseUrl('/whats-new')}>What's New</a>
+                            <a tabIndex={0} href={urlWithBaseUrl('/whats-new')}>
+                                What's New
+                            </a>
                         </div>
                     )}
 

--- a/external/ag-website-shared/src/components/footer/Footer.tsx
+++ b/external/ag-website-shared/src/components/footer/Footer.tsx
@@ -38,6 +38,7 @@ const MenuColumns = ({ footerItems }: { footerItems: FooterItem[] }) => {
                         <li key={`${title}_${name}`}>
                             <a
                                 id={`${slugger.slug(name)}-nav`}
+                                tabIndex={0}
                                 href={urlWithBaseUrl(url)}
                                 onClick={showCookiesPrefs ? toggleCookiesPrefs : undefined}
                                 {...(newTab ? { target: '_blank', rel: 'noreferrer' } : {})}

--- a/external/ag-website-shared/src/components/markdown-actions/MarkdownActions.tsx
+++ b/external/ag-website-shared/src/components/markdown-actions/MarkdownActions.tsx
@@ -92,7 +92,7 @@ export const MarkdownActions: FunctionComponent<Props> = ({ markdownHref, framew
 
     return (
         <div className={styles.markdownActions}>
-            <button type="button" className={styles.primaryAction} onClick={copyMarkdown}>
+            <button type="button" tabIndex={0} className={styles.primaryAction} onClick={copyMarkdown}>
                 {/* The hidden copy reserves room for the longest label so confirming a
                     copy cannot resize the button and shift the controls beside it. */}
                 <span className={styles.labelStack}>
@@ -104,7 +104,7 @@ export const MarkdownActions: FunctionComponent<Props> = ({ markdownHref, framew
             </button>
 
             <DropdownMenu.Root>
-                <DropdownMenu.Trigger className={styles.trigger} aria-label="More markdown actions">
+                <DropdownMenu.Trigger tabIndex={0} className={styles.trigger} aria-label="More markdown actions">
                     <ChevronDown className={styles.chevron} />
                 </DropdownMenu.Trigger>
 

--- a/external/ag-website-shared/src/components/product-dropdown/ProductDropdown.tsx
+++ b/external/ag-website-shared/src/components/product-dropdown/ProductDropdown.tsx
@@ -136,7 +136,11 @@ export const ProductDropdown = ({ items, children }: { items: ProductMenu; child
 
     return (
         <div ref={dropdownRef} className={`${styles.customMenu} ${isOpen ? styles.open : ''}`}>
-            <button className={`${styles.customTrigger} ${isOpen ? styles.open : ''}`} onClick={handleMenuToggle}>
+            <button
+                className={`${styles.customTrigger} ${isOpen ? styles.open : ''}`}
+                onClick={handleMenuToggle}
+                tabIndex={0}
+            >
                 Products
                 <span className={styles.arrow}></span>
             </button>
@@ -162,7 +166,7 @@ export const ProductDropdown = ({ items, children }: { items: ProductMenu; child
                                             {item.inlineHeading}
                                         </div>
                                     )}
-                                    <a href={item.url} className={styles.itemsWrapper}>
+                                    <a tabIndex={0} href={item.url} className={styles.itemsWrapper}>
                                         <div className={placeholderClass}>{getIconComponent(item)}</div>
                                         <div className={styles.productsWrapper}>
                                             <div className={styles.productTitle}>{item.title}</div>

--- a/external/ag-website-shared/src/components/site-header/DarkModeToggle.tsx
+++ b/external/ag-website-shared/src/components/site-header/DarkModeToggle.tsx
@@ -11,6 +11,7 @@ export const DarkModeToggle = () => {
             <button
                 className={classNames(styles.navLink, 'button-style-none')}
                 aria-label="Dark mode selector"
+                tabIndex={0}
                 onClick={() => setDarkmode(!darkmode)}
             >
                 <div className={classNames(styles.icon, styles.pseudoIcon)} />

--- a/external/ag-website-shared/src/components/site-header/HeaderNav.tsx
+++ b/external/ag-website-shared/src/components/site-header/HeaderNav.tsx
@@ -82,6 +82,7 @@ const HeaderLinks = ({
                             id={`${toggleIsOpen ? 'mobile-' : ''}${slugger.slug(title)}-nav`}
                             className={styles.navLink}
                             href={href}
+                            tabIndex={0}
                             onClick={() => {
                                 if (isOpen) {
                                     toggleIsOpen?.();

--- a/external/ag-website-shared/src/components/site-header/SiteHeader.astro
+++ b/external/ag-website-shared/src/components/site-header/SiteHeader.astro
@@ -50,6 +50,7 @@ const allPaths = [
                             id="top-bar-docs-button"
                             class:list={[styles.mobileNavButton, 'button-secondary']}
                             type="button"
+                            tabindex={0}
                             data-toggle="collapse"
                             data-target="#side-nav"
                             aria-controls="side-nav"

--- a/external/ag-website-shared/src/components/tabs/TabNavItem.tsx
+++ b/external/ag-website-shared/src/components/tabs/TabNavItem.tsx
@@ -20,6 +20,7 @@ export const TabNavItem = ({
                     onSelect(label);
                 }}
                 role="tab"
+                tabIndex={0}
                 disabled={selected}
             >
                 {label}


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-18342

Sets an explicit `tabindex="0"` on the docs links and buttons Safari skips, porting the equivalent AG Charts fixes (ag-charts#7898, ag-charts#7695).

Fix [AG-18342](https://ag-grid.atlassian.net/browse/AG-18342)
