### PR TITLE
AG-18315: Fix scroll-spy regression from the replaceHistoryUrl switch

### DIFF
--- a/documentation/ag-grid-docs/src/components/pages-navigation/components/SideNavigation.tsx
+++ b/documentation/ag-grid-docs/src/components/pages-navigation/components/SideNavigation.tsx
@@ -1,6 +1,5 @@
 import { Icon } from '@ag-website-shared/components/icon/Icon';
-import { replaceHistoryUrl } from '@ag-website-shared/utils/historyUrl';
-import { scrollIntoViewById } from '@ag-website-shared/utils/navigation';
+import { navigate, scrollIntoViewById } from '@ag-website-shared/utils/navigation';
 import { useScrollSpy } from '@components/pages-navigation/hooks/useScrollSpy';
 import { addNonBreakingSpaceBetweenLastWords } from '@utils/addNonBreakingSpaceBetweenLastWords';
 import type { MarkdownHeading } from 'astro';
@@ -35,7 +34,11 @@ export function SideNavigation({ headings, delayedScrollSpy }: Props) {
                                     onClick={(event) => {
                                         event.preventDefault();
                                         scrollIntoViewById(slug);
-                                        replaceHistoryUrl(`#${slug}`);
+                                        navigate({
+                                            pathname: window.location.pathname,
+                                            search: window.location.search,
+                                            hash: slug,
+                                        });
                                     }}
                                 >
                                     {addNonBreakingSpaceBetweenLastWords(displayText)}
@@ -52,7 +55,11 @@ export function SideNavigation({ headings, delayedScrollSpy }: Props) {
                         onClick={(event) => {
                             event.preventDefault();
                             scrollIntoViewById('top');
-                            replaceHistoryUrl('#top');
+                            navigate({
+                                pathname: window.location.pathname,
+                                search: window.location.search,
+                                hash: 'top',
+                            });
                         }}
                     >
                         <Icon name="backToTop" svgClasses={styles.backToTopIcon} />


### PR DESCRIPTION
## Summary
Follow-up to #14975 (merged), which switched `SideNavigation.tsx`'s "On this page" anchor links from `navigate()` to `replaceHistoryUrl` to fix a stale-pathname bug after client-side navigation via Astro's `<ClientRouter />`.

While porting that same change to ag-charts, its equivalent `e2e/docs-page-nav.spec.ts` caught a regression: `useScrollSpy`'s effect depends on `useLocation()`'s hash (backed by the `history` package's `browserHistory.listen()`) to re-run `scrollspy()` on click. `replaceHistoryUrl` calls the native `history.replaceState` directly and fires no listener, so that reactivity - previously assumed to be a redundant safety net alongside the live `scroll` listener - turned out to be load-bearing for at least one case: clicking a heading near the bottom of a long API-reference page.

Grid's `useScrollSpy` (`documentation/ag-grid-docs/src/components/pages-navigation/hooks/useScrollSpy.ts`) has the identical `[location?.hash, ...]` dependency, so #14975 likely introduced the same scroll-spy regression here - just without an equivalent e2e test to catch it, since grid has no `docs-page-nav`-style spec.

## Fix
Revert to `navigate()`, but pass `pathname: window.location.pathname` explicitly instead of relying on `browserHistory`'s cached (and, per the original bug, stale) location to fill it in. This fixes the original stale-pathname issue while keeping the scroll-spy's `browserHistory.listen()` reactivity intact.

## Test plan
- [x] `./checks.sh` (type-check + lint) passes
- [x] Verified in ag-charts via a real Playwright run (no equivalent test exists in this repo): the `replaceHistoryUrl` version fails "highlights the clicked section on an API page" at the second-to-last heading, and the `navigate()` + explicit `pathname` version passes both cases
- [ ] Manually verify on this repo: navigate via left-hand menu to a page with a long "On this page" list (e.g. an API reference page), click through several headings including ones near the bottom, and confirm the correct entry gets highlighted each time
- [ ] Manually verify the original AG-18315 repro is still fixed: navigate via the left-hand menu to a new page, click an "On this page" anchor link, and confirm the URL reflects the current page's path, not the first page loaded in the session