### PR TITLE
AG-18348: Fix tab links using a stale pathname after SPA navigation

### DIFF
--- a/documentation/ag-grid-docs/src/components/reference-documentation/components/Property.tsx
+++ b/documentation/ag-grid-docs/src/components/reference-documentation/components/Property.tsx
@@ -3,7 +3,6 @@ import Code from '@ag-website-shared/components/code/Code';
 import { Icon } from '@ag-website-shared/components/icon/Icon';
 import { LinkIcon } from '@ag-website-shared/components/link-icon/LinkIcon';
 import styles from '@ag-website-shared/components/reference-documentation/ApiReference.module.scss';
-import { useScrollToAnchor } from '@ag-website-shared/utils/navigation';
 import { urlWithPrefix } from '@utils/urlWithPrefix';
 import classnames from 'classnames';
 import { Fragment, type FunctionComponent, useCallback, useEffect, useRef, useState } from 'react';
@@ -240,7 +239,6 @@ export const Property: FunctionComponent<{
 
     const propertyRef = useRef<HTMLTableRowElement>(null);
     const [isExpanded, setExpanded] = useState(config.defaultExpand);
-    const scrollToAnchor = useScrollToAnchor();
 
     useEffect(() => {
         const hashId = location.hash.slice(1); // Remove the '#' symbol
@@ -271,7 +269,6 @@ export const Property: FunctionComponent<{
                             <span dangerouslySetInnerHTML={{ __html: displayNameSplit }}></span>
                             <LinkIcon
                                 href={`#${idName}`}
-                                onClick={scrollToAnchor}
                                 className={styles.linkIcon}
                                 aria-label={`Link to ${name} property`}
                             />

--- a/external/ag-website-shared/src/components/tabs/TabsWithHtmlChildren.astro
+++ b/external/ag-website-shared/src/components/tabs/TabsWithHtmlChildren.astro
@@ -112,7 +112,16 @@ const { tabItemIdPrefix, headerLinks, snippetTabs } = Astro.props as Props;
                     this.updateTabs();
 
                     const tabId = getTabId({ id: this.selected.id, prefix: this.tabItemIdPrefix });
-                    navigate(`#${tabId}`);
+                    // Pass the whole location: a bare hash is resolved against the `history`
+                    // package's cached location, which Astro's `<ClientRouter />` never
+                    // refreshes, leaving the pathname on whichever page loaded first. Keep
+                    // `navigate` rather than `replaceHistoryUrl` - the `browserHistory`
+                    // listener above syncs sibling tab groups, and only a push fires it.
+                    navigate({
+                        pathname: window.location.pathname,
+                        search: window.location.search,
+                        hash: tabId,
+                    });
                 });
             });
         }

--- a/external/ag-website-shared/src/utils/navigation.ts
+++ b/external/ag-website-shared/src/utils/navigation.ts
@@ -1,7 +1,6 @@
 import type { Location, To, Update } from 'history';
 import { createBrowserHistory } from 'history';
-import { useCallback, useEffect, useState } from 'react';
-import type { MouseEventHandler } from 'react';
+import { useEffect, useState } from 'react';
 
 export const browserHistory = import.meta.env.SSR ? null : createBrowserHistory();
 
@@ -13,19 +12,6 @@ export function useLocation() {
     const [location, setLocation] = useState<Location | null>(browserHistory?.location ?? null);
     useHistory(({ location }) => setLocation(location));
     return location;
-}
-
-export function useScrollToAnchor() {
-    const handleScroll: MouseEventHandler<HTMLAnchorElement> = useCallback((event) => {
-        event.preventDefault();
-        navigate(event.currentTarget.href);
-        const href = event.currentTarget.getAttribute('href');
-        if (href?.startsWith('#')) {
-            scrollIntoViewById(href.substring(1));
-        }
-    }, []);
-
-    return handleScroll;
 }
 
 export function navigate(to: To, options?: { state?: any; replace?: boolean }) {


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-18348

Fix [AG-18348](https://ag-grid.atlassian.net/browse/AG-18348)

Tab clicks passed a bare hash to `navigate()`, so the `history` package filled the
pathname in from its own cached location, which Astro's `<ClientRouter />` only
refreshes on `popstate`. After a client-side navigation the URL kept the pathname of
the page loaded first. The full location is now passed explicitly. `navigate()` is kept
rather than `replaceHistoryUrl` because only a push fires the `browserHistory` listener
that keeps sibling tab groups in sync.

The ticket's second issue asked for the property reference anchor links to migrate to
`replaceHistoryUrl`. That migration is already in place by another route: `LinkIcon`
spreads incoming props before setting its own `onClick`, so the `useScrollToAnchor`
handler passed to it was overridden and never ran, and `LinkIcon`'s handler already
calls `replaceHistoryUrl`. That is why the reported symptoms do not occur on `latest` -
repeated property anchor clicks leave `history.length` unchanged and Astro's
`history.state` keys intact. The dead prop and the now-unreachable hook are removed
instead of migrating code that never executed.