### PR TITLE
AG-18121: fix keyboard tabbing in the API reference

### DIFF
--- a/documentation/ag-grid-docs/src/components/reference-documentation/components/Property.tsx
+++ b/documentation/ag-grid-docs/src/components/reference-documentation/components/Property.tsx
@@ -192,14 +192,30 @@ function getDetailsId(id: string) {
     return `${id}-details`;
 }
 
-function CollapsibleButton({ name, isExpanded, onClick }: { name: string; isExpanded?: boolean; onClick: () => void }) {
+function CollapsibleButton({
+    name,
+    isExpanded,
+    detailsId,
+    onClick,
+}: {
+    name: string;
+    isExpanded?: boolean;
+    detailsId: string;
+    onClick: () => void;
+}) {
     return (
         <button
+            type="button"
+            // Safari omits buttons from the tab order without an explicit tabindex.
+            tabIndex={0}
             className={classnames(styles.seeMore, 'button-tertiary', {
                 [styles.isExpanded]: isExpanded,
             })}
             onClick={onClick}
-            aria-label={`See more details about ${name}`}
+            aria-expanded={Boolean(isExpanded)}
+            // Only reference the panel while it exists — it is unmounted when collapsed.
+            aria-controls={isExpanded ? detailsId : undefined}
+            aria-label={`${isExpanded ? 'Hide' : 'See more'} details about ${name}`}
         >
             <Icon className={`${styles.chevron} ${isExpanded ? 'expandedIcon' : ''}`} name="chevronDown" />
         </button>
@@ -280,11 +296,13 @@ export const Property: FunctionComponent<{
                                     <CollapsibleButton
                                         name={more?.name ?? name}
                                         isExpanded={isExpanded}
+                                        detailsId={getDetailsId(idName)}
                                         onClick={onCollapseClick}
                                     />
                                 )}
                                 {typeUrl ? (
                                     <a
+                                        tabIndex={0}
                                         className={styles.metaValue}
                                         href={typeUrl}
                                         target={typeUrl.startsWith('http') ? '_blank' : '_self'}
@@ -296,7 +314,7 @@ export const Property: FunctionComponent<{
                                     <span
                                         onClick={onCollapseClick}
                                         className={classnames(styles.metaValue, {
-                                            [styles.isExpandable]: detailsCode,
+                                            [styles.isClickable]: detailsCode,
                                         })}
                                     >
                                         {propertyType}
@@ -316,6 +334,7 @@ export const Property: FunctionComponent<{
                             {isInitial && (
                                 <div className={classnames(styles.metaItem, styles.initialItem)}>
                                     <a
+                                        tabIndex={0}
                                         className={classnames(styles.metaValue)}
                                         href={urlWithPrefix({
                                             url: config?.initialLink ?? './grid-interface/#initial-grid-options',
@@ -340,7 +359,11 @@ export const Property: FunctionComponent<{
                         <div className={styles.actions}>
                             {isObject && (
                                 <div>
-                                    See <a href={`#reference-${id}.${name}`}>{name}</a> for more details.
+                                    See{' '}
+                                    <a tabIndex={0} href={`#reference-${id}.${name}`}>
+                                        {name}
+                                    </a>{' '}
+                                    for more details.
                                 </div>
                             )}
 
@@ -358,6 +381,7 @@ export const Property: FunctionComponent<{
 
                             {more != null && more.url && !config.hideMore && (
                                 <a
+                                    tabIndex={0}
                                     className={styles.docLink}
                                     href={urlWithPrefix({
                                         url: more.url,

--- a/documentation/ag-grid-docs/src/components/reference-documentation/components/PropertyModules.module.scss
+++ b/documentation/ag-grid-docs/src/components/reference-documentation/components/PropertyModules.module.scss
@@ -4,7 +4,8 @@
     font-family: var(--text-monospace-font-family);
     position: relative;
 
-    span {
+    span,
+    button {
         margin-top: 2px;
     }
 
@@ -32,6 +33,11 @@
 .moduleCount {
     --icon-color: var(--color-link);
 
+    // Undo the design system's <button> chrome; this is styled as an inline pill.
+    border: none;
+    box-shadow: none;
+    font-family: inherit;
+
     color: var(--color-link);
     cursor: pointer;
     font-size: var(--text-fs-sm);
@@ -45,6 +51,18 @@
     &:hover,
     &.moduleCountActive {
         background: var(--color-util-brand-100);
+    }
+
+    // The design system offsets icons inside a <button>; this one is sized here.
+    :global(.icon) {
+        position: static;
+        display: inline;
+        margin: 0 $spacing-size-2 0 0;
+    }
+
+    // Restores the ring lost with the resting box-shadow; the base rule has no outline.
+    &:focus-visible {
+        box-shadow: 0 0 0 $spacing-size-1 var(--color-button-primary-shadow-focus);
     }
 
     #{$selector-darkmode} & {

--- a/documentation/ag-grid-docs/src/components/reference-documentation/components/PropertyModules.tsx
+++ b/documentation/ag-grid-docs/src/components/reference-documentation/components/PropertyModules.tsx
@@ -2,7 +2,7 @@ import type { Framework } from '@ag-grid-types';
 import { Icon } from '@ag-website-shared/components/icon/Icon';
 import { urlWithPrefix } from '@utils/urlWithPrefix';
 import classnames from 'classnames';
-import { type FunctionComponent, useCallback, useEffect, useState } from 'react';
+import { type FunctionComponent, useCallback, useEffect, useId, useRef, useState } from 'react';
 
 import styles from './PropertyModules.module.scss';
 
@@ -12,6 +12,7 @@ const Module: FunctionComponent<{
 }> = ({ module, framework }) => {
     return (
         <a
+            tabIndex={0}
             href={urlWithPrefix({
                 url: './modules',
                 framework,
@@ -32,6 +33,8 @@ export const PropertyModules: FunctionComponent<{
     const otherModules = modules.slice(0) ?? [];
 
     const labelCount = otherModules.length - 1;
+    const tooltipId = useId();
+    const toggleRef = useRef<HTMLButtonElement>(null);
     const [isModuleTooltipVisible, setIsModuleTooltipVisible] = useState(false);
 
     const toggleModuleTooltip = useCallback(() => {
@@ -49,10 +52,19 @@ export const PropertyModules: FunctionComponent<{
             }
         };
 
+        const handleKeyDown = (event: KeyboardEvent) => {
+            if (isModuleTooltipVisible && event.key === 'Escape') {
+                setIsModuleTooltipVisible(false);
+                toggleRef.current?.focus();
+            }
+        };
+
         document.addEventListener('click', handleClickOutside);
+        document.addEventListener('keydown', handleKeyDown);
 
         return () => {
             document.removeEventListener('click', handleClickOutside);
+            document.removeEventListener('keydown', handleKeyDown);
         };
     }, [isModuleTooltipVisible]);
 
@@ -63,10 +75,17 @@ export const PropertyModules: FunctionComponent<{
 
                 {otherModules.length > 1 && (
                     <>
-                        <span
+                        <button
+                            ref={toggleRef}
+                            type="button"
+                            // Safari omits buttons from the tab order without an explicit tabindex.
+                            tabIndex={0}
                             className={classnames(styles.moduleCount, {
                                 [styles.moduleCountActive]: isModuleTooltipVisible,
                             })}
+                            aria-expanded={isModuleTooltipVisible}
+                            aria-controls={tooltipId}
+                            aria-label={`${isModuleTooltipVisible ? 'Hide' : 'Show'} ${labelCount} more modules`}
                             onClick={(e) => {
                                 e.preventDefault();
                                 e.stopPropagation();
@@ -74,9 +93,10 @@ export const PropertyModules: FunctionComponent<{
                             }}
                         >
                             +{labelCount} <Icon name="chevronDown" />
-                        </span>
+                        </button>
 
                         <div
+                            id={tooltipId}
                             className={classnames(styles.moduleTooltip, {
                                 [styles.isVisible]: isModuleTooltipVisible,
                             })}

--- a/documentation/ag-grid-docs/src/components/reference-documentation/components/Section.tsx
+++ b/documentation/ag-grid-docs/src/components/reference-documentation/components/Section.tsx
@@ -30,7 +30,7 @@ const Breadcrumbs = ({ breadcrumbs }: { breadcrumbs: Record<string, string> }) =
         if (index < breadcrumbsLength - 1) {
             links.push(
                 <Fragment key={key}>
-                    <a href={`#${href}`} title={text}>
+                    <a tabIndex={0} href={`#${href}`} title={text}>
                         {key}
                     </a>{' '}
                     &gt;{' '}
@@ -90,7 +90,7 @@ const ObjectCodeSample: React.FC<ObjectCode> = ({ framework, id, breadcrumbs = {
             isObject = true;
         }
 
-        line += `: ${isObject ? `<a href='#reference-${id}.${key}'>${type}</a>` : getLinkedType(type, framework)};`;
+        line += `: ${isObject ? `<a tabindex='0' href='#reference-${id}.${key}'>${type}</a>` : getLinkedType(type, framework)};`;
 
         if (definition.default != null) {
             line += ` // default: ${formatJson(definition.default)}`;
@@ -139,7 +139,7 @@ const SectionHeader = ({
             {!hideHeader && (
                 <HeaderTag id={`reference-${id}`} style={{ position: 'relative' }}>
                     {displayName}
-                    <a href={`#reference-${id}`} className="docs-header-icon">
+                    <a tabIndex={0} href={`#reference-${id}`} className="docs-header-icon">
                         <Icon name="link" />
                     </a>
                 </HeaderTag>
@@ -148,7 +148,11 @@ const SectionHeader = ({
             {descriptionDisplay && <p dangerouslySetInnerHTML={{ __html: descriptionDisplay }}></p>}
             {page && (
                 <p>
-                    See <a href={urlWithPrefix({ url: page.url, framework })}>{page.name}</a> for more information.
+                    See{' '}
+                    <a tabIndex={0} href={urlWithPrefix({ url: page.url, framework })}>
+                        {page.name}
+                    </a>{' '}
+                    for more information.
                 </p>
             )}
 

--- a/documentation/ag-grid-docs/src/components/reference-documentation/utils/documentation-helpers.ts
+++ b/documentation/ag-grid-docs/src/components/reference-documentation/utils/documentation-helpers.ts
@@ -37,7 +37,7 @@ export const convertMarkdown = (content: string | undefined, framework: Framewor
         .replace(/`(.*?)`/g, '<code>$1</code>')
         .replace(
             /\[([^\]]+)\]\(([^)]+)\)/g,
-            (_, text, href) => `<a href="${urlWithPrefix({ url: href, framework })}">${text}</a>`
+            (_, text, href) => `<a tabindex="0" href="${urlWithPrefix({ url: href, framework })}">${text}</a>`
         )
         .replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>');
 
@@ -106,7 +106,7 @@ export function getLinkedType(type: string | string[], framework: Framework) {
                     return url
                         ? {
                               toReplace: typeName,
-                              link: `<a href="${url}" target="${url.startsWith('http') ? '_blank' : '_self'}" rel="noreferrer">${typeName}</a>`,
+                              link: `<a tabindex="0" href="${url}" target="${url.startsWith('http') ? '_blank' : '_self'}" rel="noreferrer">${typeName}</a>`,
                           }
                         : undefined;
                 })


### PR DESCRIPTION
[AG-18121](https://ag-grid.atlassian.net/browse/AG-18121)

Safari omits links and buttons from the tab order unless they carry an explicit `tabindex` — in Chrome and Firefox it is implicitly `0`. The sites set it explicitly nearly everywhere, but nothing in the API reference did, so the whole component was unreachable by keyboard in Safari.

This is a partial delivery against the ticket, scoped to the API reference component. The ticket's repro page lists other areas that still need the same treatment.

## Changes

Explicit `tabIndex={0}` on the reference's links — the type link, `Initial`, the "more" doc link, breadcrumbs, section heading anchors, module links, and the anchors generated by `convertMarkdown` / `getLinkedType`.

Beyond the Safari convention, two disclosure widgets were not keyboard operable in **any** browser:

- **The "see more" chevron** is now a proper disclosure button — `type="button"`, `aria-expanded`, `aria-controls` on the details panel (whose id was being generated but referenced by nothing), and a label that reflects the current state.
- **The "+n" module count** was a click-handling `<span>`, so keyboard users could not open the module tooltip at all. It is a `<button>` now. The stylesheet undoes the design system's in-button chrome and its `.icon` offset so the pill renders identically, and restates the focus ring over the removed resting `box-shadow`. Escape closes the tooltip and returns focus to the toggle.

Also fixed `styles.isExpandable` on the property-type text, which `ApiReference.module.scss` does not define — the class resolved to `undefined`, so its `cursor: pointer` never applied. It now points at `isClickable`.

## Notes for review

**The property-type text stays mouse-only.** It toggles the same panel as the chevron directly above it. The chevron is the keyboard route, so the functionality is accessible; making the text a second tab stop would double the tab stops on tables with hundreds of rows.

**`convertMarkdown` / `getLinkedType` are reference-only.** Both are consumed solely by `Section.tsx` and `Property.tsx`, and the `.md` export strips HTML tags, so the added `tabindex` does not leak into generated Markdown.

**This component is duplicated in ag-studio-docs.** `Property.tsx` there is identical apart from `gridOpProp`/`studioProp` renames, and none of these hunks touch those — they port across unchanged. ag-charts has no copy. Files to sync:

```
src/components/reference-documentation/components/Property.tsx
src/components/reference-documentation/components/PropertyModules.tsx
src/components/reference-documentation/components/PropertyModules.module.scss
src/components/reference-documentation/components/Section.tsx
src/components/reference-documentation/utils/documentation-helpers.ts
```

## Testing

ESLint, Prettier, `sass` compile (emitted CSS checked against the pre-change output to confirm the pill is unchanged), and the existing `buildApiReferenceSection` suite — 15/15.

Not verified in a real browser: the worktree has no `node_modules` and the docs site needs a full monorepo build. The residual risk is confined to the `+n` module pill's appearance, which was verified against the compiled CSS rather than on screen. Worth a look at a page with a multi-module property.
