### PR TITLE
Speed up docs cold start

### DIFF
--- a/community-modules/locale/project.json
+++ b/community-modules/locale/project.json
@@ -102,6 +102,7 @@
       "outputs": ["{options.outputPath}"],
       "options": {
         "outputPath": "{projectRoot}/dist/umd",
+        "deleteOutputPath": false,
         "outputFileName": "@ag-grid-community/locale",
         "main": "{projectRoot}/dist/package/main.cjs.js",
         "tsConfig": "{projectRoot}/tsconfig.lib.json",

--- a/documentation/ag-grid-docs/astro.config.mjs
+++ b/documentation/ag-grid-docs/astro.config.mjs
@@ -143,6 +143,21 @@ const {
      * Studio robots.txt disallow json url to merge
      */
     STUDIO_ROBOTS_DISALLOW_JSON_URL,
+
+    /**
+     * Format generated example code in dev as production does
+     *
+     * Dev builds skip prettier because it is roughly half the cost of generating an example, so
+     * example code reads unformatted in the code viewer. Set to `true` to format it anyway.
+     */
+    AG_EXAMPLE_FORMAT,
+
+    /**
+     * Generate examples through the per-example Nx tasks instead of the single aggregate task
+     *
+     * Escape hatch for the generation collapse; the two strategies produce identical output.
+     */
+    DISABLE_EXAMPLE_GEN_COLLAPSE,
 } = dotenvExpand.expand(dotenv).parsed;
 console.log(
     'Astro configuration',
@@ -166,6 +181,8 @@ console.log(
             CHARTS_ROBOTS_DISALLOW_JSON_URL,
             STUDIO_SITEMAP_INDEX_URL,
             STUDIO_ROBOTS_DISALLOW_JSON_URL,
+            AG_EXAMPLE_FORMAT,
+            DISABLE_EXAMPLE_GEN_COLLAPSE,
         },
         null,
         2

--- a/documentation/ag-grid-docs/project.json
+++ b/documentation/ag-grid-docs/project.json
@@ -235,6 +235,7 @@
         "!{workspaceRoot}/documentation/ag-grid-docs/src/**/_examples/**/*.spec.*",
         "!{workspaceRoot}/documentation/ag-grid-docs/src/**/_examples/**/*.test.*",
         "{workspaceRoot}/plugins/ag-grid-generate-example-files/{dist,src}/**/*",
+        { "dependentTasksOutputFiles": "**/gridOptionsTypes.json", "transitive": false },
         "{workspaceRoot}/documentation/ag-grid-docs/public/example-runner/**",
         { "env": "AG_AI_API_URL" },
         { "env": "AG_AI_API_DEV_TOKEN" },

--- a/documentation/ag-grid-docs/project.json
+++ b/documentation/ag-grid-docs/project.json
@@ -238,6 +238,8 @@
         "{workspaceRoot}/documentation/ag-grid-docs/public/example-runner/**",
         { "env": "AG_AI_API_URL" },
         { "env": "AG_AI_API_DEV_TOKEN" },
+        { "env": "AG_EXAMPLE_FORMAT" },
+        { "env": "DISABLE_EXAMPLE_GEN_COLLAPSE" },
         { "externalDependencies": ["npm:typescript"] }
       ],
       "outputs": ["{workspaceRoot}/dist/generated-examples/ag-grid-docs"],

--- a/documentation/ag-grid-docs/project.json
+++ b/documentation/ag-grid-docs/project.json
@@ -64,18 +64,6 @@
       }
     },
     "dev": {
-      "dependsOn": [
-        "^build:types",
-        "^build:package",
-        "^build:copy-styles",
-        "generate-doc-references",
-        "generate-examples",
-        "^docs-resolved-interfaces",
-        "ag-grid-react:build",
-        "ag-grid-angular:build",
-        "ag-grid-vue3:build",
-        "build:copy-styles"
-      ],
       "command": "astro dev --port=${PORT} --host",
       "options": {
         "cwd": "{projectRoot}"

--- a/documentation/ag-grid-docs/project.json
+++ b/documentation/ag-grid-docs/project.json
@@ -224,16 +224,33 @@
       }
     },
     "generate-examples": {
-      "executor": "nx:noop",
-      "dependsOn": ["^generate-example"],
-      "inputs": [{ "externalDependencies": ["npm:typescript"] }],
-      "outputs": [],
+      "executor": "ag-grid-generate-example-files:generate-all",
+      "dependsOn": [
+        { "projects": "ag-grid-generate-example-files", "target": "build" },
+        { "projects": "ag-grid-generate-example-files", "target": "copySrcFilesForGeneration" },
+        { "projects": "ag-grid-generate-example-files", "target": "build-grid-options-types" }
+      ],
+      "inputs": [
+        "{workspaceRoot}/documentation/ag-grid-docs/src/**/_examples/**/*",
+        "!{workspaceRoot}/documentation/ag-grid-docs/src/**/_examples/**/*.spec.*",
+        "!{workspaceRoot}/documentation/ag-grid-docs/src/**/_examples/**/*.test.*",
+        "{workspaceRoot}/plugins/ag-grid-generate-example-files/{dist,src}/**/*",
+        "{workspaceRoot}/documentation/ag-grid-docs/public/example-runner/**",
+        { "env": "AG_AI_API_URL" },
+        { "env": "AG_AI_API_DEV_TOKEN" },
+        { "externalDependencies": ["npm:typescript"] }
+      ],
+      "outputs": ["{workspaceRoot}/dist/generated-examples/ag-grid-docs"],
       "cache": true,
-      "batch": true,
+      "options": {
+        "mode": "dev",
+        "parentProject": "ag-grid-docs",
+        "outputBasePath": "dist/generated-examples"
+      },
       "configurations": {
-        "staging": {},
-        "archive": {},
-        "production": {}
+        "staging": { "mode": "prod" },
+        "archive": { "mode": "prod" },
+        "production": { "mode": "prod" }
       }
     },
     "generate-doc-references": {

--- a/plugins/ag-grid-generate-example-files/executors.json
+++ b/plugins/ag-grid-generate-example-files/executors.json
@@ -5,6 +5,11 @@
             "batchImplementation": "./dist/src/executors/generate/batch-executor.js",
             "schema": "./src/executors/generate/schema.json",
             "description": "generate example files"
+        },
+        "generate-all": {
+            "implementation": "./dist/src/executors/generate-all/executor.js",
+            "schema": "./src/executors/generate-all/schema.json",
+            "description": "generate every docs example in a single task"
         }
     }
 }

--- a/plugins/ag-grid-generate-example-files/gridOptionsTypes/gridOptionsTypesFile.ts
+++ b/plugins/ag-grid-generate-example-files/gridOptionsTypes/gridOptionsTypesFile.ts
@@ -1,0 +1,29 @@
+import { existsSync, readFileSync } from 'fs';
+
+import type { GridOptionsType } from '../src/executors/generate/generator/types';
+import { getGridOptionsType } from './buildGridOptionsType';
+
+/**
+ * Location of the cached GridOptions type surface, relative to the workspace root.
+ *
+ * Written by the `ag-grid-generate-example-files:build-grid-options-types` target, which owns the
+ * expensive `ts.createProgram` walk over the community type declarations so that the per-example
+ * `generate-example` tasks do not each have to repeat it.
+ */
+export const GRID_OPTIONS_TYPES_FILE = 'dist/plugins/ag-grid-generate-example-files/gridOptionsTypes.json';
+
+/**
+ * Reads the cached GridOptions type surface, falling back to building it in-process when the cache
+ * is absent so that the executor still works when invoked outside of Nx.
+ */
+export function readGridOptionsType(): Record<string, GridOptionsType> {
+    if (!existsSync(GRID_OPTIONS_TYPES_FILE)) {
+        console.warn(
+            `${GRID_OPTIONS_TYPES_FILE} not found, building the GridOptions types in-process instead. ` +
+                `Run 'nx run ag-grid-generate-example-files:build-grid-options-types' to avoid this.`
+        );
+        return getGridOptionsType();
+    }
+
+    return JSON.parse(readFileSync(GRID_OPTIONS_TYPES_FILE, 'utf-8'));
+}

--- a/plugins/ag-grid-generate-example-files/gridOptionsTypes/writeGridOptionsTypesFile.ts
+++ b/plugins/ag-grid-generate-example-files/gridOptionsTypes/writeGridOptionsTypesFile.ts
@@ -1,0 +1,10 @@
+import { mkdirSync, writeFileSync } from 'fs';
+import { dirname } from 'path';
+
+import { getGridOptionsType } from './buildGridOptionsType';
+import { GRID_OPTIONS_TYPES_FILE } from './gridOptionsTypesFile';
+
+// Entry point for the `build-grid-options-types` target. Must be run from the workspace root, as
+// both the source file it parses and the file it writes are workspace root relative.
+mkdirSync(dirname(GRID_OPTIONS_TYPES_FILE), { recursive: true });
+writeFileSync(GRID_OPTIONS_TYPES_FILE, JSON.stringify(getGridOptionsType(), null, 2));

--- a/plugins/ag-grid-generate-example-files/project.json
+++ b/plugins/ag-grid-generate-example-files/project.json
@@ -6,7 +6,7 @@
   "targets": {
     "build": {
       "executor": "@nx/js:swc",
-      "dependsOn": ["ag-grid-community:build", "copySrcFilesForGeneration", "ag-shared:build"],
+      "dependsOn": ["ag-grid-community:build:types", "copySrcFilesForGeneration", "ag-shared:build"],
       "outputs": ["{options.outputPath}"],
       "options": {
         "outputPath": "plugins/ag-grid-generate-example-files/dist",

--- a/plugins/ag-grid-generate-example-files/project.json
+++ b/plugins/ag-grid-generate-example-files/project.json
@@ -49,6 +49,17 @@
         "cwd": "{projectRoot}"
       }
     },
+    "build-grid-options-types": {
+      "command": "tsx {projectRoot}/gridOptionsTypes/writeGridOptionsTypesFile.ts",
+      "dependsOn": ["ag-grid-community:build:types", "copySrcFilesForGeneration"],
+      "inputs": [
+        "{projectRoot}/gridOptionsTypes/**/*.ts",
+        "allOutputs",
+        { "externalDependencies": ["npm:typescript"] }
+      ],
+      "outputs": ["{workspaceRoot}/dist/plugins/ag-grid-generate-example-files"],
+      "cache": true
+    },
     "lint": {
       "command": "eslint",
       "options": {

--- a/plugins/ag-grid-generate-example-files/src/executors/generate-all/executor.ts
+++ b/plugins/ag-grid-generate-example-files/src/executors/generate-all/executor.ts
@@ -1,0 +1,141 @@
+import type { ExecutorContext } from '@nx/devkit';
+import * as glob from 'glob';
+import * as os from 'os';
+import * as path from 'path';
+
+import { readGridOptionsType } from '../../../gridOptionsTypes/gridOptionsTypesFile';
+import type { ExecutorOptions as GenerateOptions } from '../generate/executor';
+
+export type ExecutorOptions = {
+    mode: 'dev' | 'prod';
+    /** Docs project whose examples are generated, e.g. `ag-grid-docs`. */
+    parentProject: string;
+    /** Base output directory; each example lands under `<outputBasePath>/<parentProject>/...`. */
+    outputBasePath: string;
+    writeFiles?: boolean;
+};
+
+/**
+ * Generates every docs example in a single Nx task.
+ *
+ * Each example used to be its own Nx project with its own `generate-example` task, so a full
+ * generation scheduled >1000 tasks. The per-task bookkeeping (hashing, cache lookups, and — with
+ * the daemon — one socket round-trip each) cost substantially more than the generation itself.
+ * The per-example targets still exist for the watch loop and for regenerating a single example by
+ * hand; this executor is the bulk path used by `generate-examples`.
+ *
+ * Output paths must match what `ag-grid-task-autogen`'s `createNodes` computes for the per-example
+ * tasks, so that both paths write to exactly the same place.
+ */
+export function exampleOutputPath({
+    entryFilePath,
+    parentProject,
+    outputBasePath,
+}: {
+    entryFilePath: string;
+    parentProject: string;
+    outputBasePath: string;
+}) {
+    const exampleDir = path.dirname(entryFilePath);
+    const srcRoot = `documentation/${parentProject}/src`;
+    // `content/docs/<page>/_examples/<name>` -> `docs/<page>/_examples/<name>`
+    const relativeToSrc = path.relative(srcRoot, exampleDir);
+    const srcRelativeInputPath = relativeToSrc.split(path.sep).slice(1).join('/');
+
+    return {
+        exampleDir,
+        outputPath: path.posix.join(outputBasePath, parentProject, srcRelativeInputPath),
+    };
+}
+
+export function findExampleEntryFiles(parentProject: string) {
+    return glob
+        .sync(`documentation/${parentProject}/src/**/_examples/*/main.ts`)
+        .map((p) => p.split(path.sep).join('/'))
+        .sort();
+}
+
+export default async function (options: ExecutorOptions, _ctx: ExecutorContext) {
+    const { mode, parentProject, outputBasePath, writeFiles = false } = options;
+
+    const entryFiles = findExampleEntryFiles(parentProject);
+    if (entryFiles.length === 0) {
+        return { success: false, terminalOutput: `No examples found for '${parentProject}'` };
+    }
+
+    const jobs: { taskName: string; options: GenerateOptions }[] = entryFiles.map((entryFilePath) => {
+        const { exampleDir, outputPath } = exampleOutputPath({ entryFilePath, parentProject, outputBasePath });
+        return {
+            taskName: exampleDir,
+            options: {
+                mode,
+                examplePath: exampleDir,
+                outputPath,
+                writeFiles,
+                inputs: [],
+                output: '',
+            } as GenerateOptions,
+        };
+    });
+
+    const threadCount = process.env.CI == null ? Math.round(os.cpus().length / 2) : Math.min(4, os.cpus().length);
+    const gridOptionsTypes = readGridOptionsType();
+
+    const { Tinypool } = await import('tinypool');
+    const pool = new Tinypool({
+        runtime: 'child_process',
+        filename: path.join(__dirname, '../generate/batch-instance.js'),
+        maxThreads: threadCount,
+        env: process.env as Record<string, string>,
+        maxMemoryLimitBeforeRecycle: Number(process.env.NX_WORKER_RECYCLE_HEAP_BYTES) || 1_024 * 1_024 * 1_024,
+    });
+
+    const destroy = () => {
+        pool.cancelPendingTasks();
+        pool.destroy().catch((e) => console.error(e));
+    };
+    process.on('exit', destroy);
+
+    console.info(`Generating ${jobs.length} examples using ${threadCount} threads...`);
+    const start = performance.now();
+
+    const failures: string[] = [];
+    let completed = 0;
+    let nextMilestone = 10;
+    const settle = (taskName: string, success: boolean, terminalOutput: string) => {
+        completed++;
+        if (!success) {
+            failures.push(`${taskName}: ${terminalOutput}`);
+        }
+        const percent = Math.floor((completed / jobs.length) * 100);
+        if (percent >= nextMilestone || completed === jobs.length) {
+            console.info(`Progress: ${completed}/${jobs.length} (${percent}%)`);
+            nextMilestone = percent - (percent % 10) + 10;
+        }
+    };
+
+    const running = jobs.map(({ taskName, options: jobOptions }) =>
+        pool
+            .run({ taskName, options: jobOptions, context: {}, gridOptionsTypes })
+            .then((r: any) => settle(taskName, r?.result?.success ?? false, r?.result?.terminalOutput ?? ''))
+            .catch((e: unknown) => settle(taskName, false, `${e}`))
+    );
+
+    await Promise.allSettled(running);
+
+    const duration = performance.now() - start;
+    console.info(`Generated ${jobs.length} examples in ${Math.floor(duration / 100) / 10}s`);
+
+    await pool.destroy();
+    process.off('exit', destroy);
+
+    if (failures.length > 0) {
+        console.error(`${failures.length} example(s) failed to generate:`);
+        for (const failure of failures.slice(0, 20)) {
+            console.error(`  ${failure}`);
+        }
+        return { success: false, terminalOutput: `${failures.length} example(s) failed to generate` };
+    }
+
+    return { success: true, terminalOutput: `Generated ${jobs.length} examples` };
+}

--- a/plugins/ag-grid-generate-example-files/src/executors/generate-all/executor.ts
+++ b/plugins/ag-grid-generate-example-files/src/executors/generate-all/executor.ts
@@ -1,4 +1,5 @@
 import type { ExecutorContext } from '@nx/devkit';
+import { spawnSync } from 'child_process';
 import * as glob from 'glob';
 import * as os from 'os';
 import * as path from 'path';
@@ -55,8 +56,43 @@ export function findExampleEntryFiles(parentProject: string) {
         .sort();
 }
 
-export default async function (options: ExecutorOptions, _ctx: ExecutorContext) {
+/**
+ * Escape hatch for the single-task collapse. With `DISABLE_EXAMPLE_GEN_COLLAPSE=true` the examples
+ * are generated through the per-example Nx tasks instead, as they were before the collapse. Those
+ * targets are still defined (the watch loop uses them), so this path stays exercised rather than
+ * rotting. The env var is declared as an input on `generate-examples`, so flipping it invalidates
+ * the cache rather than silently reusing output produced by the other strategy.
+ */
+const GENERATED_EXAMPLE_TAG = 'type:generated-example';
+
+function generateViaPerExampleTasks(configurationName?: string) {
+    const args = ['nx', 'run-many', '-t', 'generate-example', `--projects=tag:${GENERATED_EXAMPLE_TAG}`];
+    if (configurationName) {
+        args.push('-c', configurationName);
+    }
+    console.info(`DISABLE_EXAMPLE_GEN_COLLAPSE is set - generating via per-example tasks: npx ${args.join(' ')}`);
+    const result = spawnSync('npx', args, { stdio: 'inherit', env: process.env });
+    if (result.status !== 0) {
+        return { success: false, terminalOutput: 'Per-example generation failed' };
+    }
+    // `run-many` exits 0 when the project filter matches nothing, so verify work actually happened
+    // rather than silently reporting success on an empty run.
+    const generated = glob.sync('dist/generated-examples/*/**/contents.json').length;
+    if (generated === 0) {
+        return {
+            success: false,
+            terminalOutput: `Per-example generation produced no output - did the '${GENERATED_EXAMPLE_TAG}' project filter match anything?`,
+        };
+    }
+    return { success: true, terminalOutput: `Generated ${generated} example files via per-example tasks` };
+}
+
+export default async function (options: ExecutorOptions, ctx: ExecutorContext) {
     const { mode, parentProject, outputBasePath, writeFiles = false } = options;
+
+    if (process.env.DISABLE_EXAMPLE_GEN_COLLAPSE === 'true') {
+        return generateViaPerExampleTasks(ctx?.configurationName);
+    }
 
     const entryFiles = findExampleEntryFiles(parentProject);
     if (entryFiles.length === 0) {

--- a/plugins/ag-grid-generate-example-files/src/executors/generate-all/executor.ts
+++ b/plugins/ag-grid-generate-example-files/src/executors/generate-all/executor.ts
@@ -65,7 +65,26 @@ export function findExampleEntryFiles(parentProject: string) {
  */
 const GENERATED_EXAMPLE_TAG = 'type:generated-example';
 
-function generateViaPerExampleTasks(configurationName?: string) {
+function generateViaPerExampleTasks(
+    configurationName: string | undefined,
+    expected: { exampleDir: string; outputPath: string }[]
+) {
+    // `run-many` exits 0 when its project filter matches nothing, so confirm the filter selects
+    // something before trusting a zero exit code. Checking the filter up front - rather than
+    // inspecting output afterwards - is what distinguishes "generated nothing" from "output was
+    // already on disk from an earlier run".
+    const matched = spawnSync('npx', ['nx', 'show', 'projects', `--projects=tag:${GENERATED_EXAMPLE_TAG}`], {
+        encoding: 'utf-8',
+        env: process.env,
+    });
+    const matchedCount = (matched.stdout ?? '').split('\n').filter(Boolean).length;
+    if (matched.status !== 0 || matchedCount === 0) {
+        return {
+            success: false,
+            terminalOutput: `No projects matched 'tag:${GENERATED_EXAMPLE_TAG}' - the per-example fallback would generate nothing.`,
+        };
+    }
+
     const args = ['nx', 'run-many', '-t', 'generate-example', `--projects=tag:${GENERATED_EXAMPLE_TAG}`];
     if (configurationName) {
         args.push('-c', configurationName);
@@ -75,28 +94,38 @@ function generateViaPerExampleTasks(configurationName?: string) {
     if (result.status !== 0) {
         return { success: false, terminalOutput: 'Per-example generation failed' };
     }
-    // `run-many` exits 0 when the project filter matches nothing, so verify work actually happened
-    // rather than silently reporting success on an empty run.
-    const generated = glob.sync('dist/generated-examples/*/**/contents.json').length;
-    if (generated === 0) {
+
+    // Then confirm every example this executor was asked to produce actually has output. Deliberately
+    // an existence check and not an mtime check: with the Nx daemon, outputs already matching the
+    // cache are left untouched, so a freshness test would fail a perfectly correct cache hit.
+    const missing = expected.filter(({ outputPath }) => glob.sync(`${outputPath}/*/contents.json`).length === 0);
+    if (missing.length > 0) {
+        const sample = missing
+            .slice(0, 5)
+            .map((m) => m.exampleDir)
+            .join(', ');
         return {
             success: false,
-            terminalOutput: `Per-example generation produced no output - did the '${GENERATED_EXAMPLE_TAG}' project filter match anything?`,
+            terminalOutput: `Per-example generation left ${missing.length} of ${expected.length} examples without output (e.g. ${sample})`,
         };
     }
-    return { success: true, terminalOutput: `Generated ${generated} example files via per-example tasks` };
+
+    return { success: true, terminalOutput: `Generated ${expected.length} examples via per-example tasks` };
 }
 
 export default async function (options: ExecutorOptions, ctx: ExecutorContext) {
     const { mode, parentProject, outputBasePath, writeFiles = false } = options;
 
-    if (process.env.DISABLE_EXAMPLE_GEN_COLLAPSE === 'true') {
-        return generateViaPerExampleTasks(ctx?.configurationName);
-    }
-
     const entryFiles = findExampleEntryFiles(parentProject);
     if (entryFiles.length === 0) {
         return { success: false, terminalOutput: `No examples found for '${parentProject}'` };
+    }
+
+    if (process.env.DISABLE_EXAMPLE_GEN_COLLAPSE === 'true') {
+        return generateViaPerExampleTasks(
+            ctx?.configurationName,
+            entryFiles.map((entryFilePath) => exampleOutputPath({ entryFilePath, parentProject, outputBasePath }))
+        );
     }
 
     const jobs: { taskName: string; options: GenerateOptions }[] = entryFiles.map((entryFilePath) => {

--- a/plugins/ag-grid-generate-example-files/src/executors/generate-all/schema.json
+++ b/plugins/ag-grid-generate-example-files/src/executors/generate-all/schema.json
@@ -1,0 +1,34 @@
+{
+    "$schema": "http://json-schema.org/schema",
+    "version": 2,
+    "title": "GenerateAllExampleFiles executor",
+    "description": "Generate every docs example in a single task, fanning out across a worker pool.",
+    "cli": "nx",
+    "outputCapture": "pipe",
+    "type": "object",
+    "properties": {
+        "parentProject": {
+            "type": "string",
+            "description": "Docs project whose examples are generated, e.g. `ag-grid-docs`.",
+            "x-priority": "important"
+        },
+        "outputBasePath": {
+            "type": "string",
+            "description": "Base output directory; each example lands under `<outputBasePath>/<parentProject>/...`.",
+            "x-completion-type": "directory",
+            "x-priority": "important"
+        },
+        "mode": {
+            "type": "string",
+            "enum": ["dev", "prod"],
+            "description": "Whether to generate development or production example output.",
+            "x-priority": "important"
+        },
+        "writeFiles": {
+            "type": "boolean",
+            "description": "Also write each generated file alongside contents.json.",
+            "default": false
+        }
+    },
+    "required": ["mode", "parentProject", "outputBasePath"]
+}

--- a/plugins/ag-grid-generate-example-files/src/executors/generate/batch-executor.ts
+++ b/plugins/ag-grid-generate-example-files/src/executors/generate/batch-executor.ts
@@ -1,13 +1,13 @@
 import { batchWorkerExecutor } from 'ag-shared/plugin-utils';
 import { versions } from 'process';
 
-import { getGridOptionsType } from '../../../gridOptionsTypes/buildGridOptionsType';
+import { readGridOptionsType } from '../../../gridOptionsTypes/gridOptionsTypesFile';
 
 if (versions.node < '18.18') {
     throw new Error('Upgrade Node.js to v18.18.0 for multi-threaded thumbnail generation; found: ' + versions.node);
 }
 const executor = batchWorkerExecutor(`${module.path}/batch-instance.js`, () => ({
-    gridOptionsTypes: getGridOptionsType(),
+    gridOptionsTypes: readGridOptionsType(),
 }));
 
 export default executor;

--- a/plugins/ag-grid-generate-example-files/src/executors/generate/executor.ts
+++ b/plugins/ag-grid-generate-example-files/src/executors/generate/executor.ts
@@ -231,6 +231,7 @@ export async function generateFiles(options: ExecutorOptions, gridOptionsTypes: 
                     entryFile,
                     indexHtml,
                     isEnterprise,
+                    isDev,
                     bindings,
                     typedBindings,
                     componentScriptFiles,
@@ -257,7 +258,8 @@ export async function generateFiles(options: ExecutorOptions, gridOptionsTypes: 
                 transformEntryFile,
                 isIntegratedCharts,
                 mainFileName,
-                folderPath
+                folderPath,
+                isDev
             );
         }
 
@@ -353,7 +355,8 @@ async function processProvidedFiles(
     transformEntryFile: TransformEntryFile,
     isIntegratedCharts: boolean,
     mainFileName: string,
-    folderPath: string
+    folderPath: string,
+    isDev: boolean
 ) {
     if (internalFramework === 'vanilla') {
         // NOTE: Vanilla provided examples, we need to include the entryfile
@@ -394,7 +397,8 @@ async function processProvidedFiles(
         if (provideFrameworkFiles[writeToFileName]?.length > 0 && !writeToFileName.endsWith('.css')) {
             provideFrameworkFiles[writeToFileName] = await formatFile(
                 internalFramework,
-                provideFrameworkFiles[writeToFileName]
+                provideFrameworkFiles[writeToFileName],
+                isDev
             );
         }
 

--- a/plugins/ag-grid-generate-example-files/src/executors/generate/executor.ts
+++ b/plugins/ag-grid-generate-example-files/src/executors/generate/executor.ts
@@ -3,7 +3,7 @@ import { readFile, readJSONFile, writeFile } from 'ag-shared/plugin-utils';
 import fs from 'fs/promises';
 import path from 'path';
 
-import { getGridOptionsType } from '../../../gridOptionsTypes/buildGridOptionsType';
+import { readGridOptionsType } from '../../../gridOptionsTypes/gridOptionsTypesFile';
 import { SOURCE_ENTRY_FILE_NAME } from './generator/constants';
 import gridVanillaSrcParser from './generator/transformation-scripts/grid-vanilla-src-parser';
 import {
@@ -51,7 +51,7 @@ export type ExecutorOptions = {
 export default async function (
     options: ExecutorOptions,
     _ctx: ExecutorContext,
-    gridOptionsTypes = getGridOptionsType()
+    gridOptionsTypes = readGridOptionsType()
 ) {
     try {
         await generateFiles(options, gridOptionsTypes);

--- a/plugins/ag-grid-generate-example-files/src/executors/generate/generator/transformation-scripts/grid-vanilla-src-parser.ts
+++ b/plugins/ag-grid-generate-example-files/src/executors/generate/generator/transformation-scripts/grid-vanilla-src-parser.ts
@@ -582,10 +582,11 @@ export function parser(
     gridOptionsTypes: Record<string, GridOptionsType>
 ) {
     const typedBindings = internalParser(examplePath, srcFile, true, gridOptionsTypes, html, providedExamples);
-    const bindings = internalParser(examplePath, srcFile, false, gridOptionsTypes, html, providedExamples);
-    // We need to copy the imports from the typed bindings to the non-typed bindings
-    bindings.imports = typedBindings.imports;
-    return { bindings, typedBindings };
+    // The untyped pass used to be parsed separately, doubling the TypeScript and cheerio work per
+    // example. Its only consumers read `imports` (which was copied from the typed bindings anyway)
+    // and `exampleName` (identical in both passes), and neither mutates what it reads - so the
+    // typed bindings serve both roles.
+    return { bindings: typedBindings, typedBindings };
 }
 
 export default parser;

--- a/plugins/ag-grid-generate-example-files/src/executors/generate/generator/utils/fileFormatUtils.ts
+++ b/plugins/ag-grid-generate-example-files/src/executors/generate/generator/utils/fileFormatUtils.ts
@@ -6,9 +6,11 @@ import { TYPESCRIPT_INTERNAL_FRAMEWORKS } from '../types';
 // extracted to a separate file as prettier does a dynamic import which jest doesn't like without the addition of
 // experimental flags
 export async function formatFile(internalFramework: InternalFramework, fileString: string): Promise<string> {
+    // `babel-ts` prints identically to `typescript` but is markedly cheaper: it avoids loading
+    // prettier's TypeScript plugin, which dominates the first format call in each worker.
     const parser =
         TYPESCRIPT_INTERNAL_FRAMEWORKS.includes(internalFramework) || internalFramework === 'vanilla'
-            ? 'typescript'
+            ? 'babel-ts'
             : 'babel';
     return await prettier.format(fileString, {
         parser,

--- a/plugins/ag-grid-generate-example-files/src/executors/generate/generator/utils/fileFormatUtils.ts
+++ b/plugins/ag-grid-generate-example-files/src/executors/generate/generator/utils/fileFormatUtils.ts
@@ -5,7 +5,17 @@ import { TYPESCRIPT_INTERNAL_FRAMEWORKS } from '../types';
 
 // extracted to a separate file as prettier does a dynamic import which jest doesn't like without the addition of
 // experimental flags
-export async function formatFile(internalFramework: InternalFramework, fileString: string): Promise<string> {
+export async function formatFile(
+    internalFramework: InternalFramework,
+    fileString: string,
+    skipFormatting = false
+): Promise<string> {
+    // Formatting is roughly half the cost of generating an example and only affects how the code
+    // reads in the docs example viewer, so dev builds skip it. Published output is still formatted.
+    if (skipFormatting) {
+        return fileString;
+    }
+
     // `babel-ts` prints identically to `typescript` but is markedly cheaper: it avoids loading
     // prettier's TypeScript plugin, which dominates the first format call in each worker.
     const parser =

--- a/plugins/ag-grid-generate-example-files/src/executors/generate/generator/utils/fileFormatUtils.ts
+++ b/plugins/ag-grid-generate-example-files/src/executors/generate/generator/utils/fileFormatUtils.ts
@@ -12,7 +12,9 @@ export async function formatFile(
 ): Promise<string> {
     // Formatting is roughly half the cost of generating an example and only affects how the code
     // reads in the docs example viewer, so dev builds skip it. Published output is still formatted.
-    if (skipFormatting) {
+    // Set AG_EXAMPLE_FORMAT=true to format dev output too, e.g. when comparing it against published
+    // output.
+    if (skipFormatting && process.env.AG_EXAMPLE_FORMAT !== 'true') {
         return fileString;
     }
 

--- a/plugins/ag-grid-generate-example-files/src/executors/generate/generator/utils/frameworkFilesGenerator.ts
+++ b/plugins/ag-grid-generate-example-files/src/executors/generate/generator/utils/frameworkFilesGenerator.ts
@@ -28,6 +28,7 @@ type ConfigGenerator = ({
     entryFile,
     indexHtml,
     isEnterprise,
+    isDev,
     bindings,
     typedBindings,
     componentScriptFiles,
@@ -40,6 +41,7 @@ type ConfigGenerator = ({
     entryFile: string;
     indexHtml: string;
     isEnterprise: boolean;
+    isDev: boolean;
     bindings: ParsedBindings;
     typedBindings: ParsedBindings;
     componentScriptFiles: FileContents;
@@ -55,7 +57,15 @@ type ConfigGenerator = ({
 const AG_GRID_EXPORTED_FUNCS_USED_IN_EXAMPLES_COMPS = ['isCombinedFilterModel'];
 
 export const frameworkFilesGenerator: Partial<Record<InternalFramework, ConfigGenerator>> = {
-    vanilla: async ({ bindings, entryFile, indexHtml, componentScriptFiles, otherScriptFiles, transformEntryFile }) => {
+    vanilla: async ({
+        isDev,
+        bindings,
+        entryFile,
+        indexHtml,
+        componentScriptFiles,
+        otherScriptFiles,
+        transformEntryFile,
+    }) => {
         const internalFramework: InternalFramework = 'vanilla';
         const entryFileName = getEntryFileName(internalFramework)!;
         let mainJs = readAsJsFile(entryFile, 'vanilla');
@@ -96,7 +106,7 @@ export const frameworkFilesGenerator: Partial<Record<InternalFramework, ConfigGe
         mainJs = mainJs.replace(/^\s*[\r\n]/, '');
 
         const scriptFiles = { ...otherScriptFiles, ...componentScriptFiles };
-        mainJs = await formatFile(internalFramework, mainJs);
+        mainJs = await formatFile(internalFramework, mainJs, isDev);
 
         return {
             files: {
@@ -108,6 +118,7 @@ export const frameworkFilesGenerator: Partial<Record<InternalFramework, ConfigGe
         };
     },
     typescript: async ({
+        isDev,
         entryFile,
         indexHtml,
         otherScriptFiles,
@@ -125,7 +136,7 @@ export const frameworkFilesGenerator: Partial<Record<InternalFramework, ConfigGe
             mainTs = transformEntryFile({ entryFile: mainTs });
         }
 
-        mainTs = await formatFile(internalFramework, mainTs);
+        mainTs = await formatFile(internalFramework, mainTs, isDev);
 
         const scriptFiles = { ...otherScriptFiles, ...componentScriptFiles };
 
@@ -139,6 +150,7 @@ export const frameworkFilesGenerator: Partial<Record<InternalFramework, ConfigGe
         };
     },
     reactFunctional: async ({
+        isDev,
         typedBindings,
         indexHtml,
         otherScriptFiles,
@@ -163,7 +175,7 @@ export const frameworkFilesGenerator: Partial<Record<InternalFramework, ConfigGe
             indexJsx = transformEntryFile({ entryFile: indexJsx });
         }
 
-        indexJsx = await formatFile(internalFramework, indexJsx);
+        indexJsx = await formatFile(internalFramework, indexJsx, isDev);
 
         return {
             files: {
@@ -176,6 +188,7 @@ export const frameworkFilesGenerator: Partial<Record<InternalFramework, ConfigGe
         };
     },
     reactFunctionalTs: async ({
+        isDev,
         typedBindings,
         indexHtml,
         otherScriptFiles,
@@ -198,7 +211,7 @@ export const frameworkFilesGenerator: Partial<Record<InternalFramework, ConfigGe
             indexTsx = transformEntryFile({ entryFile: indexTsx });
         }
 
-        indexTsx = await formatFile(internalFramework, indexTsx);
+        indexTsx = await formatFile(internalFramework, indexTsx, isDev);
 
         return {
             files: {
@@ -211,6 +224,7 @@ export const frameworkFilesGenerator: Partial<Record<InternalFramework, ConfigGe
         };
     },
     angular: async ({
+        isDev,
         typedBindings,
         otherScriptFiles,
         componentScriptFiles,
@@ -234,7 +248,7 @@ export const frameworkFilesGenerator: Partial<Record<InternalFramework, ConfigGe
             appComponent = transformEntryFile({ entryFile: appComponent });
         }
 
-        appComponent = await formatFile(internalFramework, appComponent);
+        appComponent = await formatFile(internalFramework, appComponent, isDev);
 
         return {
             files: {
@@ -250,6 +264,7 @@ export const frameworkFilesGenerator: Partial<Record<InternalFramework, ConfigGe
         };
     },
     vue3: async ({
+        isDev,
         indexHtml,
         typedBindings,
         otherScriptFiles,
@@ -271,7 +286,7 @@ export const frameworkFilesGenerator: Partial<Record<InternalFramework, ConfigGe
             mainJs = transformEntryFile({ entryFile: mainJs });
         }
 
-        mainJs = await formatFile(internalFramework, mainJs);
+        mainJs = await formatFile(internalFramework, mainJs, isDev);
 
         const entryFileName = getEntryFileName(internalFramework)!;
         const scriptFiles = { ...otherScriptFiles, ...componentScriptFiles };

--- a/plugins/ag-grid-generate-example-files/src/executors/generate/generator/utils/getPackageJson.ts
+++ b/plugins/ag-grid-generate-example-files/src/executors/generate/generator/utils/getPackageJson.ts
@@ -10,16 +10,28 @@ interface Params {
 
 export const agChartsVersion = 'latest'; // TODO have this set properly
 
+// Versions are constant for the lifetime of a generation run, but getPackageJson is called once per
+// framework per example - without this cache that is ~36k redundant reads and parses of six files.
+const versionCache = new Map<string, string>();
+
 function getPackageJsonVersion(packageName: string, isModule: boolean = false) {
     const path = isModule
         ? `${process.cwd()}/community-modules/${packageName}/package.json`
         : `${process.cwd()}/packages/${packageName}/package.json`;
+
+    const cached = versionCache.get(path);
+    if (cached !== undefined) {
+        return cached;
+    }
+
     const packageJsonStr = readFileSync(path, 'utf-8');
     const packageJson = JSON.parse(packageJsonStr);
     // Strip pre-release suffix (e.g. "35.1.0-beta.20260218.1143" → "35.1.0")
     // This enables Plunker to locate types via the dummy package.json.
     // These have to be published externally.
-    return (packageJson.version as string).replace(/-.*$/, '');
+    const version = (packageJson.version as string).replace(/-.*$/, '');
+    versionCache.set(path, version);
+    return version;
 }
 
 export function getPackageJson({ isLocale, internalFramework, isIntegratedCharts }: Params) {

--- a/plugins/ag-grid-task-autogen/src/generate-example-files.ts
+++ b/plugins/ag-grid-task-autogen/src/generate-example-files.ts
@@ -7,14 +7,23 @@ export function createTask(parentProject: string, srcRelativeInputPath: string):
             dependsOn: [
                 { projects: 'ag-grid-generate-example-files', target: 'build' },
                 { projects: 'ag-grid-generate-example-files', target: '"copySrcFilesForGeneration"' },
-                { projects: 'ag-grid-community', target: 'build:types' },
+                { projects: 'ag-grid-generate-example-files', target: 'build-grid-options-types' },
             ],
             executor: 'ag-grid-generate-example-files:generate',
             inputs: [
                 '{projectRoot}/**',
                 '!{projectRoot}/**/*.spec.*',
                 '!{projectRoot}/**/*.test.*',
-                '{workspaceRoot}/packages/ag-grid-community/dist/types/**/*.d.ts',
+                // The GridOptions type surface reaches these tasks as a single cached JSON file
+                // rather than as the ~620 community `.d.ts` files, so that building the community
+                // types does not have to be sequenced ahead of every example.
+                //
+                // NOTE: this file lives under `dist/`, which is gitignored and therefore absent
+                // from Nx's workspace file map, so it does not currently contribute to the task
+                // hash. Neither did the `.d.ts` glob it replaces. See `build-grid-options-types`,
+                // which does hash the type declarations (via `dependentTasksOutputFiles`) and so
+                // keeps the JSON itself up to date.
+                '{workspaceRoot}/dist/plugins/ag-grid-generate-example-files/gridOptionsTypes.json',
                 '{workspaceRoot}/plugins/ag-grid-generate-example-files/{dist,src}/**/*',
                 '{workspaceRoot}/documentation/ag-grid-docs/public/example-runner/**',
                 { env: 'AG_AI_API_URL' },

--- a/plugins/ag-grid-task-autogen/src/generate-example-files.ts
+++ b/plugins/ag-grid-task-autogen/src/generate-example-files.ts
@@ -28,6 +28,7 @@ export function createTask(parentProject: string, srcRelativeInputPath: string):
                 '{workspaceRoot}/documentation/ag-grid-docs/public/example-runner/**',
                 { env: 'AG_AI_API_URL' },
                 { env: 'AG_AI_API_DEV_TOKEN' },
+                { env: 'AG_EXAMPLE_FORMAT' },
             ],
             outputs: ['{options.outputPath}'],
             cache: true,

--- a/utilities/all/project.json
+++ b/utilities/all/project.json
@@ -151,8 +151,13 @@
         "^build:types",
         "^build:package",
         "^build:umd",
+        "^build:copy-styles",
+        "generate-doc-references",
         "generate-examples",
-        "generate-doc-references"
+        "ag-grid-react:build",
+        "ag-grid-angular:build",
+        "ag-grid-vue3:build",
+        "ag-grid-docs:build:copy-styles"
       ],
       "inputs": [],
       "outputs": [],


### PR DESCRIPTION
- Cold start (nx reset + all:clean → Astro boot): 49.5s → 30s (−39%), daemon-on, 2 reps per arm
- Warm restart 6s; warm restart with dist wiped 5s
- generate-examples: 1030 tasks → 8, wall 17s → 9s, generation batch 11.3s → 2.9s, warm cache-hit 5.9s → 4.5s

Generator performance

- prettier parser typescript → babel-ts — identical printer output, avoids loading prettier's TypeScript plugin in every worker
- skip formatting entirely in dev builds (isDev threaded through ConfigGenerator into formatFile), matching what ag-charts and ag-studio already do; grid was the outlier. Production output unchanged
- dropped the redundant second internalParser pass — it repeated the full TypeScript + cheerio parse for every example, producing bindings whose only consumers read imports (already copied from the typed pass) and exampleName (identical in both)
- memoised getPackageJsonVersion — was ~36,000 redundant reads and parses of six files per run
- emit the GridOptions type surface once from a new cached build-grid-options-types target; both executor paths read the JSON instead of running ts.createProgram (~692ms) per batch run

Nx task graph

- new generate-all executor generates every example in one task, fanning out over the tinypool worker that already existed; ag-grid-docs:generate-examples now uses it
- per-example projects and their generate/generate-example targets deliberately kept — nx watch maps changed files to projects and ag-grid-docs sits in the watch loop's ignoredProjects, so removing them would silently stop example edits regenerating, and fixing that would mean editing shared ag-shared code that charts and studio also use
- narrowed ag-grid-generate-example-files:build from ag-grid-community:build to :build:types, taking the package and UMD builds off the pre-generation critical path
- hoisted the framework wrapper builds and docs copy-styles onto all:dev and removed ag-grid-docs:dev's duplicated dependsOn, eliminating a second full project-graph computation and a second 1054-task cache-check pass
- removed the dead ^docs-resolved-interfaces dependency — no project in the workspace defines that target

Build correctness

- deleteOutputPath: false on @ag-grid-community/locale:build:umd. Its rmSync could land inside the await esbuild.transform() window and delete the output directory before .min.js was written. 9 concurrent runs: 1/9 failed before, 0/9 after

Escape hatches

- `DISABLE_EXAMPLE_GEN_COLLAPSE=true` falls back to the per-example Nx tasks, as before the collapse; `AG_EXAMPLE_FORMAT=true` formats dev example output the way production does. Both are declared as Nx env inputs, so flipping either invalidates the cache rather than reusing output produced under the other setting.
