### PR TITLE
SE-166 Resolve the framework whats-new redirects in one hop

### DIFF
--- a/documentation/ag-grid-docs/src/utils/htaccess/__snapshots__/htaccessRules.test.ts.snap
+++ b/documentation/ag-grid-docs/src/utils/htaccess/__snapshots__/htaccessRules.test.ts.snap
@@ -75,7 +75,7 @@ AddCharset utf-8 .md
     RewriteEngine On
 
     RewriteCond %{HTTP_HOST} !^(www\\.)?ag-grid\\.com$ [NC]
-    RewriteRule ^ - [S=235]
+    RewriteRule ^ - [S=239]
 
     # SE-64 / SE-66: single-hop chain shortening. These run before the https-upgrade and
     # host-swap so a matching legacy path on either www.ag-grid.com or ag-grid.com (any

--- a/documentation/ag-grid-docs/src/utils/htaccess/__snapshots__/htaccessRules.test.ts.snap
+++ b/documentation/ag-grid-docs/src/utils/htaccess/__snapshots__/htaccessRules.test.ts.snap
@@ -81,6 +81,10 @@ AddCharset utf-8 .md
     # host-swap so a matching legacy path on either www.ag-grid.com or ag-grid.com (any
     # scheme) lands on its final www URL in ONE 301. Inbound query strings are preserved
     # (targets carry none). See SITE_SINGLE_HOP_REWRITES in redirects.ts.
+    RewriteRule "^/?react-data-grid/whats-new$" "https://www.ag-grid.com/whats-new/" [R=301,L]
+    RewriteRule "^/?vue-data-grid/whats-new$" "https://www.ag-grid.com/whats-new/" [R=301,L]
+    RewriteRule "^/?angular-data-grid/whats-new$" "https://www.ag-grid.com/whats-new/" [R=301,L]
+    RewriteRule "^/?javascript-data-grid/whats-new$" "https://www.ag-grid.com/whats-new/" [R=301,L]
     RewriteRule "^/?javascript-grid/cell-rendering/$" "https://www.ag-grid.com/javascript-data-grid/component-cell-renderer/" [R=301,L]
     RewriteRule "^/?javascript-grid/client-side-model/$" "https://www.ag-grid.com/javascript-data-grid/row-models/" [R=301,L]
     RewriteRule "^/?javascript-grid/component-cell-editor/$" "https://www.ag-grid.com/javascript-data-grid/cell-editors/" [R=301,L]
@@ -2628,10 +2632,10 @@ AddCharset utf-8 .md
     Redirect 301 /license-pricing.php /license-pricing/
     Redirect 301 /example.php /example/
     Redirect 301 /ag-grid-jobs-board.php /ag-grid-jobs-board
-    Redirect 301 /react-data-grid/whats-new /whats-new/
-    Redirect 301 /vue-data-grid/whats-new /whats-new/
-    Redirect 301 /angular-data-grid/whats-new /whats-new/
-    Redirect 301 /javascript-data-grid/whats-new /whats-new/
+    Redirect 301 /react-data-grid/whats-new /whats-new
+    Redirect 301 /vue-data-grid/whats-new /whats-new
+    Redirect 301 /angular-data-grid/whats-new /whats-new
+    Redirect 301 /javascript-data-grid/whats-new /whats-new
     Redirect 301 /vue-data-grid/framework-data-flow /vue-data-grid/getting-started/
     Redirect 301 /react-data-grid/licensing/ /react-data-grid/community-vs-enterprise/
     Redirect 301 /vue-data-grid/licensing/ /vue-data-grid/community-vs-enterprise/

--- a/documentation/ag-grid-docs/src/utils/htaccess/redirects.ts
+++ b/documentation/ag-grid-docs/src/utils/htaccess/redirects.ts
@@ -33,6 +33,12 @@ const pageForAllFrameworks = (from: string, to: string): Redirect[] => [
 // no query string, so Apache preserves any inbound query). Destinations were derived by
 // replaying the current redirect rules to their fixpoint.
 export const SITE_SINGLE_HOP_REWRITES: SimpleRedirectRule[] = [
+    // The slash-less framework whats-new paths, which would otherwise pick up the
+    // add-trailing-slash 301 first and reach /whats-new/ in two hops.
+    { from: '/react-data-grid/whats-new', to: 'https://www.ag-grid.com/whats-new/' },
+    { from: '/vue-data-grid/whats-new', to: 'https://www.ag-grid.com/whats-new/' },
+    { from: '/angular-data-grid/whats-new', to: 'https://www.ag-grid.com/whats-new/' },
+    { from: '/javascript-data-grid/whats-new', to: 'https://www.ag-grid.com/whats-new/' },
     // Shadowed /{framework}-grid/<subpage>/ rules converted to single hop. The broad /{fw}-grid/
     // prefix rule (mod_alias, first-match) otherwise shadows these specifics: 128 took 2 hops and 14
     // landed on the wrong (404) page. As mod_rewrite, these run before mod_alias so each resolves in
@@ -3123,10 +3129,13 @@ export const SITE_301_REDIRECTS: Redirect[] = [
     { from: '/example.php', to: '/example/' },
     { from: '/ag-grid-jobs-board.php', to: '/ag-grid-jobs-board' },
 
-    { from: '/react-data-grid/whats-new', to: '/whats-new/' },
-    { from: '/vue-data-grid/whats-new', to: '/whats-new/' },
-    { from: '/angular-data-grid/whats-new', to: '/whats-new/' },
-    { from: '/javascript-data-grid/whats-new', to: '/whats-new/' },
+    // Targets are deliberately slash-less: `Redirect` prefix-matches and appends the remainder,
+    // so the slashed request lands on /whats-new/ exactly, while a slashed target yields
+    // /whats-new//. The slash-less request is handled by SITE_SINGLE_HOP_REWRITES above.
+    { from: '/react-data-grid/whats-new', to: '/whats-new' },
+    { from: '/vue-data-grid/whats-new', to: '/whats-new' },
+    { from: '/angular-data-grid/whats-new', to: '/whats-new' },
+    { from: '/javascript-data-grid/whats-new', to: '/whats-new' },
     { from: '/vue-data-grid/framework-data-flow', to: '/vue-data-grid/getting-started/' },
 
     { from: '/react-data-grid/licensing/', to: '/react-data-grid/community-vs-enterprise/' },

--- a/documentation/ag-grid-docs/testing/htaccess-harness/expectations.generated.tsv
+++ b/documentation/ag-grid-docs/testing/htaccess-harness/expectations.generated.tsv
@@ -6883,6 +6883,10 @@ www	/charts/vue-charts/license-pricing/	200
 www	/charts/vue-charts/license-pricing	301	/charts/vue-charts/license-pricing/
 
 # converted shadowed /{fw}-grid/<subpage>/ rules — apex single-hop coverage
+apex	/react-data-grid/whats-new	301	https://www.ag-grid.com/whats-new/
+apex	/vue-data-grid/whats-new	301	https://www.ag-grid.com/whats-new/
+apex	/angular-data-grid/whats-new	301	https://www.ag-grid.com/whats-new/
+apex	/javascript-data-grid/whats-new	301	https://www.ag-grid.com/whats-new/
 apex	/javascript-grid/cell-rendering/	301	https://www.ag-grid.com/javascript-data-grid/component-cell-renderer/
 apex	/javascript-grid/client-side-model/	301	https://www.ag-grid.com/javascript-data-grid/row-models/
 apex	/javascript-grid/component-cell-editor/	301	https://www.ag-grid.com/javascript-data-grid/cell-editors/

--- a/documentation/ag-grid-docs/testing/htaccess-harness/expectations.generated.tsv
+++ b/documentation/ag-grid-docs/testing/htaccess-harness/expectations.generated.tsv
@@ -6052,13 +6052,13 @@ www	/about.php	301	/about/
 www	/license-pricing.php	301	/license-pricing/
 www	/example.php	301	/example/
 www	/ag-grid-jobs-board.php	301	/ag-grid-jobs-board
-www	/react-data-grid/whats-new	301	/react-data-grid/whats-new/
+www	/react-data-grid/whats-new	301	https://www.ag-grid.com/whats-new/
 www	/react-data-grid/whats-new/	301	/whats-new/
-www	/vue-data-grid/whats-new	301	/vue-data-grid/whats-new/
+www	/vue-data-grid/whats-new	301	https://www.ag-grid.com/whats-new/
 www	/vue-data-grid/whats-new/	301	/whats-new/
-www	/angular-data-grid/whats-new	301	/angular-data-grid/whats-new/
+www	/angular-data-grid/whats-new	301	https://www.ag-grid.com/whats-new/
 www	/angular-data-grid/whats-new/	301	/whats-new/
-www	/javascript-data-grid/whats-new	301	/javascript-data-grid/whats-new/
+www	/javascript-data-grid/whats-new	301	https://www.ag-grid.com/whats-new/
 www	/javascript-data-grid/whats-new/	301	/whats-new/
 www	/vue-data-grid/framework-data-flow	301	/vue-data-grid/framework-data-flow/
 www	/vue-data-grid/framework-data-flow/	301	/vue-data-grid/getting-started/

--- a/documentation/ag-grid-docs/testing/htaccess-harness/expectations.tsv
+++ b/documentation/ag-grid-docs/testing/htaccess-harness/expectations.tsv
@@ -78,6 +78,16 @@ www	/blog/whats-new-in-ag-grid-v24/	410
 www	/blog/whats-new-in-ag-grid-v24/amp/	410
 www	/blog/whats-new-in-ag-grid-v24-part-2/	200
 
+# --- SE-166: framework whats-new must reach /whats-new/ in ONE hop, and never /whats-new// ---
+www	/react-data-grid/whats-new	301	https://www.ag-grid.com/whats-new/
+www	/vue-data-grid/whats-new	301	https://www.ag-grid.com/whats-new/
+www	/angular-data-grid/whats-new	301	https://www.ag-grid.com/whats-new/
+www	/javascript-data-grid/whats-new	301	https://www.ag-grid.com/whats-new/
+www	/react-data-grid/whats-new/	301	/whats-new/
+www	/vue-data-grid/whats-new/	301	/whats-new/
+www	/angular-data-grid/whats-new/	301	/whats-new/
+www	/javascript-data-grid/whats-new/	301	/whats-new/
+
 # --- No-shadow negatives: real live pages must NOT be redirected (expect 200) ---
 www	/angular-data-grid/getting-started/	200
 www	/react-data-grid/cell-editing/	200


### PR DESCRIPTION
Fixes a regression from #14986, found in live QA.

## What went wrong

#14986 changed the four framework `whats-new` targets from `/whats-new` to `/whats-new/`. That removed no hop and produced a malformed URL:

```
/react-data-grid/whats-new  ->  /react-data-grid/whats-new/  ->  /whats-new//
```

Apache's `Redirect` prefix-matches and appends the unmatched remainder. For the slashed request the remainder is `/`, so a slash-less target lands on `/whats-new/` exactly, while a slashed target yields `/whats-new//`. The slash-less target was correct all along, for a non-obvious reason that is now written down next to it.

`/whats-new//` serves 200 and self-canonicalises to `/whats-new/`, so impact was limited, but it was worse than before the change.

## The fix

Two mechanisms, each used as designed:

- **Targets go back to slash-less**, so the slashed request resolves to `/whats-new/` in one hop via `mod_alias`.
- **The slash-less request gets a `SITE_SINGLE_HOP_REWRITES` entry**, which emits as `mod_rewrite` and runs well before the add-trailing-slash 301 that previously gave it a second hop. Verified in the emitted file: the single-hop rules land at line 81, "Add trailing slash for directories" at line 550.

Both slash forms now reach `/whats-new/` in a single hop, and no rule can produce `//`.

## Verification

Emitted the production `.htaccess` from this branch and checked the rules directly; the snapshot is confirmed byte-identical to the emitted output for these lines.

`expectations.tsv` gains eight rows asserting one hop for both slash forms of all four frameworks — the guard that was missing.

## A caveat on expectations.generated.tsv

Four rows were hand-edited, which its README forbids. The documented regenerate-and-merge is not reproducible: `gen-main-expectations.mjs` alone yields 7,260 rows against the committed 7,057 with different `/charts` coverage, there is no merge script, and the generator emits two conflicting rows for a path covered by both a single-hop rewrite and a `mod_alias` rule without resolving precedence. The four edited rows use the generator's own prediction for the single-hop form. Worth a proper regeneration by whoever owns the harness.

Also note the frozen rows already disagreed with production before this PR — they predicted `/whats-new/` where Apache serves `/whats-new//` — so running the harness against real Apache would have caught the regression pre-merge.

Jira: SE-166