### PR TITLE
AG-18306 multi-filter-refresh

### DIFF
--- a/packages/ag-grid-community/src/filter/columnFilterService.ts
+++ b/packages/ag-grid-community/src/filter/columnFilterService.ts
@@ -46,7 +46,13 @@ import type {
 } from '../interfaces/iFilter';
 import { isColumnFilterComp } from '../interfaces/iFilter';
 import type { UserCompDetails } from '../interfaces/iUserCompDetails';
-import type { FilterHandlerName, FilterUi, FilterWrapper, LegacyFilterWrapper } from './columnFilterUtils';
+import type {
+    FilterHandlerName,
+    FilterUi,
+    FilterWrapper,
+    HandlerFilterWrapper,
+    LegacyFilterWrapper,
+} from './columnFilterUtils';
 import {
     FILTER_HANDLERS,
     FILTER_HANDLER_MAP,
@@ -79,6 +85,11 @@ interface HandlerDoesFilterPassWrapper {
 }
 
 type DoesFilterPassWrapper = CompDoesFilterPassWrapper | HandlerDoesFilterPassWrapper;
+
+interface HandlerFunc {
+    filterHandler: CreateFilterHandlerFunc;
+    handlerNameOrCallback?: FilterHandlerName | ((params: DoesFilterPassParams) => boolean);
+}
 
 export interface FilterDisplayWrapper {
     comp: IFilterComp | FilterDisplayComp;
@@ -959,16 +970,7 @@ export class ColumnFilterService
         };
     }
 
-    private createHandlerFunc(
-        column: AgColumn,
-        filterDef: IFilterDef,
-        defaultFilter: string
-    ):
-        | {
-              filterHandler: CreateFilterHandlerFunc;
-              handlerNameOrCallback?: FilterHandlerName | ((params: DoesFilterPassParams) => boolean);
-          }
-        | undefined {
+    private createHandlerFunc(column: AgColumn, filterDef: IFilterDef, defaultFilter: string): HandlerFunc | undefined {
         const { gos, frameworkOverrides, registry } = this.beans;
         // need to keep track of this so we can compare when col defs change
         let doesFilterPass: ((params: DoesFilterPassParams) => boolean) | undefined;
@@ -1336,6 +1338,60 @@ export class ColumnFilterService
         };
     }
 
+    /** Returns whether the model was cleared, which happens only when the handler could not take the new params. */
+    private refreshOrRecreateHandler(
+        filterWrapper: HandlerFilterWrapper,
+        handlerFunc: HandlerFunc,
+        compDetails: UserCompDetails | null,
+        newFilterParams: any,
+        source: FilterChangedEventSourceType
+    ): boolean {
+        const column = filterWrapper.column;
+        const colId = column.getColId();
+        const handlerGenerator = handlerFunc.handlerNameOrCallback ?? handlerFunc.filterHandler;
+        const existingModel = _getFilterModel(this.model, colId);
+        let recreateHandler = filterWrapper.handlerGenerator != handlerGenerator;
+        if (!recreateHandler) {
+            // `false` means the handler cannot take the new params
+            const handlerParams = this.createHandlerParams(column, compDetails?.params);
+            filterWrapper.handlerParams = handlerParams;
+            recreateHandler =
+                filterWrapper.handler.refresh?.({
+                    ...handlerParams,
+                    source: 'colDef',
+                    model: existingModel,
+                }) === false;
+        }
+        if (!recreateHandler) {
+            return false;
+        }
+
+        const oldHandler = filterWrapper.handler;
+        const { handler, handlerParams } = this.createHandlerFromFunc(
+            column,
+            handlerFunc.filterHandler,
+            newFilterParams
+        );
+        filterWrapper.handler = handler;
+        filterWrapper.handlerParams = handlerParams;
+        filterWrapper.handlerGenerator = handlerGenerator;
+
+        delete this.model[colId];
+        // the ui state describes the model that has just gone
+        this.state.delete(colId);
+        handler.init?.({ ...handlerParams, source: 'init', model: null });
+        // destroy the old handler after creating and assigning the new one in case anything
+        // is listening to events on the handler and needs to resubscribe to the new one
+        this.destroyBean(oldHandler);
+        if (existingModel != null) {
+            this.beans.filterManager?.onFilterChanged({
+                columns: [column],
+                source,
+            });
+        }
+        return true;
+    }
+
     public filterParamsChanged(colId: string, source: FilterChangedEventSourceType = 'api'): void {
         const filterWrapper = this.allColumnFilters.get(colId);
         if (!filterWrapper) {
@@ -1377,46 +1433,13 @@ export class ColumnFilterService
         // a cleared model makes the params derived above stale, so the ui must re-derive them
         let modelCleared = false;
         if (wasHandler) {
-            const handlerGenerator = handlerFunc?.handlerNameOrCallback ?? handlerFunc?.filterHandler;
-            const existingModel = _getFilterModel(this.model, colId);
-            let recreateHandler = filterWrapper.handlerGenerator != handlerGenerator;
-            if (!recreateHandler) {
-                // `false` means the handler cannot take the new params
-                const handlerParams = this.createHandlerParams(column, compDetails?.params);
-                filterWrapper.handlerParams = handlerParams;
-                recreateHandler =
-                    filterWrapper.handler.refresh?.({
-                        ...handlerParams,
-                        source: 'colDef',
-                        model: existingModel,
-                    }) === false;
-            }
-            if (recreateHandler) {
-                const oldHandler = filterWrapper.handler;
-                const { handler, handlerParams } = this.createHandlerFromFunc(
-                    column,
-                    handlerFunc!.filterHandler,
-                    newFilterParams
-                );
-                filterWrapper.handler = handler;
-                filterWrapper.handlerParams = handlerParams;
-                filterWrapper.handlerGenerator = handlerGenerator!;
-
-                delete this.model[colId];
-                // the ui state describes the model that has just gone
-                this.state.delete(colId);
-                modelCleared = true;
-                handler.init?.({ ...handlerParams, source: 'init', model: null });
-                // destroy the old handler after creating and assigning the new one in case anything
-                // is listening to events on the handler and needs to resubscribe to the new one
-                this.destroyBean(oldHandler);
-                if (existingModel != null) {
-                    this.beans.filterManager?.onFilterChanged({
-                        columns: [column],
-                        source,
-                    });
-                }
-            }
+            modelCleared = this.refreshOrRecreateHandler(
+                filterWrapper,
+                handlerFunc!,
+                compDetails,
+                newFilterParams,
+                source
+            );
         }
 
         const filterUi = filterWrapper.filterUi;

--- a/packages/ag-grid-community/src/filter/columnFilterService.ts
+++ b/packages/ag-grid-community/src/filter/columnFilterService.ts
@@ -883,11 +883,13 @@ export class ColumnFilterService
 
     private createFilterUiForHandler(
         compDetails: UserCompDetails | null,
-        createFilterUi: ((update?: boolean) => AgPromise<FilterDisplayComp>) | null
+        createFilterUi: ((update?: boolean) => AgPromise<FilterDisplayComp>) | null,
+        refreshed?: boolean
     ): FilterUi<FilterDisplayComp, FilterDisplayParams> | null {
         return createFilterUi
             ? {
                   created: false,
+                  refreshed,
                   create: createFilterUi,
                   filterParams: compDetails!.params,
                   compDetails: compDetails!,
@@ -1222,7 +1224,8 @@ export class ColumnFilterService
             delete this.initialModel[colId];
             this.state.delete(colId);
             const filterUi = filterWrapper.filterUi;
-            const newFilterUi = this.createFilterUiForHandler(compDetails, createFilterUi as any);
+            // the state just deleted is baked into compDetails, so the replacement must re-derive
+            const newFilterUi = this.createFilterUiForHandler(compDetails, createFilterUi as any, true);
             filterWrapper.filterUi = newFilterUi;
             const eventSvc = this.eventSvc;
             // destroy the old one after creating the new one
@@ -1371,11 +1374,24 @@ export class ColumnFilterService
                 this.createFilterCompParams(column, isHandler, 'colDef') as IFilterParams
             );
 
+        // a cleared model makes the params derived above stale, so the ui must re-derive them
+        let modelCleared = false;
         if (wasHandler) {
             const handlerGenerator = handlerFunc?.handlerNameOrCallback ?? handlerFunc?.filterHandler;
             const existingModel = _getFilterModel(this.model, colId);
-            if (filterWrapper.handlerGenerator != handlerGenerator) {
-                // handler has changed
+            let recreateHandler = filterWrapper.handlerGenerator != handlerGenerator;
+            if (!recreateHandler) {
+                // `false` means the handler cannot take the new params
+                const handlerParams = this.createHandlerParams(column, compDetails?.params);
+                filterWrapper.handlerParams = handlerParams;
+                recreateHandler =
+                    filterWrapper.handler.refresh?.({
+                        ...handlerParams,
+                        source: 'colDef',
+                        model: existingModel,
+                    }) === false;
+            }
+            if (recreateHandler) {
                 const oldHandler = filterWrapper.handler;
                 const { handler, handlerParams } = this.createHandlerFromFunc(
                     column,
@@ -1387,6 +1403,9 @@ export class ColumnFilterService
                 filterWrapper.handlerGenerator = handlerGenerator!;
 
                 delete this.model[colId];
+                // the ui state describes the model that has just gone
+                this.state.delete(colId);
+                modelCleared = true;
                 handler.init?.({ ...handlerParams, source: 'init', model: null });
                 // destroy the old handler after creating and assigning the new one in case anything
                 // is listening to events on the handler and needs to resubscribe to the new one
@@ -1397,30 +1416,24 @@ export class ColumnFilterService
                         source,
                     });
                 }
-            } else {
-                const handlerParams = this.createHandlerParams(column, compDetails?.params);
-                // handler exists and is the same
-                filterWrapper.handlerParams = handlerParams;
-                filterWrapper.handler.refresh?.({
-                    ...handlerParams,
-                    source: 'colDef',
-                    model: existingModel,
-                });
             }
+        }
+
+        const filterUi = filterWrapper.filterUi;
+        if (wasHandler && filterUi && compDetails && !filterUi.created) {
+            // nothing has been built from the old col def yet, so swap the plan instead of destroying
+            filterWrapper.filterUi = this.createFilterUiForHandler(compDetails, createFilterUi as any, modelCleared);
+            return;
         }
 
         // Case when filter component changes
         // or when filter wrapper does not have promise to retrieve FilterComp, destroy
-        if (
-            this.areFilterCompsDifferent(filterWrapper.filterUi?.compDetails ?? null, compDetails) ||
-            !filterWrapper.filterUi ||
-            !compDetails
-        ) {
+        if (this.areFilterCompsDifferent(filterUi?.compDetails ?? null, compDetails) || !filterUi || !compDetails) {
             this.destroyFilterUi(filterWrapper, column, compDetails, createFilterUi);
             return;
         }
 
-        filterWrapper.filterUi.filterParams = newFilterParams;
+        filterUi.filterParams = newFilterParams;
 
         // Otherwise - Check for refresh method before destruction
         // If refresh() method is implemented - call it and destroy filter if it returns false

--- a/packages/ag-grid-community/src/filter/columnFilterUtils.ts
+++ b/packages/ag-grid-community/src/filter/columnFilterUtils.ts
@@ -71,7 +71,7 @@ export interface LegacyFilterWrapper extends BaseFilterWrapper<IFilterComp, IFil
     filter?: IFilterComp;
 }
 
-interface HandlerFilterWrapper extends BaseFilterWrapper<FilterDisplayComp, FilterDisplayParams> {
+export interface HandlerFilterWrapper extends BaseFilterWrapper<FilterDisplayComp, FilterDisplayParams> {
     isHandler: true;
     handler: FilterHandler;
     /** This is only used to see whether the handler has changed */

--- a/packages/ag-grid-community/src/interfaces/iFilter.ts
+++ b/packages/ag-grid-community/src/interfaces/iFilter.ts
@@ -67,8 +67,12 @@ export interface FilterHandler<TData = any, TContext = any, TModel = any, TCusto
     extends SharedFilter, ReadOnlyFloatingFilterParent<TModel> {
     /** Optional: Called once when the handler is created. */
     init?(params: FilterHandlerParams<TData, TContext, TModel, TCustomParams>): void;
-    /** Optional: Called every time the handler is updated, e.g. when the model changes. */
-    refresh?(params: FilterHandlerParams<TData, TContext, TModel, TCustomParams>): void;
+    /**
+     * Optional: Called every time the handler is updated, e.g. when the model changes.
+     * When `source` is `'colDef'`, return `false` if the new params cannot be applied and the grid will
+     * recreate the handler with a null model. The return value is ignored for every other source.
+     */
+    refresh?(params: FilterHandlerParams<TData, TContext, TModel, TCustomParams>): void | boolean;
     /**
      * The grid will ask each active filter, in turn, whether each row in the grid passes. If any
      * filter fails, then the row will be excluded from the final set.
@@ -244,7 +248,14 @@ export interface IFilter extends BaseFilter {
 }
 
 export interface FilterDisplay<TData = any, TContext = any, TModel = any, TState = any> extends SharedFilterUi {
-    /** Called when the column definition, state or model is updated. */
+    /**
+     * Called when the column definition, state or model is updated.
+     *
+     * @returns {boolean} - `true` means that the component should be refreshed and kept.
+     * `false` means that it will be destroyed and a new instance created, which is what to return when
+     * the new params are not compatible with the existing component. Only honoured when the column
+     * definition changed; the return value is ignored for a state or model update.
+     */
     refresh(newParams: FilterDisplayParams<TData, TContext, TModel, TState>): boolean;
 }
 

--- a/packages/ag-grid-enterprise/src/multiFilter/multiFilter.ts
+++ b/packages/ag-grid-enterprise/src/multiFilter/multiFilter.ts
@@ -11,7 +11,6 @@ import type {
     IDoesFilterPassParams,
     IFilter,
     IFilterComp,
-    IFilterParams,
     IMultiFilter,
     IMultiFilterDef,
     IMultiFilterModel,
@@ -33,7 +32,12 @@ import {
 
 import type { BaseFilterComponent } from './baseMultiFilter';
 import { BaseMultiFilter } from './baseMultiFilter';
-import { getFilterModelForIndex, getMultiFilterDefs, updateGetValue } from './multiFilterUtil';
+import {
+    getFilterModelForIndex,
+    getMultiFilterDefs,
+    multiFilterChildrenChanged,
+    updateGetValue,
+} from './multiFilterUtil';
 
 interface MultiFilterWrapper {
     filter: IFilterComp;
@@ -91,10 +95,12 @@ export class MultiFilter extends BaseMultiFilter<MultiFilterWrapper> implements 
         });
     }
 
-    public refresh(params: IFilterParams): boolean {
-        // multi filter has never been reactive. Implementing this would require extracting
-        // even more logic from ColumnFilterService to determine if the filter has changed.
-        // Just update the params for the latest model.
+    public refresh(params: MultiFilterParams): boolean {
+        if (multiFilterChildrenChanged(this.filterDefs, getMultiFilterDefs(params))) {
+            return false;
+        }
+        // `filterDefs` is deliberately not updated: the gui is built from it once, so fresh defs beside a
+        // stale gui would misreport each child's `display` to `afterGuiAttached`.
         this.params = params;
         return true;
     }

--- a/packages/ag-grid-enterprise/src/multiFilter/multiFilterHandler.ts
+++ b/packages/ag-grid-enterprise/src/multiFilter/multiFilterHandler.ts
@@ -18,6 +18,7 @@ import {
     getFilterModelForIndex,
     getMultiFilterDefs,
     getUpdatedMultiFilterModel,
+    multiFilterChildrenChanged,
     updateGetValue,
 } from './multiFilterUtil';
 
@@ -61,31 +62,48 @@ export class MultiFilterHandler
         this.resetActiveList(params.model);
     }
 
-    public refresh(params: FilterHandlerParams<any, any, IMultiFilterModel> & IMultiFilterParams): void {
-        this.params = params;
-        const { model, source, filterParams } = params;
-        const filters = filterParams?.filters;
-
-        this.handlerWrappers.forEach((wrapper, index) => {
-            if (wrapper) {
-                const updatedParams = this.updateHandlerParams(params, index, false, filters?.[index].filterParams);
-                wrapper.handlerParams = updatedParams;
-                wrapper.handler.refresh?.({
-                    ...updatedParams,
-                    model: getFilterModelForIndex(model, index),
-                    source,
-                });
+    public refresh(params: FilterHandlerParams<any, any, IMultiFilterModel, IMultiFilterParams>): boolean {
+        const { model, source } = params;
+        const isColDef = source === 'colDef';
+        if (isColDef) {
+            const newDefs = getMultiFilterDefs(params.filterParams);
+            if (multiFilterChildrenChanged(this.filterDefs, newDefs)) {
+                return false;
             }
-        });
-        if (params.source !== 'floating' && params.source !== 'ui') {
-            this.resetActiveList(params.model);
+            this.filterDefs = newDefs;
+        }
+        const { filterDefs, handlerWrappers } = this;
+        this.params = params;
+
+        // a child cannot be rebuilt on its own, so one refusing the new params recreates the whole handler
+        let childRefused = false;
+        for (let i = 0, len = handlerWrappers.length; i < len; ++i) {
+            const wrapper = handlerWrappers[i];
+            if (!wrapper) {
+                continue;
+            }
+            const updatedParams = this.updateHandlerParams(params, i, false, filterDefs[i].filterParams);
+            wrapper.handlerParams = updatedParams;
+            const refreshed = wrapper.handler.refresh?.({
+                ...updatedParams,
+                model: getFilterModelForIndex(model, i),
+                source,
+            });
+            childRefused ||= refreshed === false;
+        }
+        if (childRefused && isColDef) {
+            return false;
+        }
+        if (source !== 'floating' && source !== 'ui') {
+            this.resetActiveList(model);
         }
         // Floating filter changes bypass MultiFilterUi (whose onModelChange triggers sibling
         // notification for the 'ui' source). Cross-column onAnyFilterChanged notification skips
         // the active column, so siblings within this Multi Filter would otherwise never refresh.
-        if (params.additionalEventAttributes?.fromButtons || params.source === 'floating') {
+        if (params.additionalEventAttributes?.fromButtons || source === 'floating') {
             this.onAnyFilterChanged();
         }
+        return true;
     }
 
     private updateHandlerParams(

--- a/packages/ag-grid-enterprise/src/multiFilter/multiFilterUi.ts
+++ b/packages/ag-grid-enterprise/src/multiFilter/multiFilterUi.ts
@@ -77,8 +77,7 @@ export class MultiFilterUi
     public refresh(params: IMultiFilterParams & FilterDisplayParams<any, any, IMultiFilterModel>): boolean {
         const { model, state, source } = params;
         if (source === 'colDef') {
-            // multi filter has never been reactive. Implementing this would require extracting
-            // even more logic from ColumnFilterService to determine if the filter has changed
+            // rebuilt wholesale rather than diffed, so a change to any child's params, title or display applies
             return false;
         }
         this.params = params;

--- a/packages/ag-grid-enterprise/src/multiFilter/multiFilterUtil.ts
+++ b/packages/ag-grid-enterprise/src/multiFilter/multiFilterUtil.ts
@@ -1,3 +1,5 @@
+import { _areEqual } from 'ag-stack';
+
 import type {
     AgColumn,
     BeanCollection,
@@ -9,12 +11,42 @@ import type {
 } from 'ag-grid-community';
 import { ProvidedFilter } from 'ag-grid-community';
 
-export function getMultiFilterDefs(params: IMultiFilterParams): IMultiFilterDef[] {
-    const { filters } = params;
+export function getMultiFilterDefs(params: IMultiFilterParams | undefined): IMultiFilterDef[] {
+    const filters = params?.filters;
 
     return filters && filters.length > 0
         ? filters
         : [{ filter: 'agTextColumnFilter' }, { filter: 'agSetColumnFilter' }];
+}
+
+/** `true` means "use the default", which for a Multi Filter child is always the text filter. `undefined` is
+ *  deliberately not folded in: the handler path gives it no filter at all rather than the default. */
+function getChildFilter(def: IMultiFilterDef): IMultiFilterDef['filter'] {
+    const filter = def.filter;
+    return filter === true ? 'agTextColumnFilter' : filter;
+}
+
+/** The `{ component, handler, doesFilterPass }` form is rebuilt inline with the col def, so the wrapper's
+ *  own identity says nothing; both resolvers key on its contents. */
+function childFilterEqual(oldDef: IMultiFilterDef, newDef: IMultiFilterDef): boolean {
+    const oldFilter = getChildFilter(oldDef);
+    const newFilter = getChildFilter(newDef);
+    if (oldFilter === newFilter) {
+        return true;
+    }
+    if (typeof oldFilter !== 'object' || typeof newFilter !== 'object') {
+        return false;
+    }
+    return (
+        oldFilter.component === newFilter.component &&
+        oldFilter.handler === newFilter.handler &&
+        oldFilter.doesFilterPass === newFilter.doesFilterPass
+    );
+}
+
+/** Children are built once, so a different child set means the Multi Filter has to be recreated. */
+export function multiFilterChildrenChanged(oldDefs: IMultiFilterDef[], newDefs: IMultiFilterDef[]): boolean {
+    return !_areEqual(oldDefs, newDefs, childFilterEqual);
 }
 
 export function forEachReverse<T>(list: T[] | null | undefined, action: (value: T, index: number) => void): void {

--- a/testing/behavioural/src/filters/filter-behaviour/filter-state-and-events.test.ts
+++ b/testing/behavioural/src/filters/filter-behaviour/filter-state-and-events.test.ts
@@ -470,4 +470,33 @@ describe('Filter State & Events', () => {
         const noMatches = document.querySelector('.ag-filter-menu .ag-filter-no-matches');
         expect(noMatches?.classList.contains('ag-hidden')).toBe(true);
     });
+
+    test('restored filter state survives a column definition change before the filter is opened', async () => {
+        // The model is what creates the filter wrapper, and so the colDefChanged listener, while closed.
+        const state = {
+            filter: {
+                filterModel: { athlete: { filterType: 'set', values: ['Alicia Coutts'] } },
+                columnFilterState: { athlete: { miniFilterValue: 'li' } },
+            },
+        } as GridState;
+
+        const api: GridApi = await gridsManager.createGridAndWait('grid1', {
+            columnDefs: [{ field: 'athlete', filter: 'agSetColumnFilter' }],
+            rowData: ATHLETES,
+            initialState: state,
+        });
+        expect(api.getState().filter?.columnFilterState?.athlete).toEqual({ miniFilterValue: 'li' });
+
+        // The filter has never been opened, so its ui does not exist yet and an unrelated col def edit
+        // must not be treated as a reason to throw the restored state away.
+        api.setGridOption('columnDefs', [{ field: 'athlete', headerName: 'Renamed', filter: 'agSetColumnFilter' }]);
+        await asyncSetTimeout(0);
+
+        expect(api.getState().filter?.columnFilterState?.athlete).toEqual({ miniFilterValue: 'li' });
+        expect(api.getColumnFilterModel('athlete')).toEqual({ filterType: 'set', values: ['Alicia Coutts'] });
+
+        // and it still drives the mini filter when the filter is finally opened
+        const filter = await ColumnFilterHarness.open(api, 'athlete');
+        await waitFor(() => expect(filter.setFilterItemLabels()).toEqual(LI_MATCHES));
+    });
 });

--- a/testing/behavioural/src/filters/filter-behaviour/multi-filter.test.ts
+++ b/testing/behavioural/src/filters/filter-behaviour/multi-filter.test.ts
@@ -10,7 +10,9 @@ import {
 
 import type { GridApi, GridOptions } from 'ag-grid-community';
 import { ClientSideRowModelModule, NumberFilterModule, TextFilterModule, setupAgTestIds } from 'ag-grid-community';
-import { ColumnMenuModule, MultiFilterModule, SetFilterModule } from 'ag-grid-enterprise';
+import { ColumnMenuModule, FiltersToolPanelModule, MultiFilterModule, SetFilterModule } from 'ag-grid-enterprise';
+
+import { FILTERS_SIDEBAR, openFiltersPanel } from './toolPanelHarness';
 
 interface Row {
     name?: string | null;
@@ -24,15 +26,18 @@ const ROWS: Row[] = [
     { name: 'alice', age: 35 },
 ];
 
-/** The `.ag-multi-floating-filter` cell's currently displayed child (the non-hidden sub-floating-filter). */
-function visibleFloatingChild(): HTMLElement {
+/** Every sub-floating-filter in the `.ag-multi-floating-filter` cell, hidden ones included. */
+function floatingChildren(): HTMLElement[] {
     const container = document.querySelector<HTMLElement>('.ag-multi-floating-filter');
     if (!container) {
         throw new Error('Multi floating filter container not present');
     }
-    const shown = Array.from(container.children).filter(
-        (c): c is HTMLElement => c instanceof HTMLElement && !c.classList.contains('ag-hidden')
-    );
+    return Array.from(container.children).filter((c): c is HTMLElement => c instanceof HTMLElement);
+}
+
+/** The `.ag-multi-floating-filter` cell's currently displayed child (the non-hidden sub-floating-filter). */
+function visibleFloatingChild(): HTMLElement {
+    const shown = floatingChildren().filter((c) => !c.classList.contains('ag-hidden'));
     if (shown.length !== 1) {
         throw new Error(`Expected exactly one visible multi floating child, found ${shown.length}`);
     }
@@ -67,6 +72,7 @@ describe('Multi Filter — sub-filter combos & combined model (coverage)', () =>
             MultiFilterModule,
             SetFilterModule,
             ColumnMenuModule,
+            FiltersToolPanelModule,
         ],
     });
 
@@ -437,6 +443,334 @@ describe('Multi Filter — sub-filter combos & combined model (coverage)', () =>
             ├── LEAF id:0 name:"michael"
             └── LEAF id:1 name:"michelle"
         `);
+    });
+
+    // The documented custom-child form (filter-multi/custom-filter): a fresh wrapper object each time the
+    // colDefs are rebuilt, around a stable component and doesFilterPass.
+    test('an object-form child rebuilt inline is not treated as a different child', async () => {
+        const doesFilterPass = () => true;
+        const objectFormChild = () => ({ filter: { component: 'agTextColumnFilter', doesFilterPass } });
+        const colDefs = () => [
+            {
+                field: 'name',
+                filter: 'agMultiColumnFilter',
+                filterParams: { filters: [objectFormChild(), { filter: 'agSetColumnFilter' }] },
+            },
+        ];
+
+        const api: GridApi = await gridsManager.createGridAndWait('grid1', {
+            enableFilterHandlers: true,
+            columnDefs: colDefs(),
+            rowData: ROWS,
+        });
+
+        await api.setColumnFilterModel('name', {
+            filterType: 'multi',
+            filterModels: [null, { filterType: 'set', values: ['bob'] }],
+        });
+        api.onFilterChanged();
+        await asyncSetTimeout(0);
+        await new GridRows(api, 'object-form child, set model applied').check(`
+            ROOT id:ROOT_NODE_ID
+            └── LEAF id:2 name:"bob"
+        `);
+
+        api.setGridOption('columnDefs', colDefs());
+        await asyncSetTimeout(0);
+
+        expect(api.getColumnFilterModel('name')).toEqual({
+            filterType: 'multi',
+            filterModels: [null, { filterType: 'set', values: ['bob'] }],
+        });
+        await new GridRows(api, 'object-form child survives a colDef rebuild').check(`
+            ROOT id:ROOT_NODE_ID
+            └── LEAF id:2 name:"bob"
+        `);
+    });
+
+    describe.each([false, true])('filterParams.filters changed (enableFilterHandlers: %s)', (enableFilterHandlers) => {
+        const TEXT_CHILD = { filter: 'agTextColumnFilter', filterParams: { debounceMs: 0, maxNumConditions: 1 } };
+
+        const colDefsWith = (filters: object[], extra?: object) => [
+            { field: 'name', filter: 'agMultiColumnFilter', filterParams: { filters }, ...extra },
+        ];
+
+        const numChildFilters = async (api: GridApi) =>
+            ((await api.getColumnFilterInstance('name')) as { getNumChildFilters(): number }).getNumChildFilters();
+
+        const setFilterList = () => document.querySelector('.ag-filter-menu')!.querySelector('.ag-set-filter-list');
+
+        test('a removed child leaves the popup and stops filtering', async () => {
+            const api: GridApi = await gridsManager.createGridAndWait('grid1', {
+                enableFilterHandlers,
+                columnDefs: colDefsWith([TEXT_CHILD, { filter: 'agSetColumnFilter' }]),
+                rowData: ROWS,
+            });
+
+            await api.setColumnFilterModel('name', {
+                filterType: 'multi',
+                filterModels: [null, { filterType: 'set', values: ['bob'] }],
+            });
+            api.onFilterChanged();
+            await asyncSetTimeout(0);
+            await new GridRows(api, 'set child filtering to bob').check(`
+                ROOT id:ROOT_NODE_ID
+                └── LEAF id:2 name:"bob"
+            `);
+
+            api.setGridOption('columnDefs', colDefsWith([TEXT_CHILD]));
+            await asyncSetTimeout(0);
+
+            expect(await numChildFilters(api)).toBe(1);
+            await new GridRows(api, 'removed set child no longer filters').check(`
+                ROOT id:ROOT_NODE_ID
+                ├── LEAF id:0 name:"michael"
+                ├── LEAF id:1 name:"michelle"
+                ├── LEAF id:2 name:"bob"
+                └── LEAF id:3 name:"alice"
+            `);
+
+            await ColumnFilterHarness.open(api, 'name');
+            expect(setFilterList()).toBeNull();
+        });
+
+        test('an unrelated colDef change leaves the child set and the model alone', async () => {
+            const api: GridApi = await gridsManager.createGridAndWait('grid1', {
+                enableFilterHandlers,
+                columnDefs: colDefsWith([TEXT_CHILD, { filter: 'agSetColumnFilter' }]),
+                rowData: ROWS,
+            });
+
+            await api.setColumnFilterModel('name', {
+                filterType: 'multi',
+                filterModels: [{ filterType: 'text', type: 'contains', filter: 'mich' }, null],
+            });
+            api.onFilterChanged();
+            await asyncSetTimeout(0);
+
+            // Same children, different headerName: nothing about the filter may be rebuilt or reset.
+            api.setGridOption(
+                'columnDefs',
+                colDefsWith([TEXT_CHILD, { filter: 'agSetColumnFilter' }], { headerName: 'Renamed' })
+            );
+            await asyncSetTimeout(0);
+
+            expect(api.getColumnFilterModel('name')).toEqual({
+                filterType: 'multi',
+                filterModels: [{ filterType: 'text', type: 'contains', filter: 'mich' }, null],
+            });
+            await new GridRows(api, 'unrelated colDef change keeps filtering').check(`
+                ROOT id:ROOT_NODE_ID
+                ├── LEAF id:0 name:"michael"
+                └── LEAF id:1 name:"michelle"
+            `);
+        });
+
+        test('removing the first child does not hand its model to the survivor', async () => {
+            const api: GridApi = await gridsManager.createGridAndWait('grid1', {
+                enableFilterHandlers,
+                columnDefs: colDefsWith([TEXT_CHILD, { filter: 'agSetColumnFilter' }]),
+                rowData: ROWS,
+            });
+
+            await api.setColumnFilterModel('name', {
+                filterType: 'multi',
+                filterModels: [{ filterType: 'text', type: 'contains', filter: 'mich' }, null],
+            });
+            api.onFilterChanged();
+            await asyncSetTimeout(0);
+
+            // Drop the text child. The set child moves to index 0, where the text model used to sit.
+            api.setGridOption('columnDefs', colDefsWith([{ filter: 'agSetColumnFilter' }]));
+            await asyncSetTimeout(0);
+
+            expect(await numChildFilters(api)).toBe(1);
+            const model = api.getColumnFilterModel('name') as { filterModels?: unknown[] } | null;
+            expect(model?.filterModels?.[0]).not.toEqual({ filterType: 'text', type: 'contains', filter: 'mich' });
+            await new GridRows(api, 'first child removed leaves no stale filtering').check(`
+                ROOT id:ROOT_NODE_ID
+                ├── LEAF id:0 name:"michael"
+                ├── LEAF id:1 name:"michelle"
+                ├── LEAF id:2 name:"bob"
+                └── LEAF id:3 name:"alice"
+            `);
+        });
+
+        test('the reopened popup agrees with the rows after a surviving child loses its model', async () => {
+            const api: GridApi = await gridsManager.createGridAndWait('grid1', {
+                enableFilterHandlers,
+                columnDefs: colDefsWith([TEXT_CHILD, { filter: 'agSetColumnFilter' }]),
+                rowData: ROWS,
+            });
+
+            // Open first, so the filter ui really exists before the col def changes.
+            const filter = await ColumnFilterHarness.open(api, 'name');
+            await filter.selectOperator('Contains', 0);
+            await filter.setText('mich', 0);
+            await asyncSetTimeout(0);
+            api.hideColumnFilter();
+            await new GridRows(api, 'text child filtering before the change').check(`
+                ROOT id:ROOT_NODE_ID
+                ├── LEAF id:0 name:"michael"
+                └── LEAF id:1 name:"michelle"
+            `);
+
+            // Swap the second child's type. The text child survives, but the model is reset.
+            api.setGridOption('columnDefs', colDefsWith([TEXT_CHILD, { filter: 'agNumberColumnFilter' }]));
+            await asyncSetTimeout(0);
+
+            await new GridRows(api, 'model reset leaves every row visible').check(`
+                ROOT id:ROOT_NODE_ID
+                ├── LEAF id:0 name:"michael"
+                ├── LEAF id:1 name:"michelle"
+                ├── LEAF id:2 name:"bob"
+                └── LEAF id:3 name:"alice"
+            `);
+
+            // The popup must not claim a filter the grid is no longer applying.
+            await ColumnFilterHarness.open(api, 'name');
+            const textInput = document
+                .querySelector('.ag-filter-menu')!
+                .querySelector<HTMLInputElement>('.ag-filter-body input[type="text"]:not([disabled])');
+            expect(textInput?.value ?? '').toBe('');
+        });
+
+        test('filter: true and the default filter name are the same child', async () => {
+            const api: GridApi = await gridsManager.createGridAndWait('grid1', {
+                enableFilterHandlers,
+                columnDefs: colDefsWith([{ filter: true }, { filter: 'agSetColumnFilter' }]),
+                rowData: ROWS,
+            });
+
+            await api.setColumnFilterModel('name', {
+                filterType: 'multi',
+                filterModels: [null, { filterType: 'set', values: ['bob'] }],
+            });
+            api.onFilterChanged();
+            await asyncSetTimeout(0);
+
+            // `true` means the default, which for a child is the text filter: naming it explicitly is
+            // the same child, so nothing may be rebuilt and the model must survive.
+            api.setGridOption(
+                'columnDefs',
+                colDefsWith([{ filter: 'agTextColumnFilter' }, { filter: 'agSetColumnFilter' }])
+            );
+            await asyncSetTimeout(0);
+
+            expect(api.getColumnFilterModel('name')).toEqual({
+                filterType: 'multi',
+                filterModels: [null, { filterType: 'set', values: ['bob'] }],
+            });
+            await new GridRows(api, 'filter:true child survives being named').check(`
+                ROOT id:ROOT_NODE_ID
+                └── LEAF id:2 name:"bob"
+            `);
+        });
+
+        test('an empty filters array falls back to the default children and still refreshes', async () => {
+            const api: GridApi = await gridsManager.createGridAndWait('grid1', {
+                enableFilterHandlers,
+                columnDefs: colDefsWith([]),
+                rowData: ROWS,
+            });
+
+            // Defaults are text + set, so the popup has both and nothing throws on refresh.
+            expect(await numChildFilters(api)).toBe(2);
+            api.setGridOption('columnDefs', colDefsWith([], { headerName: 'Renamed' }));
+            await asyncSetTimeout(0);
+            expect(await numChildFilters(api)).toBe(2);
+
+            await ColumnFilterHarness.open(api, 'name');
+            expect(setFilterList()).not.toBeNull();
+        });
+
+        test('the filters tool panel follows a removed child', async () => {
+            const api: GridApi = await gridsManager.createGridAndWait('grid1', {
+                enableFilterHandlers,
+                columnDefs: colDefsWith([TEXT_CHILD, { filter: 'agSetColumnFilter' }]),
+                rowData: ROWS,
+                sideBar: FILTERS_SIDEBAR,
+            });
+
+            const panel = await openFiltersPanel(api);
+            await panel.expandGroup('Name');
+            expect(panel.isSetListShown('Name')).toBe(true);
+
+            api.setGridOption('columnDefs', colDefsWith([TEXT_CHILD]));
+            await asyncSetTimeout(0);
+
+            await panel.expandGroup('Name');
+            expect(panel.isSetListShown('Name')).toBe(false);
+        });
+
+        test('the floating filter follows a removed child', async () => {
+            const api: GridApi = await gridsManager.createGridAndWait('grid1', {
+                enableFilterHandlers,
+                columnDefs: colDefsWith([TEXT_CHILD, { filter: 'agSetColumnFilter' }], { floatingFilter: true }),
+                rowData: ROWS,
+            });
+
+            expect(floatingChildren()).toHaveLength(2);
+
+            api.setGridOption('columnDefs', colDefsWith([TEXT_CHILD], { floatingFilter: true }));
+            await asyncSetTimeout(0);
+
+            expect(floatingChildren()).toHaveLength(1);
+        });
+
+        test('the child set keeps tracking columnDefs across repeated changes', async () => {
+            const api: GridApi = await gridsManager.createGridAndWait('grid1', {
+                enableFilterHandlers,
+                columnDefs: colDefsWith([TEXT_CHILD, { filter: 'agSetColumnFilter' }]),
+                rowData: ROWS,
+            });
+
+            api.setGridOption('columnDefs', colDefsWith([TEXT_CHILD]));
+            await asyncSetTimeout(0);
+            expect(await numChildFilters(api)).toBe(1);
+
+            // The first change destroys the column filter, taking its colDefChanged listener with it;
+            // a second change is what proves the listener came back.
+            api.setGridOption('columnDefs', colDefsWith([TEXT_CHILD, { filter: 'agSetColumnFilter' }]));
+            await asyncSetTimeout(0);
+            expect(await numChildFilters(api)).toBe(2);
+
+            api.setGridOption('columnDefs', colDefsWith([TEXT_CHILD, { filter: 'agNumberColumnFilter' }]));
+            await asyncSetTimeout(0);
+            expect(await numChildFilters(api)).toBe(2);
+
+            await ColumnFilterHarness.open(api, 'name');
+            expect(setFilterList()).toBeNull();
+        });
+
+        test('an added child appears in the popup and filters', async () => {
+            const api: GridApi = await gridsManager.createGridAndWait('grid1', {
+                enableFilterHandlers,
+                columnDefs: colDefsWith([TEXT_CHILD]),
+                rowData: ROWS,
+            });
+
+            await ColumnFilterHarness.open(api, 'name');
+            expect(setFilterList()).toBeNull();
+            api.hideColumnFilter();
+
+            api.setGridOption('columnDefs', colDefsWith([TEXT_CHILD, { filter: 'agSetColumnFilter' }]));
+            await asyncSetTimeout(0);
+
+            expect(await numChildFilters(api)).toBe(2);
+
+            const filter = await ColumnFilterHarness.open(api, 'name');
+            expect(setFilterList()).not.toBeNull();
+
+            await filter.toggleSetItem('michelle');
+            await filter.toggleSetItem('alice');
+            await filter.toggleSetItem('bob');
+            await asyncSetTimeout(0);
+            await new GridRows(api, 'added set child filters').check(`
+                ROOT id:ROOT_NODE_ID
+                └── LEAF id:0 name:"michael"
+            `);
+        });
     });
 });
 


### PR DESCRIPTION
<!-- base: latest -->
# AG-18306: A Multi Filter now rebuilds its children when `filterParams.filters` changes

FIX AG-18306

A Multi Filter resolved its child filters once, when it was created, and never again. Changing
`filterParams.filters` on the column definition had no effect: a removed child stayed in the popup and
went on filtering, and an added child was never created, so it never appeared and its model was ignored.

| scope  | net lines |  lines changed | hunks | files changed |
| ------ | --------: | -------------: | ----: | ------------: |
| source |       +79 | 177 (+128 -49) |    26 |      6 edited |
| tests  |      +363 |  375 (+369 -6) |     6 |      2 edited |

## Behaviour change: a changed child set resets that column's filter model

`filterModels` is positional and a Multi Filter child has no identity, so there is no sound way to tell a
child that moved from a child that changed type, and two children of the same type is a supported
configuration. The whole model is therefore reset, which is what the grid already does when a column's
filter component changes. This only happens where the change was previously ignored outright.

No API changes. `FilterHandler.refresh` may now return `false` in addition to returning nothing, which is
additive; `IMultiFilterModel` is untouched, so persisted `GridState` filter models still load.

The scope is the child *set*. A change to a child's own `filterParams`, `title` or `display` that leaves the
set intact is applied in the handler path and, as before, ignored in the default one.

## Detecting the change ([AG-18306](https://ag-grid.atlassian.net/browse/AG-18306))

`multiFilterChildrenChanged` compares the child count and the child filter at each index. Two normalisations
matter, because both decide whether a user's model survives an ordinary `setGridOption('columnDefs')`:

- `filter: true` means the default, which for a child is the text filter, so it matches
  `filter: 'agTextColumnFilter'`.
- the `{ component, handler, doesFilterPass }` child form is rebuilt inline with the column definition, so
  the comparison keys on its contents rather than the wrapper object, matching what both resolvers do.

`filter: undefined` is deliberately not folded into the default: the component path resolves it to the text
filter but the handler path gives it no filter at all, so treating them as one child would hide a real
change in the handler path.

`MultiFilter.refresh` (the default, `enableFilterHandlers = false`) signals a change through the `false`
return `ColumnFilterService` already honours for filter components, and `MultiFilterHandler.refresh` through
the new handler equivalent, gated on `source === 'colDef'` since no other source can change the definitions.
The grid recreates the handler with a null model, the branch it already had for a changed handler generator,
and now also clears the UI state that described the model that has gone. A child handler that refuses the
new params recreates the whole Multi Filter, since a child cannot be rebuilt on its own.

## An uncreated handler UI kept building from the previous column definition

A handler column whose filter popup has never been opened holds a filter UI that has not been created yet.
`filterParamsChanged` skips creating one just to refresh it, so that UI was never told about the column
definition change and would later build itself from the superseded one. Its plan is now swapped in place.

Both column-definition paths also mark the replacement UI for re-derivation, so it is built from the model
that exists when it is finally created rather than the one captured while the column definition was being
handled.

## Reading `filters` by wrapper index no longer throws

`MultiFilterHandler.refresh` indexed `filterParams.filters` with the position of each existing child handler
and dereferenced the result unguarded, so it threw whenever `filters` was shorter than the child list. It now
resolves the definitions only on a column-definition change and reads the ones it was built with otherwise.
`getMultiFilterDefs` also tolerates absent `filterParams` again.
