### PR TITLE
gh-triage: wire the 'Force Full Retriage' manual-trigger button

### DIFF
--- a/.github/workflows/github-triage-pipeline.yml
+++ b/.github/workflows/github-triage-pipeline.yml
@@ -41,6 +41,21 @@ name: GitHub issue AI triage
 #        rules.md, letting repro-rebuild run without ever needing browser-verify.
 #        POST /repos/ag-grid/ag-grid/dispatches
 #        {"event_type":"gh-triage-manual-repro-rebuild","client_payload":{"issue_key":"AITGH-XXX"}})
+#   repository_dispatch gh-triage-manual-triage → ALWAYS stage=triage — a fourth AITGH
+#       button, "Force Full Retriage". DESTRUCTIVE, unlike the three above: `triage`
+#       never rehydrates prior state (pre(triage) never calls pullState), so it
+#       overwrites ai_summary/ai_analysis/ai_suggested_action/ai_bug_draft from a
+#       clean re-read of the GitHub issue, discarding every human comment's
+#       influence, any browser-verify evidence, and any repro-rebuild TC1 swap
+#       already on the ticket. Reach for it only when the analysis is WRONG, not
+#       merely stale — "Resume Analysis" (gh-triage-manual-resume above) is the
+#       routine tool. Needs only `issue_key` in the payload: `pre(triage)` resolves
+#       the GH issue number from the mapping ticket's own `gh_issue_number` field
+#       whenever an issue key is passed (see ag-dev-prompts github-triage-pipeline
+#       action's CLAUDE.md § "A drag on a ticket whose triage left NOTHING routes
+#       triage, not resume"), so this needed zero action-side code changes.
+#       POST /repos/ag-grid/ag-grid/dispatches
+#       {"event_type":"gh-triage-manual-triage","client_payload":{"issue_key":"AITGH-XXX"}})
 #   workflow_dispatch                  → force a stage (dry-run / debugging)
 # ============================================================================
 
@@ -60,7 +75,7 @@ on:
     issues:
         types: [opened, labeled]
     repository_dispatch:
-        types: [gh-triage-resume, gh-triage-manual-resume, gh-triage-manual-browser-verify, gh-triage-manual-repro-rebuild]
+        types: [gh-triage-resume, gh-triage-manual-resume, gh-triage-manual-browser-verify, gh-triage-manual-repro-rebuild, gh-triage-manual-triage]
     workflow_dispatch:
         inputs:
             stage:
@@ -265,7 +280,7 @@ jobs:
     # -------------------------------------------------- run
     # The parameterised stage runner (triage / resume / execute / browser-verify /
     # repro-rebuild). Runs on a dispatch (forced, or the auto-triage self-dispatch
-    # from `redispatch` above), a non-empty preflight route, or one of the three
+    # from `redispatch` above), a non-empty preflight route, or one of the four
     # manual-trigger button events (which — unlike gh-triage-resume — always resolve
     # to ONE specific stage directly, no preflight/routing involved: the PM's button
     # click IS the unambiguous intent signal).
@@ -283,6 +298,7 @@ jobs:
               || (github.event_name == 'repository_dispatch' && github.event.action == 'gh-triage-manual-resume')
               || (github.event_name == 'repository_dispatch' && github.event.action == 'gh-triage-manual-browser-verify')
               || (github.event_name == 'repository_dispatch' && github.event.action == 'gh-triage-manual-repro-rebuild')
+              || (github.event_name == 'repository_dispatch' && github.event.action == 'gh-triage-manual-triage')
             ) &&
             needs.preflight.outputs.stage != 'execute' && inputs.stage != 'execute'
         runs-on: ubuntu-latest
@@ -328,7 +344,7 @@ jobs:
                   # makes it structurally impossible for anything
                   # preflight-related to override or block a manual dispatch,
                   # regardless of preflight's own behaviour.
-                  stage: ${{ (github.event.action == 'gh-triage-manual-resume' && 'resume') || (github.event.action == 'gh-triage-manual-browser-verify' && 'browser-verify') || (github.event.action == 'gh-triage-manual-repro-rebuild' && 'repro-rebuild') || needs.preflight.outputs.stage || inputs.stage || 'triage' }}
+                  stage: ${{ (github.event.action == 'gh-triage-manual-resume' && 'resume') || (github.event.action == 'gh-triage-manual-browser-verify' && 'browser-verify') || (github.event.action == 'gh-triage-manual-repro-rebuild' && 'repro-rebuild') || (github.event.action == 'gh-triage-manual-triage' && 'triage') || needs.preflight.outputs.stage || inputs.stage || 'triage' }}
                   product: grid
                   # NOTE: `allowed_non_write_users` is deliberately NOT passed, and must
                   # stay unset — setting it re-breaks the auto-triage path. The actor is a


### PR DESCRIPTION
## Summary
Wires a fourth Jira "Manual trigger" button — **Force Full Retriage** —
alongside the existing "Resume Analysis" / "Verify Repro (Browser)" /
"Rebuild Repro Link". Dispatches `stage=triage` directly (no
preflight/routing), same pattern as the other three manual buttons.

**Destructive, unlike the other three**: `triage` never rehydrates prior
state, so it overwrites the ticket's AI analysis/summary/suggested-action/
bug-draft from a clean re-read of the GitHub issue — discarding any human
comments, browser-verify evidence, or repro-rebuild TC1 swap already on the
ticket. It's the tool for "the analysis is *wrong*, not just stale" — see
the Jira Automation setup instructions for how it's positioned/labelled.

**No pipeline (action-side) code changes needed** — `pre(triage)` already
resolves the GH issue number from the mapping ticket's own `gh_issue_number`
field whenever an issue key is passed with no `gh_issue`, which is exactly
this button's minimal payload shape (`{"issue_key": "AITGH-XXX"}`, same as
"Resume Analysis"). See `ag-dev-prompts`'s
`.github/actions/github-triage-pipeline/CLAUDE.md` § *"Force Full Retriage"
Jira button*.

## Test plan
- [x] `actionlint` on the modified workflow — clean.
- [x] Diff reviewed against the three existing manual-trigger buttons for
      pattern consistency (dispatch type list, `run` job `if:`, stage
      resolution ternary — same priority position, evaluated before
      `preflight`'s output per the existing #14624 precedent).
- [ ] Live dispatch smoke test after merge (companion Jira Automation rule
      needs setting up first — see ag-dev-prompts docs).
