### PR TITLE
Add browser caching headers for content-addressed assets

### DIFF
--- a/documentation/ag-grid-docs/src/utils/htaccess/__snapshots__/htaccessRules.test.ts.snap
+++ b/documentation/ag-grid-docs/src/utils/htaccess/__snapshots__/htaccessRules.test.ts.snap
@@ -16,25 +16,13 @@ AddType text/markdown md
 AddCharset utf-8 .md
 
 
-<IfModule mod_expires.c>
-    # Adds caching headers
-    ExpiresActive On
+# Current pages: always revalidate. Excludes /archive/<v>/ which is immutable.
+Header set Cache-Control "no-cache" "expr=%{CONTENT_TYPE} =~ m#^text/html# && !( %{REQUEST_URI} =~ m#^/(charts/|studio/)?archive/[0-9]# )"
 
-    # Default directive
-    ExpiresDefault "access plus 1 year"
 
-    ExpiresByType application/json "access plus 1 hour"
-    ExpiresByType text/html "access plus 1 hour"
-    ExpiresByType text/markdown "access plus 1 hour"
-    ExpiresByType text/plain "access plus 1 hour"
-    ExpiresByType text/richtext "access plus 1 hour"
-    ExpiresByType text/xml "access plus 1 hour"
-    ExpiresByType text/xsd "access plus 1 hour"
-    ExpiresByType text/xsl "access plus 1 hour"
-
-    # CSS
-    ExpiresByType text/css "access plus 1 month"
-</IfModule>
+# Content-addressed assets - the filename carries a content hash, so changed content is
+# always a different URL. Matched by hash shape, so anything unhashed is not cached.
+Header set Cache-Control "public, max-age=604800, s-maxage=31536000" "expr=%{REQUEST_URI} =~ m#/_astro/[^/]+\\.[A-Za-z0-9_-]{8}\\.[a-z0-9]+$# || %{REQUEST_URI} =~ m#/_astro/.*/[0-9a-f]{16}\\.[a-z0-9]+$#"
 
 
 <IfModule mod_deflate.c>
@@ -62,12 +50,6 @@ AddCharset utf-8 .md
     AddOutputFilterByType DEFLATE text/markdown
     AddOutputFilterByType DEFLATE text/plain
     AddOutputFilterByType DEFLATE text/xml
-
-    # Remove browser bugs (only needed for really old browsers)
-    BrowserMatch ^Mozilla/4 gzip-only-text/html
-    BrowserMatch ^Mozilla/4\\.0[678] no-gzip
-    BrowserMatch \\bMSIE !no-gzip !gzip-only-text/html
-    Header append Vary User-Agent
 </IfModule>
 
 
@@ -2995,6 +2977,10 @@ AddType text/markdown md
 # ...as UTF-8, so glyphs like ✓/✗ in generated tables aren't mojibaked by a
 # Latin-1 fallback (the .md endpoint sets this charset; static hosting must too).
 AddCharset utf-8 .md
+
+
+# Current pages: always revalidate. Excludes /archive/<v>/ which is immutable.
+Header set Cache-Control "no-cache" "expr=%{CONTENT_TYPE} =~ m#^text/html# && !( %{REQUEST_URI} =~ m#^/(charts/|studio/)?archive/[0-9]# )"
 
 
 <IfModule mod_rewrite.c>

--- a/documentation/ag-grid-docs/src/utils/htaccess/htaccessRules.test.ts
+++ b/documentation/ag-grid-docs/src/utils/htaccess/htaccessRules.test.ts
@@ -90,6 +90,174 @@ describe('htaccessRules', () => {
         });
     });
 
+    describe('Caching phase 1: content-addressed asset headers', () => {
+        // Pulls the expr= regexes out of the GENERATED output rather than re-declaring them:
+        // a copy would let the rule and its test drift apart.
+        const getCacheRuleMatcher = (content: string) => {
+            const line = content.split('\n').find((l) => l.includes('max-age=604800'));
+            expect(line).toBeDefined();
+            const patterns = [...line!.matchAll(/m#([^#]+)#/g)].map(([, re]) => new RegExp(re));
+            expect(patterns).toHaveLength(2);
+            return (uri: string) => patterns.some((re) => re.test(uri));
+        };
+
+        it('should set Cache-Control on production', () => {
+            expect(productionContent).toContain('Header set Cache-Control');
+            expect(productionContent).toContain('max-age=604800');
+            expect(productionContent).toContain('s-maxage=31536000');
+        });
+
+        it('should NOT long-cache on staging, so testers never see a stale asset', () => {
+            // Staging carries the no-cache document rule but no max-age of any kind.
+            expect(stagingContent).not.toContain('max-age');
+        });
+
+        it('should NOT use immutable, which would make a mistake unfixable for a year', () => {
+            // Scoped to the Cache-Control line on purpose: the site has legitimate
+            // /immutable-data/ redirect URLs, so a site-wide assertion is a false positive.
+            const line = productionContent.split('\n').find((l) => l.includes('max-age=604800'));
+            expect(line).toBeDefined();
+            expect(line).not.toContain('immutable');
+        });
+
+        it('should have removed the inert mod_expires block', () => {
+            // Never took effect (module not loaded, <IfModule> skips silently), and its
+            // ExpiresDefault "access plus 1 year" would have fired if anyone enabled it.
+            expect(productionContent).not.toContain('mod_expires');
+            expect(productionContent).not.toContain('ExpiresActive');
+            expect(productionContent).not.toContain('ExpiresDefault');
+            expect(productionContent).not.toContain('ExpiresByType');
+        });
+
+        it('should not guard the rule with <IfModule>, so a missing module fails loudly', () => {
+            const lines = productionContent.split('\n');
+            const idx = lines.findIndex((l) => l.includes('max-age=604800'));
+            const preceding = lines.slice(0, idx).join('\n');
+            const openGuards = (preceding.match(/<IfModule/g) ?? []).length;
+            const closeGuards = (preceding.match(/<\/IfModule>/g) ?? []).length;
+            expect(openGuards).toBe(closeGuards);
+        });
+
+        describe('matches every content-hashed shape the build emits', () => {
+            const hashed = [
+                // name.HASH8.ext -- Vite's default, 126 of 128 live references
+                '/_astro/design-system.BcXAtF3c.css',
+                '/_astro/_pageName_.C5AIcGk_.css',
+                '/_astro/_pageName_.astro_astro_type_script_index_0_lang.D12oPI3R.js',
+                '/_astro/ag-grid-alpine-quartz-themes.tErC2lp7.png',
+                // fonts/HASH16.ext -- whole basename is a 16-char hex hash
+                '/_astro/fonts/2eb6e0e4fc33dd24.woff2',
+                // archive assets live at /archive/<v>/_astro/, so the pattern must be unanchored
+                '/archive/32.3.9/_astro/DocsExampleRunner.CiSTQ4_g.css',
+                '/charts/archive/11.0.0/_astro/example-finance.bBLOPnBQ.css',
+            ];
+
+            hashed.forEach((uri) => {
+                it(`caches ${uri}`, () => {
+                    expect(getCacheRuleMatcher(productionContent)(uri)).toBe(true);
+                });
+            });
+        });
+
+        describe('does not match anything mutable', () => {
+            // Everything here is a stable URL with mutable content. Caching any of it could
+            // hide a fix from users and testers, which phase 1 must not be able to do.
+            const mutable = [
+                '/react-data-grid/column-moving/',
+                '/archive/32.3.9/react-data-grid/getting-started/',
+                '/documentation-archive',
+                '/charts/documentation-archive/',
+                '/sitemap-index.xml',
+                '/llms.txt',
+                '/robots.txt',
+                '/images/logo.png',
+                '/theme-icons/alpine.svg',
+                '/example-assets/olympic-winners.json',
+                '/example/foo.js',
+                '/scripts/main.js',
+                '/favicon.ico',
+                // In _astro but NOT hash-shaped: matching on shape rather than directory is
+                // what makes an unhashed file added to the build later fall through safely.
+                '/_astro/unhashed-file.css',
+                '/_astro/name.SHORT.css',
+                '/_astro/name.TOOLONGHASH9.css',
+                '/_astro/fonts/notahexhash1234.woff2',
+            ];
+
+            mutable.forEach((uri) => {
+                it(`does not cache ${uri}`, () => {
+                    expect(getCacheRuleMatcher(productionContent)(uri)).toBe(false);
+                });
+            });
+        });
+    });
+
+    describe('Caching phase 2: Vary: User-Agent removed', () => {
+        it('should not send Vary: User-Agent, which forks a shared cache per UA string', () => {
+            // It was appended inside the mod_deflate block alongside BrowserMatch workarounds for
+            // Netscape 4 and IE6. Harmless to browsers (a given browser's UA is constant) but it
+            // would hold the CloudFront hit rate near zero, so it has to go before edge caching.
+            expect(productionContent).not.toMatch(/Vary\s+User-Agent/);
+            expect(stagingContent).not.toMatch(/Vary\s+User-Agent/);
+        });
+
+        it('should not carry the obsolete BrowserMatch gzip workarounds', () => {
+            expect(productionContent).not.toContain('BrowserMatch');
+        });
+
+        it('should keep Vary: Accept, which is a different mechanism (SE-80 markdown negotiation)', () => {
+            expect(productionContent).toContain('Header append Vary Accept');
+        });
+
+        it('should keep compressing the same content types', () => {
+            // Removing BrowserMatch must not disturb the DEFLATE filter list.
+            ['text/html', 'text/css', 'text/javascript', 'application/json', 'image/svg+xml'].forEach((type) => {
+                expect(productionContent).toContain(`AddOutputFilterByType DEFLATE ${type}`);
+            });
+        });
+    });
+
+    describe('Caching phase 2: no heuristic caching of current pages', () => {
+        // With Last-Modified but no Cache-Control, browsers invent a freshness lifetime of
+        // ~10% of the document's age, growing without bound since the last deploy. That is the
+        // stale-page-until-hard-refresh behaviour. no-cache removes it.
+        const getNoCacheRule = (content: string) => {
+            const line = content.split('\n').find((l) => l.includes('"no-cache"'));
+            expect(line).toBeDefined();
+            return line!;
+        };
+
+        it('should set no-cache on current pages, in both envs', () => {
+            [productionContent, stagingContent].forEach((content) => {
+                expect(getNoCacheRule(content)).toContain('Cache-Control "no-cache"');
+            });
+        });
+
+        it('should scope it to HTML documents, not assets', () => {
+            expect(getNoCacheRule(productionContent)).toContain('%{CONTENT_TYPE} =~ m#^text/html#');
+        });
+
+        it('should exclude archived versions, which are immutable', () => {
+            const rule = getNoCacheRule(productionContent);
+            expect(rule).toContain('!(');
+            expect(rule).toContain('archive/[0-9]');
+        });
+
+        it('should use no-cache rather than no-store, to keep back/forward navigation', () => {
+            expect(productionContent).not.toContain('no-store');
+        });
+
+        it('should not override the hashed-asset long cache', () => {
+            // The two rules have disjoint conditions (text/html vs a hashed filename), but the
+            // asset rule is emitted after the document rule so it wins on any future overlap.
+            const lines = productionContent.split('\n');
+            const noCacheAt = lines.findIndex((l) => l.includes('"no-cache"'));
+            const assetAt = lines.findIndex((l) => l.includes('max-age=604800'));
+            expect(noCacheAt).toBeGreaterThan(-1);
+            expect(assetAt).toBeGreaterThan(noCacheAt);
+        });
+    });
+
     describe('SE-81: agent-useful Link header', () => {
         it('should include a Link header pointing at llms.txt, the sitemap index and the MCP server', () => {
             expect(productionContent).toContain('Header set Link');
@@ -224,9 +392,11 @@ describe('htaccessRules', () => {
             expect(stagingContent).not.toContain('https://www.ag-grid.com/$1 [R=301,L]');
         });
 
-        it('should include mod_expires rules in production only', () => {
-            expect(productionContent).toContain('mod_expires.c');
-            expect(stagingContent).not.toContain('mod_expires.c');
+        it('should include the asset cache header in production only', () => {
+            // Replaces an assertion that the (inert, now removed) mod_expires block was
+            // present. Staging gets no max-age so testers never hit a stale asset.
+            expect(productionContent).toContain('max-age=604800');
+            expect(stagingContent).not.toContain('max-age');
         });
 
         it('should include CORS headers in production only', () => {

--- a/documentation/ag-grid-docs/src/utils/htaccess/htaccessRules.ts
+++ b/documentation/ag-grid-docs/src/utils/htaccess/htaccessRules.ts
@@ -34,26 +34,23 @@ export const PERMISSIONS_POLICY_VALUE = 'geolocation=(), microphone=(), camera=(
  * Note: when changing this file please add/update the tests in
  * documentation/ag-grid-docs/testing/htaccess-harness
  */
-const modExpiresRules = `
-<IfModule mod_expires.c>
-    # Adds caching headers
-    ExpiresActive On
+// Without Cache-Control, browsers heuristically cache for ~10% of a page's age - the
+// "had to hard-refresh" behaviour. no-cache (store, but always revalidate) removes it while
+// keeping back/forward navigation. Archived versions keep the heuristic window: immutable,
+// and cheaper to leave cached.
+const documentNoCacheRules = `
+# Current pages: always revalidate. Excludes /archive/<v>/ which is immutable.
+Header set Cache-Control "no-cache" "expr=%{CONTENT_TYPE} =~ m#^text/html# && !( %{REQUEST_URI} =~ m#^/(charts/|studio/)?archive/[0-9]# )"
+`;
 
-    # Default directive
-    ExpiresDefault "access plus 1 year"
-
-    ExpiresByType application/json "access plus 1 hour"
-    ExpiresByType text/html "access plus 1 hour"
-    ExpiresByType text/markdown "access plus 1 hour"
-    ExpiresByType text/plain "access plus 1 hour"
-    ExpiresByType text/richtext "access plus 1 hour"
-    ExpiresByType text/xml "access plus 1 hour"
-    ExpiresByType text/xsd "access plus 1 hour"
-    ExpiresByType text/xsl "access plus 1 hour"
-
-    # CSS
-    ExpiresByType text/css "access plus 1 month"
-</IfModule>
+// Long-cache content-addressed assets. Matched on hash SHAPE rather than the /_astro/
+// directory so anything unhashed is never cached: a changed hash is a different URL, so a
+// fix can never be served stale. Replaces an inert mod_expires block - hence no <IfModule>
+// guard here, so a missing module fails loudly rather than silently.
+const hashedAssetCacheRules = `
+# Content-addressed assets - the filename carries a content hash, so changed content is
+# always a different URL. Matched by hash shape, so anything unhashed is not cached.
+Header set Cache-Control "public, max-age=604800, s-maxage=31536000" "expr=%{REQUEST_URI} =~ m#/_astro/[^/]+\\.[A-Za-z0-9_-]{8}\\.[a-z0-9]+$# || %{REQUEST_URI} =~ m#/_astro/.*/[0-9a-f]{16}\\.[a-z0-9]+$#"
 `;
 
 const modDeflateRules = `
@@ -82,12 +79,6 @@ const modDeflateRules = `
     AddOutputFilterByType DEFLATE text/markdown
     AddOutputFilterByType DEFLATE text/plain
     AddOutputFilterByType DEFLATE text/xml
-
-    # Remove browser bugs (only needed for really old browsers)
-    BrowserMatch ^Mozilla/4 gzip-only-text/html
-    BrowserMatch ^Mozilla/4\\.0[678] no-gzip
-    BrowserMatch \\bMSIE !no-gzip !gzip-only-text/html
-    Header append Vary User-Agent
 </IfModule>
 `;
 
@@ -464,6 +455,7 @@ AddCharset utf-8 .md
 
 function getStagingHtaccessContent(): string {
     return `${baseRules}
+${documentNoCacheRules}
 
 ${markdownNegotiationBlock}
 
@@ -483,7 +475,8 @@ Options -Indexes
 
 function getProductionHtaccessContent(): string {
     return `${baseRules}
-${modExpiresRules}
+${documentNoCacheRules}
+${hashedAssetCacheRules}
 ${modDeflateRules}
 ${getModRewriteRules()}
 


### PR DESCRIPTION
**What it adds.** Today nothing sets `Cache-Control`, so browsers invent freshness at ~10% of a page's age — a window that grows without bound since the last deploy (25 min on a 4-hour-old page, 5 hours on a 2-day-old one) and is invisible in any config. The changeset replaces guesswork with two explicit rules: hashed assets get a long, safe cache they were only getting by accident, and current pages get `no-cache`, which removes the heuristic window entirely and ends the hard-refresh/DevTools-open problem. Net effect: more caching where it's provably safe, none where it can hide a fix.

**What is now cached.** Only content-addressed assets — files whose name carries a build hash, matched on hash shape (`name.HASH8.ext` or `fonts/HASH16.ext`) rather than by directory, wherever they live. They get `max-age=604800` (**7 days in the browser**) and `s-maxage=31536000` (1 year at the CDN, inert until CloudFront caching is enabled in Phase 3). That's roughly **1.32M requests/day, ~58% of all traffic**. It cannot hide a fix: changed content means a changed hash, which means a different URL and a guaranteed cache miss. No `immutable`, so a mistake self-heals in 7 days and a hard reload fixes it immediately.

**What is not cached.** Current pages (`text/html` outside `/archive/`) now carry `no-cache` — stored but always revalidated, so a patch is visible on the next request. Revalidation is a cheap 304 against the existing `ETag`, and unlike `no-store` it keeps back/forward navigation working. Everything else — `/images/`, `/theme-icons/`, `/example/`, `/example-assets/`, `/scripts/`, `sitemap*.xml`, `llms.txt`, `robots.txt`, and any unhashed file inside `_astro` — gets no header at all and keeps today's heuristic behaviour, unchanged. Those are stable URLs with mutable content, so they're deliberately left for Phase 4.

**Archives.** Archived versions are split. Their hashed assets (`/archive/<v>/_astro/…`, `/charts/archive/…`, `/studio/archive/…` — 180,513 requests/day) **are** cached for 7 days, safely, since they're content-addressed. Their HTML is explicitly **excluded** from the `no-cache` rule and keeps its long heuristic window — 34 days on a 342-day-old page — which is doing useful work given archives are immutable and never rebuilt (confirmed: each version's `last-modified` tracks its own release date across 2023–2026). Stripping that would have added ~96.5k origin requests/day for no benefit. Archive HTML gets an explicit `s-maxage` in Phase 3 instead. In-flight release archives need no special handling here: rebuilding one changes its asset hashes, and its HTML is on the same heuristic path as before.
