### PR TITLE
SE-166 Point internal links at final URLs instead of redirects

### DIFF
--- a/documentation/ag-grid-docs/src/components/campaigns-components/ReturnToSupportPage.tsx
+++ b/documentation/ag-grid-docs/src/components/campaigns-components/ReturnToSupportPage.tsx
@@ -273,7 +273,7 @@ const ReturnToSupportPage: React.FC<ReturnToSupportPageProps> = ({ versionsData,
                 title="Recent improvements"
                 subtitle="The latest updates and improvements to AG Grid"
                 viewAllButtonText="View recent releases"
-                viewAllButtonUrl="/whats-new"
+                viewAllButtonUrl="/whats-new/"
             />
 
             <section className={styles.rtsTrustedSection}>

--- a/documentation/ag-grid-docs/src/content/docs-nav/nav.json
+++ b/documentation/ag-grid-docs/src/content/docs-nav/nav.json
@@ -541,7 +541,7 @@
                         {
                             "type": "item",
                             "title": "See AG Charts",
-                            "url": "https://www.ag-grid.com/charts"
+                            "url": "https://www.ag-grid.com/charts/"
                         }
                     ]
                 },
@@ -552,7 +552,7 @@
                         {
                             "type": "item",
                             "title": "See AG Studio",
-                            "url": "https://www.ag-grid.com/studio"
+                            "url": "https://www.ag-grid.com/studio/"
                         }
                     ]
                 },

--- a/documentation/ag-grid-docs/src/content/site-header/header.json
+++ b/documentation/ag-grid-docs/src/content/site-header/header.json
@@ -3,12 +3,12 @@
         "items": [
             {
                 "title": "AG Charts",
-                "url": "https://www.ag-grid.com/charts",
+                "url": "https://www.ag-grid.com/charts/",
                 "isCollapsed": true
             },
             {
                 "title": "AG Studio",
-                "url": "https://www.ag-grid.com/studio",
+                "url": "https://www.ag-grid.com/studio/",
                 "isCollapsed": true
             },
             {

--- a/documentation/ag-grid-docs/src/utils/htaccess/__snapshots__/htaccessRules.test.ts.snap
+++ b/documentation/ag-grid-docs/src/utils/htaccess/__snapshots__/htaccessRules.test.ts.snap
@@ -2624,7 +2624,7 @@ AddCharset utf-8 .md
     Redirect 301 /react-data-grid/component-cell-editor-imperative-react/ /react-data-grid/cell-editors/
     Redirect 301 /cookies.php /cookies/
     Redirect 301 /privacy.php /privacy/
-    Redirect 301 /about.php /about
+    Redirect 301 /about.php /about/
     Redirect 301 /license-pricing.php /license-pricing/
     Redirect 301 /example.php /example/
     Redirect 301 /ag-grid-jobs-board.php /ag-grid-jobs-board

--- a/documentation/ag-grid-docs/src/utils/htaccess/__snapshots__/htaccessRules.test.ts.snap
+++ b/documentation/ag-grid-docs/src/utils/htaccess/__snapshots__/htaccessRules.test.ts.snap
@@ -2628,10 +2628,10 @@ AddCharset utf-8 .md
     Redirect 301 /license-pricing.php /license-pricing/
     Redirect 301 /example.php /example/
     Redirect 301 /ag-grid-jobs-board.php /ag-grid-jobs-board
-    Redirect 301 /react-data-grid/whats-new /whats-new
-    Redirect 301 /vue-data-grid/whats-new /whats-new
-    Redirect 301 /angular-data-grid/whats-new /whats-new
-    Redirect 301 /javascript-data-grid/whats-new /whats-new
+    Redirect 301 /react-data-grid/whats-new /whats-new/
+    Redirect 301 /vue-data-grid/whats-new /whats-new/
+    Redirect 301 /angular-data-grid/whats-new /whats-new/
+    Redirect 301 /javascript-data-grid/whats-new /whats-new/
     Redirect 301 /vue-data-grid/framework-data-flow /vue-data-grid/getting-started/
     Redirect 301 /react-data-grid/licensing/ /react-data-grid/community-vs-enterprise/
     Redirect 301 /vue-data-grid/licensing/ /vue-data-grid/community-vs-enterprise/

--- a/documentation/ag-grid-docs/src/utils/htaccess/__snapshots__/htaccessRules.test.ts.snap
+++ b/documentation/ag-grid-docs/src/utils/htaccess/__snapshots__/htaccessRules.test.ts.snap
@@ -2882,6 +2882,7 @@ AddCharset utf-8 .md
     RedirectMatch 301 "^/community-forums/$" "/community/"
     RedirectMatch 410 "^/forum/.+"
     Redirect 410 /testimonials.php
+    Redirect 410 /blog/whats-new-in-ag-grid-v24/
     Redirect 301 /start-trial.php /license-pricing/
     Redirect 301 /options/series/radial-column/ https://www.ag-grid.com/charts/options/series/radial-column/
     Redirect 301 /options/series/area/ https://www.ag-grid.com/charts/options/series/area/

--- a/documentation/ag-grid-docs/src/utils/htaccess/redirects.ts
+++ b/documentation/ag-grid-docs/src/utils/htaccess/redirects.ts
@@ -3321,6 +3321,9 @@ export const SITE_301_REDIRECTS: Redirect[] = [
     { fromPattern: '^/community-forums/$', to: '/community/' },
     { fromPattern: '^/forum/.+', gone: true },
     { from: '/testimonials.php', gone: true },
+    // The trailing slash is required: Apache's `Redirect` prefix-matches, so without it this
+    // would also swallow the live /blog/whats-new-in-ag-grid-v24-part-2/.
+    { from: '/blog/whats-new-in-ag-grid-v24/', gone: true },
     { from: '/start-trial.php', to: '/license-pricing/' },
     { from: '/options/series/radial-column/', to: 'https://www.ag-grid.com/charts/options/series/radial-column/' },
     { from: '/options/series/area/', to: 'https://www.ag-grid.com/charts/options/series/area/' },

--- a/documentation/ag-grid-docs/src/utils/htaccess/redirects.ts
+++ b/documentation/ag-grid-docs/src/utils/htaccess/redirects.ts
@@ -3118,7 +3118,7 @@ export const SITE_301_REDIRECTS: Redirect[] = [
     // SE-64: target the final (trailing-slashed) page directly to remove the extra hop
     { from: '/cookies.php', to: '/cookies/' },
     { from: '/privacy.php', to: '/privacy/' },
-    { from: '/about.php', to: '/about' },
+    { from: '/about.php', to: '/about/' },
     { from: '/license-pricing.php', to: '/license-pricing/' },
     { from: '/example.php', to: '/example/' },
     { from: '/ag-grid-jobs-board.php', to: '/ag-grid-jobs-board' },

--- a/documentation/ag-grid-docs/src/utils/htaccess/redirects.ts
+++ b/documentation/ag-grid-docs/src/utils/htaccess/redirects.ts
@@ -3123,10 +3123,10 @@ export const SITE_301_REDIRECTS: Redirect[] = [
     { from: '/example.php', to: '/example/' },
     { from: '/ag-grid-jobs-board.php', to: '/ag-grid-jobs-board' },
 
-    { from: '/react-data-grid/whats-new', to: '/whats-new' },
-    { from: '/vue-data-grid/whats-new', to: '/whats-new' },
-    { from: '/angular-data-grid/whats-new', to: '/whats-new' },
-    { from: '/javascript-data-grid/whats-new', to: '/whats-new' },
+    { from: '/react-data-grid/whats-new', to: '/whats-new/' },
+    { from: '/vue-data-grid/whats-new', to: '/whats-new/' },
+    { from: '/angular-data-grid/whats-new', to: '/whats-new/' },
+    { from: '/javascript-data-grid/whats-new', to: '/whats-new/' },
     { from: '/vue-data-grid/framework-data-flow', to: '/vue-data-grid/getting-started/' },
 
     { from: '/react-data-grid/licensing/', to: '/react-data-grid/community-vs-enterprise/' },

--- a/documentation/ag-grid-docs/testing/htaccess-harness/expectations.generated.tsv
+++ b/documentation/ag-grid-docs/testing/htaccess-harness/expectations.generated.tsv
@@ -6048,7 +6048,7 @@ www	/react-data-grid/component-cell-editor-imperative-react/child	301	/react-dat
 www	/react-data-grid/component-cell-editor-imperative-react/child/	301	/react-data-grid/cell-editors/child/
 www	/cookies.php	301	/cookies/
 www	/privacy.php	301	/privacy/
-www	/about.php	301	/about
+www	/about.php	301	/about/
 www	/license-pricing.php	301	/license-pricing/
 www	/example.php	301	/example/
 www	/ag-grid-jobs-board.php	301	/ag-grid-jobs-board

--- a/documentation/ag-grid-docs/testing/htaccess-harness/expectations.generated.tsv
+++ b/documentation/ag-grid-docs/testing/htaccess-harness/expectations.generated.tsv
@@ -6053,13 +6053,13 @@ www	/license-pricing.php	301	/license-pricing/
 www	/example.php	301	/example/
 www	/ag-grid-jobs-board.php	301	/ag-grid-jobs-board
 www	/react-data-grid/whats-new	301	/react-data-grid/whats-new/
-www	/react-data-grid/whats-new/	301	/whats-new
+www	/react-data-grid/whats-new/	301	/whats-new/
 www	/vue-data-grid/whats-new	301	/vue-data-grid/whats-new/
-www	/vue-data-grid/whats-new/	301	/whats-new
+www	/vue-data-grid/whats-new/	301	/whats-new/
 www	/angular-data-grid/whats-new	301	/angular-data-grid/whats-new/
-www	/angular-data-grid/whats-new/	301	/whats-new
+www	/angular-data-grid/whats-new/	301	/whats-new/
 www	/javascript-data-grid/whats-new	301	/javascript-data-grid/whats-new/
-www	/javascript-data-grid/whats-new/	301	/whats-new
+www	/javascript-data-grid/whats-new/	301	/whats-new/
 www	/vue-data-grid/framework-data-flow	301	/vue-data-grid/framework-data-flow/
 www	/vue-data-grid/framework-data-flow/	301	/vue-data-grid/getting-started/
 www	/react-data-grid/licensing/	301	/react-data-grid/community-vs-enterprise/

--- a/documentation/ag-grid-docs/testing/htaccess-harness/expectations.tsv
+++ b/documentation/ag-grid-docs/testing/htaccess-harness/expectations.tsv
@@ -73,6 +73,11 @@ www	/react-grid/rxjs/	301	https://www.ag-grid.com/react-data-grid/data-update/
 # --- AG-17694: Beyond the Prompt moved /campaigns/ -> /community/ ---
 www	/campaigns/beyond-the-prompt/	301	/community/beyond-the-prompt/
 
+# --- SE-166: /blog/whats-new-in-ag-grid-v24/ is gone on www too, and must not swallow -part-2 ---
+www	/blog/whats-new-in-ag-grid-v24/	410
+www	/blog/whats-new-in-ag-grid-v24/amp/	410
+www	/blog/whats-new-in-ag-grid-v24-part-2/	200
+
 # --- No-shadow negatives: real live pages must NOT be redirected (expect 200) ---
 www	/angular-data-grid/getting-started/	200
 www	/react-data-grid/cell-editing/	200

--- a/external/ag-website-shared/src/components/contact-form/ContactResultPage.astro
+++ b/external/ag-website-shared/src/components/contact-form/ContactResultPage.astro
@@ -31,7 +31,7 @@ const resources = [
         title: "See what's new",
         description: "Check out recent releases and see what we've improved",
         linkText: 'Learn more',
-        linkUrl: urlWithBaseUrl('/whats-new'),
+        linkUrl: urlWithBaseUrl('/whats-new/'),
     },
 ];
 

--- a/external/ag-website-shared/src/components/docs-navigation/DocsNav.tsx
+++ b/external/ag-website-shared/src/components/docs-navigation/DocsNav.tsx
@@ -274,7 +274,7 @@ export function DocsNav({
                 <div className={styles.docsNavInner}>
                     {showWhatsNew && (
                         <div className={styles.whatsNewLink}>
-                            <a tabIndex={0} href={urlWithBaseUrl('/whats-new')}>
+                            <a tabIndex={0} href={urlWithBaseUrl('/whats-new/')}>
                                 What's New
                             </a>
                         </div>

--- a/external/ag-website-shared/src/components/landing-pages/sections/HeroSection.astro
+++ b/external/ag-website-shared/src/components/landing-pages/sections/HeroSection.astro
@@ -54,7 +54,7 @@ const showCustomerLogos = section.showCustomerLogos !== false;
                 {
                     section.showVersionBadge && latestVersion && (
                         <a
-                            href={urlWithBaseUrl('./whats-new')}
+                            href={urlWithBaseUrl('./whats-new/')}
                             class:list={[
                                 styles.heroSectionVersionTagContainer,
                                 `plausible-event-name=${pageContent.analyticsPrefix}-whats-new`,

--- a/external/ag-website-shared/src/components/releases-section/ReleasesSection.tsx
+++ b/external/ag-website-shared/src/components/releases-section/ReleasesSection.tsx
@@ -33,7 +33,7 @@ export const ReleasesSection: React.FC<ReleasesSectionProps> = ({
     subtitle = "Here's what you've missed since you've been gone",
     showViewAllButton = true,
     viewAllButtonText = 'View recent releases',
-    viewAllButtonUrl = '/whats-new',
+    viewAllButtonUrl = '/whats-new/',
 }) => {
     // Filter versions that have highlights and are not hidden
     const filteredVersions = versionsData

--- a/external/ag-website-shared/src/components/roadmap/Roadmap.tsx
+++ b/external/ag-website-shared/src/components/roadmap/Roadmap.tsx
@@ -55,7 +55,7 @@ export const Roadmap: React.FC<RoadmapProps> = ({ roadmapData, versionData }) =>
                                     Release Notes <Icon name="chevronRight" />
                                 </a>
                             )}
-                            <a href={urlWithBaseUrl('./whats-new')} target="_blank" className={styles.heroCta}>
+                            <a href={urlWithBaseUrl('./whats-new/')} target="_blank" className={styles.heroCta}>
                                 What's New <Icon name="chevronRight" />
                             </a>
                         </div>

--- a/external/ag-website-shared/src/content/products/menu.json
+++ b/external/ag-website-shared/src/content/products/menu.json
@@ -10,12 +10,12 @@
             {
                 "title": "AG Charts",
                 "description": "Best JavaScript Charts in the World",
-                "url": "https://www.ag-grid.com/charts"
+                "url": "https://www.ag-grid.com/charts/"
             },
             {
                 "title": "AG Studio",
                 "description": "Best JavaScript Dashboard in the World",
-                "url": "https://www.ag-grid.com/studio"
+                "url": "https://www.ag-grid.com/studio/"
             },
             {
                 "title": "Bryntum Gantt",


### PR DESCRIPTION
Internal links that resolve to a 301 make every visitor and crawler take an extra hop. This covers the in-repo surfaces.

Trailing slashes added to the bare `/charts` and `/studio` URLs, which appear in three nav files rather than only the site header as the ticket states:

- `documentation/ag-grid-docs/src/content/site-header/header.json`
- `documentation/ag-grid-docs/src/content/docs-nav/nav.json`
- `external/ag-website-shared/src/content/products/menu.json`

Plus `DocsNav.tsx`'s `/whats-new` link, and the four `whats-new` redirect targets in `redirects.ts`, which pointed at `/whats-new` and so chained through a second hop to `/whats-new/`.

A second commit fixes `/about.php`, whose target was still `/about` inside the block SE-64 added specifically to remove that extra hop. `/ag-grid-jobs-board` is deliberately left alone: the slash-less form is registered in `IGNORE_PAGES` and no such page exists.

The slash-less relative `path` values in `header.json` are intentionally unchanged. They are rendered through `urlWithPrefix`, which defaults `trailingSlash: true` and appends one regardless, so they already emit a trailing slash and do not redirect. Only the absolute `url` entries are emitted verbatim, which is why only those were broken.

Note `external/ag-website-shared` is a git-subrepo, so these changes also need `yarn run subrepo push external/ag-website-shared` or they will be rebased away on the next pull.

Jira: SE-166