### PR TITLE
AG-11294 date-filter-process-blank

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/filter-date/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/filter-date/index.mdoc
@@ -320,7 +320,7 @@ Applying the Date Filter is described in more detail in the following sections:
 
 ## Blank Cells
 
-If the row data contains blanks (i.e. `null` or `undefined`), by default the row won't be included in filter results. To change this, use the filter params `includeBlanksInEquals`, `includeBlanksInNotEqual`, `includeBlanksInLessThan`, `includeBlanksInGreaterThan` and `includeBlanksInRange`. For example, the code snippet below configures a filter to include `null` for equals, but not for less than, greater than or in range (between):
+If the row data contains blanks (i.e. `null`, `undefined`, or an empty or whitespace-only string), by default the row won't be included in filter results. To change this, use the filter params `includeBlanksInEquals`, `includeBlanksInNotEqual`, `includeBlanksInLessThan`, `includeBlanksInGreaterThan` and `includeBlanksInRange`. For example, the code snippet below configures a filter to include `null` for equals, but not for less than, greater than or in range (between):
 
 ```js
 const filterParams = {

--- a/documentation/ag-grid-docs/src/content/docs/filter-number/_examples/number-null-filtering/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/filter-number/_examples/number-null-filtering/example.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from '@utils/grid/test-utils';
 
-// Row data (fixed): Alberto=36 (id 0), Niall=40 (id 1), Sean=null (id 2), Robert=undefined (id 3).
+// Row data (fixed): Alberto=36 (id 0), Niall=40 (id 1), Sean=null (id 2), Robert=undefined (id 3),
+// Kirsten='' (id 4) — an empty string is a blank too.
 test.agExample(import.meta, () => {
     test.eachFramework('Blank cells excluded from lessThan by default', async ({ page, agIdFor }) => {
         const filterButton = agIdFor.headerFilterButton('age');
@@ -20,6 +21,7 @@ test.agExample(import.meta, () => {
         await expect(agIdFor.rowNode('1')).not.toBeVisible();
         await expect(agIdFor.rowNode('2')).not.toBeVisible();
         await expect(agIdFor.rowNode('3')).not.toBeVisible();
+        await expect(agIdFor.rowNode('4')).not.toBeVisible();
     });
 
     test.eachFramework('includeBlanksInLessThan toggle includes blank rows', async ({ page, agIdFor }) => {
@@ -32,17 +34,19 @@ test.agExample(import.meta, () => {
         await agIdFor.numberFilterInstanceInput({ source: 'column-filter' }).fill('40');
         await agIdFor.cell('0', 'age').click();
 
-        // Blank rows (Sean, Robert) are excluded before the toggle.
+        // Blank rows (Sean, Robert, Kirsten) are excluded before the toggle.
         await expect(agIdFor.rowNode('2')).not.toBeVisible();
         await expect(agIdFor.rowNode('3')).not.toBeVisible();
+        await expect(agIdFor.rowNode('4')).not.toBeVisible();
 
         // Toggle includeBlanksInLessThan on, which re-applies the filter.
         await page.locator('#checkboxLessThan').check();
 
-        // Alberto (36) plus both blank rows are now shown.
+        // Alberto (36) plus every blank row is now shown, the empty string included.
         await expect(agIdFor.cell('0', 'age')).toContainText('36');
         await expect(agIdFor.rowNode('2')).toBeVisible();
         await expect(agIdFor.rowNode('3')).toBeVisible();
+        await expect(agIdFor.rowNode('4')).toBeVisible();
         // Niall (40) is still excluded (40 is not < 40 and is not blank).
         await expect(agIdFor.rowNode('1')).not.toBeVisible();
     });

--- a/documentation/ag-grid-docs/src/content/docs/filter-number/_examples/number-null-filtering/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/filter-number/_examples/number-null-filtering/main.ts
@@ -61,6 +61,10 @@ const gridOptions: GridOptions = {
             athlete: 'Robert Clarke',
             age: undefined,
         },
+        {
+            athlete: 'Kirsten Flipkens',
+            age: '',
+        },
     ],
 };
 

--- a/documentation/ag-grid-docs/src/content/docs/filter-number/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/filter-number/index.mdoc
@@ -205,7 +205,7 @@ Applying the Number Filter is described in more detail in the following sections
 
 ## Blank Cells
 
-If the row data contains blanks (i.e. `null` or `undefined`), by default the row won't be included in filter results. To change this, use the filter params `includeBlanksInEquals`, `includeBlanksInNotEqual`, `includeBlanksInLessThan`, `includeBlanksInGreaterThan` and `includeBlanksInRange`. For example, the code snippet below configures a filter to include `null` for equals, but not for less than, greater than or in range (between):
+If the row data contains blanks (i.e. `null`, `undefined`, or an empty or whitespace-only string), by default the row won't be included in filter results. To change this, use the filter params `includeBlanksInEquals`, `includeBlanksInNotEqual`, `includeBlanksInLessThan`, `includeBlanksInGreaterThan` and `includeBlanksInRange`. For example, the code snippet below configures a filter to include `null` for equals, but not for less than, greater than or in range (between):
 
 ```js
 const filterParams = {

--- a/packages/ag-grid-community/src/filter/provided/bigInt/bigIntFilterHandler.test.ts
+++ b/packages/ag-grid-community/src/filter/provided/bigInt/bigIntFilterHandler.test.ts
@@ -55,15 +55,13 @@ describe('BigIntFilterHandler', () => {
         expect(handler.doesFilterPass({ node: { value: null }, model: params.model } as any)).toBe(true);
     });
 
-    it('should handle invalid cell values (mixed data)', () => {
+    it('compares a cell holding a number or a string as the bigint it reads as', () => {
         const params = createParams({}, { filterType: 'bigint', type: 'equals', filter: '10' });
         handler.init(params);
 
-        // Equals should still return false for mixed types because of === in comparator
-        expect(handler.doesFilterPass({ node: { value: 10 }, model: params.model } as any)).toBe(false);
-        expect(handler.doesFilterPass({ node: { value: '10' }, model: params.model } as any)).toBe(false);
+        expect(handler.doesFilterPass({ node: { value: 10 }, model: params.model } as any)).toBe(true);
+        expect(handler.doesFilterPass({ node: { value: '10' }, model: params.model } as any)).toBe(true);
 
-        // But lessThan should work if we updated isValid to be more robust
         const lessThanParams = createParams({}, { filterType: 'bigint', type: 'lessThan', filter: '20' });
         handler.init(lessThanParams);
         expect(handler.doesFilterPass({ node: { value: 10 }, model: lessThanParams.model } as any)).toBe(true);

--- a/packages/ag-grid-community/src/filter/provided/bigInt/bigIntFilterHandler.ts
+++ b/packages/ag-grid-community/src/filter/provided/bigInt/bigIntFilterHandler.ts
@@ -25,11 +25,13 @@ export class BigIntFilterHandler extends ScalarFilterHandler<BigIntFilterModel, 
 
     protected override comparator(): Comparator<bigint> {
         return (left: bigint, right: bigint): number => {
-            if (left === right) {
+            // The cell holds whatever the row data does — `10n`, `'10'` or `10` — and `10n === 10` is false.
+            const cellValue = _parseBigIntOrNull(right)!;
+            if (left === cellValue) {
                 return 0;
             }
 
-            return left < right ? 1 : -1;
+            return left < cellValue ? 1 : -1;
         };
     }
 

--- a/packages/ag-grid-community/src/filter/provided/iScalarFilter.ts
+++ b/packages/ag-grid-community/src/filter/provided/iScalarFilter.ts
@@ -12,15 +12,15 @@ export type ScalarFilterParams<TData = any> = IScalarFilterParams & IFilterParam
 export interface IScalarFilterParams extends ISimpleFilterParams {
     /** If `true`, the `'inRange'` filter option will include values equal to the start and end of the range. */
     inRangeInclusive?: boolean;
-    /** If `true`, blank (`null` or `undefined`) values will pass the `'equals'` filter option. */
+    /** If `true`, blank (`null`, `undefined`, or an empty or whitespace-only string) values will pass the `'equals'` filter option. */
     includeBlanksInEquals?: boolean;
-    /** If `true`, blank (`null` or `undefined`) values will pass the `'notEqual'` filter option. */
+    /** If `true`, blank (`null`, `undefined`, or an empty or whitespace-only string) values will pass the `'notEqual'` filter option. */
     includeBlanksInNotEqual?: boolean;
-    /** If `true`, blank (`null` or `undefined`) values will pass the `'lessThan'` and `'lessThanOrEqual'` filter options. */
+    /** If `true`, blank (`null`, `undefined`, or an empty or whitespace-only string) values will pass the `'lessThan'` and `'lessThanOrEqual'` filter options. */
     includeBlanksInLessThan?: boolean;
-    /** If `true`, blank (`null` or `undefined`) values will pass the `'greaterThan'` and `'greaterThanOrEqual'` filter options. */
+    /** If `true`, blank (`null`, `undefined`, or an empty or whitespace-only string) values will pass the `'greaterThan'` and `'greaterThanOrEqual'` filter options. */
     includeBlanksInGreaterThan?: boolean;
-    /** If `true`, blank (`null` or `undefined`) values will pass the `'inRange'` filter option. */
+    /** If `true`, blank (`null`, `undefined`, or an empty or whitespace-only string) values will pass the `'inRange'` filter option. */
     includeBlanksInRange?: boolean;
 }
 

--- a/packages/ag-grid-community/src/filter/provided/scalarFilterHandler.ts
+++ b/packages/ag-grid-community/src/filter/provided/scalarFilterHandler.ts
@@ -1,7 +1,7 @@
 import type { Comparator, IScalarFilterParams } from './iScalarFilter';
 import type { FilterOptionKey, ISimpleFilterModel, Tuple } from './iSimpleFilter';
 import { SimpleFilterHandler } from './simpleFilterHandler';
-import { isBlank } from './simpleFilterUtils';
+import { _isBlank } from './simpleFilterUtils';
 
 export abstract class ScalarFilterHandler<
     TModel extends ISimpleFilterModel,
@@ -11,6 +11,11 @@ export abstract class ScalarFilterHandler<
     protected abstract comparator(): Comparator<TValue>;
 
     protected abstract isValid(value: TValue): boolean;
+
+    /** A scalar has no use for a string that is empty or only whitespace, so it counts as absent. */
+    protected override isNullValue(cellValue: unknown): boolean {
+        return _isBlank(cellValue);
+    }
 
     protected evaluateNullValue(filterType?: FilterOptionKey | null) {
         const {
@@ -64,6 +69,14 @@ export abstract class ScalarFilterHandler<
             return type === 'notEqual' || type === 'notBlank';
         }
 
+        // `isNullValue` consumed every blank before this ran, so these two need no comparator and no value.
+        if (type === 'blank') {
+            return false;
+        }
+        if (type === 'notBlank') {
+            return true;
+        }
+
         const comparator = this.comparator();
 
         const compareResult = values[0] != null ? comparator(values[0], cellValue) : 0;
@@ -93,12 +106,6 @@ export abstract class ScalarFilterHandler<
                     ? compareResult >= 0 && compareToResult <= 0
                     : compareResult > 0 && compareToResult < 0;
             }
-
-            case 'blank':
-                return isBlank(cellValue);
-
-            case 'notBlank':
-                return !isBlank(cellValue);
 
             default:
                 this.warnUnexpectedFilterType(type);

--- a/packages/ag-grid-community/src/filter/provided/simpleFilterHandler.ts
+++ b/packages/ag-grid-community/src/filter/provided/simpleFilterHandler.ts
@@ -51,6 +51,11 @@ export abstract class SimpleFilterHandler<
 
     protected abstract evaluateNullValue(filterType?: FilterOptionKey | null): boolean;
 
+    /** An empty string is a value the text filter can match, so only a scalar filter widens absence beyond `null`. */
+    protected isNullValue(cellValue: unknown): boolean {
+        return cellValue == null;
+    }
+
     /**
      * Once per key, never per row: a log call formats its message and doc URL before the once-per-message guard
      * discards the duplicate. A Custom Filter Option owns its key, so a skipped predicate is a missing value.
@@ -215,7 +220,7 @@ export abstract class SimpleFilterHandler<
             return customFilterResult;
         }
 
-        if (cellValue == null) {
+        if (this.isNullValue(cellValue)) {
             return this.evaluateNullValue(filterModel.type);
         }
 

--- a/packages/ag-grid-community/src/filter/provided/simpleFilterUtils.ts
+++ b/packages/ag-grid-community/src/filter/provided/simpleFilterUtils.ts
@@ -42,8 +42,19 @@ export function removeItems<T>(items: T[], startPosition: number, deleteCount?: 
     return deleteCount == null ? items.splice(startPosition) : items.splice(startPosition, deleteCount);
 }
 
-export function isBlank<V>(cellValue: V) {
-    return cellValue == null || (typeof cellValue === 'string' && cellValue.trim().length === 0);
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
+export function _isBlank<V>(cellValue: V): boolean {
+    if (typeof cellValue === 'string') {
+        // No code point in 33..159 is whitespace to `trim`, so one read settles the common case.
+        const first = cellValue.codePointAt(0) ?? 0;
+        return first > 32 && first < 160 ? false : !cellValue.trim();
+    }
+    return cellValue == null;
+}
+
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
+export function _hasValue<V>(cellValue: V): boolean {
+    return !_isBlank(cellValue);
 }
 
 export function getDefaultJoinOperator(defaultJoinOperator?: JoinOperator): JoinOperator {

--- a/packages/ag-grid-community/src/filter/provided/text/textFilterHandler.ts
+++ b/packages/ag-grid-community/src/filter/provided/text/textFilterHandler.ts
@@ -4,7 +4,7 @@ import type { FilterOptionKey, ICombinedSimpleModel, TextFilterOptionKey, Tuple 
 import { isCombinedFilterModel } from '../iSimpleFilter';
 import type { OptionsFactory } from '../optionsFactory';
 import { SimpleFilterHandler } from '../simpleFilterHandler';
-import { isBlank } from '../simpleFilterUtils';
+import { _hasValue, _isBlank } from '../simpleFilterUtils';
 import type { ITextFilterParams, TextFilterModel, TextFormatter, TextMatcher } from './iTextFilter';
 import { DEFAULT_TEXT_FILTER_OPTIONS } from './textFilterConstants';
 import { TextFilterModelFormatter } from './textFilterModelFormatter';
@@ -116,9 +116,9 @@ export class TextFilterHandler extends SimpleFilterHandler<TextFilterModel, stri
 
         const type = filterModel.type;
         if (type === 'blank') {
-            return isBlank(cellValue);
+            return _isBlank(cellValue);
         } else if (type === 'notBlank') {
-            return !isBlank(cellValue);
+            return _hasValue(cellValue);
         }
 
         if (this.isUnmatchable(type)) {

--- a/packages/ag-grid-community/src/interfaces/advancedFilterModel.ts
+++ b/packages/ag-grid-community/src/interfaces/advancedFilterModel.ts
@@ -31,7 +31,7 @@ export type ScalarAdvancedFilterModelType =
     | 'blank'
     | 'notBlank';
 
-export type BooleanAdvancedFilterModelType = 'true' | 'false';
+export type BooleanAdvancedFilterModelType = 'true' | 'false' | 'blank' | 'notBlank';
 
 /** Represents a single filter condition for a text column */
 export interface TextAdvancedFilterModel {

--- a/packages/ag-grid-community/src/main-internal.ts
+++ b/packages/ag-grid-community/src/main-internal.ts
@@ -143,7 +143,7 @@ export type { FilterValueService } from './filter/filterValueService';
 export { FilterWrapperComp } from './filter/filterWrapperComp';
 export { _getDefaultFloatingFilterType } from './filter/floating/floatingFilterMapper';
 export { _isUseApplyButton } from './filter/provided/providedFilterUtils';
-export { _bindFilterCallback } from './filter/provided/simpleFilterUtils';
+export { _bindFilterCallback, _isBlank, _hasValue } from './filter/provided/simpleFilterUtils';
 export type { FocusService } from './focusService';
 export { _getGlobalGridOption } from './globalGridOptions';
 export { GridCoreCreator } from './grid';

--- a/packages/ag-grid-enterprise/src/advancedFilter/advancedFilterExpressionService.ts
+++ b/packages/ag-grid-enterprise/src/advancedFilter/advancedFilterExpressionService.ts
@@ -437,6 +437,10 @@ export class AdvancedFilterExpressionService extends BeanStub implements NamedBe
                     };
                 }
                 break;
+            case 'bigint':
+                // `10n === 10` is false, so a cell holding `'10'` or `10` has to be parsed before it compares.
+                params = { valueConverter: (v: any) => _parseBigIntOrNull(v) };
+                break;
             case 'text':
             case undefined:
                 params = { valueConverter: (v: any) => _toStringOrNull(v) };

--- a/packages/ag-grid-enterprise/src/advancedFilter/filterExpressionOperators.ts
+++ b/packages/ag-grid-enterprise/src/advancedFilter/filterExpressionOperators.ts
@@ -1,5 +1,6 @@
 import { _hasOwn } from 'ag-stack';
 
+import { _hasValue, _isBlank } from 'ag-grid-community';
 import type { BaseCellDataType, IRowNode } from 'ag-grid-community';
 
 import type { ADVANCED_FILTER_LOCALE_TEXT } from './advancedFilterLocaleText';
@@ -156,12 +157,12 @@ export class TextFilterExpressionOperators<TValue = string> implements DataTypeF
             },
             blank: {
                 displayValue: translate('advancedFilterBlank'),
-                evaluator: (value) => value == null || (typeof value === 'string' && value.trim().length === 0),
+                evaluator: _isBlank,
                 numOperands: 0,
             },
             notBlank: {
                 displayValue: translate('advancedFilterNotBlank'),
-                evaluator: (value) => value != null && (typeof value !== 'string' || value.trim().length > 0),
+                evaluator: _hasValue,
                 numOperands: 0,
             },
         };
@@ -286,12 +287,12 @@ export class ScalarFilterExpressionOperators<
             },
             blank: {
                 displayValue: translate('advancedFilterBlank'),
-                evaluator: (value) => value == null,
+                evaluator: _isBlank,
                 numOperands: 0,
             },
             notBlank: {
                 displayValue: translate('advancedFilterNotBlank'),
-                evaluator: (value) => value != null,
+                evaluator: _hasValue,
                 numOperands: 0,
             },
         };
@@ -306,7 +307,9 @@ export class ScalarFilterExpressionOperators<
         expression: (value: ConvertedTValue, operand: ConvertedTValue) => boolean,
         isNegated?: boolean
     ): boolean {
-        if (value == null) {
+        // A scalar has no use for a blank string, so it counts as absent — as it does in the column filter.
+        // The `== null` half is what narrows `value`; `_isBlank` alone would not.
+        if (value == null || _isBlank(value)) {
             return nullsMatch;
         }
         const convertedValue = params.valueConverter(value, node);
@@ -345,12 +348,12 @@ export class BooleanFilterExpressionOperators implements DataTypeFilterExpressio
             },
             blank: {
                 displayValue: translate('advancedFilterBlank'),
-                evaluator: (value) => value == null,
+                evaluator: _isBlank,
                 numOperands: 0,
             },
             notBlank: {
                 displayValue: translate('advancedFilterNotBlank'),
-                evaluator: (value) => value != null,
+                evaluator: _hasValue,
                 numOperands: 0,
             },
         };

--- a/testing/behavioural/src/filters/advanced-filter/advanced-filter-column-filter-parity.test.ts
+++ b/testing/behavioural/src/filters/advanced-filter/advanced-filter-column-filter-parity.test.ts
@@ -1,29 +1,38 @@
 import { TestGridsManager, asyncSetTimeout } from 'ag-test-utils';
 
 import type { AdvancedFilterModel, ColumnAdvancedFilterModel, GridApi, GridOptions } from 'ag-grid-community';
-import { ClientSideRowModelModule, DateFilterModule, NumberFilterModule, TextFilterModule } from 'ag-grid-community';
+import {
+    BigIntFilterModule,
+    ClientSideRowModelModule,
+    DateFilterModule,
+    NumberFilterModule,
+    TextFilterModule,
+} from 'ag-grid-community';
 import { AdvancedFilterModule } from 'ag-grid-enterprise';
 
 interface TestRow {
     id: number;
     athlete: string | null;
-    age: number | null;
+    age: number | string | null;
     date: string | null;
+    qty: bigint | string | number | null;
 }
 
 const ROW_DATA: TestRow[] = [
-    { id: 0, athlete: 'Alpha', age: 1, date: '2008-08-24' },
-    { id: 1, athlete: 'alpha beta', age: 2, date: '   ' },
-    { id: 2, athlete: '', age: 3, date: null },
-    { id: 3, athlete: '   ', age: null, date: '2020-07-23' },
-    { id: 4, athlete: null, age: 0, date: 'not a date' },
-    { id: 5, athlete: 'Beta', age: -2, date: '2012-08-05' },
+    { id: 0, athlete: 'Alpha', age: 1, date: '2008-08-24', qty: 10n },
+    { id: 1, athlete: 'alpha beta', age: 2, date: '   ', qty: '10' },
+    { id: 2, athlete: '', age: 3, date: null, qty: 10 },
+    { id: 3, athlete: '   ', age: null, date: '2020-07-23', qty: null },
+    { id: 4, athlete: null, age: 0, date: 'not a date', qty: 'nope' },
+    { id: 5, athlete: 'Beta', age: -2, date: '2012-08-05', qty: -5n },
+    { id: 6, athlete: 'Gamma', age: '', date: '', qty: '' },
 ];
 
 const COLUMN_DEFS: GridOptions<TestRow>['columnDefs'] = [
     { field: 'athlete', filter: 'agTextColumnFilter' },
-    { field: 'age', filter: 'agNumberColumnFilter', filterParams: { includeBlanksInNotEqual: true } },
+    { field: 'age', filter: 'agNumberColumnFilter' },
     { field: 'date', cellDataType: 'dateString', filter: 'agDateColumnFilter' },
+    { field: 'qty', cellDataType: 'bigint', filter: 'agBigIntColumnFilter' },
 ];
 
 function getDisplayedIds(api: GridApi<TestRow>): number[] {
@@ -40,6 +49,7 @@ describe('Advanced Filter matches the column filter', () => {
             TextFilterModule,
             NumberFilterModule,
             DateFilterModule,
+            BigIntFilterModule,
             AdvancedFilterModule,
             ClientSideRowModelModule,
         ],
@@ -48,8 +58,8 @@ describe('Advanced Filter matches the column filter', () => {
     afterEach(() => gridsManager.reset());
 
     /** The rows a column filter shows for `model`, applied to a grid with no Advanced Filter. */
-    async function withColumnFilter(colId: string, model: object): Promise<number[]> {
-        const api = gridsManager.createGrid('columnFilterGrid', { columnDefs: COLUMN_DEFS, rowData: ROW_DATA });
+    async function withColumnFilter(colId: string, model: object, columnDefs = COLUMN_DEFS): Promise<number[]> {
+        const api = gridsManager.createGrid('columnFilterGrid', { columnDefs, rowData: ROW_DATA });
         await asyncSetTimeout(0);
         await api.setColumnFilterModel(colId, model);
         api.onFilterChanged();
@@ -60,9 +70,9 @@ describe('Advanced Filter matches the column filter', () => {
     }
 
     /** The rows the Advanced Filter shows for the equivalent condition. */
-    async function withAdvancedFilter(model: AdvancedFilterModel): Promise<number[]> {
+    async function withAdvancedFilter(model: AdvancedFilterModel, columnDefs = COLUMN_DEFS): Promise<number[]> {
         const api = gridsManager.createGrid('advancedFilterGrid', {
-            columnDefs: COLUMN_DEFS,
+            columnDefs,
             rowData: ROW_DATA,
             enableAdvancedFilter: true,
         });
@@ -121,12 +131,50 @@ describe('Advanced Filter matches the column filter', () => {
     });
 
     test('`includeBlanksInNotEqual` admits a blank to `notEqual` in both', async () => {
-        const columnFilterIds = await withColumnFilter('age', { filterType: 'number', type: 'notEqual', filter: 2 });
+        const defs = COLUMN_DEFS!.map((def) =>
+            (def as { field?: string }).field === 'age'
+                ? { ...def, filterParams: { includeBlanksInNotEqual: true } }
+                : def
+        );
+        const columnFilterIds = await withColumnFilter(
+            'age',
+            { filterType: 'number', type: 'notEqual', filter: 2 },
+            defs
+        );
 
         expect(columnFilterIds).toContain(3); // the row with a null age
-        expect(await withAdvancedFilter({ filterType: 'number', colId: 'age', type: 'notEqual', filter: 2 })).toEqual(
-            columnFilterIds
-        );
+        expect(columnFilterIds).toContain(6); // and the row with an empty-string age
+        expect(
+            await withAdvancedFilter({ filterType: 'number', colId: 'age', type: 'notEqual', filter: 2 }, defs)
+        ).toEqual(columnFilterIds);
+    });
+
+    // Boolean has no column-filter counterpart to compare against — its options are `true`/`false`, not
+    // `blank` — so this is the Advanced Filter alone, pinning that it answers blank the way every other type does.
+    test('a boolean column answers blank for an empty or whitespace-only value', async () => {
+        const defs = [
+            { field: 'id' },
+            { field: 'active', cellDataType: 'boolean' as const, filter: 'agTextColumnFilter' },
+        ];
+        const rowData = [
+            { id: 0, active: true },
+            { id: 1, active: false },
+            { id: 2, active: null },
+            { id: 3, active: '' },
+            { id: 4, active: '   ' },
+        ];
+        const api = gridsManager.createGrid('booleanGrid', { columnDefs: defs, rowData, enableAdvancedFilter: true });
+        await asyncSetTimeout(0);
+
+        api.setAdvancedFilterModel({ filterType: 'boolean', colId: 'active', type: 'blank' });
+        api.onFilterChanged();
+        await asyncSetTimeout(0);
+        expect(getDisplayedIds(api as GridApi<TestRow>)).toEqual([2, 3, 4]);
+
+        api.setAdvancedFilterModel({ filterType: 'boolean', colId: 'active', type: 'notBlank' });
+        api.onFilterChanged();
+        await asyncSetTimeout(0);
+        expect(getDisplayedIds(api as GridApi<TestRow>)).toEqual([0, 1]);
     });
 
     // The column filter's `isValid(cellValue)` gate keeps an unreadable date out of the comparison; the
@@ -153,9 +201,10 @@ describe('Advanced Filter matches the column filter', () => {
             dateFrom: '2008-08-24',
         });
 
-        expect(columnFilterIds).toContain(1); // whitespace
-        expect(columnFilterIds).toContain(4); // 'not a date'
-        expect(columnFilterIds).not.toContain(2); // null is blank, not unreadable
+        expect(columnFilterIds).toContain(4); // 'not a date' is unreadable
+        expect(columnFilterIds).not.toContain(1); // whitespace is blank, not unreadable
+        expect(columnFilterIds).not.toContain(2); // and so are null
+        expect(columnFilterIds).not.toContain(6); // and the empty string
         expect(
             await withAdvancedFilter({
                 filterType: 'dateString',
@@ -164,16 +213,5 @@ describe('Advanced Filter matches the column filter', () => {
                 filter: '2008-08-24',
             })
         ).toEqual(columnFilterIds);
-    });
-
-    // A whitespace date is rejected as an invalid date before either filter asks whether it is blank, so
-    // `isBlank`'s treatment of whitespace never reaches it. Pinned because it is the surprise.
-    test('a whitespace `dateString` is not blank to either', async () => {
-        const columnFilterIds = await withColumnFilter('date', { filterType: 'date', type: 'blank' });
-
-        expect(columnFilterIds).toEqual([2]);
-        expect(await withAdvancedFilter({ filterType: 'dateString', colId: 'date', type: 'blank' })).toEqual(
-            columnFilterIds
-        );
     });
 });

--- a/testing/behavioural/src/filters/blank-and-unreadable-values.test.ts
+++ b/testing/behavioural/src/filters/blank-and-unreadable-values.test.ts
@@ -1,0 +1,190 @@
+import { TestGridsManager, asyncSetTimeout } from 'ag-test-utils';
+
+import type { AdvancedFilterModel, ColumnAdvancedFilterModel, GridApi } from 'ag-grid-community';
+import {
+    BigIntFilterModule,
+    ClientSideRowModelModule,
+    DateFilterModule,
+    NumberFilterModule,
+    TextFilterModule,
+} from 'ag-grid-community';
+import { AdvancedFilterModule } from 'ag-grid-enterprise';
+
+/**
+ * The three states a cell can be in, for every provided filter and both filter engines. Missing (`null`,
+ * `undefined`, empty or whitespace-only) answers `blank`, and only the matching `includeBlanksIn*` admits it to a
+ * comparison. Unreadable (present, but not the column's type) answers `notBlank`, is excluded from every
+ * comparison except a negation, and no param can reach it. Readable is compared.
+ *
+ * Sibling-less by design: the rule spans `scalarFilterHandler`, `bigIntFilterHandler`, `textFilterHandler`,
+ * `filterExpressionOperators` and `advancedFilterExpressionService`, so no one module owns it. Every case here is
+ * also a row of AG-18279's acceptance table, which is why the answers are pinned rather than only the agreement.
+ */
+describe('Blank and unreadable values', () => {
+    const gridsManager = new TestGridsManager({
+        modules: [
+            NumberFilterModule,
+            BigIntFilterModule,
+            DateFilterModule,
+            TextFilterModule,
+            AdvancedFilterModule,
+            ClientSideRowModelModule,
+        ],
+    });
+
+    afterEach(() => gridsManager.reset());
+
+    const ROWS = {
+        number: [
+            { id: 'A', value: 0 },
+            { id: 'B', value: 7 },
+            { id: 'C', value: '' },
+            { id: 'D', value: '   ' },
+            { id: 'E', value: null },
+        ],
+        bigint: [
+            { id: 'A', value: 0 },
+            { id: 'B', value: '0' },
+            { id: 'C', value: 0n },
+            { id: 'D', value: 7 },
+            { id: 'E', value: '' },
+        ],
+        date: [
+            { id: 'A', value: '2024-01-10' },
+            { id: 'B', value: '2024-06-01' },
+            { id: 'C', value: '' },
+            { id: 'D', value: null },
+            { id: 'E', value: 'not a date' },
+        ],
+        text: [
+            { id: 'A', value: 'abc' },
+            { id: 'B', value: 'xyz' },
+            { id: 'C', value: '' },
+            { id: 'D', value: '   ' },
+            { id: 'E', value: null },
+        ],
+    };
+
+    const COLUMN: Record<string, { cellDataType: string; filter: string }> = {
+        number: { cellDataType: 'number', filter: 'agNumberColumnFilter' },
+        bigint: { cellDataType: 'bigint', filter: 'agBigIntColumnFilter' },
+        date: { cellDataType: 'dateString', filter: 'agDateColumnFilter' },
+        text: { cellDataType: 'text', filter: 'agTextColumnFilter' },
+    };
+
+    function displayedIds(api: GridApi): string {
+        const ids: string[] = [];
+        for (let i = 0; i < api.getDisplayedRowCount(); i++) {
+            ids.push(api.getDisplayedRowAtIndex(i)!.data!.id);
+        }
+        return ids.join(' ');
+    }
+
+    /**
+     * The rows each engine shows for one condition. Returning both in one object makes a failure say which
+     * engine broke, and asserting them together pins the answer rather than only that the two agree.
+     */
+    async function bothEngines(
+        kind: keyof typeof ROWS,
+        model: object,
+        filterParams: object = {}
+    ): Promise<{ columnFilter: string; advancedFilter: string }> {
+        const { cellDataType, filter } = COLUMN[kind];
+        const columnDefs = [{ field: 'id' }, { field: 'value', cellDataType, filter, filterParams }] as any;
+        const rowData = ROWS[kind];
+
+        const columnFilterApi: GridApi = await gridsManager.createGridAndWait('columnFilterGrid', {
+            columnDefs,
+            rowData,
+        });
+        await columnFilterApi.setColumnFilterModel('value', { filterType: kind, ...model });
+        columnFilterApi.onFilterChanged();
+        await asyncSetTimeout(0);
+        const columnFilter = displayedIds(columnFilterApi);
+        columnFilterApi.destroy();
+
+        const { type, filter: operand, dateFrom } = model as any;
+        const advancedFilterModel: ColumnAdvancedFilterModel = {
+            filterType: kind === 'date' ? 'dateString' : kind,
+            colId: 'value',
+            type,
+            ...(operand !== undefined ? { filter: operand } : {}),
+            ...(dateFrom !== undefined ? { filter: dateFrom } : {}),
+        } as ColumnAdvancedFilterModel;
+
+        const advancedFilterApi: GridApi = await gridsManager.createGridAndWait('advancedFilterGrid', {
+            columnDefs,
+            rowData,
+            enableAdvancedFilter: true,
+        });
+        advancedFilterApi.setAdvancedFilterModel(advancedFilterModel as AdvancedFilterModel);
+        advancedFilterApi.onFilterChanged();
+        await asyncSetTimeout(0);
+        const advancedFilter = displayedIds(advancedFilterApi);
+        advancedFilterApi.destroy();
+
+        return { columnFilter, advancedFilter };
+    }
+
+    /** Both engines show exactly `expected`. */
+    function shows(expected: string) {
+        return { columnFilter: expected, advancedFilter: expected };
+    }
+
+    // A=0 B=7 C='' D='   ' E=null
+    test('a number column reads an empty or whitespace cell as missing, not as zero', async () => {
+        expect(await bothEngines('number', { type: 'blank' })).toEqual(shows('C D E'));
+        expect(await bothEngines('number', { type: 'notBlank' })).toEqual(shows('A B'));
+
+        // The zero row is the discriminator: a blank that coerced to 0 would join every one of these.
+        expect(await bothEngines('number', { type: 'equals', filter: 0 })).toEqual(shows('A'));
+        expect(await bothEngines('number', { type: 'notEqual', filter: 0 })).toEqual(shows('B'));
+        expect(await bothEngines('number', { type: 'lessThan', filter: 5 })).toEqual(shows('A'));
+        expect(await bothEngines('number', { type: 'greaterThan', filter: -5 })).toEqual(shows('A B'));
+
+        const includeEquals = { includeBlanksInEquals: true };
+        expect(await bothEngines('number', { type: 'equals', filter: 0 }, includeEquals)).toEqual(shows('A C D E'));
+        const includeLessThan = { includeBlanksInLessThan: true };
+        expect(await bothEngines('number', { type: 'lessThan', filter: 5 }, includeLessThan)).toEqual(shows('A C D E'));
+        const includeNotEqual = { includeBlanksInNotEqual: true };
+        expect(await bothEngines('number', { type: 'notEqual', filter: 0 }, includeNotEqual)).toEqual(shows('B C D E'));
+    });
+
+    // A='2024-01-10' B='2024-06-01' C='' D=null E='not a date'
+    test('a date column separates a missing date from one it cannot read', async () => {
+        expect(await bothEngines('date', { type: 'blank' })).toEqual(shows('C D'));
+        // E is present and unreadable, so it is not blank, and no `includeBlanksIn*` below reaches it.
+        expect(await bothEngines('date', { type: 'notBlank' })).toEqual(shows('A B E'));
+
+        expect(await bothEngines('date', { type: 'equals', dateFrom: '2024-01-10' })).toEqual(shows('A'));
+        // `notEqual` is the one comparison an unreadable value passes: it equals nothing.
+        expect(await bothEngines('date', { type: 'notEqual', dateFrom: '2024-01-10' })).toEqual(shows('B E'));
+
+        const includeNotEqual = { includeBlanksInNotEqual: true };
+        expect(await bothEngines('date', { type: 'notEqual', dateFrom: '2024-01-10' }, includeNotEqual)).toEqual(
+            shows('B C D E')
+        );
+        const includeLessThan = { includeBlanksInLessThan: true };
+        expect(await bothEngines('date', { type: 'lessThan', dateFrom: '2024-06-01' }, includeLessThan)).toEqual(
+            shows('A C D')
+        );
+    });
+
+    // A=0 (number) B='0' (string) C=0n (bigint) D=7 (number) E=''
+    test('a bigint column compares the same number however the row data writes it', async () => {
+        // `0n === 0` is false, so comparing the cell value unparsed would match C alone.
+        expect(await bothEngines('bigint', { type: 'equals', filter: '0' })).toEqual(shows('A B C'));
+        expect(await bothEngines('bigint', { type: 'notEqual', filter: '0' })).toEqual(shows('D'));
+        expect(await bothEngines('bigint', { type: 'blank' })).toEqual(shows('E'));
+    });
+
+    // A='abc' B='xyz' C='' D='   ' E=null
+    test('a text column counts an empty value as blank but still matches it as text', async () => {
+        expect(await bothEngines('text', { type: 'blank' })).toEqual(shows('C D E'));
+        expect(await bothEngines('text', { type: 'notBlank' })).toEqual(shows('A B'));
+
+        // Unlike a scalar, text keeps an empty string as a value: C and D are matchable, and reach `notEqual`.
+        expect(await bothEngines('text', { type: 'contains', filter: 'abc' })).toEqual(shows('A'));
+        expect(await bothEngines('text', { type: 'notEqual', filter: 'abc' })).toEqual(shows('B C D E'));
+    });
+});

--- a/testing/behavioural/src/filters/filter-behaviour/date-filter-conditions.test.ts
+++ b/testing/behavioural/src/filters/filter-behaviour/date-filter-conditions.test.ts
@@ -216,10 +216,18 @@ describe('Date Filter — conditions coverage', () => {
         expect(filter.getModel()).toMatchObject({ type: 'greaterThan', dateFrom: '2024-03-15' });
     });
 
-    test('blank and notBlank partition null vs non-null rows', async () => {
+    test('blank, notBlank and equals partition every way of writing no date', async () => {
         const api: GridApi = await gridsManager.createGridAndWait('grid1', {
             columnDefs: [{ field: 'date', filter: 'agDateColumnFilter', filterParams: { debounceMs: 0 } }],
-            rowData: [{ date: '2024-01-10' }, { date: null }, { date: '2024-05-20' }, { date: null }],
+            // A non-breaking space is whitespace to `trim`, and so blank, however printable its code point.
+            rowData: [
+                { date: '2024-01-10' },
+                { date: null },
+                { date: '2024-05-20' },
+                { date: null },
+                { date: '' },
+                { date: '\u00A0' },
+            ],
         });
 
         const filter = await ColumnFilterHarness.open(api, 'date');
@@ -241,9 +249,13 @@ describe('Date Filter — conditions coverage', () => {
         await new GridRows(api, 'blank rows').check(`
             ROOT id:ROOT_NODE_ID
             ├── LEAF id:1 date:null
-            └── LEAF id:3 date:null
+            ├── LEAF id:3 date:null
+            ├── LEAF id:4 date:""
+            └── LEAF id:5 date:""
         `);
         expect(filter.getModel()).toMatchObject({ type: 'blank' });
+        // Both blank rows serialise as `date:""`, so the ids are what say which is the non-breaking space.
+        expect(api.getDisplayedRowAtIndex(3)!.data.date).toBe('\u00A0');
 
         await filter.selectOperator('Not blank');
         await asyncSetTimeout(0);
@@ -253,6 +265,63 @@ describe('Date Filter — conditions coverage', () => {
             └── LEAF id:2 date:"2024-05-20"
         `);
         expect(filter.getModel()).toMatchObject({ type: 'notBlank' });
+
+        // Blanks are out of an `equals` unless asked for, whichever way they are written.
+        await filter.selectOperator('Equals');
+        await filter.setDate('2024-01-10', 0);
+        await asyncSetTimeout(0);
+        await new GridRows(api, 'equals rows').check(`
+            ROOT id:ROOT_NODE_ID
+            └── LEAF id:0 date:"2024-01-10"
+        `);
+        expect(filter.getModel()).toMatchObject({ type: 'equals', dateFrom: '2024-01-10' });
+    });
+
+    test('includeBlanksInEquals admits an empty string as well as a null', async () => {
+        const api: GridApi = await gridsManager.createGridAndWait('grid1', {
+            columnDefs: [
+                {
+                    field: 'date',
+                    filter: 'agDateColumnFilter',
+                    filterParams: { debounceMs: 0, includeBlanksInEquals: true },
+                },
+            ],
+            rowData: [{ date: '2024-01-10' }, { date: null }, { date: '2024-05-20' }, { date: '' }],
+        });
+
+        const filter = await ColumnFilterHarness.open(api, 'date');
+        await filter.selectOperator('Equals');
+        await filter.setDate('2024-01-10', 0);
+        await asyncSetTimeout(0);
+
+        await new GridRows(api, 'equals with blanks included').check(`
+            ROOT id:ROOT_NODE_ID
+            ├── LEAF id:0 date:"2024-01-10"
+            ├── LEAF id:1 date:null
+            └── LEAF id:3 date:""
+        `);
+    });
+
+    // A lenient `comparator` reports "equal" for input it cannot parse, so a blank must not reach it.
+    test('an empty string never reaches the comparator', async () => {
+        const comparator = vi.fn(dayMonthYearComparator);
+        const api: GridApi = await gridsManager.createGridAndWait('grid1', {
+            columnDefs: [
+                { field: 'date', filter: 'agDateColumnFilter', cellDataType: false, filterParams: { comparator } },
+            ],
+            rowData: [{ date: null }, { date: '' }, { date: '25/10/2016' }],
+        });
+
+        const filter = await ColumnFilterHarness.open(api, 'date');
+        await filter.selectOperator('Equals');
+        await filter.setDate('2016-10-25', 0);
+        await asyncSetTimeout(0);
+
+        await new GridRows(api, 'only the row that holds the date').check(`
+            ROOT id:ROOT_NODE_ID
+            └── LEAF id:2 date:"25/10/2016"
+        `);
+        expect(comparator.mock.calls.map(([, cellValue]) => cellValue)).toEqual(['25/10/2016']);
     });
 
     const BOUNDARY = [
@@ -817,6 +886,19 @@ describe('Date Filter — conditions coverage', () => {
         `);
     });
 });
+
+/** Reads `dd/mm/yyyy` and reports "equal" for anything it cannot parse. */
+function dayMonthYearComparator(filterDate: Date, cellValue: string): number {
+    const [day, month, year] = cellValue.split('/');
+    const cellDate = new Date(Number(year), Number(month) - 1, Number(day));
+    if (cellDate < filterDate) {
+        return -1;
+    }
+    if (cellDate > filterDate) {
+        return 1;
+    }
+    return 0;
+}
 
 /** Day-granularity date comparator (cell vs filter): ignores the time-of-day component. */
 function sameDayComparator(filterDate: Date, cellValue: Date): number {

--- a/testing/behavioural/src/filters/filter-behaviour/number-filter-conditions.test.ts
+++ b/testing/behavioural/src/filters/filter-behaviour/number-filter-conditions.test.ts
@@ -285,6 +285,50 @@ describe('Number Filter — conditions coverage', () => {
         `);
     });
 
+    // An empty string orders as a zero against every bound, but never equals one: `0 === ''` is false.
+    test('an empty string is a blank, not a zero', async () => {
+        const api: GridApi = await gridsManager.createGridAndWait('grid1', {
+            columnDefs: [{ field: 'val', filter: 'agNumberColumnFilter', filterParams: { debounceMs: 0 } }],
+            rowData: [{ val: 5 }, { val: '' }, { val: null }, { val: -3 }],
+        });
+
+        const filter = await ColumnFilterHarness.open(api, 'val');
+
+        await filter.selectOperator('Less than');
+        await filter.setNumber(0, 0);
+        await asyncSetTimeout(0);
+        await new GridRows(api, 'lessThan excludes the empty string alongside the null').check(`
+            ROOT id:ROOT_NODE_ID
+            └── LEAF id:3 val:-3
+        `);
+
+        // Below the empty string's own coercion to zero, so ordering it as a value would let it through here.
+        await filter.selectOperator('Greater than');
+        await filter.setNumber(-1, 0);
+        await asyncSetTimeout(0);
+        await new GridRows(api, 'greaterThan excludes it too').check(`
+            ROOT id:ROOT_NODE_ID
+            └── LEAF id:0 val:5
+        `);
+
+        await filter.selectOperator('Does not equal');
+        await filter.setNumber(9, 0);
+        await asyncSetTimeout(0);
+        await new GridRows(api, 'notEqual drops it with the null, though it equals nothing').check(`
+            ROOT id:ROOT_NODE_ID
+            ├── LEAF id:0 val:5
+            └── LEAF id:3 val:-3
+        `);
+
+        await filter.selectOperator('Between');
+        await filter.setNumber(-1, 0);
+        await filter.setNumber(1, 1);
+        await asyncSetTimeout(0);
+        await new GridRows(api, 'inRange spanning zero no longer contains it').check(`
+            ROOT id:ROOT_NODE_ID
+        `);
+    });
+
     test('notEqual excludes blank rows by default', async () => {
         const api: GridApi = await gridsManager.createGridAndWait('grid1', {
             columnDefs: [{ field: 'val', filter: 'agNumberColumnFilter', filterParams: { debounceMs: 0 } }],
@@ -387,18 +431,20 @@ describe('Number Filter — conditions coverage', () => {
                     filterParams: { debounceMs: 0, includeBlanksInLessThan: true },
                 },
             ],
-            rowData: [{ val: 1 }, { val: null }, { val: 9 }],
+            rowData: [{ val: 1 }, { val: null }, { val: 9 }, { val: '' }, { val: -5 }],
         });
 
         const filter = await ColumnFilterHarness.open(api, 'val');
+        // Negative, so the empty string can only arrive as a blank: ordered as a value it coerces to zero.
         await filter.selectOperator('Less than');
-        await filter.setNumber(5, 0);
+        await filter.setNumber(-1, 0);
         await asyncSetTimeout(0);
 
         await new GridRows(api, 'lessThan includes blank rows').check(`
             ROOT id:ROOT_NODE_ID
-            ├── LEAF id:0 val:1
-            └── LEAF id:1 val:null
+            ├── LEAF id:1 val:null
+            ├── LEAF id:3 val:"Invalid Number"
+            └── LEAF id:4 val:-5
         `);
     });
 

--- a/testing/behavioural/src/filters/filter-behaviour/text-filter-conditions.test.ts
+++ b/testing/behavioural/src/filters/filter-behaviour/text-filter-conditions.test.ts
@@ -27,7 +27,7 @@ describe('Text Filter — conditions coverage', () => {
     afterAll(() => uninstallFilterLayoutMock());
     afterEach(() => gridsManager.reset());
 
-    // Distinctive rows: null and '' exercise the null-value / isBlank branches of every operator.
+    // Distinctive rows: null and '' exercise the null-value / blank branches of every operator.
     const OPERATOR_ROWS = [
         { name: 'Apple' },
         { name: 'Banana' },


### PR DESCRIPTION
<!-- base: latest -->

# Blank values in the number, bigint and date filters

FIX AG-11294
FIX AG-18279

A cell on a number, bigint or date column is now one of three things. Missing (`null`, `undefined`, an empty
string, or only spaces) answers `blank`, and the `includeBlanksIn*` params decide whether a comparison admits it.
Unreadable (present but not the column's type, such as `abc`) answers `notBlank`, is excluded from comparisons
except negations, and no param reaches it. Readable is compared. The column filter and the Advanced Filter now
give the same answer for every combination of the two.

| scope  | net lines |  lines changed | hunks |    files changed |
| ------ | --------: | -------------: | ----: | ---------------: |
| source |       +32 |   90 (+61 -29) |    28 |        10 edited |
| tests  |      +354 | 442 (+398 -44) |    30 | 6 (+1, 5 edited) |
| docs   |        +8 |    18 (+13 -5) |     9 |         4 edited |

## Behaviour changes

Filter models are unchanged, so there is no migration step. Text columns, the Quick Filter and the floating
filter are unaffected. What changes is which rows pass, for data that was being read as something it is not.

- **An empty or whitespace-only string is missing.** A number column read it as the number zero, so one cell
  answered `blank` and also answered less than 5, greater than -5, and not equal to 0. A bigint or date column
  rejected it at its validity gate instead, so it answered `notBlank`. Fewer rows now pass a comparison, more
  pass `blank`, and the `includeBlanksIn*` params can put them back, which they previously could not do for data
  that uses an empty string rather than `null`.
- **A whitespace-only value on a `dateString` column moves from unreadable to missing**, so it no longer passes
  `notEqual`.
- **A bigint cell is parsed before it is compared.** `equals 10` matches a row holding `10n`, `'10'` or `10`,
  where it previously matched only the `bigint`; `notEqual 10` no longer matches rows that are equal to 10.
- **The Advanced Filter's `blank` and `notBlank` answer the same way for a boolean column**, and
  `BooleanAdvancedFilterModelType` gains `'blank' | 'notBlank'`, which the runtime, the autocomplete and the
  documentation already offered.

## Blank is decided before the value is read ([AG-11294](https://ag-grid.atlassian.net/browse/AG-11294))

`SimpleFilterHandler` gains an overridable `isNullValue`. The text filter keeps `cellValue == null`, because an
empty string is a value it can match; `ScalarFilterHandler` widens it to `_isBlank`. Deciding this before the
per-type validity gate is what lets a bigint or date column tell a missing value from an unreadable one, and what
puts both within reach of `includeBlanksIn*`.

`isBlank` becomes `_isBlank` and is exported from `main-internal` alongside a new `_isNotBlank`, so the Advanced
Filter's operators share one definition with the column filters rather than carrying inlined copies.

## The two engines agree ([AG-18279](https://ag-grid.atlassian.net/browse/AG-18279))

`ScalarFilterExpressionOperators` treats a blank value as absent on the same terms, and the `bigint` data type
gets a `valueConverter` of `_parseBigIntOrNull` rather than falling through to identity, which also routes an
unreadable bigint into the guard that already exists for unreadable dates.

`testing/behavioural/src/filters/blank-and-unreadable-values.test.ts` drives every combination of the three
states through both engines and asserts the rows each returns, so a divergence fails rather than only a
disagreement.

## Performance

`_isBlank` runs per row per condition on the scalar path. A first character in the open interval `(32, 160)`
cannot be whitespace to `trim`, so one `codePointAt` settles the common case:

| cell values                       | before   | after    |
| --------------------------------- | -------- | -------- |
| date strings                      | 7.52 ns  | 5.75 ns  |
| text                              | 6.93 ns  | 5.22 ns  |
| strings beginning with whitespace | 10.96 ns | 13.28 ns |
