### PR TITLE
SE-165: Backport - Exclude /reference/ and /licensing/ forward-on pages from the sitemap

### DIFF
--- a/documentation/ag-grid-docs/src/utils/sitemap.test.ts
+++ b/documentation/ag-grid-docs/src/utils/sitemap.test.ts
@@ -1,0 +1,27 @@
+import { getSitemapConfig } from './sitemap';
+
+describe('sitemap filter (SE-165)', () => {
+    const { filter } = getSitemapConfig({});
+
+    test.each([
+        'https://www.ag-grid.com/reference/',
+        'https://www.ag-grid.com/licensing/',
+        'https://www.ag-grid.com/documentation/',
+        'https://www.ag-grid.com/react-data-grid/',
+        'https://www.ag-grid.com/angular-data-grid/',
+        'https://www.ag-grid.com/javascript-data-grid/',
+        'https://www.ag-grid.com/vue-data-grid/',
+        'https://www.ag-grid.com/data-grid/getting-started/',
+    ])('excludes the forward-on stub page %s', (page) => {
+        expect(filter(page)).toBe(false);
+    });
+
+    test.each([
+        'https://www.ag-grid.com/theme-builder/',
+        'https://www.ag-grid.com/sitemap/',
+        'https://www.ag-grid.com/landing-pages/react-data-grid/',
+        'https://www.ag-grid.com/react-data-grid/reference/',
+    ])('keeps the real page %s', (page) => {
+        expect(filter(page)).toBe(true);
+    });
+});

--- a/documentation/ag-grid-docs/src/utils/sitemap.ts
+++ b/documentation/ag-grid-docs/src/utils/sitemap.ts
@@ -1,5 +1,4 @@
 import { FRAMEWORK_REDIRECT_PATH } from '../constants';
-import { STATIC_PAGE_CONTENT } from './markdown-pages/staticPageContent';
 
 /**
  * Example runner pages
@@ -30,19 +29,6 @@ export const isTestPage = (page: string) => {
 };
 
 /*
- * Static pages that only forward on to a framework-specific docs page (e.g. `/reference/` redirects
- * to `/react-data-grid/reference/`). Any `STATIC_PAGE_CONTENT` entry with a `redirectPageName` is one
- * of these stubs, so deriving the list from there catches new ones automatically instead of requiring
- * a new hardcoded suffix here each time (SE-165).
- *
- * Matched against the page's pathname, not just a suffix - the destination the stub redirects to
- * (e.g. `/react-data-grid/reference/`) ends with the same page name and must stay in the sitemap.
- */
-const staticRedirectPagePaths = Object.entries(STATIC_PAGE_CONTENT)
-    .filter(([, content]) => 'redirectPageName' in content)
-    .map(([pageName]) => `/${pageName}/`);
-
-/*
  * Documentation redirect pages
  */
 const isRedirectPage = (page: string) => {
@@ -53,7 +39,10 @@ const isRedirectPage = (page: string) => {
         (!page.endsWith('/landing-pages/javascript-data-grid/') && page.endsWith('/javascript-data-grid/')) ||
         (!page.endsWith('/landing-pages/vue-data-grid/') && page.endsWith('/vue-data-grid/')) ||
         page.includes(`/${FRAMEWORK_REDIRECT_PATH}/`) ||
-        staticRedirectPagePaths.includes(new URL(page).pathname)
+        // SE-165: /reference/ and /licensing/ are FrameworkRedirectPage stubs like the above, but their
+        // destination (e.g. /react-data-grid/reference/) ends with the same segment, so an endsWith
+        // suffix would wrongly exclude the destination too - match the bare top-level path instead.
+        ['/reference/', '/licensing/'].includes(new URL(page).pathname)
     );
 };
 

--- a/documentation/ag-grid-docs/src/utils/sitemap.ts
+++ b/documentation/ag-grid-docs/src/utils/sitemap.ts
@@ -39,9 +39,6 @@ const isRedirectPage = (page: string) => {
         (!page.endsWith('/landing-pages/javascript-data-grid/') && page.endsWith('/javascript-data-grid/')) ||
         (!page.endsWith('/landing-pages/vue-data-grid/') && page.endsWith('/vue-data-grid/')) ||
         page.includes(`/${FRAMEWORK_REDIRECT_PATH}/`) ||
-        // SE-165: /reference/ and /licensing/ are FrameworkRedirectPage stubs like the above, but their
-        // destination (e.g. /react-data-grid/reference/) ends with the same segment, so an endsWith
-        // suffix would wrongly exclude the destination too - match the bare top-level path instead.
         ['/reference/', '/licensing/'].includes(new URL(page).pathname)
     );
 };

--- a/documentation/ag-grid-docs/src/utils/sitemap.ts
+++ b/documentation/ag-grid-docs/src/utils/sitemap.ts
@@ -1,4 +1,5 @@
 import { FRAMEWORK_REDIRECT_PATH } from '../constants';
+import { STATIC_PAGE_CONTENT } from './markdown-pages/staticPageContent';
 
 /**
  * Example runner pages
@@ -29,6 +30,19 @@ export const isTestPage = (page: string) => {
 };
 
 /*
+ * Static pages that only forward on to a framework-specific docs page (e.g. `/reference/` redirects
+ * to `/react-data-grid/reference/`). Any `STATIC_PAGE_CONTENT` entry with a `redirectPageName` is one
+ * of these stubs, so deriving the list from there catches new ones automatically instead of requiring
+ * a new hardcoded suffix here each time (SE-165).
+ *
+ * Matched against the page's pathname, not just a suffix - the destination the stub redirects to
+ * (e.g. `/react-data-grid/reference/`) ends with the same page name and must stay in the sitemap.
+ */
+const staticRedirectPagePaths = Object.entries(STATIC_PAGE_CONTENT)
+    .filter(([, content]) => 'redirectPageName' in content)
+    .map(([pageName]) => `/${pageName}/`);
+
+/*
  * Documentation redirect pages
  */
 const isRedirectPage = (page: string) => {
@@ -38,7 +52,8 @@ const isRedirectPage = (page: string) => {
         (!page.endsWith('/landing-pages/angular-data-grid/') && page.endsWith('/angular-data-grid/')) ||
         (!page.endsWith('/landing-pages/javascript-data-grid/') && page.endsWith('/javascript-data-grid/')) ||
         (!page.endsWith('/landing-pages/vue-data-grid/') && page.endsWith('/vue-data-grid/')) ||
-        page.includes(`/${FRAMEWORK_REDIRECT_PATH}/`)
+        page.includes(`/${FRAMEWORK_REDIRECT_PATH}/`) ||
+        staticRedirectPagePaths.includes(new URL(page).pathname)
     );
 };
 


### PR DESCRIPTION
## Summary
Backport of #14991 to `b36.1.0`.

- `/reference/` and `/licensing/` render `FrameworkRedirectPage` and immediately redirect client-side to a framework-specific docs page, but the sitemap's `isRedirectPage` filter only checked a hardcoded set of URL suffixes, so these two slipped through.
- Matches the two stub paths directly by pathname rather than deriving from `STATIC_PAGE_CONTENT`, since that entry point is also loaded by `astro.config.mjs` outside of Vite's alias-resolution context and would break config loading (as caught in CI on #14991).

https://ag-grid.atlassian.net/browse/SE-165

## Test plan
- [x] `nx run ag-grid-docs:test:vitest -- src/utils/sitemap.test.ts` passes (12 tests).
- [x] `nx run ag-grid-docs:lint` passes.