### PR TITLE
SE-162 Remove the incomplete Enterprise offer from the docs product structured data

### DIFF
--- a/documentation/ag-grid-docs/src/layouts/Layout.astro
+++ b/documentation/ag-grid-docs/src/layouts/Layout.astro
@@ -187,11 +187,6 @@ const structuredData: JsonLdObject[] = includeStructuredData
                       priceCurrency: 'USD',
                       url: licensePricingUrl,
                   },
-                  {
-                      '@type': 'Offer',
-                      name: 'AG Grid Enterprise',
-                      url: licensePricingUrl,
-                  },
               ],
           }),
           ...(pageStructuredData ?? []),


### PR DESCRIPTION
Google reports 2 errors on the SoftwareApplication JSON-LD emitted by the shared docs layout, so it shows as invalid structured data in Search Console across around 2,480 documentation pages: two `offers` where Community is priced 0 and Enterprise gives a url with no price, and no rating or review.

These are documentation pages, not a product or pricing page, so the aim is to clear the invalid markup rather than earn a product result. No price is added (Enterprise pricing is quote-based) and no rating is added (a rating should only come from real reviews).

Removing the incomplete Enterprise offer leaves the valid Community offer and clears both errors.

Re-check in Google's Rich Results Test after deploy.

Jira: SE-162