### PR TITLE
AG-10029 advanced filter builtin ranges

### DIFF
--- a/community-modules/locale/src/ar-EG.ts
+++ b/community-modules/locale/src/ar-EG.ts
@@ -135,6 +135,7 @@ export const AG_GRID_LOCALE_EG = {
     advancedFilterGreaterThanOrEqual: '>=',
     advancedFilterLessThan: '<',
     advancedFilterLessThanOrEqual: '<=',
+    advancedFilterInRange: 'بين',
     advancedFilterTrue: 'صحيح',
     advancedFilterFalse: 'خاطئ',
     advancedFilterAnd: 'و',

--- a/community-modules/locale/src/bg-BG.ts
+++ b/community-modules/locale/src/bg-BG.ts
@@ -135,6 +135,7 @@ export const AG_GRID_LOCALE_BG = {
     advancedFilterGreaterThanOrEqual: '>=',
     advancedFilterLessThan: '<',
     advancedFilterLessThanOrEqual: '<=',
+    advancedFilterInRange: 'между',
     advancedFilterTrue: 'е вярно',
     advancedFilterFalse: 'е невярно',
     advancedFilterAnd: 'И',

--- a/community-modules/locale/src/cs-CZ.ts
+++ b/community-modules/locale/src/cs-CZ.ts
@@ -135,6 +135,7 @@ export const AG_GRID_LOCALE_CZ = {
     advancedFilterGreaterThanOrEqual: '>=',
     advancedFilterLessThan: '<',
     advancedFilterLessThanOrEqual: '<=',
+    advancedFilterInRange: 'mezi',
     advancedFilterTrue: 'je pravda',
     advancedFilterFalse: 'je nepravda',
     advancedFilterAnd: 'A',

--- a/community-modules/locale/src/da-DK.ts
+++ b/community-modules/locale/src/da-DK.ts
@@ -135,6 +135,7 @@ export const AG_GRID_LOCALE_DK = {
     advancedFilterGreaterThanOrEqual: '>=',
     advancedFilterLessThan: '<',
     advancedFilterLessThanOrEqual: '<=',
+    advancedFilterInRange: 'mellem',
     advancedFilterTrue: 'er-sand',
     advancedFilterFalse: 'er-falsk',
     advancedFilterAnd: 'OG',

--- a/community-modules/locale/src/de-DE.ts
+++ b/community-modules/locale/src/de-DE.ts
@@ -135,6 +135,7 @@ export const AG_GRID_LOCALE_DE = {
     advancedFilterGreaterThanOrEqual: '>=',
     advancedFilterLessThan: '<',
     advancedFilterLessThanOrEqual: '<=',
+    advancedFilterInRange: 'zwischen',
     advancedFilterTrue: 'ist-wahr',
     advancedFilterFalse: 'ist-falsch',
     advancedFilterAnd: 'UND',

--- a/community-modules/locale/src/el-GR.ts
+++ b/community-modules/locale/src/el-GR.ts
@@ -135,6 +135,7 @@ export const AG_GRID_LOCALE_GR = {
     advancedFilterGreaterThanOrEqual: '>=',
     advancedFilterLessThan: '<',
     advancedFilterLessThanOrEqual: '<=',
+    advancedFilterInRange: 'μεταξύ',
     advancedFilterTrue: 'είναι αληθές',
     advancedFilterFalse: 'είναι ψευδές',
     advancedFilterAnd: 'ΚΑΙ',

--- a/community-modules/locale/src/en-US.ts
+++ b/community-modules/locale/src/en-US.ts
@@ -126,6 +126,7 @@ export const AG_GRID_LOCALE_EN = {
     advancedFilterGreaterThanOrEqual: '>=',
     advancedFilterLessThan: '<',
     advancedFilterLessThanOrEqual: '<=',
+    advancedFilterInRange: 'between',
     advancedFilterTrue: 'is true',
     advancedFilterFalse: 'is false',
     advancedFilterAnd: 'AND',

--- a/community-modules/locale/src/es-ES.ts
+++ b/community-modules/locale/src/es-ES.ts
@@ -135,6 +135,7 @@ export const AG_GRID_LOCALE_ES = {
     advancedFilterGreaterThanOrEqual: '>=',
     advancedFilterLessThan: '<',
     advancedFilterLessThanOrEqual: '<=',
+    advancedFilterInRange: 'entre',
     advancedFilterTrue: 'es verdadero',
     advancedFilterFalse: 'es falso',
     advancedFilterAnd: 'Y',

--- a/community-modules/locale/src/fa-IR.ts
+++ b/community-modules/locale/src/fa-IR.ts
@@ -135,6 +135,7 @@ export const AG_GRID_LOCALE_IR = {
     advancedFilterGreaterThanOrEqual: '>=',
     advancedFilterLessThan: '<',
     advancedFilterLessThanOrEqual: '<=',
+    advancedFilterInRange: 'بین',
     advancedFilterTrue: 'درست است',
     advancedFilterFalse: 'نادرست است',
     advancedFilterAnd: 'و',

--- a/community-modules/locale/src/fi-FI.ts
+++ b/community-modules/locale/src/fi-FI.ts
@@ -135,6 +135,7 @@ export const AG_GRID_LOCALE_FI = {
     advancedFilterGreaterThanOrEqual: '>=',
     advancedFilterLessThan: '<',
     advancedFilterLessThanOrEqual: '<=',
+    advancedFilterInRange: 'välillä',
     advancedFilterTrue: 'on tosi',
     advancedFilterFalse: 'on epätosi',
     advancedFilterAnd: 'JA',

--- a/community-modules/locale/src/fr-FR.ts
+++ b/community-modules/locale/src/fr-FR.ts
@@ -135,6 +135,7 @@ export const AG_GRID_LOCALE_FR = {
     advancedFilterGreaterThanOrEqual: '>=',
     advancedFilterLessThan: '<',
     advancedFilterLessThanOrEqual: '<=',
+    advancedFilterInRange: 'entre',
     advancedFilterTrue: 'est vrai',
     advancedFilterFalse: 'est faux',
     advancedFilterAnd: 'ET',

--- a/community-modules/locale/src/he-IL.ts
+++ b/community-modules/locale/src/he-IL.ts
@@ -135,6 +135,7 @@ export const AG_GRID_LOCALE_IL = {
     advancedFilterGreaterThanOrEqual: '>=',
     advancedFilterLessThan: '<',
     advancedFilterLessThanOrEqual: '<=',
+    advancedFilterInRange: 'בין',
     advancedFilterTrue: 'אמת',
     advancedFilterFalse: 'שקר',
     advancedFilterAnd: 'וגם',

--- a/community-modules/locale/src/hr-HR.ts
+++ b/community-modules/locale/src/hr-HR.ts
@@ -135,6 +135,7 @@ export const AG_GRID_LOCALE_HR = {
     advancedFilterGreaterThanOrEqual: '>=',
     advancedFilterLessThan: '<',
     advancedFilterLessThanOrEqual: '<=',
+    advancedFilterInRange: 'između',
     advancedFilterTrue: 'je točno',
     advancedFilterFalse: 'je netočno',
     advancedFilterAnd: 'I',

--- a/community-modules/locale/src/hu-HU.ts
+++ b/community-modules/locale/src/hu-HU.ts
@@ -135,6 +135,7 @@ export const AG_GRID_LOCALE_HU = {
     advancedFilterGreaterThanOrEqual: '>=',
     advancedFilterLessThan: '<',
     advancedFilterLessThanOrEqual: '<=',
+    advancedFilterInRange: 'között',
     advancedFilterTrue: 'igaz',
     advancedFilterFalse: 'hamis',
     advancedFilterAnd: 'ÉS',

--- a/community-modules/locale/src/it-IT.ts
+++ b/community-modules/locale/src/it-IT.ts
@@ -135,6 +135,7 @@ export const AG_GRID_LOCALE_IT = {
     advancedFilterGreaterThanOrEqual: '>=',
     advancedFilterLessThan: '<',
     advancedFilterLessThanOrEqual: '<=',
+    advancedFilterInRange: 'tra',
     advancedFilterTrue: 'è vero',
     advancedFilterFalse: 'è falso',
     advancedFilterAnd: 'E',

--- a/community-modules/locale/src/ja-JP.ts
+++ b/community-modules/locale/src/ja-JP.ts
@@ -135,6 +135,7 @@ export const AG_GRID_LOCALE_JP = {
     advancedFilterGreaterThanOrEqual: '>=',
     advancedFilterLessThan: '<',
     advancedFilterLessThanOrEqual: '<=',
+    advancedFilterInRange: 'の間',
     advancedFilterTrue: '真',
     advancedFilterFalse: '偽',
     advancedFilterAnd: 'かつ',

--- a/community-modules/locale/src/ko-KR.ts
+++ b/community-modules/locale/src/ko-KR.ts
@@ -135,6 +135,7 @@ export const AG_GRID_LOCALE_KR = {
     advancedFilterGreaterThanOrEqual: '>=',
     advancedFilterLessThan: '<',
     advancedFilterLessThanOrEqual: '<=',
+    advancedFilterInRange: '사이',
     advancedFilterTrue: '참임',
     advancedFilterFalse: '거짓임',
     advancedFilterAnd: 'AND',

--- a/community-modules/locale/src/nb-NO.ts
+++ b/community-modules/locale/src/nb-NO.ts
@@ -135,6 +135,7 @@ export const AG_GRID_LOCALE_NO = {
     advancedFilterGreaterThanOrEqual: '>=',
     advancedFilterLessThan: '<',
     advancedFilterLessThanOrEqual: '<=',
+    advancedFilterInRange: 'mellom',
     advancedFilterTrue: 'er-sann',
     advancedFilterFalse: 'er-falsk',
     advancedFilterAnd: 'OG',

--- a/community-modules/locale/src/nl-NL.ts
+++ b/community-modules/locale/src/nl-NL.ts
@@ -135,6 +135,7 @@ export const AG_GRID_LOCALE_NL = {
     advancedFilterGreaterThanOrEqual: '>=',
     advancedFilterLessThan: '<',
     advancedFilterLessThanOrEqual: '<=',
+    advancedFilterInRange: 'tussen',
     advancedFilterTrue: 'is-waar',
     advancedFilterFalse: 'is-niet-waar',
     advancedFilterAnd: 'EN',

--- a/community-modules/locale/src/pl-PL.ts
+++ b/community-modules/locale/src/pl-PL.ts
@@ -135,6 +135,7 @@ export const AG_GRID_LOCALE_PL = {
     advancedFilterGreaterThanOrEqual: '>=',
     advancedFilterLessThan: '<',
     advancedFilterLessThanOrEqual: '<=',
+    advancedFilterInRange: 'pomiędzy',
     advancedFilterTrue: 'jest prawdą',
     advancedFilterFalse: 'jest fałszem',
     advancedFilterAnd: 'AND',

--- a/community-modules/locale/src/pt-BR.ts
+++ b/community-modules/locale/src/pt-BR.ts
@@ -135,6 +135,7 @@ export const AG_GRID_LOCALE_BR = {
     advancedFilterGreaterThanOrEqual: '>=',
     advancedFilterLessThan: '<',
     advancedFilterLessThanOrEqual: '<=',
+    advancedFilterInRange: 'entre',
     advancedFilterTrue: 'é verdadeiro',
     advancedFilterFalse: 'é falso',
     advancedFilterAnd: 'E',

--- a/community-modules/locale/src/pt-PT.ts
+++ b/community-modules/locale/src/pt-PT.ts
@@ -135,6 +135,7 @@ export const AG_GRID_LOCALE_PT = {
     advancedFilterGreaterThanOrEqual: '>=',
     advancedFilterLessThan: '<',
     advancedFilterLessThanOrEqual: '<=',
+    advancedFilterInRange: 'entre',
     advancedFilterTrue: 'é verdadeiro',
     advancedFilterFalse: 'é falso',
     advancedFilterAnd: 'E',

--- a/community-modules/locale/src/ro-RO.ts
+++ b/community-modules/locale/src/ro-RO.ts
@@ -135,6 +135,7 @@ export const AG_GRID_LOCALE_RO = {
     advancedFilterGreaterThanOrEqual: '>=',
     advancedFilterLessThan: '<',
     advancedFilterLessThanOrEqual: '<=',
+    advancedFilterInRange: 'între',
     advancedFilterTrue: 'este adevărat',
     advancedFilterFalse: 'este fals',
     advancedFilterAnd: 'ȘI',

--- a/community-modules/locale/src/sk-SK.ts
+++ b/community-modules/locale/src/sk-SK.ts
@@ -135,6 +135,7 @@ export const AG_GRID_LOCALE_SK = {
     advancedFilterGreaterThanOrEqual: '>=',
     advancedFilterLessThan: '<',
     advancedFilterLessThanOrEqual: '<=',
+    advancedFilterInRange: 'medzi',
     advancedFilterTrue: 'je pravdivé',
     advancedFilterFalse: 'je nepravdivé',
     advancedFilterAnd: 'A',

--- a/community-modules/locale/src/sv-SE.ts
+++ b/community-modules/locale/src/sv-SE.ts
@@ -135,6 +135,7 @@ export const AG_GRID_LOCALE_SE = {
     advancedFilterGreaterThanOrEqual: '>=',
     advancedFilterLessThan: '<',
     advancedFilterLessThanOrEqual: '<=',
+    advancedFilterInRange: 'mellan',
     advancedFilterTrue: 'är-sann',
     advancedFilterFalse: 'är-falsk',
     advancedFilterAnd: 'OCH',

--- a/community-modules/locale/src/tr-TR.ts
+++ b/community-modules/locale/src/tr-TR.ts
@@ -135,6 +135,7 @@ export const AG_GRID_LOCALE_TR = {
     advancedFilterGreaterThanOrEqual: '>=',
     advancedFilterLessThan: '<',
     advancedFilterLessThanOrEqual: '<=',
+    advancedFilterInRange: 'arasında',
     advancedFilterTrue: 'doğru',
     advancedFilterFalse: 'yanlış',
     advancedFilterAnd: 'VE',

--- a/community-modules/locale/src/uk-UA.ts
+++ b/community-modules/locale/src/uk-UA.ts
@@ -135,6 +135,7 @@ export const AG_GRID_LOCALE_UA = {
     advancedFilterGreaterThanOrEqual: '>=',
     advancedFilterLessThan: '<',
     advancedFilterLessThanOrEqual: '<=',
+    advancedFilterInRange: 'між',
     advancedFilterTrue: 'є істинним',
     advancedFilterFalse: 'є хибним',
     advancedFilterAnd: 'І',

--- a/community-modules/locale/src/ur-PK.ts
+++ b/community-modules/locale/src/ur-PK.ts
@@ -135,6 +135,7 @@ export const AG_GRID_LOCALE_PK = {
     advancedFilterGreaterThanOrEqual: '>=',
     advancedFilterLessThan: '<',
     advancedFilterLessThanOrEqual: '<=',
+    advancedFilterInRange: 'کے درمیان',
     advancedFilterTrue: 'درست ہے',
     advancedFilterFalse: 'غلط ہے',
     advancedFilterAnd: 'اور',

--- a/community-modules/locale/src/vi-VN.ts
+++ b/community-modules/locale/src/vi-VN.ts
@@ -135,6 +135,7 @@ export const AG_GRID_LOCALE_VN = {
     advancedFilterGreaterThanOrEqual: '>=',
     advancedFilterLessThan: '<',
     advancedFilterLessThanOrEqual: '<=',
+    advancedFilterInRange: 'giữa',
     advancedFilterTrue: 'đúng',
     advancedFilterFalse: 'sai',
     advancedFilterAnd: 'VÀ',

--- a/community-modules/locale/src/zh-CN.ts
+++ b/community-modules/locale/src/zh-CN.ts
@@ -135,6 +135,7 @@ export const AG_GRID_LOCALE_CN = {
     advancedFilterGreaterThanOrEqual: '>=',
     advancedFilterLessThan: '<',
     advancedFilterLessThanOrEqual: '<=',
+    advancedFilterInRange: '介于',
     advancedFilterTrue: '为真',
     advancedFilterFalse: '为假',
     advancedFilterAnd: '且',

--- a/community-modules/locale/src/zh-HK.ts
+++ b/community-modules/locale/src/zh-HK.ts
@@ -135,6 +135,7 @@ export const AG_GRID_LOCALE_HK = {
     advancedFilterGreaterThanOrEqual: '>=',
     advancedFilterLessThan: '<',
     advancedFilterLessThanOrEqual: '<=',
+    advancedFilterInRange: '介於',
     advancedFilterTrue: '為真',
     advancedFilterFalse: '為假',
     advancedFilterAnd: '和',

--- a/community-modules/locale/src/zh-TW.ts
+++ b/community-modules/locale/src/zh-TW.ts
@@ -135,6 +135,7 @@ export const AG_GRID_LOCALE_TW = {
     advancedFilterGreaterThanOrEqual: '>=',
     advancedFilterLessThan: '<',
     advancedFilterLessThanOrEqual: '<=',
+    advancedFilterInRange: '介於',
     advancedFilterTrue: '為真',
     advancedFilterFalse: '為假',
     advancedFilterAnd: '和',

--- a/documentation/ag-grid-docs/src/content/docs/filter-advanced/_examples/built-in-filter-options/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/filter-advanced/_examples/built-in-filter-options/example.spec.ts
@@ -1,0 +1,98 @@
+import type { Page } from '@playwright/test';
+import { ensureGridReady, expect, orderedValues, test, waitForGridContent } from '@utils/grid/test-utils';
+
+const filterInput = (page: Page) => page.locator('.ag-advanced-filter input[type=text]');
+
+/** Types `expression`, closes the suggestion popup covering the buttons, then applies it. */
+async function applyExpression(page: Page, expression: string): Promise<void> {
+    await filterInput(page).fill(expression);
+    await page.keyboard.press('Escape');
+    await expect(page.locator('.ag-autocomplete-list-popup')).toBeHidden();
+    await page.locator('.ag-advanced-filter-buttons').getByText('Apply').click();
+}
+
+/** Every rendered date, once the grid has settled on the applied expression. */
+async function expectDates(page: Page, isOutsideFilter: (date: string) => boolean): Promise<void> {
+    await expect(async () => {
+        const dates = await orderedValues(page, 'date');
+        expect(dates.length).toBeGreaterThan(0);
+        expect(dates.filter(isOutsideFilter)).toEqual([]);
+    }).toPass();
+}
+
+function daysAgo(days: number): string {
+    const date = new Date();
+    date.setDate(date.getDate() - days);
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    return `${date.getFullYear()}-${month}-${String(date.getDate()).padStart(2, '0')}`;
+}
+
+test.agExample(import.meta, () => {
+    test.eachFramework('should offer Between for a column with no options of its own', async ({ page }) => {
+        await ensureGridReady(page);
+        await waitForGridContent(page);
+
+        await filterInput(page).fill('[Age] ');
+
+        const autocompleteList = page.locator('.ag-autocomplete-list-popup');
+        await expect(autocompleteList).toBeVisible();
+        await expect(autocompleteList.locator('.ag-autocomplete-row')).toHaveText([
+            '=',
+            '!=',
+            '>',
+            '>=',
+            '<',
+            '<=',
+            'between',
+            'is blank',
+            'is not blank',
+        ]);
+    });
+
+    // Asserted as a whole list, so the narrowing the page describes is covered as well as the options.
+    test.eachFramework('should offer only the options the date column names', async ({ page }) => {
+        await ensureGridReady(page);
+        await waitForGridContent(page);
+
+        await filterInput(page).fill('[Date] ');
+
+        const autocompleteList = page.locator('.ag-autocomplete-list-popup');
+        await expect(autocompleteList).toBeVisible();
+        await expect(autocompleteList.locator('.ag-autocomplete-row')).toHaveText([
+            '=',
+            'between',
+            'Last 7 Days',
+            'Last 30 Days',
+            'This Year',
+            'Last Year',
+            'Last 24 Months',
+        ]);
+    });
+
+    test.eachFramework('should filter a number column with Between', async ({ page }) => {
+        await ensureGridReady(page);
+        await waitForGridContent(page);
+
+        await applyExpression(page, '[Age] between (20, 25)');
+        await expect(async () => {
+            const ages = await orderedValues(page, 'age');
+            expect(ages.length).toBeGreaterThan(0);
+            expect(ages.map(Number).filter((age) => age <= 20 || age >= 25)).toEqual([]);
+        }).toPass();
+    });
+
+    test.eachFramework('should filter the date column with Between and a relative option', async ({ page }) => {
+        await ensureGridReady(page);
+        await waitForGridContent(page);
+
+        const sevenDaysAgo = daysAgo(7);
+        await applyExpression(page, '[Date] Last 7 Days');
+        await expectDates(page, (date) => date < sevenDaysAgo);
+
+        await applyExpression(page, '[Date] Last 30 Days');
+        await expectDates(page, (date) => date < daysAgo(30));
+
+        await applyExpression(page, `[Date] between ("${daysAgo(30)}", "${daysAgo(1)}")`);
+        await expectDates(page, (date) => date <= daysAgo(30) || date >= daysAgo(1));
+    });
+});

--- a/documentation/ag-grid-docs/src/content/docs/filter-advanced/_examples/built-in-filter-options/index.html
+++ b/documentation/ag-grid-docs/src/content/docs/filter-advanced/_examples/built-in-filter-options/index.html
@@ -1,0 +1,1 @@
+<div id="myGrid" style="height: 100%"></div>

--- a/documentation/ag-grid-docs/src/content/docs/filter-advanced/_examples/built-in-filter-options/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/filter-advanced/_examples/built-in-filter-options/main.ts
@@ -1,0 +1,81 @@
+import type { GridApi, GridOptions, IDateFilterParams } from 'ag-grid-community';
+import {
+    ClientSideRowModelModule,
+    DateFilterModule,
+    ModuleRegistry,
+    NumberFilterModule,
+    TextFilterModule,
+    createGrid,
+    enableDevValidations,
+} from 'ag-grid-community';
+import { AdvancedFilterModule, ColumnMenuModule, ContextMenuModule } from 'ag-grid-enterprise';
+
+if (process.env.NODE_ENV !== 'production') {
+    // Enable extended validations only for development
+    enableDevValidations();
+}
+
+ModuleRegistry.registerModules([
+    TextFilterModule,
+    NumberFilterModule,
+    DateFilterModule,
+    AdvancedFilterModule,
+    ClientSideRowModelModule,
+    ColumnMenuModule,
+    ContextMenuModule,
+]);
+
+let gridApi: GridApi<IRow>;
+
+interface IRow {
+    athlete: string;
+    age: number;
+    sport: string;
+    date: string;
+}
+
+/** The `yyyy-mm-dd` of a Date (String) column, so the data means something relative to whenever it is read. */
+function daysAgo(days: number): string {
+    const date = new Date();
+    date.setDate(date.getDate() - days);
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    return `${date.getFullYear()}-${month}-${String(date.getDate()).padStart(2, '0')}`;
+}
+
+const rowData: IRow[] = [
+    { athlete: 'Michael Phelps', age: 23, sport: 'Swimming', date: daysAgo(0) },
+    { athlete: 'Natalie Coughlin', age: 25, sport: 'Swimming', date: daysAgo(3) },
+    { athlete: 'Aleksey Nemov', age: 24, sport: 'Gymnastics', date: daysAgo(20) },
+    { athlete: 'Alicia Coutts', age: 24, sport: 'Swimming', date: daysAgo(75) },
+    { athlete: 'Missy Franklin', age: 17, sport: 'Swimming', date: daysAgo(200) },
+    { athlete: 'Ryan Lochte', age: 27, sport: 'Swimming', date: daysAgo(400) },
+    { athlete: 'Allison Schmitt', age: 22, sport: 'Swimming', date: daysAgo(600) },
+    { athlete: 'Ian Thorpe', age: 17, sport: 'Swimming', date: daysAgo(900) },
+    { athlete: 'Dara Torres', age: 33, sport: 'Swimming', date: daysAgo(1500) },
+];
+
+const dateFilterParams: IDateFilterParams = {
+    filterOptions: ['equals', 'inRange', 'last7Days', 'last30Days', 'thisYear', 'lastYear', 'last24Months'],
+};
+
+const gridOptions: GridOptions<IRow> = {
+    columnDefs: [
+        { field: 'athlete' },
+        { field: 'age', minWidth: 120 },
+        { field: 'sport' },
+        { field: 'date', filter: 'agDateColumnFilter', filterParams: dateFilterParams },
+    ],
+    defaultColDef: {
+        flex: 1,
+        minWidth: 150,
+        filter: true,
+    },
+    rowData,
+    enableAdvancedFilter: true,
+};
+
+// setup the grid after the page has finished loading
+document.addEventListener('DOMContentLoaded', () => {
+    const gridDiv = document.querySelector<HTMLElement>('#myGrid')!;
+    gridApi = createGrid(gridDiv, gridOptions);
+});

--- a/documentation/ag-grid-docs/src/content/docs/filter-advanced/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/filter-advanced/index.mdoc
@@ -136,8 +136,13 @@ The available options are as follows:
 | >=               | `greaterThanOrEqual` | `number`, `date`, `dateString`, `dateTime`, `dateTimeString`                              |
 | <                | `lessThan`           | `number`, `date`, `dateString`, `dateTime`, `dateTimeString`                              |
 | <=               | `lessThanOrEqual`    | `number`, `date`, `dateString`, `dateTime`, `dateTimeString`                              |
+| between          | `inRange`            | `number`, `date`, `dateString`, `dateTime`, `dateTimeString`                              |
 | is true          | `true`               | `boolean`                                                                                 |
 | is false         | `false`              | `boolean`                                                                                 |
+
+`between` takes two values, written as a comma-separated pair: `[Age] between (21, 38)`. The range is exclusive of both ends unless `inRangeInclusive = true` is set, exactly as it is in the [Number Filter](./filter-number/) and the [Date Filter](./filter-date/).
+
+The Advanced Filter does not validate the order of the two values, where the column filters refuse to apply a range whose first value is not below its second. A reversed range is applied here and matches no row.
 
 For `text` and `object` Cell Data Types, `caseSensitive = true` can be set to enable case sensitivity.
 
@@ -147,8 +152,46 @@ For `number`, `date`, `dateString`, `dateTime` and `dateTimeString` Cell Data Ty
 - `includeBlanksInNotEqual = true`
 - `includeBlanksInLessThan = true`
 - `includeBlanksInGreaterThan = true`
+- `includeBlanksInRange = true`
 
 These settings only apply when using the Client-Side Row Model. You need to implement support for these in your server-side filtering logic when using the Server-Side Row Model.
+
+### Relative Date Options
+
+`date`, `dateString`, `dateTime` and `dateTimeString` columns also support the Date Filter's [built-in relative date options](./filter-date/#available-built-in-date-filter-options) — `Today`, `Last Year`, `Last 90 Days` and the rest. As in the Date Filter, none of them is offered by default: a column opts in by naming them in `filterOptions`.
+
+```{% frameworkTransform=true %}
+const gridOptions = {
+    columnDefs: [
+        {
+            field: 'date',
+            cellDataType: 'date',
+            filterParams: {
+                filterOptions: ['equals', 'thisYear', 'lastYear'],
+            },
+        },
+    ],
+}
+```
+
+They take no value, so an expression is the column and the option alone, and the filter model holds only the option key:
+
+```text
+[Date] Last Year
+```
+
+```js
+const advancedFilterModel = { filterType: 'date', colId: 'date', type: 'lastYear' };
+```
+
+The option stays relative to the current date rather than being resolved to fixed dates when it is applied, so a saved filter model means the same thing whenever it is restored. With the Server-Side Row Model the option key reaches the server with no values, as the Date Filter's does — see [Preset Date Range Filters](./server-side-model-filtering/#preset-date-range-filters).
+
+The following example demonstrates the built-in range and relative date options:
+
+- The **Age** column offers `between`, which it and every other Number column do by default.
+- The **Date** column narrows its options to `=`, `between`, `Last 7 Days`, `Last 30 Days`, `This Year`, `Last Year` and `Last 24 Months`.
+
+{% gridExampleRunner title="Built-in Range and Relative Date Options" name="built-in-filter-options" /%}
 
 ### Custom Filter Options
 
@@ -204,7 +247,7 @@ const advancedFilterModel = {
 
 A `displayKey` is resolved against the column being filtered, so different columns can reuse the same key. Reusing an Option Key from the table above replaces that built-in option for the column, the same as it does in the column filter.
 
-A column's list decides what the Advanced Filter suggests for it, not what it can read. An expression naming an option the list leaves out — one saved before the list was narrowed, for example — still applies, so changing `filterOptions` does not discard filters that have already been stored. Where a list names no option the Advanced Filter has, such as the relative date presets, the column keeps the standard options for its Cell Data Type.
+A column's list decides what the Advanced Filter suggests for it, not what it can read. An expression naming an option the list leaves out — one saved before the list was narrowed, for example — still applies, so changing `filterOptions` does not discard filters that have already been stored. Where a list names no option the Advanced Filter has, the column keeps the standard options for its Cell Data Type — which for a date column means the standard options rather than the relative date ones, since those are never standard.
 
 The following example demonstrates custom filter options taking different numbers of values:
 

--- a/packages/ag-grid-community/src/filter/filterLocaleText.ts
+++ b/packages/ag-grid-community/src/filter/filterLocaleText.ts
@@ -85,6 +85,7 @@ const FILTER_LOCALE_TEXT = {
     maxValueValidation: (variableValues: string[]) => `Must be less than or equal to ${variableValues[0]}`,
 };
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export type FilterLocaleTextKey = keyof typeof FILTER_LOCALE_TEXT;
 
 /**

--- a/packages/ag-grid-community/src/filter/provided/date/dateFilterHandler.ts
+++ b/packages/ag-grid-community/src/filter/provided/date/dateFilterHandler.ts
@@ -1,12 +1,15 @@
+import { _getOwn } from 'ag-stack';
+
 import type { Column } from '../../../interfaces/iColumn';
 import type { Comparator } from '../iScalarFilter';
-import type { ISimpleFilterModelPresetType, Tuple } from '../iSimpleFilter';
+import type { Tuple } from '../iSimpleFilter';
 import type { OptionsFactory } from '../optionsFactory';
 import { ScalarFilterHandler } from '../scalarFilterHandler';
 import { DEFAULT_DATE_FILTER_OPTIONS } from './dateFilterConstants';
 import { DateFilterModelFormatter } from './dateFilterModelFormatter';
 import { mapValuesFromDateFilterModel } from './dateFilterUtils';
 import type { DateFilterModel, IDateFilterParams } from './iDateFilter';
+import { RelativeDateRangeCache, presetDateFilterTypeRelativeFromToMap } from './relativeDateRanges';
 
 function defaultDateComparator(filterDate: Date, cellValue: any): number {
     // The default comparator assumes that the cellValue is a date
@@ -22,15 +25,9 @@ function defaultDateComparator(filterDate: Date, cellValue: any): number {
     return 0;
 }
 
-type Range = { fromTime: number; toTime: number };
-
-interface RangeCacheItem extends Range {
-    expires: number;
-}
-
 export class DateFilterHandler extends ScalarFilterHandler<DateFilterModel, Date, IDateFilterParams> {
     public readonly filterType = 'date' as const;
-    private readonly filterTypeToRangeCache = new Map<ISimpleFilterModelPresetType, RangeCacheItem>();
+    private readonly rangeCache = new RelativeDateRangeCache();
 
     constructor() {
         super(mapValuesFromDateFilterModel, DEFAULT_DATE_FILTER_OPTIONS);
@@ -42,27 +39,6 @@ export class DateFilterHandler extends ScalarFilterHandler<DateFilterModel, Date
         column: Column
     ): DateFilterModelFormatter {
         return new DateFilterModelFormatter(optionsFactory, filterParams, column);
-    }
-
-    /** Times rather than dates: nothing a user `comparator` can normalise ever reaches the cache. */
-    public getOrRefreshRangeCacheItem(
-        key: ISimpleFilterModelPresetType,
-        rangeFn: (s: Date, e: Date) => [Date, Date]
-    ): Range {
-        const { filterTypeToRangeCache } = this;
-        const now = Date.now();
-        let cache = filterTypeToRangeCache.get(key);
-        // The ranges are half-open, so at the instant it expires the cached one already excludes `now`.
-        if (cache && cache.expires <= now) {
-            cache = undefined;
-        }
-        if (!cache) {
-            const [from, to] = rangeFn(new Date(now), new Date(now));
-            const expires = setStartOfNextDay(new Date(now)).getTime();
-            cache = { fromTime: from.getTime(), toTime: to.getTime(), expires };
-            filterTypeToRangeCache.set(key, cache);
-        }
-        return cache;
     }
 
     protected override comparator(): Comparator<Date> {
@@ -84,13 +60,11 @@ export class DateFilterHandler extends ScalarFilterHandler<DateFilterModel, Date
         if (!this.isValid(cellValue)) {
             return type === 'notEqual' || type === 'notBlank';
         }
-        const maybeTypeAsPreset = type as ISimpleFilterModelPresetType;
-        const presetDateRangeFn = presetDateFilterTypeRelativeFromToMap[maybeTypeAsPreset] as
-            | RelativeRangeFn
-            | undefined;
+        // A filter model's `type` is any string at all, hence the own-property lookup.
+        const presetDateRangeFn = type == null ? undefined : _getOwn(presetDateFilterTypeRelativeFromToMap, type);
         if (presetDateRangeFn) {
             // user selected a preset, calculate what they mean
-            const { fromTime, toTime } = this.getOrRefreshRangeCacheItem(maybeTypeAsPreset, presetDateRangeFn);
+            const { fromTime, toTime } = this.rangeCache.getRange(type!, presetDateRangeFn);
             const userComparator = this.params.filterParams.comparator;
             if (userComparator) {
                 // Dates of its own, built for each of the rows this runs on: a user comparator is free to
@@ -108,242 +82,3 @@ export class DateFilterHandler extends ScalarFilterHandler<DateFilterModel, Date
         return super.evaluateNonNullValue(values, cellValue, filterModel);
     }
 }
-
-type RelativeDateFn = (date: Date) => Date;
-type RelativeRangeFn = (from: Date, to: Date) => [Date, Date];
-
-const DEFAULT_FIRST_DAY_OF_WEEK = 1;
-let cachedFirstDayOfWeek: number | null = null;
-
-const getFirstDayOfWeek = (): number => {
-    if (cachedFirstDayOfWeek != null) {
-        return cachedFirstDayOfWeek;
-    }
-
-    let firstDay: number | undefined;
-    const locale = typeof navigator === 'undefined' ? undefined : (navigator.languages?.[0] ?? navigator.language);
-
-    if (locale && typeof Intl !== 'undefined' && typeof (Intl as any).Locale === 'function') {
-        try {
-            const weekInfo = new (Intl as any).Locale(locale).getWeekInfo?.();
-            firstDay = weekInfo?.firstDay;
-        } catch {
-            firstDay = undefined;
-        }
-    }
-
-    cachedFirstDayOfWeek = firstDay == null ? DEFAULT_FIRST_DAY_OF_WEEK : firstDay % 7;
-    return cachedFirstDayOfWeek;
-};
-
-// Reusable fns
-const setStartOfDay: RelativeDateFn = (date: Date) => {
-    date.setHours(0, 0, 0, 0);
-    return date;
-};
-
-const setStartOfWeek: RelativeDateFn = (date: Date) => {
-    const day = date.getDay();
-    const weekStart = getFirstDayOfWeek();
-    const diff = (day - weekStart + 7) % 7;
-    date.setDate(date.getDate() - diff);
-
-    return setStartOfDay(date);
-};
-const setPreviousNDay = (date: Date, n = 1) => {
-    date.setDate(date.getDate() - n);
-    return date;
-};
-const setStartOfNextDay: RelativeDateFn = (date: Date) => {
-    date.setDate(date.getDate() + 1);
-    return setStartOfDay(date);
-};
-const setStartOfNextWeek: RelativeDateFn = (date: Date) => {
-    setStartOfWeek(date);
-    date.setDate(date.getDate() + 6); // end of week
-    return setStartOfNextDay(date);
-};
-const setStartOfMonth: RelativeDateFn = (date: Date) => {
-    date.setDate(1);
-    return setStartOfDay(date);
-};
-const setStartOfNextMonth: RelativeDateFn = (date: Date) => {
-    date.setDate(1);
-    date.setMonth(date.getMonth() + 1);
-    return setStartOfDay(date);
-};
-const setStartOfQuarter: RelativeDateFn = (date: Date) => {
-    const quarter = Math.floor(date.getMonth() / 3); // [0, 3]
-    date.setMonth(quarter * 3);
-    return setStartOfMonth(date);
-};
-
-const setStartOfNextQuarter: RelativeDateFn = (date: Date) => {
-    const quarter = Math.floor(date.getMonth() / 3); // [0, 3]
-    date.setMonth(quarter * 3 + 2);
-    return setStartOfNextMonth(date);
-};
-
-const setStartOfYear: RelativeDateFn = (date: Date) => {
-    date.setMonth(0, 1);
-    return setStartOfDay(date);
-};
-const setStartOfNextYear: RelativeDateFn = (date: Date) => {
-    date.setMonth(12, 0);
-    return setStartOfNextDay(date);
-};
-const setPreviousDay: RelativeDateFn = (date: Date) => setPreviousNDay(date);
-const setPreviousWeek: RelativeDateFn = (date: Date) => setPreviousDay(setStartOfWeek(date));
-const setPreviousMonth: RelativeDateFn = (date: Date) => setPreviousDay(setStartOfMonth(date));
-const setPreviousQuarter: RelativeDateFn = (date: Date) => setPreviousDay(setStartOfQuarter(date));
-
-// Range fns
-const today: RelativeRangeFn = (from: Date, to: Date) => [setStartOfDay(from), setStartOfNextDay(to)];
-const yesterday: RelativeRangeFn = (from: Date, to: Date) => today(setPreviousDay(from), setPreviousDay(to));
-const thisWeek: RelativeRangeFn = (from: Date, to: Date) => [setStartOfWeek(from), setStartOfNextWeek(to)];
-const lastWeek: RelativeRangeFn = (from: Date, to: Date) => thisWeek(setPreviousWeek(from), setPreviousWeek(to));
-const thisMonth: RelativeRangeFn = (from: Date, to: Date) => [setStartOfMonth(from), setStartOfNextMonth(to)];
-const lastMonth: RelativeRangeFn = (from: Date, to: Date) => thisMonth(setPreviousMonth(from), setPreviousMonth(to));
-const thisQuarter: RelativeRangeFn = (from: Date, to: Date) => [setStartOfQuarter(from), setStartOfNextQuarter(to)];
-const lastQuarter: RelativeRangeFn = (from: Date, to: Date) =>
-    thisQuarter(setPreviousQuarter(from), setPreviousQuarter(to));
-const thisYear: RelativeRangeFn = (from: Date, to: Date) => [setStartOfYear(from), setStartOfNextYear(to)];
-const yearToDate: RelativeRangeFn = (from: Date, to: Date) => [setStartOfYear(from), setStartOfNextDay(to)];
-const last7Days: RelativeRangeFn = (from: Date, to: Date) => [
-    setStartOfDay(setPreviousNDay(from, 7)),
-    setStartOfNextDay(to),
-];
-const last30Days: RelativeRangeFn = (from: Date, to: Date) => [
-    setStartOfDay(setPreviousNDay(from, 30)),
-    setStartOfNextDay(to),
-];
-const last90Days: RelativeRangeFn = (from: Date, to: Date) => [
-    setStartOfDay(setPreviousNDay(from, 90)),
-    setStartOfNextDay(to),
-];
-
-const last6Months: RelativeRangeFn = (from: Date, to: Date) => {
-    from.setFullYear(from.getFullYear() - 1);
-    from.setMonth(from.getMonth() + 6);
-    return [setStartOfDay(from), setStartOfNextDay(to)];
-};
-const last12Months: RelativeRangeFn = (from: Date, to: Date) => {
-    from.setFullYear(from.getFullYear() - 1);
-    return [setStartOfDay(from), setStartOfNextDay(to)];
-};
-const last24Months: RelativeRangeFn = (from: Date, to: Date) => {
-    from.setFullYear(from.getFullYear() - 2);
-    return [setStartOfDay(from), setStartOfNextDay(to)];
-};
-const lastYear: RelativeRangeFn = (from: Date, to: Date) => {
-    from.setFullYear(from.getFullYear() - 1);
-    to.setFullYear(to.getFullYear() - 1);
-    return thisYear(from, to);
-};
-const nextYear: RelativeRangeFn = (from: Date, to: Date) => {
-    from.setFullYear(from.getFullYear() + 1);
-    to.setFullYear(to.getFullYear() + 1);
-    return thisYear(from, to);
-};
-const nextQuarter: RelativeRangeFn = (from: Date, to: Date) => {
-    from.setMonth(from.getMonth() + 3);
-    to.setMonth(to.getMonth() + 3);
-    return thisQuarter(from, to);
-};
-const nextMonth: RelativeRangeFn = (from: Date, to: Date) => {
-    from.setMonth(from.getMonth() + 1);
-    to.setMonth(to.getMonth() + 1);
-    return thisMonth(from, to);
-};
-const nextWeek: RelativeRangeFn = (from: Date, to: Date) => {
-    from.setDate(from.getDate() + 7);
-    to.setDate(to.getDate() + 7);
-    return thisWeek(from, to);
-};
-const tomorrow: RelativeRangeFn = (from: Date, to: Date) => {
-    from.setDate(from.getDate() + 1);
-    to.setDate(to.getDate() + 1);
-    return today(from, to);
-};
-
-/**
- * Spec:
- * Today                   today               [startOfToday, startOfTomorrow)
- * Yesterday               yesterday           [startOfYesterday, startOfToday)
- * Tomorrow                tomorrow            [startOfTomorrow, startOfDayAfterTomorrow)
- * This Week               thisWeek            [startOfCurrentWeek, startOfNextWeek)
- * Last Week               lastWeek            [startOfPreviousWeek, startOfCurrentWeek)
- * Next Week               nextWeek            [startOfNextWeek, startOfWeekAfterNext)
- * This Month              thisMonth           [startOfCurrentMonth, startOfNextMonth)
- * Last Month              lastMonth           [startOfPreviousMonth, startOfCurrentMonth)
- * Next Month              nextMonth           [startOfNextMonth, startOfMonthAfterNext)
- * This Quarter            thisQuarter         [startOfCurrentQuarter, startOfNextQuarter)
- * Last Quarter            lastQuarter         [startOfPreviousQuarter, startOfCurrentQuarter)
- * Next Quarter            nextQuarter         [startOfNextQuarter, startOfQuarterAfterNext)
- * This Year               thisYear            [startOfCurrentYear, startOfNextYear)
- * Last Year               lastYear            [startOfPreviousYear, startOfCurrentYear)
- * Next Year               nextYear            [startOfNextYear, startOfYearAfterNext)
- * Year to Date (YTD)      yearToDate          [startOfCurrentYear, startOfTomorrow)
- * Last 7 days             last7Days           [startOfToday − 7 days, startOfTomorrow)
- * Last 30 days            last30Days          [startOfToday − 30 days, startOfTomorrow)
- * Last 90 days            last90Days          [startOfToday − 90 days, startOfTomorrow)
- * Last 6 months           last6Months         [startOfToday − 6 months, startOfTomorrow)
- * Last 12 months          last12Months        [startOfToday − 12 months, startOfTomorrow)
- * Last 24 months          last24Months        [startOfToday − 24 months, startOfTomorrow)
- * @knipIgnore Used in tests
- */
-export const presetDateFilterTypeRelativeFromToMap: Record<
-    | ISimpleFilterModelPresetType
-    | 'setStartOfDay'
-    | 'setStartOfWeek'
-    | 'setStartOfNextDay'
-    | 'setStartOfNextWeek'
-    | 'setStartOfMonth'
-    | 'setStartOfNextMonth'
-    | 'setStartOfQuarter'
-    | 'setStartOfNextQuarter'
-    | 'setStartOfYear'
-    | 'setStartOfNextYear'
-    | 'setPreviousDay'
-    | 'setPreviousWeek'
-    | 'setPreviousMonth'
-    | 'setPreviousQuarter',
-    RelativeRangeFn | RelativeDateFn
-> = {
-    today,
-    yesterday,
-    tomorrow,
-    thisWeek,
-    lastWeek,
-    nextWeek,
-    thisMonth,
-    lastMonth,
-    nextMonth,
-    thisQuarter,
-    lastQuarter,
-    nextQuarter,
-    thisYear,
-    lastYear,
-    nextYear,
-    yearToDate,
-    last7Days,
-    last30Days,
-    last90Days,
-    last6Months,
-    last12Months,
-    last24Months,
-    setStartOfDay,
-    setStartOfWeek,
-    setStartOfNextDay,
-    setStartOfNextWeek,
-    setStartOfMonth,
-    setStartOfNextMonth,
-    setStartOfQuarter,
-    setStartOfNextQuarter,
-    setStartOfYear,
-    setStartOfNextYear,
-    setPreviousDay,
-    setPreviousWeek,
-    setPreviousMonth,
-    setPreviousQuarter,
-};

--- a/packages/ag-grid-community/src/filter/provided/date/relativeDateRanges.test.ts
+++ b/packages/ag-grid-community/src/filter/provided/date/relativeDateRanges.test.ts
@@ -1,11 +1,14 @@
 import type { ISimpleFilterModelPresetType } from '../iSimpleFilter';
-import { DateFilterHandler, presetDateFilterTypeRelativeFromToMap } from './dateFilterHandler';
+import {
+    RelativeDateRangeCache,
+    presetDateFilterTypeRelativeFromToMap,
+    relativeDateHelperFns,
+} from './relativeDateRanges';
 
 type PresetKey = keyof typeof presetDateFilterTypeRelativeFromToMap;
-type RangeFn = (from: Date, to: Date) => [Date, Date];
-type DateFn = (date: Date) => Date;
+type HelperKey = keyof typeof relativeDateHelperFns;
 
-describe('presetDateFilterTypeRelativeFromToMap', () => {
+describe('relative date ranges', () => {
     beforeAll(() => {
         if (typeof navigator === 'undefined') {
             return;
@@ -90,10 +93,10 @@ describe('presetDateFilterTypeRelativeFromToMap', () => {
     ])('%s', (fnName, expected) =>
         it('returns correct from/to', () =>
             expect(
-                (presetDateFilterTypeRelativeFromToMap[fnName] as RangeFn)(FROM, TO).map((d: Date) => d.toString())
+                presetDateFilterTypeRelativeFromToMap[fnName](FROM, TO).map((d: Date) => d.toString())
             ).toStrictEqual(expected))
     );
-    describe.each<[PresetKey, string]>([
+    describe.each<[HelperKey, string]>([
         ['setStartOfDay', ANSWERS.startOfToday],
         ['setStartOfWeek', ANSWERS.startOfCurrentWeek],
         ['setStartOfNextDay', ANSWERS.startOfTomorrow],
@@ -109,8 +112,7 @@ describe('presetDateFilterTypeRelativeFromToMap', () => {
         ['setPreviousMonth', ANSWERS.previousMonth],
         ['setPreviousQuarter', ANSWERS.previousQuarter],
     ])('%s', (fnName, expected) =>
-        it('works', () =>
-            expect((presetDateFilterTypeRelativeFromToMap[fnName] as DateFn)(FROM).toString()).toContain(expected))
+        it('works', () => expect(relativeDateHelperFns[fnName](FROM).toString()).toContain(expected))
     );
 });
 
@@ -146,15 +148,15 @@ describe('getFirstDayOfWeek', () => {
             value: { language: 'en-US', languages: ['en-US'] },
         });
 
-        const { presetDateFilterTypeRelativeFromToMap: map } = await import('./dateFilterHandler');
-        const result = (map.setStartOfWeek as DateFn)(new Date(base));
+        const { relativeDateHelperFns: helpers } = await import('./relativeDateRanges');
+        const result = helpers.setStartOfWeek(new Date(base));
         expect(result.toUTCString()).toContain('Sun, 05 Apr 2020');
 
         expect(getWeekInfo).toHaveBeenCalledTimes(1);
     });
 });
 
-describe('getOrRefreshRangeCacheItem', () => {
+describe('RelativeDateRangeCache', () => {
     const key = 'today' as ISimpleFilterModelPresetType;
 
     beforeEach(() => {
@@ -173,12 +175,12 @@ describe('getOrRefreshRangeCacheItem', () => {
         ['later the same day', new Date('2026-08-10T09:00:00Z'), new Date('2026-08-10T09:00:01Z')],
     ])('returns cached range for the same key before expiry, %s', (_name, start, next) => {
         vi.setSystemTime(start);
-        const handler = new DateFilterHandler();
+        const cache = new RelativeDateRangeCache();
         const rangeFn = vi.fn(() => [new Date(1), new Date(2)] as [Date, Date]);
 
-        const first = handler.getOrRefreshRangeCacheItem(key, rangeFn);
+        const first = cache.getRange(key, rangeFn);
         vi.setSystemTime(next);
-        const second = handler.getOrRefreshRangeCacheItem(key, rangeFn);
+        const second = cache.getRange(key, rangeFn);
 
         expect(rangeFn).toHaveBeenCalledTimes(1);
         expect([first.fromTime, first.toTime]).toStrictEqual([1, 2]);
@@ -188,7 +190,7 @@ describe('getOrRefreshRangeCacheItem', () => {
     // The range reaches a user `comparator` as dates it is free to normalise, so the cache keeps times:
     // there is nothing in it a caller holds a reference to.
     it('caches times rather than the dates the range function built', () => {
-        const handler = new DateFilterHandler();
+        const cache = new RelativeDateRangeCache();
         const built: Date[] = [];
         const rangeFn = vi.fn(() => {
             const range: [Date, Date] = [new Date(1_000), new Date(2_000)];
@@ -196,7 +198,7 @@ describe('getOrRefreshRangeCacheItem', () => {
             return range;
         });
 
-        const cached = handler.getOrRefreshRangeCacheItem(key, rangeFn);
+        const cached = cache.getRange(key, rangeFn);
         for (const date of built) {
             date.setTime(999_999);
         }
@@ -213,29 +215,29 @@ describe('getOrRefreshRangeCacheItem', () => {
     // The ranges are half-open, so the expiry instant already belongs to the day the cached range excludes.
     it('refreshes the cache at the instant it expires', () => {
         vi.setSystemTime(MIDMORNING);
-        const handler = new DateFilterHandler();
+        const cache = new RelativeDateRangeCache();
         const rangeFn = vi.fn(() => [new Date(1), new Date(2)] as [Date, Date]);
 
-        handler.getOrRefreshRangeCacheItem(key, rangeFn);
+        cache.getRange(key, rangeFn);
         vi.setSystemTime(NEXT_MIDNIGHT);
-        handler.getOrRefreshRangeCacheItem(key, rangeFn);
+        cache.getRange(key, rangeFn);
 
         expect(rangeFn).toHaveBeenCalledTimes(2);
     });
 
     it('refreshes the cache when expired', () => {
         vi.setSystemTime(MIDMORNING);
-        const handler = new DateFilterHandler();
+        const cache = new RelativeDateRangeCache();
         const rangeFn = vi
             .fn()
             .mockImplementationOnce(() => [new Date(1), new Date(2)] as [Date, Date])
             .mockImplementationOnce(() => [new Date(3), new Date(4)] as [Date, Date]);
 
-        const first = handler.getOrRefreshRangeCacheItem(key, rangeFn);
+        const first = cache.getRange(key, rangeFn);
 
         vi.setSystemTime(new Date(NEXT_MIDNIGHT.getTime() + 1));
 
-        const second = handler.getOrRefreshRangeCacheItem(key, rangeFn);
+        const second = cache.getRange(key, rangeFn);
 
         expect(rangeFn).toHaveBeenCalledTimes(2);
         expect([first.fromTime, first.toTime]).toStrictEqual([1, 2]);
@@ -243,12 +245,12 @@ describe('getOrRefreshRangeCacheItem', () => {
     });
 
     it('keeps separate caches per key', () => {
-        const handler = new DateFilterHandler();
+        const cache = new RelativeDateRangeCache();
         const rangeFnToday = vi.fn(() => [new Date(10), new Date(20)] as [Date, Date]);
         const rangeFnYesterday = vi.fn(() => [new Date(30), new Date(40)] as [Date, Date]);
 
-        const today = handler.getOrRefreshRangeCacheItem('today', rangeFnToday);
-        const yesterday = handler.getOrRefreshRangeCacheItem('yesterday', rangeFnYesterday);
+        const today = cache.getRange('today', rangeFnToday);
+        const yesterday = cache.getRange('yesterday', rangeFnYesterday);
 
         expect(rangeFnToday).toHaveBeenCalledTimes(1);
         expect(rangeFnYesterday).toHaveBeenCalledTimes(1);

--- a/packages/ag-grid-community/src/filter/provided/date/relativeDateRanges.ts
+++ b/packages/ag-grid-community/src/filter/provided/date/relativeDateRanges.ts
@@ -1,0 +1,271 @@
+import type { ISimpleFilterModelPresetType } from '../iSimpleFilter';
+
+type RelativeDateFn = (date: Date) => Date;
+type RelativeRangeFn = (from: Date, to: Date) => [Date, Date];
+
+const DEFAULT_FIRST_DAY_OF_WEEK = 1;
+let cachedFirstDayOfWeek: number | null = null;
+
+const getFirstDayOfWeek = (): number => {
+    if (cachedFirstDayOfWeek != null) {
+        return cachedFirstDayOfWeek;
+    }
+
+    let firstDay: number | undefined;
+    const locale = typeof navigator === 'undefined' ? undefined : (navigator.languages?.[0] ?? navigator.language);
+
+    if (locale && typeof Intl !== 'undefined' && typeof (Intl as any).Locale === 'function') {
+        try {
+            const weekInfo = new (Intl as any).Locale(locale).getWeekInfo?.();
+            firstDay = weekInfo?.firstDay;
+        } catch {
+            firstDay = undefined;
+        }
+    }
+
+    cachedFirstDayOfWeek = firstDay == null ? DEFAULT_FIRST_DAY_OF_WEEK : firstDay % 7;
+    return cachedFirstDayOfWeek;
+};
+
+// Reusable fns
+const setStartOfDay: RelativeDateFn = (date: Date) => {
+    date.setHours(0, 0, 0, 0);
+    return date;
+};
+
+const setStartOfWeek: RelativeDateFn = (date: Date) => {
+    const day = date.getDay();
+    const weekStart = getFirstDayOfWeek();
+    const diff = (day - weekStart + 7) % 7;
+    date.setDate(date.getDate() - diff);
+
+    return setStartOfDay(date);
+};
+const setPreviousNDay = (date: Date, n = 1) => {
+    date.setDate(date.getDate() - n);
+    return date;
+};
+const setStartOfNextDay: RelativeDateFn = (date: Date) => {
+    date.setDate(date.getDate() + 1);
+    return setStartOfDay(date);
+};
+const setStartOfNextWeek: RelativeDateFn = (date: Date) => {
+    setStartOfWeek(date);
+    date.setDate(date.getDate() + 6); // end of week
+    return setStartOfNextDay(date);
+};
+const setStartOfMonth: RelativeDateFn = (date: Date) => {
+    date.setDate(1);
+    return setStartOfDay(date);
+};
+const setStartOfNextMonth: RelativeDateFn = (date: Date) => {
+    date.setDate(1);
+    date.setMonth(date.getMonth() + 1);
+    return setStartOfDay(date);
+};
+const setStartOfQuarter: RelativeDateFn = (date: Date) => {
+    const quarter = Math.floor(date.getMonth() / 3); // [0, 3]
+    date.setMonth(quarter * 3);
+    return setStartOfMonth(date);
+};
+
+const setStartOfNextQuarter: RelativeDateFn = (date: Date) => {
+    const quarter = Math.floor(date.getMonth() / 3); // [0, 3]
+    date.setMonth(quarter * 3 + 2);
+    return setStartOfNextMonth(date);
+};
+
+const setStartOfYear: RelativeDateFn = (date: Date) => {
+    date.setMonth(0, 1);
+    return setStartOfDay(date);
+};
+const setStartOfNextYear: RelativeDateFn = (date: Date) => {
+    date.setMonth(12, 0);
+    return setStartOfNextDay(date);
+};
+const setPreviousDay: RelativeDateFn = (date: Date) => setPreviousNDay(date);
+const setPreviousWeek: RelativeDateFn = (date: Date) => setPreviousDay(setStartOfWeek(date));
+const setPreviousMonth: RelativeDateFn = (date: Date) => setPreviousDay(setStartOfMonth(date));
+const setPreviousQuarter: RelativeDateFn = (date: Date) => setPreviousDay(setStartOfQuarter(date));
+
+// Range fns
+const today: RelativeRangeFn = (from: Date, to: Date) => [setStartOfDay(from), setStartOfNextDay(to)];
+const yesterday: RelativeRangeFn = (from: Date, to: Date) => today(setPreviousDay(from), setPreviousDay(to));
+const thisWeek: RelativeRangeFn = (from: Date, to: Date) => [setStartOfWeek(from), setStartOfNextWeek(to)];
+const lastWeek: RelativeRangeFn = (from: Date, to: Date) => thisWeek(setPreviousWeek(from), setPreviousWeek(to));
+const thisMonth: RelativeRangeFn = (from: Date, to: Date) => [setStartOfMonth(from), setStartOfNextMonth(to)];
+const lastMonth: RelativeRangeFn = (from: Date, to: Date) => thisMonth(setPreviousMonth(from), setPreviousMonth(to));
+const thisQuarter: RelativeRangeFn = (from: Date, to: Date) => [setStartOfQuarter(from), setStartOfNextQuarter(to)];
+const lastQuarter: RelativeRangeFn = (from: Date, to: Date) =>
+    thisQuarter(setPreviousQuarter(from), setPreviousQuarter(to));
+const thisYear: RelativeRangeFn = (from: Date, to: Date) => [setStartOfYear(from), setStartOfNextYear(to)];
+const yearToDate: RelativeRangeFn = (from: Date, to: Date) => [setStartOfYear(from), setStartOfNextDay(to)];
+const last7Days: RelativeRangeFn = (from: Date, to: Date) => [
+    setStartOfDay(setPreviousNDay(from, 7)),
+    setStartOfNextDay(to),
+];
+const last30Days: RelativeRangeFn = (from: Date, to: Date) => [
+    setStartOfDay(setPreviousNDay(from, 30)),
+    setStartOfNextDay(to),
+];
+const last90Days: RelativeRangeFn = (from: Date, to: Date) => [
+    setStartOfDay(setPreviousNDay(from, 90)),
+    setStartOfNextDay(to),
+];
+
+const last6Months: RelativeRangeFn = (from: Date, to: Date) => {
+    from.setFullYear(from.getFullYear() - 1);
+    from.setMonth(from.getMonth() + 6);
+    return [setStartOfDay(from), setStartOfNextDay(to)];
+};
+const last12Months: RelativeRangeFn = (from: Date, to: Date) => {
+    from.setFullYear(from.getFullYear() - 1);
+    return [setStartOfDay(from), setStartOfNextDay(to)];
+};
+const last24Months: RelativeRangeFn = (from: Date, to: Date) => {
+    from.setFullYear(from.getFullYear() - 2);
+    return [setStartOfDay(from), setStartOfNextDay(to)];
+};
+const lastYear: RelativeRangeFn = (from: Date, to: Date) => {
+    from.setFullYear(from.getFullYear() - 1);
+    to.setFullYear(to.getFullYear() - 1);
+    return thisYear(from, to);
+};
+const nextYear: RelativeRangeFn = (from: Date, to: Date) => {
+    from.setFullYear(from.getFullYear() + 1);
+    to.setFullYear(to.getFullYear() + 1);
+    return thisYear(from, to);
+};
+const nextQuarter: RelativeRangeFn = (from: Date, to: Date) => {
+    from.setMonth(from.getMonth() + 3);
+    to.setMonth(to.getMonth() + 3);
+    return thisQuarter(from, to);
+};
+const nextMonth: RelativeRangeFn = (from: Date, to: Date) => {
+    from.setMonth(from.getMonth() + 1);
+    to.setMonth(to.getMonth() + 1);
+    return thisMonth(from, to);
+};
+const nextWeek: RelativeRangeFn = (from: Date, to: Date) => {
+    from.setDate(from.getDate() + 7);
+    to.setDate(to.getDate() + 7);
+    return thisWeek(from, to);
+};
+const tomorrow: RelativeRangeFn = (from: Date, to: Date) => {
+    from.setDate(from.getDate() + 1);
+    to.setDate(to.getDate() + 1);
+    return today(from, to);
+};
+
+/**
+ * Spec:
+ * Today                   today               [startOfToday, startOfTomorrow)
+ * Yesterday               yesterday           [startOfYesterday, startOfToday)
+ * Tomorrow                tomorrow            [startOfTomorrow, startOfDayAfterTomorrow)
+ * This Week               thisWeek            [startOfCurrentWeek, startOfNextWeek)
+ * Last Week               lastWeek            [startOfPreviousWeek, startOfCurrentWeek)
+ * Next Week               nextWeek            [startOfNextWeek, startOfWeekAfterNext)
+ * This Month              thisMonth           [startOfCurrentMonth, startOfNextMonth)
+ * Last Month              lastMonth           [startOfPreviousMonth, startOfCurrentMonth)
+ * Next Month              nextMonth           [startOfNextMonth, startOfMonthAfterNext)
+ * This Quarter            thisQuarter         [startOfCurrentQuarter, startOfNextQuarter)
+ * Last Quarter            lastQuarter         [startOfPreviousQuarter, startOfCurrentQuarter)
+ * Next Quarter            nextQuarter         [startOfNextQuarter, startOfQuarterAfterNext)
+ * This Year               thisYear            [startOfCurrentYear, startOfNextYear)
+ * Last Year               lastYear            [startOfPreviousYear, startOfCurrentYear)
+ * Next Year               nextYear            [startOfNextYear, startOfYearAfterNext)
+ * Year to Date (YTD)      yearToDate          [startOfCurrentYear, startOfTomorrow)
+ * Last 7 days             last7Days           [startOfToday − 7 days, startOfTomorrow)
+ * Last 30 days            last30Days          [startOfToday − 30 days, startOfTomorrow)
+ * Last 90 days            last90Days          [startOfToday − 90 days, startOfTomorrow)
+ * Last 6 months           last6Months         [startOfToday − 6 months, startOfTomorrow)
+ * Last 12 months          last12Months        [startOfToday − 12 months, startOfTomorrow)
+ * Last 24 months          last24Months        [startOfToday − 24 months, startOfTomorrow)
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
+ */
+export const presetDateFilterTypeRelativeFromToMap: Record<ISimpleFilterModelPresetType, RelativeRangeFn> = {
+    today,
+    yesterday,
+    tomorrow,
+    thisWeek,
+    lastWeek,
+    nextWeek,
+    thisMonth,
+    lastMonth,
+    nextMonth,
+    thisQuarter,
+    lastQuarter,
+    nextQuarter,
+    thisYear,
+    lastYear,
+    nextYear,
+    yearToDate,
+    last7Days,
+    last30Days,
+    last90Days,
+    last6Months,
+    last12Months,
+    last24Months,
+};
+
+/**
+ * The single-date steps the ranges above are built from. Kept apart from them so a filter type can only
+ * ever resolve to a range.
+ * @knipIgnore Used in tests
+ */
+export const relativeDateHelperFns = {
+    setStartOfDay,
+    setStartOfWeek,
+    setStartOfNextDay,
+    setStartOfNextWeek,
+    setStartOfMonth,
+    setStartOfNextMonth,
+    setStartOfQuarter,
+    setStartOfNextQuarter,
+    setStartOfYear,
+    setStartOfNextYear,
+    setPreviousDay,
+    setPreviousWeek,
+    setPreviousMonth,
+    setPreviousQuarter,
+};
+
+/**
+ * The relative date options. None is a default: a column opts into them through `filterParams.filterOptions`.
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
+ */
+export const PRESET_DATE_FILTER_TYPES = Object.keys(
+    presetDateFilterTypeRelativeFromToMap
+) as ISimpleFilterModelPresetType[];
+
+type Range = { fromTime: number; toTime: number };
+
+interface RangeCacheItem extends Range {
+    expires: number;
+}
+
+/**
+ * What a relative date option means right now, held until the day it was computed on ends.
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
+ */
+export class RelativeDateRangeCache {
+    private readonly ranges = new Map<string, RangeCacheItem>();
+
+    /** Times rather than dates: nothing a user `comparator` can normalise ever reaches the cache. */
+    public getRange(key: string, rangeFn: RelativeRangeFn): Range {
+        const ranges = this.ranges;
+        const now = Date.now();
+        let cache = ranges.get(key);
+        // The ranges are half-open, so at the instant it expires the cached one already excludes `now`.
+        if (cache && cache.expires <= now) {
+            cache = undefined;
+        }
+        if (!cache) {
+            const [from, to] = rangeFn(new Date(now), new Date(now));
+            const expires = setStartOfNextDay(new Date(now)).getTime();
+            cache = { fromTime: from.getTime(), toTime: to.getTime(), expires };
+            ranges.set(key, cache);
+        }
+        return cache;
+    }
+}

--- a/packages/ag-grid-community/src/filter/provided/simpleFilterUtils.ts
+++ b/packages/ag-grid-community/src/filter/provided/simpleFilterUtils.ts
@@ -4,6 +4,7 @@ import type { Column } from '../../interfaces/iColumn';
 import type { FilterInputCallbackParams } from '../../interfaces/iFilter';
 import type { LogService } from '../../validation/logService';
 import type { FilterLocaleTextKey } from '../filterLocaleText';
+import { PRESET_DATE_FILTER_TYPES } from './date/relativeDateRanges';
 import type { FilterOptionKey, IFilterOptionDef, ISimpleFilterModelType, JoinOperator, Tuple } from './iSimpleFilter';
 import type { OptionsFactory } from './optionsFactory';
 
@@ -94,28 +95,7 @@ const zeroInputTypes: ReadonlySet<string> = new Set<ISimpleFilterModelType>([
     'empty',
     'notBlank',
     'blank',
-    'today',
-    'yesterday',
-    'tomorrow',
-    'thisWeek',
-    'lastWeek',
-    'nextWeek',
-    'thisMonth',
-    'lastMonth',
-    'nextMonth',
-    'thisQuarter',
-    'lastQuarter',
-    'nextQuarter',
-    'thisYear',
-    'lastYear',
-    'nextYear',
-    'yearToDate',
-    'last7Days',
-    'last30Days',
-    'last90Days',
-    'last6Months',
-    'last12Months',
-    'last24Months',
+    ...PRESET_DATE_FILTER_TYPES,
 ]);
 
 /** An entry missing any of these cannot be offered; they are listed so the warning can name the missing one. */

--- a/packages/ag-grid-community/src/interfaces/advancedFilterModel.ts
+++ b/packages/ag-grid-community/src/interfaces/advancedFilterModel.ts
@@ -1,5 +1,5 @@
 import type { CheckDataTypes } from '../entities/dataType';
-import type { CustomFilterOptionKey } from '../filter/provided/iSimpleFilter';
+import type { CustomFilterOptionKey, ISimpleFilterModelPresetType } from '../filter/provided/iSimpleFilter';
 
 export type AdvancedFilterModel = JoinAdvancedFilterModel | ColumnAdvancedFilterModel;
 
@@ -29,8 +29,12 @@ export type ScalarAdvancedFilterModelType =
     | 'lessThanOrEqual'
     | 'greaterThan'
     | 'greaterThanOrEqual'
+    | 'inRange'
     | 'blank'
     | 'notBlank';
+
+/** A date column additionally offers the Date Filter's relative options, which take no value. */
+export type DateAdvancedFilterModelType = ScalarAdvancedFilterModelType | ISimpleFilterModelPresetType;
 
 export type BooleanAdvancedFilterModelType = 'true' | 'false' | 'blank' | 'notBlank';
 
@@ -79,7 +83,7 @@ export interface DateAdvancedFilterModel {
     /** The ID of the column being filtered. */
     colId: string;
     /** The filter option that is being applied. */
-    type: ScalarAdvancedFilterModelType | CustomFilterOptionKey;
+    type: DateAdvancedFilterModelType | CustomFilterOptionKey;
     /** The value to filter on. This is in format `YYYY-MM-DD`. */
     filter?: string;
     /** The second value to filter on, where the filter option takes two. */
@@ -92,7 +96,7 @@ export interface DateStringAdvancedFilterModel {
     /** The ID of the column being filtered. */
     colId: string;
     /** The filter option that is being applied. */
-    type: ScalarAdvancedFilterModelType | CustomFilterOptionKey;
+    type: DateAdvancedFilterModelType | CustomFilterOptionKey;
     /** The value to filter on. This is in format `YYYY-MM-DD`. */
     filter?: string;
     /** The second value to filter on, where the filter option takes two. */
@@ -130,7 +134,7 @@ export interface DateTimeAdvancedFilterModel {
     /** The ID of the column being filtered. */
     colId: string;
     /** The filter option that is being applied. */
-    type: ScalarAdvancedFilterModelType | CustomFilterOptionKey;
+    type: DateAdvancedFilterModelType | CustomFilterOptionKey;
     /** The value to filter on. This is in format `YYYY-MM-DDTHH:mm:ss`. */
     filter?: string;
     /** The second value to filter on, where the filter option takes two. */
@@ -142,7 +146,7 @@ export interface DateTimeStringAdvancedFilterModel {
     /** The ID of the column being filtered. */
     colId: string;
     /** The filter option that is being applied. */
-    type: ScalarAdvancedFilterModelType | CustomFilterOptionKey;
+    type: DateAdvancedFilterModelType | CustomFilterOptionKey;
     /** The value to filter on. This is in format `YYYY-MM-DD HH:mm:ss`. */
     filter?: string;
     /** The second value to filter on, where the filter option takes two. */

--- a/packages/ag-grid-community/src/main-internal.ts
+++ b/packages/ag-grid-community/src/main-internal.ts
@@ -142,6 +142,12 @@ export {
     _isGridSuppliedFilterOptions,
 } from './filter/filterDataTypeUtils';
 export { translateForFilter as _translateForFilter } from './filter/filterLocaleText';
+export type { FilterLocaleTextKey as _FilterLocaleTextKey } from './filter/filterLocaleText';
+export {
+    PRESET_DATE_FILTER_TYPES as _PRESET_DATE_FILTER_TYPES,
+    RelativeDateRangeCache as _RelativeDateRangeCache,
+    presetDateFilterTypeRelativeFromToMap as _PRESET_DATE_FILTER_RANGES,
+} from './filter/provided/date/relativeDateRanges';
 export type { FilterManager } from './filter/filterManager';
 export type { FilterValueService } from './filter/filterValueService';
 export { FilterWrapperComp } from './filter/filterWrapperComp';

--- a/packages/ag-grid-community/src/main.ts
+++ b/packages/ag-grid-community/src/main.ts
@@ -282,6 +282,7 @@ export type {
     BooleanAdvancedFilterModelType,
     ColumnAdvancedFilterModel,
     DateAdvancedFilterModel,
+    DateAdvancedFilterModelType,
     DateStringAdvancedFilterModel,
     DateTimeAdvancedFilterModel,
     DateTimeStringAdvancedFilterModel,

--- a/packages/ag-grid-enterprise/src/advancedFilter/advancedFilterExpressionService.ts
+++ b/packages/ag-grid-enterprise/src/advancedFilter/advancedFilterExpressionService.ts
@@ -11,8 +11,9 @@ import type {
     JoinAdvancedFilterModel,
     NamedBean,
     ValueService,
+    _FilterLocaleTextKey,
 } from 'ag-grid-community';
-import { BeanStub, _classifyFilterOptions, _toFiniteNumber } from 'ag-grid-community';
+import { BeanStub, _classifyFilterOptions, _toFiniteNumber, _translateForFilter } from 'ag-grid-community';
 
 import { ADVANCED_FILTER_LOCALE_TEXT } from './advancedFilterLocaleText';
 import type { AutocompleteEntry, AutocompleteListParams } from './autocomplete/autocompleteParams';
@@ -64,6 +65,8 @@ const COPIED_FILTER_PARAMS: (keyof FilterExpressionEvaluatorParams<any>)[] = [
     'includeBlanksInNotEqual',
     'includeBlanksInLessThan',
     'includeBlanksInGreaterThan',
+    'includeBlanksInRange',
+    'inRangeInclusive',
 ];
 
 /** A column's operators and the keys it narrows them to, classified together from its one `filterOptions`. */
@@ -440,7 +443,7 @@ export class AdvancedFilterExpressionService extends BeanStub implements NamedBe
             return undefined;
         }
         if (!column) {
-            return { operators: dataTypeOperators, activeOperators: undefined };
+            return { operators: dataTypeOperators, activeOperators: dataTypeOperators.defaultOperators };
         }
         const byDataType = this.columnExpressionOperators;
         let forDataType = byDataType[baseCellDataType!];
@@ -462,7 +465,7 @@ export class AdvancedFilterExpressionService extends BeanStub implements NamedBe
     ): ColumnOperators {
         const filterOptions = getColumnFilterOptions(column);
         if (!filterOptions) {
-            return { operators: dataTypeOperators, activeOperators: undefined };
+            return { operators: dataTypeOperators, activeOperators: dataTypeOperators.defaultOperators };
         }
         // Reported here too: a column filtered only through the Advanced Filter never builds an `OptionsFactory`.
         const { offered, customOptions } = _classifyFilterOptions(filterOptions, (keys) => this.warn(72, { keys }));
@@ -471,7 +474,10 @@ export class AdvancedFilterExpressionService extends BeanStub implements NamedBe
             ? createCustomOptionOperators(dataTypeOperators, customOptions, localeTextFunc)
             : dataTypeOperators;
         const activeOperators = [...offered.keys()].filter((key) => _getOwn(operators.operators, key));
-        return { operators, activeOperators: activeOperators.length ? activeOperators : undefined };
+        return {
+            operators,
+            activeOperators: activeOperators.length ? activeOperators : dataTypeOperators.defaultOperators,
+        };
     }
 
     public getExpressionJoinOperators(): { AND: string; OR: string } {
@@ -568,17 +574,20 @@ export class AdvancedFilterExpressionService extends BeanStub implements NamedBe
     public generateExpressionOperators(): FilterExpressionOperators {
         const translate = (key: keyof typeof ADVANCED_FILTER_LOCALE_TEXT, variableValues?: string[]) =>
             this.translate(key, variableValues);
+        const translateFilter = (key: _FilterLocaleTextKey) => _translateForFilter(this, key);
+        const baseParams = { translate, translateFilter };
         const dateOperatorsParams = {
-            translate,
+            ...baseParams,
             equals: (v: Date, o: Date) => v.getTime() === o.getTime(),
+            relativeDates: true,
         };
 
         return {
-            text: new TextFilterExpressionOperators({ translate }),
-            boolean: new BooleanFilterExpressionOperators({ translate }),
-            object: new TextFilterExpressionOperators<any>({ translate }),
-            number: new ScalarFilterExpressionOperators<number>({ translate, equals: (v, o) => v === o }),
-            bigint: new ScalarFilterExpressionOperators<bigint>({ translate, equals: (v, o) => v === o }),
+            text: new TextFilterExpressionOperators(baseParams),
+            boolean: new BooleanFilterExpressionOperators(baseParams),
+            object: new TextFilterExpressionOperators<any>(baseParams),
+            number: new ScalarFilterExpressionOperators<number>({ ...baseParams, equals: (v, o) => v === o }),
+            bigint: new ScalarFilterExpressionOperators<bigint>({ ...baseParams, equals: (v, o) => v === o }),
             date: new ScalarFilterExpressionOperators<Date>(dateOperatorsParams),
             dateString: new ScalarFilterExpressionOperators<Date, string>(dateOperatorsParams),
             dateTime: new ScalarFilterExpressionOperators<Date>(dateOperatorsParams),

--- a/packages/ag-grid-enterprise/src/advancedFilter/advancedFilterLocaleText.ts
+++ b/packages/ag-grid-enterprise/src/advancedFilter/advancedFilterLocaleText.ts
@@ -27,6 +27,7 @@ export const ADVANCED_FILTER_LOCALE_TEXT = {
     advancedFilterGreaterThanOrEqual: '>=',
     advancedFilterLessThan: '<',
     advancedFilterLessThanOrEqual: '<=',
+    advancedFilterInRange: 'between',
     advancedFilterTrue: 'is true',
     advancedFilterFalse: 'is false',
     advancedFilterAnd: 'AND',

--- a/packages/ag-grid-enterprise/src/advancedFilter/colFilterExpressionParser.ts
+++ b/packages/ag-grid-enterprise/src/advancedFilter/colFilterExpressionParser.ts
@@ -205,7 +205,7 @@ class OperatorParser implements Parser {
             minLength,
             partialSearchValue
         );
-        // Only a narrowing column has a second list; without one the two are the same scan.
+        // A second list only where what is offered is less than what resolves; otherwise the same scan twice.
         if (activeOperators) {
             const resolvable = this.matchOperatorName(
                 columnOperators!.operators.getEntries(),

--- a/packages/ag-grid-enterprise/src/advancedFilter/filterExpressionOperators.ts
+++ b/packages/ag-grid-enterprise/src/advancedFilter/filterExpressionOperators.ts
@@ -1,7 +1,13 @@
 import { _getOwn } from 'ag-stack';
 
-import { _hasValue, _isBlank } from 'ag-grid-community';
-import type { BaseCellDataType, IRowNode } from 'ag-grid-community';
+import {
+    _PRESET_DATE_FILTER_RANGES,
+    _PRESET_DATE_FILTER_TYPES,
+    _RelativeDateRangeCache,
+    _hasValue,
+    _isBlank,
+} from 'ag-grid-community';
+import type { BaseCellDataType, IRowNode, _FilterLocaleTextKey } from 'ag-grid-community';
 
 import type { ADVANCED_FILTER_LOCALE_TEXT } from './advancedFilterLocaleText';
 import type { AutocompleteEntry } from './autocomplete/autocompleteParams';
@@ -12,6 +18,8 @@ export interface FilterExpressionEvaluatorParams<ConvertedTValue, TValue = Conve
     includeBlanksInNotEqual?: boolean;
     includeBlanksInLessThan?: boolean;
     includeBlanksInGreaterThan?: boolean;
+    includeBlanksInRange?: boolean;
+    inRangeInclusive?: boolean;
     valueConverter: (value: TValue, node: IRowNode) => ConvertedTValue;
 }
 
@@ -33,6 +41,8 @@ export interface DataTypeFilterExpressionOperators<ConvertedTValue, TValue = Con
     operators: {
         [operator: string]: FilterExpressionOperator<ConvertedTValue, TValue>;
     };
+    /** What a column narrowing nothing offers, where that is less than everything it can resolve. */
+    defaultOperators?: string[];
     getEntries(activeOperators?: string[]): AutocompleteEntry[];
 }
 
@@ -100,6 +110,8 @@ export function getEntries<ConvertedTValue, TValue = ConvertedTValue>(
 
 interface FilterExpressionOperatorsParams {
     translate: (key: keyof typeof ADVANCED_FILTER_LOCALE_TEXT, variableValues?: string[]) => string;
+    /** The column filter's own name for an option, for the ones both filters share. */
+    translateFilter: (key: _FilterLocaleTextKey) => string;
 }
 
 export class TextFilterExpressionOperators<TValue = string> implements DataTypeFilterExpressionOperators<
@@ -187,6 +199,7 @@ export class TextFilterExpressionOperators<TValue = string> implements DataTypeF
 
 interface ScalarFilterExpressionOperatorsParams<ConvertedTValue> extends FilterExpressionOperatorsParams {
     equals: (value: ConvertedTValue, operand: ConvertedTValue) => boolean;
+    relativeDates?: boolean;
 }
 
 export class ScalarFilterExpressionOperators<
@@ -194,6 +207,7 @@ export class ScalarFilterExpressionOperators<
     TValue = ConvertedTValue,
 > implements DataTypeFilterExpressionOperators<ConvertedTValue, TValue> {
     public operators: { [operator: string]: FilterExpressionOperator<ConvertedTValue, TValue> };
+    public defaultOperators: string[] | undefined;
 
     constructor(private readonly params: ScalarFilterExpressionOperatorsParams<ConvertedTValue>) {
         this.initOperators();
@@ -204,7 +218,7 @@ export class ScalarFilterExpressionOperators<
     }
 
     private initOperators(): void {
-        const { translate, equals } = this.params;
+        const { translate, translateFilter, equals, relativeDates } = this.params;
         this.operators = {
             equals: {
                 displayValue: translate('advancedFilterEquals'),
@@ -285,6 +299,12 @@ export class ScalarFilterExpressionOperators<
                     ),
                 numOperands: 1,
             },
+            inRange: {
+                displayValue: translate('advancedFilterInRange'),
+                evaluator: (value, node, params, operand1, operand2) =>
+                    this.evaluateRangeExpression(value, node, params, operand1!, operand2!),
+                numOperands: 2,
+            },
             blank: {
                 displayValue: translate('advancedFilterBlank'),
                 evaluator: _isBlank,
@@ -296,6 +316,31 @@ export class ScalarFilterExpressionOperators<
                 numOperands: 0,
             },
         };
+        if (relativeDates) {
+            // Captured before the relative options join them: a date column offers one only where it asks for it.
+            this.defaultOperators = Object.keys(this.operators);
+            addRelativeDateOperators(this.operators, translateFilter);
+        }
+    }
+
+    /** Exclusive unless `inRangeInclusive`, as the column filter's own range comparison is. */
+    private evaluateRangeExpression(
+        value: TValue | null | undefined,
+        node: IRowNode,
+        params: FilterExpressionEvaluatorParams<ConvertedTValue, TValue>,
+        from: ConvertedTValue,
+        to: ConvertedTValue
+    ): boolean {
+        if (value == null || _isBlank(value)) {
+            return !!params.includeBlanksInRange;
+        }
+        const convertedValue = params.valueConverter(value, node);
+        if (convertedValue == null) {
+            return false;
+        }
+        return params.inRangeInclusive
+            ? convertedValue >= from && convertedValue <= to
+            : convertedValue > from && convertedValue < to;
     }
 
     private evaluateSingleOperandExpression(
@@ -319,6 +364,32 @@ export class ScalarFilterExpressionOperators<
             return !!isNegated;
         }
         return expression(convertedValue, operand);
+    }
+}
+
+/** One cache per data type, since a relative range depends on nothing but the clock. */
+function addRelativeDateOperators(
+    operators: { [operator: string]: FilterExpressionOperator<any> },
+    translateFilter: (key: _FilterLocaleTextKey) => string
+): void {
+    const cache = new _RelativeDateRangeCache();
+    for (let i = 0, len = _PRESET_DATE_FILTER_TYPES.length; i < len; ++i) {
+        const key = _PRESET_DATE_FILTER_TYPES[i];
+        const rangeFn = _PRESET_DATE_FILTER_RANGES[key];
+        operators[key] = {
+            displayValue: translateFilter(key),
+            evaluator: (value, node, params) => {
+                // A range has nothing to match a blank against, as the column filter has nothing either.
+                const convertedValue = value == null || _isBlank(value) ? null : params.valueConverter(value, node);
+                if (convertedValue == null) {
+                    return false;
+                }
+                const { fromTime, toTime } = cache.getRange(key, rangeFn);
+                const time = +convertedValue;
+                return time >= fromTime && time < toTime;
+            },
+            numOperands: 0,
+        };
     }
 }
 

--- a/testing/behavioural/src/ai-toolkit/structured-schema.test.ts
+++ b/testing/behavioural/src/ai-toolkit/structured-schema.test.ts
@@ -1357,6 +1357,23 @@ describe('getStructuredSchema - advanced filter', () => {
         expect(schema.$defs.joinAdvancedFilterModel).toBeDefined();
         expect(schema.$defs.advancedFilterModel).toBeDefined();
         expect(schema.$defs.advancedFilterModel.anyOf).toBeDefined();
+
+        // `inRange` is the only built-in taking two values, so it is the one def that must carry a
+        // `filterTo` slot; a def offering it beside the one-value options would ask for the wrong shape.
+        const numberDefs = Object.keys(schema.$defs).filter((key) => key.startsWith('numberAdvancedFilterModel'));
+        const rangeDef = numberDefs
+            .map((key) => schema.$defs[key])
+            .find((def) => def.properties.type.enum.includes('inRange'));
+        expect(rangeDef).toBeDefined();
+        expect(rangeDef.properties.type.enum).toEqual(['inRange']);
+        expect(Object.keys(rangeDef.properties)).toContain('filterTo');
+        for (const key of numberDefs) {
+            const def = schema.$defs[key];
+            if (def !== rangeDef) {
+                expect(def.properties.type.enum).not.toContain('inRange');
+                expect(Object.keys(def.properties)).not.toContain('filterTo');
+            }
+        }
         await new GridRows(
             api,
             `advanced filter _defs include data-type models, join model, and advancedFilterMo final state`

--- a/testing/behavioural/src/filters/advanced-filter-regression/af-autocomplete.test.ts
+++ b/testing/behavioural/src/filters/advanced-filter-regression/af-autocomplete.test.ts
@@ -592,7 +592,17 @@ describe('Advanced Filter — column & operator editing branches', () => {
         await af.type('[Age]    > 20', 6);
         await asyncSetTimeout(0);
         // Position precedes the operator's own start, so the search string is empty → full operator list.
-        expect(af.autocompleteEntries()).toEqual(['=', '!=', '>', '>=', '<', '<=', 'is blank', 'is not blank']);
+        expect(af.autocompleteEntries()).toEqual([
+            '=',
+            '!=',
+            '>',
+            '>=',
+            '<',
+            '<=',
+            'between',
+            'is blank',
+            'is not blank',
+        ]);
 
         await af.tabComplete();
         await asyncSetTimeout(0);
@@ -607,7 +617,17 @@ describe('Advanced Filter — column & operator editing branches', () => {
         // resolved yet, so the end position is scanned and the bracket marks the operand region as empty.
         await af.type('[Age]  (', 7);
         await asyncSetTimeout(0);
-        expect(af.autocompleteEntries()).toEqual(['=', '!=', '>', '>=', '<', '<=', 'is blank', 'is not blank']);
+        expect(af.autocompleteEntries()).toEqual([
+            '=',
+            '!=',
+            '>',
+            '>=',
+            '<',
+            '<=',
+            'between',
+            'is blank',
+            'is not blank',
+        ]);
 
         await af.tabComplete();
         await asyncSetTimeout(0);

--- a/testing/behavioural/src/filters/advanced-filter-regression/af-column-reuse.test.ts
+++ b/testing/behavioural/src/filters/advanced-filter-regression/af-column-reuse.test.ts
@@ -13,10 +13,10 @@ import { ClientSideRowModelModule, DateFilterModule, NumberFilterModule, setupAg
 import { SetFilterModule } from 'ag-grid-enterprise';
 
 /**
- * Regression baseline for the column-filter behaviours Advanced Filter will reuse: the built-in
- * In Range / Between (2-input) option (AG-10029 / AG-10819) — bound exclusivity, two-input model,
- * incomplete/reversed validation — and the Set Filter (AG-8950) — distinct-value derivation, value
- * formatting, blanks, mini-filter, select-all and the `{filterType:'set'}` model. Black-box via popup.
+ * Regression baseline for the column-filter behaviours the Advanced Filter reuses: the built-in
+ * In Range / Between (2-input) option — bound exclusivity, two-input model, incomplete/reversed
+ * validation — and the Set Filter — distinct-value derivation, value formatting, blanks, mini-filter,
+ * select-all and the `{filterType:'set'}` model. Black-box via popup.
  */
 describe('Simple Filter — In Range (2-input) reuse surface', () => {
     const gridsManager = new TestGridsManager({

--- a/testing/behavioural/src/filters/advanced-filter-regression/af-options.test.ts
+++ b/testing/behavioural/src/filters/advanced-filter-regression/af-options.test.ts
@@ -22,7 +22,7 @@ import {
 } from 'ag-grid-community';
 import { AdvancedFilterModule, SetFilterModule } from 'ag-grid-enterprise';
 
-/** Regression baseline for Advanced Filter grid options and the operators not offered today. */
+/** Regression baseline for Advanced Filter grid options, and which operators a column offers. */
 
 // The suggestion list virtualises, so without a layout it renders one row and assertions read that truncation.
 beforeAll(() => installFilterLayoutMock());
@@ -277,7 +277,7 @@ describe('Advanced Filter — grid options', () => {
     });
 });
 
-describe('Advanced Filter — currently-unsupported operators (baseline)', () => {
+describe('Advanced Filter — built-in range and relative date operators', () => {
     const gridsManager = new TestGridsManager({
         modules: [
             TextFilterModule,
@@ -291,8 +291,7 @@ describe('Advanced Filter — currently-unsupported operators (baseline)', () =>
     afterEach(() => gridsManager.reset());
 
     describe('relative-date-preset column (filterOptions with preset keys)', () => {
-        // Preset keys are strings, so AF lists them as active operators and must reconcile each
-        // against the built-in AF operators (which exclude presets) without crashing.
+        // A preset is offered only where the column names it, so the list decides the whole dropdown.
         const OPTS: GridOptions = {
             columnDefs: [
                 {
@@ -313,27 +312,28 @@ describe('Advanced Filter — currently-unsupported operators (baseline)', () =>
             await af.type('[Date] ');
             await asyncSetTimeout(0);
 
-            // Before the getEntries guard this threw (preset key not in the AF operator map) and the
-            // popup never opened.
+            // A key the column names but this filter has no operator for must be skipped rather than
+            // reaching the operator table, or the popup never opens at all.
             expect(af.isAutocompleteOpen()).toBe(true);
         });
 
-        test('a preset key is not an AF operator; a standard operator from the list still applies', async () => {
+        test('a preset the list names applies, as does a standard operator beside it', async () => {
             const api: GridApi = await gridsManager.createGridAndWait('grid1', OPTS);
 
-            // `today` is a preset, not an AF operator → rejected today (AG-10029 will add it).
-            await AdvancedFilterHarness.get(api).applyExpression('[Date] today');
+            // Written under the Date Filter's own name for it, which is what the dropdown offers.
+            await AdvancedFilterHarness.get(api).applyExpression('[Date] Today');
             await asyncSetTimeout(0);
-            expect(api.getAdvancedFilterModel()).toBeNull();
-            await new FilterDom(api, 'preset operator rejected').checkFilterDom(`
+            await new FilterDom(api, 'preset operator applied').checkFilterDom(`
                 ADVANCED FILTER
-                input: "[Date] today"
-                valid: false — Expression has an error. Option not found - today.
+                input: "[Date] Today"
+                valid: true
                 buttons: Apply ⊘ | Builder
-                model: null
+                model:
+                  filterType: "dateString"
+                  colId: "date"
+                  type: "today"
             `);
 
-            // `equals` is in the list and is a real AF operator → applies.
             await AdvancedFilterHarness.get(api).applyExpression('[Date] = "2024-06-15"');
             await asyncSetTimeout(0);
             expect(api.getAdvancedFilterModel()).toEqual({
@@ -348,13 +348,14 @@ describe('Advanced Filter — currently-unsupported operators (baseline)', () =>
             `);
         });
 
-        // A preset names no AF option, so only `equals` is suggested; the grammar is the data type's either way.
+        // The list is the whole dropdown, but the grammar is the data type's, so an operator typed
+        // rather than picked still reads.
         test('an operator absent from the preset list is not suggested, but still reads', async () => {
             const api: GridApi = await gridsManager.createGridAndWait('grid1', OPTS);
             const af = AdvancedFilterHarness.get(api);
 
             await af.type('[Date] ');
-            expect(af.autocompleteEntries()).toEqual(['=']);
+            expect(af.autocompleteEntries()).toEqual(['Today', 'Yesterday', '=']);
 
             await af.applyExpression('[Date] > "2024-03-01"');
             await asyncSetTimeout(0);
@@ -373,14 +374,14 @@ describe('Advanced Filter — currently-unsupported operators (baseline)', () =>
         });
     });
 
-    describe('inRange is not offered today', () => {
+    describe('an option is written under its name, not its key', () => {
         const OPTS: GridOptions = {
             columnDefs: [{ field: 'age', filter: 'agNumberColumnFilter' }],
             rowData: [{ age: 10 }, { age: 20 }, { age: 30 }],
             enableAdvancedFilter: true,
         };
 
-        test('a hand-typed inRange expression is rejected', async () => {
+        test('a hand-typed `inRange` is rejected — the name of the option is `between`', async () => {
             const api: GridApi = await gridsManager.createGridAndWait('grid1', OPTS);
 
             await AdvancedFilterHarness.get(api).applyExpression('[Age] inRange 15');
@@ -546,7 +547,9 @@ describe('Advanced Filter — string filterOptions restrict the options', () => 
         `);
     });
 
-    // A list of only presets names nothing this filter offers, so the built-ins stand rather than nothing.
+    // `empty` is the column filter's placeholder entry and names no operator here, so a list of only it
+    // names nothing this filter can offer: narrowing to nothing would leave the column unusable, so the
+    // built-ins stand as they do for a list whose every entry was dropped.
     test('a list naming no Advanced Filter option leaves the built-ins standing', async () => {
         const api: GridApi = await gridsManager.createGridAndWait('grid1', {
             columnDefs: [
@@ -554,7 +557,7 @@ describe('Advanced Filter — string filterOptions restrict the options', () => 
                     field: 'date',
                     cellDataType: 'dateString',
                     filter: 'agDateColumnFilter',
-                    filterParams: { filterOptions: ['today', 'yesterday'] },
+                    filterParams: { filterOptions: ['empty'] },
                 },
             ],
             rowData: [{ date: '2024-01-01' }],
@@ -565,7 +568,17 @@ describe('Advanced Filter — string filterOptions restrict the options', () => 
         await af.type('[Date] ');
         await asyncSetTimeout(0);
         // Every built-in, since "standing" is the whole list rather than a survivor from it.
-        expect(af.autocompleteEntries()).toEqual(['=', '!=', '>', '>=', '<', '<=', 'is blank', 'is not blank']);
+        expect(af.autocompleteEntries()).toEqual([
+            '=',
+            '!=',
+            '>',
+            '>=',
+            '<',
+            '<=',
+            'between',
+            'is blank',
+            'is not blank',
+        ]);
 
         await af.applyExpression('[Date] = "2024-01-01"');
         await asyncSetTimeout(0);

--- a/testing/behavioural/src/filters/advanced-filter/advanced-filter-builtin-ranges.test.ts
+++ b/testing/behavioural/src/filters/advanced-filter/advanced-filter-builtin-ranges.test.ts
@@ -1,0 +1,444 @@
+import { _serialiseDate } from 'ag-stack';
+import {
+    AdvancedFilterBuilderHarness,
+    AdvancedFilterHarness,
+    FilterDom,
+    TestGridsManager,
+    asyncSetTimeout,
+    installFilterLayoutMock,
+    uninstallFilterLayoutMock,
+} from 'ag-test-utils';
+
+import type { GridApi, GridOptions } from 'ag-grid-community';
+import {
+    ClientSideRowModelModule,
+    DateFilterModule,
+    LocaleModule,
+    NumberFilterModule,
+    TextFilterModule,
+    ValidationModule,
+} from 'ag-grid-community';
+import { AdvancedFilterModule } from 'ag-grid-enterprise';
+
+/**
+ * The Date and Number filters' built-in `inRange` and relative date options in the Advanced Filter: which of
+ * them a column offers, their expression grammar, the Builder, the model round-trip, and evaluation matching
+ * the equivalent column filter.
+ */
+interface TestRow {
+    id: number;
+    age: number | null;
+    day: string | null;
+}
+
+/** Built from the current date, since a relative option means whatever it means when it is evaluated. */
+function isoDaysFromToday(offset: number): string {
+    const date = new Date();
+    date.setDate(date.getDate() + offset);
+    return _serialiseDate(date, false)!;
+}
+
+const TODAY = isoDaysFromToday(0);
+const YESTERDAY = isoDaysFromToday(-1);
+const LONG_AGO = isoDaysFromToday(-400);
+
+const ROW_DATA: TestRow[] = [
+    { id: 0, age: 21, day: TODAY },
+    { id: 1, age: 30, day: YESTERDAY },
+    { id: 2, age: 38, day: LONG_AGO },
+    { id: 3, age: null, day: null },
+];
+
+const SCALAR_OPERATORS = ['=', '!=', '>', '>=', '<', '<=', 'between', 'is blank', 'is not blank'];
+
+function opts(dateFilterOptions?: string[]): GridOptions<TestRow> {
+    return {
+        columnDefs: [
+            { field: 'age', filter: 'agNumberColumnFilter' },
+            {
+                field: 'day',
+                cellDataType: 'dateString',
+                filter: 'agDateColumnFilter',
+                filterParams: dateFilterOptions ? { filterOptions: dateFilterOptions } : undefined,
+            },
+        ],
+        rowData: ROW_DATA,
+        enableAdvancedFilter: true,
+    };
+}
+
+function getDisplayedIds(api: GridApi<TestRow>): number[] {
+    const result: number[] = [];
+    for (let i = 0, len = api.getDisplayedRowCount(); i < len; i++) {
+        result.push(api.getDisplayedRowAtIndex(i)!.data!.id);
+    }
+    return result;
+}
+
+describe('Advanced Filter - built-in range and relative date options', () => {
+    const gridsManager = new TestGridsManager({
+        modules: [
+            TextFilterModule,
+            NumberFilterModule,
+            DateFilterModule,
+            LocaleModule,
+            ValidationModule,
+            AdvancedFilterModule,
+            ClientSideRowModelModule,
+        ],
+    });
+
+    beforeAll(() => installFilterLayoutMock());
+    afterAll(() => uninstallFilterLayoutMock());
+    afterEach(() => gridsManager.reset());
+
+    describe('between', () => {
+        test('is offered above `is blank` for a number and a date column alike', async () => {
+            const api = await gridsManager.createGridAndWait('grid1', opts());
+            const af = AdvancedFilterHarness.get(api);
+
+            await af.type('[Age] ');
+            expect(af.autocompleteEntries()).toEqual(SCALAR_OPERATORS);
+
+            await af.type('[Day] ');
+            expect(af.autocompleteEntries()).toEqual(SCALAR_OPERATORS);
+        });
+
+        // Numbers are written bare and dates quoted, as they are for every other option of their type.
+        test('a number pair is written unquoted, and both bounds are exclusive', async () => {
+            const api = await gridsManager.createGridAndWait('grid1', opts());
+
+            await AdvancedFilterHarness.get(api).applyExpression('[Age] between (21, 38)');
+            await asyncSetTimeout(0);
+
+            await new FilterDom(api, 'number between').checkFilterDom(`
+                ADVANCED FILTER
+                input: "[Age] between (21, 38)"
+                valid: true
+                buttons: Apply ⊘ | Builder
+                model:
+                  filterType: "number"
+                  colId: "age"
+                  type: "inRange"
+                  filter: 21
+                  filterTo: 38
+            `);
+            // Both bounds name a row, and only the row between them survives.
+            expect(getDisplayedIds(api)).toEqual([1]);
+        });
+
+        // The same claim on the date path, which converts through a different `valueConverter`.
+        test('a date pair is written quoted, and both bounds are exclusive', async () => {
+            const api = await gridsManager.createGridAndWait('grid1', opts());
+
+            await AdvancedFilterHarness.get(api).applyExpression(`[Day] between ("${LONG_AGO}", "${TODAY}")`);
+            await asyncSetTimeout(0);
+
+            expect(api.getAdvancedFilterModel()).toEqual({
+                filterType: 'dateString',
+                colId: 'day',
+                type: 'inRange',
+                filter: LONG_AGO,
+                filterTo: TODAY,
+            });
+            expect(getDisplayedIds(api)).toEqual([1]);
+        });
+
+        // No ordering validation is required, so a reversed pair applies and simply matches nothing.
+        test('a reversed pair is accepted and matches no row', async () => {
+            const api = await gridsManager.createGridAndWait('grid1', opts());
+
+            await AdvancedFilterHarness.get(api).applyExpression('[Age] between (38, 21)');
+            await asyncSetTimeout(0);
+
+            expect(api.getAdvancedFilterModel()).toEqual({
+                filterType: 'number',
+                colId: 'age',
+                type: 'inRange',
+                filter: 38,
+                filterTo: 21,
+            });
+            expect(getDisplayedIds(api)).toEqual([]);
+        });
+
+        // `inRange` is the first built-in option taking two values, so a model carrying only one is a
+        // plausible API call. It must leave the grid unfiltered rather than filtering every row out.
+        test('a model missing its second value is rejected rather than filtering every row out', async () => {
+            const api = await gridsManager.createGridAndWait('grid1', opts());
+
+            api.setAdvancedFilterModel({ filterType: 'number', colId: 'age', type: 'inRange', filter: 21 });
+            api.onFilterChanged();
+            await asyncSetTimeout(0);
+
+            await new FilterDom(api, 'half a range').checkFilterDom(`
+                ADVANCED FILTER
+                input: "[Age] between (21, )"
+                valid: false — Expression has an error. Value is missing - (21, ).
+                buttons: Apply ⊘ | Builder
+                model: null
+            `);
+            expect(getDisplayedIds(api)).toEqual([0, 1, 2, 3]);
+        });
+
+        // Two pills both called "Value" are indistinguishable to a screen reader, so the pair takes the
+        // column filter's own from/to labels.
+        test('selecting it in the Builder shows two value inputs, labelled from and to', async () => {
+            const api = await gridsManager.createGridAndWait('grid1', opts());
+            api.setAdvancedFilterModel({ filterType: 'number', colId: 'age', type: 'equals', filter: 21 });
+            api.onFilterChanged();
+            await asyncSetTimeout(0);
+
+            const builder = await AdvancedFilterBuilderHarness.open(api);
+            const [condition] = await builder.conditionItems();
+            expect(await builder.operatorOptions(condition)).toEqual(SCALAR_OPERATORS);
+            expect(builder.valuePills(condition)).toHaveLength(1);
+            expect(builder.valuePills(condition)[0].getAttribute('aria-label')).toBe('Value');
+
+            await builder.selectOperator(condition, 'between');
+            expect(builder.valuePills(condition)).toHaveLength(2);
+            expect(builder.valuePills(condition).map((pill) => pill.getAttribute('aria-label'))).toEqual([
+                'Filter from value',
+                'Filter to value',
+            ]);
+
+            await builder.setValue(condition, '21', 0);
+            await builder.setValue(condition, '38', 1);
+            await builder.apply();
+            await asyncSetTimeout(0);
+
+            expect(api.getAdvancedFilterModel()).toEqual({
+                filterType: 'number',
+                colId: 'age',
+                type: 'inRange',
+                filter: 21,
+                filterTo: 38,
+            });
+            expect(getDisplayedIds(api)).toEqual([1]);
+        });
+
+        test('a saved model restores the expression, the rows and both Builder pills', async () => {
+            const api = await gridsManager.createGridAndWait('grid1', opts());
+
+            api.setAdvancedFilterModel({
+                filterType: 'number',
+                colId: 'age',
+                type: 'inRange',
+                filter: 21,
+                filterTo: 38,
+            });
+            api.onFilterChanged();
+            await asyncSetTimeout(0);
+
+            expect(AdvancedFilterHarness.get(api).value).toBe('[Age] between (21, 38)');
+            expect(getDisplayedIds(api)).toEqual([1]);
+
+            const builder = await AdvancedFilterBuilderHarness.open(api);
+            const [condition] = await builder.conditionItems();
+            expect(builder.valuePills(condition)).toHaveLength(2);
+            expect([builder.valuePillText(condition, 0), builder.valuePillText(condition, 1)]).toEqual(['21', '38']);
+        });
+    });
+
+    describe('relative date options', () => {
+        test('none is offered where the column names none', async () => {
+            const api = await gridsManager.createGridAndWait('grid1', opts());
+            const af = AdvancedFilterHarness.get(api);
+
+            await af.type('[Day] ');
+            expect(af.autocompleteEntries()).toEqual(SCALAR_OPERATORS);
+        });
+
+        // Listed against the canonical order rather than with it: `today` precedes `last7Days` in
+        // `PRESET_DATE_FILTER_TYPES`, so a dropdown built from that order would come back reversed.
+        test('the ones the column names are offered, in the order it lists them', async () => {
+            const api = await gridsManager.createGridAndWait('grid1', opts(['last7Days', 'today', 'equals']));
+            const af = AdvancedFilterHarness.get(api);
+
+            await af.type('[Day] ');
+            expect(af.autocompleteEntries()).toEqual(['Last 7 Days', 'Today', '=']);
+        });
+
+        // The configuration the reporters filed against `inRange`, which threw before it was an operator.
+        test('the reported `inRange` configuration opens the dropdown and offers between', async () => {
+            const api = await gridsManager.createGridAndWait('grid1', opts(['equals', 'inRange']));
+            const af = AdvancedFilterHarness.get(api);
+
+            await af.type('[Day] ');
+            expect(af.isAutocompleteOpen()).toBe(true);
+            expect(af.autocompleteEntries()).toEqual(['=', 'between']);
+        });
+
+        // And the one filed against the relative options.
+        test('the reported preset configuration opens the dropdown and offers both presets', async () => {
+            const api = await gridsManager.createGridAndWait('grid1', opts(['equals', 'thisYear', 'lastYear']));
+            const af = AdvancedFilterHarness.get(api);
+
+            await af.type('[Day] ');
+            expect(af.isAutocompleteOpen()).toBe(true);
+            expect(af.autocompleteEntries()).toEqual(['=', 'This Year', 'Last Year']);
+        });
+
+        // The option is stored as its key and stays relative, so a model restored on another day means
+        // that day rather than the one it was saved on.
+        test('one takes no value, and filters as the equivalent column filter does', async () => {
+            const api = await gridsManager.createGridAndWait('grid1', opts(['today', 'last7Days']));
+
+            await AdvancedFilterHarness.get(api).applyExpression('[Day] Last 7 Days');
+            await asyncSetTimeout(0);
+
+            await new FilterDom(api, 'relative date applied').checkFilterDom(`
+                ADVANCED FILTER
+                input: "[Day] Last 7 Days"
+                valid: true
+                buttons: Apply ⊘ | Builder
+                model:
+                  filterType: "dateString"
+                  colId: "day"
+                  type: "last7Days"
+            `);
+            // The blank row is not in the range either, as it is in no range in the column filter.
+            const advancedIds = getDisplayedIds(api);
+            expect(advancedIds).toEqual([0, 1]);
+
+            // The parity suite's fixtures are fixed dates, which no relative option can match, so the
+            // comparison is built here against a grid with no Advanced Filter.
+            const columnApi: GridApi<TestRow> = await gridsManager.createGridAndWait('grid2', {
+                columnDefs: opts(['today', 'last7Days']).columnDefs,
+                rowData: ROW_DATA,
+            });
+            await columnApi.setColumnFilterModel('day', { filterType: 'date', type: 'last7Days' });
+            columnApi.onFilterChanged();
+            await asyncSetTimeout(0);
+            const columnIds = getDisplayedIds(columnApi);
+
+            // Anchored: were either side to stop filtering, both would show every row and agree.
+            expect(columnIds.length).toBeGreaterThan(0);
+            expect(columnIds.length).toBeLessThan(ROW_DATA.length);
+            expect(advancedIds).toEqual(columnIds);
+        });
+
+        test('a saved model restores the expression and the Builder row', async () => {
+            const api = await gridsManager.createGridAndWait('grid1', opts(['today', 'last7Days']));
+
+            api.setAdvancedFilterModel({ filterType: 'dateString', colId: 'day', type: 'today' });
+            api.onFilterChanged();
+            await asyncSetTimeout(0);
+
+            expect(AdvancedFilterHarness.get(api).value).toBe('[Day] Today');
+            expect(getDisplayedIds(api)).toEqual([0]);
+
+            const builder = await AdvancedFilterBuilderHarness.open(api);
+            const [condition] = await builder.conditionItems();
+            expect(await builder.operatorOptions(condition)).toEqual(['Today', 'Last 7 Days']);
+            expect(builder.valuePills(condition)).toHaveLength(0);
+        });
+
+        // Choosing one after an option that took values has to drop them, or the model would carry a slot
+        // the option does not use.
+        test('selecting one in the Builder removes the value pills of the option it replaces', async () => {
+            const api = await gridsManager.createGridAndWait('grid1', opts(['inRange', 'today']));
+            api.setAdvancedFilterModel({
+                filterType: 'dateString',
+                colId: 'day',
+                type: 'inRange',
+                filter: YESTERDAY,
+                filterTo: TODAY,
+            });
+            api.onFilterChanged();
+            await asyncSetTimeout(0);
+
+            const builder = await AdvancedFilterBuilderHarness.open(api);
+            const [condition] = await builder.conditionItems();
+            expect(builder.valuePills(condition)).toHaveLength(2);
+
+            await builder.selectOperator(condition, 'Today');
+            expect(builder.valuePills(condition)).toHaveLength(0);
+            await builder.apply();
+            await asyncSetTimeout(0);
+
+            expect(api.getAdvancedFilterModel()).toEqual({ filterType: 'dateString', colId: 'day', type: 'today' });
+            expect(getDisplayedIds(api)).toEqual([0]);
+        });
+
+        // Suggestion is what a column narrows; the grammar stays the data type's, so an option a column
+        // never names is still one an already-saved expression can spell.
+        test('one the column does not name is not suggested, but an expression naming it still applies', async () => {
+            const api = await gridsManager.createGridAndWait('grid1', opts());
+            const af = AdvancedFilterHarness.get(api);
+
+            await af.type('[Day] ');
+            expect(af.autocompleteEntries()).toEqual(SCALAR_OPERATORS);
+
+            await af.applyExpression('[Day] Yesterday');
+            await asyncSetTimeout(0);
+
+            expect(api.getAdvancedFilterModel()).toEqual({
+                filterType: 'dateString',
+                colId: 'day',
+                type: 'yesterday',
+            });
+            expect(getDisplayedIds(api)).toEqual([1]);
+        });
+
+        // A number column has no relative date option, so neither its dropdown nor its grammar has one.
+        test('a number column offers none and rejects an expression naming one', async () => {
+            const api = await gridsManager.createGridAndWait('grid1', opts());
+            const af = AdvancedFilterHarness.get(api);
+
+            await af.type('[Age] ');
+            expect(af.autocompleteEntries()).toEqual(SCALAR_OPERATORS);
+
+            await af.applyExpression('[Age] Yesterday');
+            await asyncSetTimeout(0);
+
+            await new FilterDom(api, 'preset rejected on a number column').checkFilterDom(`
+                ADVANCED FILTER
+                input: "[Age] Yesterday"
+                valid: false — Expression has an error. Option not found - Yesterday.
+                buttons: Apply ⊘ | Builder
+                model: null
+            `);
+        });
+
+        // A date column offers a preset only where it names it, so retargeting a condition to one that
+        // does not clears the operator rather than carrying it across.
+        test('retargeting a condition to a date column that does not name the preset clears it', async () => {
+            const api = await gridsManager.createGridAndWait('grid1', {
+                columnDefs: [
+                    {
+                        field: 'day',
+                        cellDataType: 'dateString',
+                        filter: 'agDateColumnFilter',
+                        filterParams: { filterOptions: ['today', 'equals'] },
+                    },
+                    { field: 'other', cellDataType: 'dateString', filter: 'agDateColumnFilter' },
+                ],
+                rowData: ROW_DATA.map((row) => ({ ...row, other: row.day })),
+                enableAdvancedFilter: true,
+            });
+            api.setAdvancedFilterModel({ filterType: 'dateString', colId: 'day', type: 'today' });
+            api.onFilterChanged();
+            await asyncSetTimeout(0);
+
+            const builder = await AdvancedFilterBuilderHarness.open(api);
+            const [condition] = await builder.conditionItems();
+            expect(await builder.operatorOptions(condition)).toEqual(['Today', '=']);
+
+            await builder.selectColumn(condition, 'Other');
+
+            expect(await builder.operatorOptions(condition)).toEqual(SCALAR_OPERATORS);
+            // The model shown is the applied one; the Builder's own edit is the cleared operator pill.
+            await new FilterDom(api, 'preset cleared by the column switch', { mode: 'builder' }).checkFilterDom(`
+                BUILDER
+                AND
+                  Other Select an option ✗
+                  + add
+                buttons: Apply ⊘ | Cancel
+                model:
+                  filterType: "dateString"
+                  colId: "day"
+                  type: "today"
+            `);
+        });
+    });
+});

--- a/testing/behavioural/src/filters/advanced-filter/advanced-filter-column-filter-parity.test.ts
+++ b/testing/behavioural/src/filters/advanced-filter/advanced-filter-column-filter-parity.test.ts
@@ -214,4 +214,132 @@ describe('Advanced Filter matches the column filter', () => {
             })
         ).toEqual(columnFilterIds);
     });
+    // `inRange` takes two values rather than one, so it cannot ride on the shared table above.
+    describe('inRange', () => {
+        test('a number range filters the same rows, exclusive of both ends', async () => {
+            const model = { filterType: 'number' as const, type: 'inRange' as const, filter: -1, filterTo: 3 };
+            const columnFilterIds = await withColumnFilter('age', model);
+
+            expect(columnFilterIds).not.toContain(2); // age 3 is the excluded upper end
+            expectFiltered(columnFilterIds);
+            expect(await withAdvancedFilter({ ...model, colId: 'age' })).toEqual(columnFilterIds);
+        });
+
+        test('`inRangeInclusive` admits both ends in both', async () => {
+            const defs = COLUMN_DEFS!.map((def) =>
+                (def as { field?: string }).field === 'age' ? { ...def, filterParams: { inRangeInclusive: true } } : def
+            );
+            const model = { filterType: 'number' as const, type: 'inRange' as const, filter: -1, filterTo: 3 };
+            const columnFilterIds = await withColumnFilter('age', model, defs);
+
+            expect(columnFilterIds).toContain(2); // age 3 is now the included upper end
+            expectFiltered(columnFilterIds);
+            expect(await withAdvancedFilter({ ...model, colId: 'age' }, defs)).toEqual(columnFilterIds);
+        });
+
+        test('`includeBlanksInRange` admits a blank in both', async () => {
+            const defs = COLUMN_DEFS!.map((def) =>
+                (def as { field?: string }).field === 'age'
+                    ? { ...def, filterParams: { includeBlanksInRange: true } }
+                    : def
+            );
+            const model = { filterType: 'number' as const, type: 'inRange' as const, filter: -1, filterTo: 3 };
+            const columnFilterIds = await withColumnFilter('age', model, defs);
+
+            expect(columnFilterIds).toContain(3); // the row with a null age
+            expect(columnFilterIds).toContain(6); // and the row with an empty-string age
+            expectFiltered(columnFilterIds);
+            expect(await withAdvancedFilter({ ...model, colId: 'age' }, defs)).toEqual(columnFilterIds);
+        });
+
+        // `bigint` reaches `evaluateRangeExpression` through its own parser and converter, not the number one.
+        test('a bigint range filters the same rows', async () => {
+            const columnFilterIds = await withColumnFilter('qty', {
+                filterType: 'bigint',
+                type: 'inRange',
+                filter: '-6',
+                filterTo: '10',
+            });
+
+            expectFiltered(columnFilterIds);
+            expect(
+                await withAdvancedFilter({
+                    filterType: 'bigint',
+                    colId: 'qty',
+                    type: 'inRange',
+                    filter: '-6',
+                    filterTo: '10',
+                })
+            ).toEqual(columnFilterIds);
+        });
+
+        test('a date range filters the same rows', async () => {
+            const columnFilterIds = await withColumnFilter('date', {
+                filterType: 'date',
+                type: 'inRange',
+                dateFrom: '2008-01-01',
+                dateTo: '2013-01-01',
+            });
+
+            expect(columnFilterIds).not.toContain(3); // 2020 is outside the range
+            expectFiltered(columnFilterIds);
+            expect(
+                await withAdvancedFilter({
+                    filterType: 'dateString',
+                    colId: 'date',
+                    type: 'inRange',
+                    filter: '2008-01-01',
+                    filterTo: '2013-01-01',
+                })
+            ).toEqual(columnFilterIds);
+        });
+
+        // The two params were proven on `number` above; the date path converts through a different
+        // `valueConverter` before it reaches the same comparison.
+        test('`inRangeInclusive` and `includeBlanksInRange` behave the same on a date column', async () => {
+            const withDateParams = (filterParams: object) =>
+                COLUMN_DEFS!.map((def) =>
+                    (def as { field?: string }).field === 'date' ? { ...def, filterParams } : def
+                );
+            const model = {
+                filterType: 'date' as const,
+                type: 'inRange' as const,
+                dateFrom: '2008-08-24',
+                dateTo: '2020-07-23',
+            };
+            const advancedModel = {
+                filterType: 'dateString' as const,
+                colId: 'date',
+                type: 'inRange' as const,
+                filter: '2008-08-24',
+                filterTo: '2020-07-23',
+            };
+
+            const inclusiveDefs = withDateParams({ inRangeInclusive: true });
+            const inclusiveIds = await withColumnFilter('date', model, inclusiveDefs);
+            expect(inclusiveIds).toContain(0); // 2008-08-24 is now the included lower end
+            expectFiltered(inclusiveIds);
+            expect(await withAdvancedFilter(advancedModel, inclusiveDefs)).toEqual(inclusiveIds);
+
+            const blanksDefs = withDateParams({ includeBlanksInRange: true });
+            const blanksIds = await withColumnFilter('date', model, blanksDefs);
+            expect(blanksIds).toContain(2); // the row with a null date
+            expectFiltered(blanksIds);
+            expect(await withAdvancedFilter(advancedModel, blanksDefs)).toEqual(blanksIds);
+        });
+
+        // Ordering is unvalidated in the Advanced Filter, so a reversed date pair applies and matches
+        // nothing rather than being rejected. Dates compare as `Date` objects, not as numbers.
+        test('a reversed date range applies and matches no row', async () => {
+            expect(
+                await withAdvancedFilter({
+                    filterType: 'dateString',
+                    colId: 'date',
+                    type: 'inRange',
+                    filter: '2020-07-23',
+                    filterTo: '2008-08-24',
+                })
+            ).toEqual([]);
+        });
+    });
 });

--- a/testing/behavioural/src/filters/advanced-filter/advanced-filter-custom-options.test.ts
+++ b/testing/behavioural/src/filters/advanced-filter/advanced-filter-custom-options.test.ts
@@ -163,14 +163,15 @@ describe('Advanced Filter - custom filter options', () => {
             expect(af.autocompleteEntries()).toEqual(['is true', 'is false', 'is blank', 'is not blank']);
         });
 
-        // This filter has no `inRange` operator, so narrowing to it alone would narrow to nothing.
+        // `empty` is the column filter's placeholder entry and names no operator here, so narrowing to it
+        // would narrow to nothing: no suggestions, an unpickable Builder row, an unsatisfiable AI schema.
         test('a list naming only options this filter cannot resolve leaves the built-ins standing', async () => {
             const api = gridsManager.createGrid('grid1', {
                 columnDefs: [
                     {
                         field: 'age',
                         filter: 'agNumberColumnFilter',
-                        filterParams: { filterOptions: ['inRange'] },
+                        filterParams: { filterOptions: ['empty'] },
                     },
                 ],
                 rowData: ROW_DATA,
@@ -181,7 +182,17 @@ describe('Advanced Filter - custom filter options', () => {
 
             await af.type('[Age] ');
             // Every built-in, not just one of them: "standing" is the whole list, not a survivor from it.
-            expect(af.autocompleteEntries()).toEqual(['=', '!=', '>', '>=', '<', '<=', 'is blank', 'is not blank']);
+            expect(af.autocompleteEntries()).toEqual([
+                '=',
+                '!=',
+                '>',
+                '>=',
+                '<',
+                '<=',
+                'between',
+                'is blank',
+                'is not blank',
+            ]);
 
             await af.applyExpression('[Age] = 25');
             await asyncSetTimeout(0);


### PR DESCRIPTION
<!-- base: latest -->

# AG-10029: Built-in Range and Relative Date Options in the Advanced Filter

FIX AG-10029

The Advanced Filter had no operator for `inRange` or for the Date Filter's relative options, so a Number or Date column could not be filtered on a range through it at all, and a column naming those keys in `filterParams.filterOptions` narrowed to nothing. It now offers `between` on every scalar Cell Data Type, and the 22 relative date options on the date ones.

| scope  | net lines |   lines changed | hunks |      files changed |
| ------ | --------: | --------------: | ----: | -----------------: |
| source |       +79 | 707 (+393 -314) |    44 | 11 (+1, 10 edited) |
| locale |       +32 |        32 added |    32 |          32 edited |
| tests  |      +635 |  747 (+691 -56) |    47 |   8 (+1, 7 edited) |
| docs   |      +223 |   225 (+224 -1) |     8 |   4 (+3, 1 edited) |

## `between` on every scalar type

`ScalarFilterExpressionOperators` gains `inRange`, taking two values through the operand grammar that already serves a Custom Filter Option of the same arity, and positioned above `is blank`. It is offered by default, as it is in the column filter, for `number`, `bigint`, `date`, `dateString`, `dateTime` and `dateTimeString`.

```text
[Age] between (21, 38)
[Date] between ("2026-07-01", "2026-08-01")
```

Evaluation follows `ScalarFilterHandler`'s range comparison: exclusive of both ends unless `inRangeInclusive`, and blank cells match only under `includeBlanksInRange`. Both params join the set the evaluator reads off `filterParams`. Two differences from the column filter, both of which the Advanced Filter already had for its other scalar options: `filterParams.comparator` is not honoured, and a reversed range is applied and matches nothing rather than being refused, which is what the ticket asks for.

## Relative date options, offered where the column asks for them

The 22 options `ISimpleFilterModelPresetType` names take no value and are evaluated against the same half-open range the Date Filter computes. The range functions, their cache and the map naming them move out of `DateFilterHandler` into `relativeDateRanges.ts`, so the two filters cannot disagree about what `Last Year` means and neither reaches the other's module; the option stays relative rather than being resolved to fixed dates when it is applied.

```text
[Date] Last 90 Days
```

`PRESET_DATE_FILTER_TYPES` comes off that map, and `zeroInputTypes` in `simpleFilterUtils` is built from it rather than repeating the 22 keys.

None of them is a default, as none is in the Date Filter, so `DataTypeFilterExpressionOperators` gains `defaultOperators`: what a column offers where it narrows nothing, as distinct from everything it can resolve. A date column suggests one only where its `filterOptions` names it, while an expression naming one it left out still parses, which is the rule the rest of the filter's options already follow.

## Both are named as the column filter names them

`between` gets an `advancedFilterInRange` entry beside the other operators', lower case as they are, seeded in every locale from the `filterSummaryInRange` the column filter already summarises the option with. `Today` and `Last 90 Days` read the Date Filter's own entries, so the two filters cannot disagree about what an option is called. The key in the filter model is the column filter's too, so `type: 'inRange'` with `filterTo`, and `type: 'lastYear'`.

`ScalarAdvancedFilterModelType` gains `'inRange'`, and the four date members of `ColumnAdvancedFilterModel` take a new `DateAdvancedFilterModelType`, which is that union plus the relative options. The ticket records that no API change is needed; these two are what lets the model express the options it now produces, and widening an accepted union breaks no caller.

## Open: the casing of the relative date names

AG-10029 asks for lowercase labels. `between` is lower case, from the summary entry that already carries it. The 22 relative options are not: they read the Date Filter's own names (`Today`, `Last 90 Days`), which have no lower-case entry, so matching them would need either a locale-aware lowercasing, wrong wherever nouns are capitalised, or 22 new translated keys.
