### PR TITLE
SE-162 SE-166 Backport the structured-data and internal-link fixes to b36.1.0

### DIFF
--- a/documentation/ag-grid-docs/src/components/campaigns-components/ReturnToSupportPage.tsx
+++ b/documentation/ag-grid-docs/src/components/campaigns-components/ReturnToSupportPage.tsx
@@ -273,7 +273,7 @@ const ReturnToSupportPage: React.FC<ReturnToSupportPageProps> = ({ versionsData,
                 title="Recent improvements"
                 subtitle="The latest updates and improvements to AG Grid"
                 viewAllButtonText="View recent releases"
-                viewAllButtonUrl="/whats-new"
+                viewAllButtonUrl="/whats-new/"
             />
 
             <section className={styles.rtsTrustedSection}>

--- a/documentation/ag-grid-docs/src/content/docs-nav/nav.json
+++ b/documentation/ag-grid-docs/src/content/docs-nav/nav.json
@@ -541,7 +541,7 @@
                         {
                             "type": "item",
                             "title": "See AG Charts",
-                            "url": "https://www.ag-grid.com/charts"
+                            "url": "https://www.ag-grid.com/charts/"
                         }
                     ]
                 },
@@ -552,7 +552,7 @@
                         {
                             "type": "item",
                             "title": "See AG Studio",
-                            "url": "https://www.ag-grid.com/studio"
+                            "url": "https://www.ag-grid.com/studio/"
                         }
                     ]
                 },

--- a/documentation/ag-grid-docs/src/content/site-header/header.json
+++ b/documentation/ag-grid-docs/src/content/site-header/header.json
@@ -3,12 +3,12 @@
         "items": [
             {
                 "title": "AG Charts",
-                "url": "https://www.ag-grid.com/charts",
+                "url": "https://www.ag-grid.com/charts/",
                 "isCollapsed": true
             },
             {
                 "title": "AG Studio",
-                "url": "https://www.ag-grid.com/studio",
+                "url": "https://www.ag-grid.com/studio/",
                 "isCollapsed": true
             },
             {

--- a/documentation/ag-grid-docs/src/layouts/Layout.astro
+++ b/documentation/ag-grid-docs/src/layouts/Layout.astro
@@ -163,11 +163,6 @@ const structuredData: JsonLdObject[] = includeStructuredData
                       priceCurrency: 'USD',
                       url: licensePricingUrl,
                   },
-                  {
-                      '@type': 'Offer',
-                      name: 'AG Grid Enterprise',
-                      url: licensePricingUrl,
-                  },
               ],
           }),
           ...(pageStructuredData ?? []),

--- a/documentation/ag-grid-docs/src/utils/htaccess/__snapshots__/htaccessRules.test.ts.snap
+++ b/documentation/ag-grid-docs/src/utils/htaccess/__snapshots__/htaccessRules.test.ts.snap
@@ -2855,6 +2855,7 @@ AddCharset utf-8 .md
     RedirectMatch 301 "^/community-forums/$" "/community/"
     RedirectMatch 410 "^/forum/.+"
     Redirect 410 /testimonials.php
+    Redirect 410 /blog/whats-new-in-ag-grid-v24/
     Redirect 301 /start-trial.php /license-pricing/
     Redirect 301 /options/series/radial-column/ https://www.ag-grid.com/charts/options/series/radial-column/
     Redirect 301 /options/series/area/ https://www.ag-grid.com/charts/options/series/area/

--- a/documentation/ag-grid-docs/src/utils/htaccess/__snapshots__/htaccessRules.test.ts.snap
+++ b/documentation/ag-grid-docs/src/utils/htaccess/__snapshots__/htaccessRules.test.ts.snap
@@ -2613,7 +2613,7 @@ AddCharset utf-8 .md
     Redirect 301 /react-data-grid/component-cell-editor-imperative-react/ /react-data-grid/cell-editors/
     Redirect 301 /cookies.php /cookies/
     Redirect 301 /privacy.php /privacy/
-    Redirect 301 /about.php /about
+    Redirect 301 /about.php /about/
     Redirect 301 /license-pricing.php /license-pricing/
     Redirect 301 /example.php /example/
     Redirect 301 /ag-grid-jobs-board.php /ag-grid-jobs-board

--- a/documentation/ag-grid-docs/src/utils/htaccess/__snapshots__/htaccessRules.test.ts.snap
+++ b/documentation/ag-grid-docs/src/utils/htaccess/__snapshots__/htaccessRules.test.ts.snap
@@ -2617,10 +2617,10 @@ AddCharset utf-8 .md
     Redirect 301 /license-pricing.php /license-pricing/
     Redirect 301 /example.php /example/
     Redirect 301 /ag-grid-jobs-board.php /ag-grid-jobs-board
-    Redirect 301 /react-data-grid/whats-new /whats-new
-    Redirect 301 /vue-data-grid/whats-new /whats-new
-    Redirect 301 /angular-data-grid/whats-new /whats-new
-    Redirect 301 /javascript-data-grid/whats-new /whats-new
+    Redirect 301 /react-data-grid/whats-new /whats-new/
+    Redirect 301 /vue-data-grid/whats-new /whats-new/
+    Redirect 301 /angular-data-grid/whats-new /whats-new/
+    Redirect 301 /javascript-data-grid/whats-new /whats-new/
     Redirect 301 /vue-data-grid/framework-data-flow /vue-data-grid/getting-started/
     Redirect 301 /react-data-grid/licensing/ /react-data-grid/community-vs-enterprise/
     Redirect 301 /vue-data-grid/licensing/ /vue-data-grid/community-vs-enterprise/

--- a/documentation/ag-grid-docs/src/utils/htaccess/redirects.ts
+++ b/documentation/ag-grid-docs/src/utils/htaccess/redirects.ts
@@ -3118,7 +3118,7 @@ export const SITE_301_REDIRECTS: Redirect[] = [
     // SE-64: target the final (trailing-slashed) page directly to remove the extra hop
     { from: '/cookies.php', to: '/cookies/' },
     { from: '/privacy.php', to: '/privacy/' },
-    { from: '/about.php', to: '/about' },
+    { from: '/about.php', to: '/about/' },
     { from: '/license-pricing.php', to: '/license-pricing/' },
     { from: '/example.php', to: '/example/' },
     { from: '/ag-grid-jobs-board.php', to: '/ag-grid-jobs-board' },

--- a/documentation/ag-grid-docs/src/utils/htaccess/redirects.ts
+++ b/documentation/ag-grid-docs/src/utils/htaccess/redirects.ts
@@ -3317,6 +3317,9 @@ export const SITE_301_REDIRECTS: Redirect[] = [
     { fromPattern: '^/community-forums/$', to: '/community/' },
     { fromPattern: '^/forum/.+', gone: true },
     { from: '/testimonials.php', gone: true },
+    // The trailing slash is required: Apache's `Redirect` prefix-matches, so without it this
+    // would also swallow the live /blog/whats-new-in-ag-grid-v24-part-2/.
+    { from: '/blog/whats-new-in-ag-grid-v24/', gone: true },
     { from: '/start-trial.php', to: '/license-pricing/' },
     { from: '/options/series/radial-column/', to: 'https://www.ag-grid.com/charts/options/series/radial-column/' },
     { from: '/options/series/area/', to: 'https://www.ag-grid.com/charts/options/series/area/' },

--- a/documentation/ag-grid-docs/src/utils/htaccess/redirects.ts
+++ b/documentation/ag-grid-docs/src/utils/htaccess/redirects.ts
@@ -3123,10 +3123,10 @@ export const SITE_301_REDIRECTS: Redirect[] = [
     { from: '/example.php', to: '/example/' },
     { from: '/ag-grid-jobs-board.php', to: '/ag-grid-jobs-board' },
 
-    { from: '/react-data-grid/whats-new', to: '/whats-new' },
-    { from: '/vue-data-grid/whats-new', to: '/whats-new' },
-    { from: '/angular-data-grid/whats-new', to: '/whats-new' },
-    { from: '/javascript-data-grid/whats-new', to: '/whats-new' },
+    { from: '/react-data-grid/whats-new', to: '/whats-new/' },
+    { from: '/vue-data-grid/whats-new', to: '/whats-new/' },
+    { from: '/angular-data-grid/whats-new', to: '/whats-new/' },
+    { from: '/javascript-data-grid/whats-new', to: '/whats-new/' },
     { from: '/vue-data-grid/framework-data-flow', to: '/vue-data-grid/getting-started/' },
 
     { from: '/react-data-grid/licensing/', to: '/react-data-grid/community-vs-enterprise/' },

--- a/documentation/ag-grid-docs/testing/htaccess-harness/expectations.generated.tsv
+++ b/documentation/ag-grid-docs/testing/htaccess-harness/expectations.generated.tsv
@@ -6048,7 +6048,7 @@ www	/react-data-grid/component-cell-editor-imperative-react/child	301	/react-dat
 www	/react-data-grid/component-cell-editor-imperative-react/child/	301	/react-data-grid/cell-editors/child/
 www	/cookies.php	301	/cookies/
 www	/privacy.php	301	/privacy/
-www	/about.php	301	/about
+www	/about.php	301	/about/
 www	/license-pricing.php	301	/license-pricing/
 www	/example.php	301	/example/
 www	/ag-grid-jobs-board.php	301	/ag-grid-jobs-board

--- a/documentation/ag-grid-docs/testing/htaccess-harness/expectations.generated.tsv
+++ b/documentation/ag-grid-docs/testing/htaccess-harness/expectations.generated.tsv
@@ -6053,13 +6053,13 @@ www	/license-pricing.php	301	/license-pricing/
 www	/example.php	301	/example/
 www	/ag-grid-jobs-board.php	301	/ag-grid-jobs-board
 www	/react-data-grid/whats-new	301	/react-data-grid/whats-new/
-www	/react-data-grid/whats-new/	301	/whats-new
+www	/react-data-grid/whats-new/	301	/whats-new/
 www	/vue-data-grid/whats-new	301	/vue-data-grid/whats-new/
-www	/vue-data-grid/whats-new/	301	/whats-new
+www	/vue-data-grid/whats-new/	301	/whats-new/
 www	/angular-data-grid/whats-new	301	/angular-data-grid/whats-new/
-www	/angular-data-grid/whats-new/	301	/whats-new
+www	/angular-data-grid/whats-new/	301	/whats-new/
 www	/javascript-data-grid/whats-new	301	/javascript-data-grid/whats-new/
-www	/javascript-data-grid/whats-new/	301	/whats-new
+www	/javascript-data-grid/whats-new/	301	/whats-new/
 www	/vue-data-grid/framework-data-flow	301	/vue-data-grid/framework-data-flow/
 www	/vue-data-grid/framework-data-flow/	301	/vue-data-grid/getting-started/
 www	/react-data-grid/licensing/	301	/react-data-grid/community-vs-enterprise/

--- a/documentation/ag-grid-docs/testing/htaccess-harness/expectations.tsv
+++ b/documentation/ag-grid-docs/testing/htaccess-harness/expectations.tsv
@@ -73,6 +73,11 @@ www	/react-grid/rxjs/	301	https://www.ag-grid.com/react-data-grid/data-update/
 # --- AG-17694: Beyond the Prompt moved /campaigns/ -> /community/ ---
 www	/campaigns/beyond-the-prompt/	301	/community/beyond-the-prompt/
 
+# --- SE-166: /blog/whats-new-in-ag-grid-v24/ is gone on www too, and must not swallow -part-2 ---
+www	/blog/whats-new-in-ag-grid-v24/	410
+www	/blog/whats-new-in-ag-grid-v24/amp/	410
+www	/blog/whats-new-in-ag-grid-v24-part-2/	200
+
 # --- No-shadow negatives: real live pages must NOT be redirected (expect 200) ---
 www	/angular-data-grid/getting-started/	200
 www	/react-data-grid/cell-editing/	200

--- a/external/ag-website-shared/src/components/contact-form/ContactResultPage.astro
+++ b/external/ag-website-shared/src/components/contact-form/ContactResultPage.astro
@@ -31,7 +31,7 @@ const resources = [
         title: "See what's new",
         description: "Check out recent releases and see what we've improved",
         linkText: 'Learn more',
-        linkUrl: urlWithBaseUrl('/whats-new'),
+        linkUrl: urlWithBaseUrl('/whats-new/'),
     },
 ];
 

--- a/external/ag-website-shared/src/components/docs-navigation/DocsNav.tsx
+++ b/external/ag-website-shared/src/components/docs-navigation/DocsNav.tsx
@@ -266,7 +266,7 @@ export function DocsNav({
                 <div className={styles.docsNavInner}>
                     {showWhatsNew && (
                         <div className={styles.whatsNewLink}>
-                            <a href={urlWithBaseUrl('/whats-new')}>What's New</a>
+                            <a href={urlWithBaseUrl('/whats-new/')}>What's New</a>
                         </div>
                     )}
 

--- a/external/ag-website-shared/src/components/landing-pages/sections/HeroSection.astro
+++ b/external/ag-website-shared/src/components/landing-pages/sections/HeroSection.astro
@@ -52,7 +52,7 @@ const showCustomerLogos = section.showCustomerLogos !== false;
                 {
                     section.showVersionBadge && latestVersion && (
                         <a
-                            href={urlWithBaseUrl('./whats-new')}
+                            href={urlWithBaseUrl('./whats-new/')}
                             class:list={[
                                 styles.heroSectionVersionTagContainer,
                                 `plausible-event-name=${pageContent.analyticsPrefix}-whats-new`,

--- a/external/ag-website-shared/src/components/releases-section/ReleasesSection.tsx
+++ b/external/ag-website-shared/src/components/releases-section/ReleasesSection.tsx
@@ -33,7 +33,7 @@ export const ReleasesSection: React.FC<ReleasesSectionProps> = ({
     subtitle = "Here's what you've missed since you've been gone",
     showViewAllButton = true,
     viewAllButtonText = 'View recent releases',
-    viewAllButtonUrl = '/whats-new',
+    viewAllButtonUrl = '/whats-new/',
 }) => {
     // Filter versions that have highlights and are not hidden
     const filteredVersions = versionsData

--- a/external/ag-website-shared/src/components/roadmap/Roadmap.tsx
+++ b/external/ag-website-shared/src/components/roadmap/Roadmap.tsx
@@ -48,7 +48,7 @@ export const Roadmap: React.FC<RoadmapProps> = ({ roadmapData, versionData }) =>
                             >
                                 Release Notes <Icon name="chevronRight" />
                             </a>
-                            <a href={urlWithBaseUrl('./whats-new')} target="_blank" className={styles.heroCta}>
+                            <a href={urlWithBaseUrl('./whats-new/')} target="_blank" className={styles.heroCta}>
                                 What's New <Icon name="chevronRight" />
                             </a>
                         </div>

--- a/external/ag-website-shared/src/content/products/menu.json
+++ b/external/ag-website-shared/src/content/products/menu.json
@@ -10,12 +10,12 @@
             {
                 "title": "AG Charts",
                 "description": "Best JavaScript Charts in the World",
-                "url": "https://www.ag-grid.com/charts"
+                "url": "https://www.ag-grid.com/charts/"
             },
             {
                 "title": "AG Studio",
                 "description": "Best JavaScript Dashboard in the World",
-                "url": "https://www.ag-grid.com/studio"
+                "url": "https://www.ag-grid.com/studio/"
             },
             {
                 "title": "Bryntum Gantt",


### PR DESCRIPTION
Backport of #14985 (SE-162) and #14986 (SE-166) onto `b36.1.0`. Four commits cherry-picked; 13 files, +27 -32.

**SE-162** — removes the `AG Grid Enterprise` Offer, which carried a url and no price, from the SoftwareApplication JSON-LD in the shared docs layout. The valid Community offer is left in place. `b36.1.0`'s `buildSoftwareApplication` call has no `sameAs` argument and none was introduced.

**SE-166** — trailing slashes on the bare `/charts` and `/studio` URLs across three nav files, the docs-nav `/whats-new` link, five further `/whats-new` links in shared components, and the redirect targets for the four framework `whats-new` rules plus `/about.php`, all of which chained through a second hop.

### Conflicts and how they were resolved

Two conflicts, both because `latest` carries unrelated changes to the same lines. In each case `b36.1.0`'s structure was kept and only the trailing slash taken, so nothing extra is backported:

- `DocsNav.tsx` — `latest` adds `tabIndex={0}` to the What's New anchor. Not backported.
- `Roadmap.tsx` — `latest` wraps the Release Notes anchor in a `versionData?.notesPath &&` guard. Not backported.

### CSP

The htaccess snapshot contains CSP directives, and `b36.1.0` carries three recent CSP hash commits (#14980, #14963) that `latest` does not. The snapshot was **not** taken from `latest`: only the five redirect rows changed. Verified by grepping the full branch diff for `content-security-policy`, `script-src`, `sha256-`, `unsafe-` and `enzuzo` — no matches. `cspRules.ts` is untouched.

### Deliberately unchanged

`/ag-grid-jobs-board` keeps its slash-less redirect target: that form is registered in `IGNORE_PAGES` and no such page exists.

The slash-less relative `path` values in `header.json` are left alone. They render through `urlWithPrefix`, which defaults `trailingSlash: true` and appends one regardless, so they already emit a trailing slash. Only the absolute `url` entries are emitted verbatim, which is why only those needed fixing.

### Note

`external/ag-website-shared` is a git-subrepo. Six of the changed files are on that side, so they also need `yarn run subrepo push external/ag-website-shared`.

Jira: SE-162, SE-166