### PR TITLE
Perf(ci): sparse-checkout the jira pipeline's preflight jobs

### DIFF
--- a/.github/workflows/jira-agent-pipeline.yml
+++ b/.github/workflows/jira-agent-pipeline.yml
@@ -80,11 +80,6 @@ jobs:
               continue-on-error: true
               with:
                   fetch-depth: 1
-                  # This job runs no repo code: all it needs from the tree is the
-                  # install-ag-dev-prompts composite action (plus the root
-                  # package.json it reads node-version from, which cone mode
-                  # includes for free). A sparse pattern also makes checkout
-                  # fetch with --filter=blob:none, skipping ~12.7k blobs.
                   sparse-checkout: external/ag-shared/github/actions
 
             - name: Install @ag-grid/dev-prompts

--- a/.github/workflows/jira-agent-pipeline.yml
+++ b/.github/workflows/jira-agent-pipeline.yml
@@ -80,6 +80,12 @@ jobs:
               continue-on-error: true
               with:
                   fetch-depth: 1
+                  # This job runs no repo code: all it needs from the tree is the
+                  # install-ag-dev-prompts composite action (plus the root
+                  # package.json it reads node-version from, which cone mode
+                  # includes for free). A sparse pattern also makes checkout
+                  # fetch with --filter=blob:none, skipping ~12.7k blobs.
+                  sparse-checkout: external/ag-shared/github/actions
 
             - name: Install @ag-grid/dev-prompts
               continue-on-error: true
@@ -131,6 +137,8 @@ jobs:
             - uses: actions/checkout@v7
               with:
                   fetch-depth: 1
+                  # See concurrency-key above: no repo code runs here either.
+                  sparse-checkout: external/ag-shared/github/actions
 
             - name: Install @ag-grid/dev-prompts
               uses: ./external/ag-shared/github/actions/install-ag-dev-prompts

--- a/.github/workflows/jira-agent-pipeline.yml
+++ b/.github/workflows/jira-agent-pipeline.yml
@@ -132,7 +132,6 @@ jobs:
             - uses: actions/checkout@v7
               with:
                   fetch-depth: 1
-                  # See concurrency-key above: no repo code runs here either.
                   sparse-checkout: external/ag-shared/github/actions
 
             - name: Install @ag-grid/dev-prompts


### PR DESCRIPTION
`concurrency-key` and `preflight` check out the whole monorepo but only use `external/ag-shared/github/actions/install-ag-dev-prompts` (plus root `package.json`). Sparse checkout also switches the fetch to `--filter=blob:none`.

Checkout was 12s of the 26s `preflight` job (10s fetch + 2.4s tree update).