### PR TITLE
Patch each archive's own .htaccess, not just the root (b36.1.0 backport)

### DIFF
--- a/scripts/deployments/prep_and_archive/patchUncachedArchives.sh
+++ b/scripts/deployments/prep_and_archive/patchUncachedArchives.sh
@@ -73,74 +73,101 @@ fi
 MARKER="# BEGIN in-flight release archives"
 CACHED_ASSET_RULE="max-age=604800"
 WARNED=0
+PREPARED=()
 
-# patchRemote <remote .htaccess> <required|optional>
+function remoteExists {
+    ssh -i $SSH_LOCATION -p $SSH_PORT $CURRENT_HOST "test -f $1"
+}
+
+# prepare <remote .htaccess> <required|optional>
+#
+# Fetches, classifies and patches a LOCAL copy. Nothing is written to the box here, so a
+# problem with the second or third file is found before the first one has been changed.
 #
 # required - the root file. Anything unexpected is fatal.
 # optional - an archive's own copy. Older archives have neither the marker block nor the
-#            hashed-asset rule, and need no patch: the root file already covers them. One
-#            that has the rule but no markers cannot be patched and is warned about, since
-#            its /_astro/ files will stay cached for the week the archive is under test.
-function patchRemote {
+#            hashed-asset rule, and need no patch: the root file already covers them.
+function prepare {
     local remote=$1
     local mode=$2
-    local local_copy staged backup
-
-    local_copy=$(mktemp)
-    staged="$remote.new-$$"
-    backup="$remote.bak-$(date +%Y%m%d%H%M%S)"
-
-    function failed {
-        echo "  $1";
-        echo "  $remote has NOT been changed.";
-        rm -f "$local_copy";
-        ssh -i $SSH_LOCATION -p $SSH_PORT $CURRENT_HOST "rm -f $staged" 2>/dev/null;
-        exit 1;
-    }
+    local local_copy
 
     echo "$remote"
 
-    if ! scp -i $SSH_LOCATION -P $SSH_PORT $CURRENT_HOST:$remote "$local_copy" 2>/dev/null
+    if ! remoteExists "$remote"
     then
         if [[ "$mode" == "optional" ]]
         then
             echo "  no .htaccess here - nothing to patch";
-            rm -f "$local_copy";
             return 0;
         fi
-        failed "Could not fetch it.";
+        echo "  It does not exist. Nothing has been changed.";
+        exit 1;
+    fi
+
+    # It exists, so a failed fetch is a real failure - never a reason to skip silently.
+    local_copy=$(mktemp)
+    if ! scp -i $SSH_LOCATION -P $SSH_PORT $CURRENT_HOST:$remote "$local_copy"
+    then
+        echo "  Could not fetch it, though it exists. Nothing has been changed.";
+        rm -f "$local_copy";
+        exit 1;
     fi
 
     if ! grep -q "$MARKER" "$local_copy"
     then
         if [[ "$mode" == "optional" ]]
         then
-            if grep -q "$CACHED_ASSET_RULE" "$local_copy"
+            # Only worth saying during set: on clear, an unpatchable file is already in the
+            # state clear is trying to reach.
+            if [[ "$ACTION" == "set" ]] && grep -q "$CACHED_ASSET_RULE" "$local_copy"
             then
                 echo "  WARNING: it caches hashed assets but has no in-flight marker block, so it";
                 echo "  cannot be patched. Its /_astro/ files will stay cached while under test.";
                 WARNED=1;
             else
-                echo "  no marker block, and it does not cache hashed assets - the root file covers it";
+                echo "  no marker block - the root file covers it";
             fi
             rm -f "$local_copy";
             return 0;
         fi
+        echo "  No in-flight marker block. It predates this feature, or is not a generated .htaccess.";
+        echo "  Nothing has been changed.";
         rm -f "$local_copy";
-        failed "No in-flight marker block. It predates this feature, or is not a generated .htaccess.";
+        exit 1;
     fi
 
+    # Patch the local copy. A guarded clear refusing is caught here, before any remote write.
     # Drop the patcher's trailing "applied to <temp file>" - the remote path is printed above.
     node "$PATCHER" "$local_copy" "$ACTION" "$VERSION" "$CHARTS_VERSION" | grep -v "^applied to " | sed 's/^/  /'
     if [ "${PIPESTATUS[0]}" -ne 0 ]
     then
-        failed "Patching failed.";
+        echo "  Patching failed. Nothing has been changed.";
+        rm -f "$local_copy";
+        exit 1;
     fi
+
+    PREPARED+=("$remote|$local_copy")
+}
+
+# commit <remote .htaccess> <patched local copy>
+function commit {
+    local remote=$1
+    local local_copy=$2
+    local staged="$remote.new-$$"
+    local backup="$remote.bak-$(date +%Y%m%d%H%M%S)"
+
+    function commitFailed {
+        echo "  $1";
+        rm -f "$local_copy";
+        ssh -i $SSH_LOCATION -p $SSH_PORT $CURRENT_HOST "rm -f $staged" 2>/dev/null;
+        exit 1;
+    }
 
     # Keep a timestamped copy on the box, so a bad patch is one cp away from being undone.
     if ! ssh -i $SSH_LOCATION -p $SSH_PORT $CURRENT_HOST "cp $remote $backup"
     then
-        failed "Could not back it up.";
+        commitFailed "Could not back up $remote.";
     fi
 
     # Upload beside it and rename over: scp writes in place, so an interrupted transfer
@@ -148,24 +175,30 @@ function patchRemote {
     # atomic, so a reader sees either the old file or the new one.
     if ! scp -i $SSH_LOCATION -P $SSH_PORT "$local_copy" $CURRENT_HOST:$staged
     then
-        failed "Could not upload the patched copy.";
+        commitFailed "Could not upload the patched $remote.";
     fi
     if ! ssh -i $SSH_LOCATION -p $SSH_PORT $CURRENT_HOST "chmod 644 $staged && mv $staged $remote"
     then
-        failed "Could not move the patched copy into place.";
+        commitFailed "Could not move the patched $remote into place.";
     fi
     rm -f "$local_copy"
 
-    echo "  patched. Previous copy kept at $backup"
+    echo "$remote patched. Previous copy kept at $backup"
 }
 
 # The root file governs each archive's HTML and its non-hashed files, and is the only place
 # that covers a charts archive whose own copy comes from the charts repo.
-patchRemote "$GRID_ROOT_DIR/.htaccess" required
+prepare "$GRID_ROOT_DIR/.htaccess" required
 
 # Each archive's own copy, which overrides the root for anything it sets a value for.
-patchRemote "$GRID_ROOT_DIR/archive/$VERSION/.htaccess" optional
-patchRemote "$GRID_ROOT_DIR/charts/archive/$CHARTS_VERSION/.htaccess" optional
+prepare "$GRID_ROOT_DIR/archive/$VERSION/.htaccess" optional
+prepare "$GRID_ROOT_DIR/charts/archive/$CHARTS_VERSION/.htaccess" optional
+
+echo ""
+for entry in "${PREPARED[@]}"
+do
+    commit "${entry%%|*}" "${entry##*|}"
+done
 
 if [ "$WARNED" -eq 1 ]
 then

--- a/scripts/deployments/prep_and_archive/patchUncachedArchives.sh
+++ b/scripts/deployments/prep_and_archive/patchUncachedArchives.sh
@@ -1,7 +1,12 @@
 #!/bin/bash
 
-# Set or clear the in-flight archive caching exemption in the root .htaccess on a remote box.
+# Set or clear the in-flight archive caching exemption on a remote box.
 # Called by uploadAndUnzipArchive.sh during a grid release candidate, and runnable on its own.
+#
+# Patches the root .htaccess and, where they carry the marker block, each archive's own copy.
+# Both are needed: Apache merges root-down and the deeper file wins on Header set, so an
+# archive that ships the hashed-asset rule keeps its /_astro/ files cached for a week unless
+# its own copy is patched too.
 
 if [ "$#" -lt 3 ]
   then
@@ -65,53 +70,111 @@ then
     exit 1;
 fi
 
-LIVE_HTACCESS=$(mktemp)
-REMOTE=".htaccess"
-STAGED="$GRID_ROOT_DIR/.htaccess.new-$$"
-BACKUP="$GRID_ROOT_DIR/.htaccess.bak-$(date +%Y%m%d%H%M%S)"
+MARKER="# BEGIN in-flight release archives"
+CACHED_ASSET_RULE="max-age=604800"
+WARNED=0
 
-function patchFailed {
-    echo "$1";
-    echo "The live root .htaccess has NOT been changed.";
-    if [[ "$ACTION" == "set" ]]
+# patchRemote <remote .htaccess> <required|optional>
+#
+# required - the root file. Anything unexpected is fatal.
+# optional - an archive's own copy. Older archives have neither the marker block nor the
+#            hashed-asset rule, and need no patch: the root file already covers them. One
+#            that has the rule but no markers cannot be patched and is warned about, since
+#            its /_astro/ files will stay cached for the week the archive is under test.
+function patchRemote {
+    local remote=$1
+    local mode=$2
+    local local_copy staged backup
+
+    local_copy=$(mktemp)
+    staged="$remote.new-$$"
+    backup="$remote.bak-$(date +%Y%m%d%H%M%S)"
+
+    function failed {
+        echo "  $1";
+        echo "  $remote has NOT been changed.";
+        rm -f "$local_copy";
+        ssh -i $SSH_LOCATION -p $SSH_PORT $CURRENT_HOST "rm -f $staged" 2>/dev/null;
+        exit 1;
+    }
+
+    echo "$remote"
+
+    if ! scp -i $SSH_LOCATION -P $SSH_PORT $CURRENT_HOST:$remote "$local_copy" 2>/dev/null
     then
-        echo "The archive is cacheable - fix this and re-run, or it will serve stale.";
+        if [[ "$mode" == "optional" ]]
+        then
+            echo "  no .htaccess here - nothing to patch";
+            rm -f "$local_copy";
+            return 0;
+        fi
+        failed "Could not fetch it.";
     fi
-    rm -f "$LIVE_HTACCESS";
-    ssh -i $SSH_LOCATION -p $SSH_PORT $CURRENT_HOST "rm -f $STAGED" 2>/dev/null;
-    exit 1;
+
+    if ! grep -q "$MARKER" "$local_copy"
+    then
+        if [[ "$mode" == "optional" ]]
+        then
+            if grep -q "$CACHED_ASSET_RULE" "$local_copy"
+            then
+                echo "  WARNING: it caches hashed assets but has no in-flight marker block, so it";
+                echo "  cannot be patched. Its /_astro/ files will stay cached while under test.";
+                WARNED=1;
+            else
+                echo "  no marker block, and it does not cache hashed assets - the root file covers it";
+            fi
+            rm -f "$local_copy";
+            return 0;
+        fi
+        rm -f "$local_copy";
+        failed "No in-flight marker block. It predates this feature, or is not a generated .htaccess.";
+    fi
+
+    # Drop the patcher's trailing "applied to <temp file>" - the remote path is printed above.
+    node "$PATCHER" "$local_copy" "$ACTION" "$VERSION" "$CHARTS_VERSION" | grep -v "^applied to " | sed 's/^/  /'
+    if [ "${PIPESTATUS[0]}" -ne 0 ]
+    then
+        failed "Patching failed.";
+    fi
+
+    # Keep a timestamped copy on the box, so a bad patch is one cp away from being undone.
+    if ! ssh -i $SSH_LOCATION -p $SSH_PORT $CURRENT_HOST "cp $remote $backup"
+    then
+        failed "Could not back it up.";
+    fi
+
+    # Upload beside it and rename over: scp writes in place, so an interrupted transfer
+    # straight onto the live file would leave a truncated one. mv within a directory is
+    # atomic, so a reader sees either the old file or the new one.
+    if ! scp -i $SSH_LOCATION -P $SSH_PORT "$local_copy" $CURRENT_HOST:$staged
+    then
+        failed "Could not upload the patched copy.";
+    fi
+    if ! ssh -i $SSH_LOCATION -p $SSH_PORT $CURRENT_HOST "chmod 644 $staged && mv $staged $remote"
+    then
+        failed "Could not move the patched copy into place.";
+    fi
+    rm -f "$local_copy"
+
+    echo "  patched. Previous copy kept at $backup"
 }
 
-echo "scp -i $SSH_LOCATION -P $SSH_PORT $CURRENT_HOST:$GRID_ROOT_DIR/$REMOTE -> local"
-if ! scp -i $SSH_LOCATION -P $SSH_PORT $CURRENT_HOST:$GRID_ROOT_DIR/$REMOTE "$LIVE_HTACCESS"
+# The root file governs each archive's HTML and its non-hashed files, and is the only place
+# that covers a charts archive whose own copy comes from the charts repo.
+patchRemote "$GRID_ROOT_DIR/.htaccess" required
+
+# Each archive's own copy, which overrides the root for anything it sets a value for.
+patchRemote "$GRID_ROOT_DIR/archive/$VERSION/.htaccess" optional
+patchRemote "$GRID_ROOT_DIR/charts/archive/$CHARTS_VERSION/.htaccess" optional
+
+if [ "$WARNED" -eq 1 ]
 then
-    patchFailed "Could not fetch the live root .htaccess.";
+    echo ""
+    echo "Finished with warnings - see above. The archives are exempt except where noted."
+else
+    echo ""
+    echo "Done."
 fi
 
-node "$PATCHER" "$LIVE_HTACCESS" "$ACTION" "$VERSION" "$CHARTS_VERSION" || patchFailed "Patching failed."
-
-# Keep a timestamped copy on the box, so a bad patch is one cp away from being undone without
-# needing this script or a deploy.
-echo "ssh -i $SSH_LOCATION -p $SSH_PORT $CURRENT_HOST \"cp $GRID_ROOT_DIR/$REMOTE $BACKUP\""
-if ! ssh -i $SSH_LOCATION -p $SSH_PORT $CURRENT_HOST "cp $GRID_ROOT_DIR/$REMOTE $BACKUP"
-then
-    patchFailed "Could not back up the live root .htaccess.";
-fi
-
-# Upload beside the live file and rename over it: scp writes in place, so an interrupted
-# transfer straight onto .htaccess would leave the site with a truncated one. mv within the
-# same directory is atomic, so a reader sees either the old file or the new one.
-echo "scp -i $SSH_LOCATION -P $SSH_PORT local -> $CURRENT_HOST:$STAGED"
-if ! scp -i $SSH_LOCATION -P $SSH_PORT "$LIVE_HTACCESS" $CURRENT_HOST:$STAGED
-then
-    patchFailed "Could not upload the patched root .htaccess.";
-fi
-if ! ssh -i $SSH_LOCATION -p $SSH_PORT $CURRENT_HOST "chmod 644 $STAGED && mv $STAGED $GRID_ROOT_DIR/$REMOTE"
-then
-    patchFailed "Could not move the patched root .htaccess into place.";
-fi
-rm -f "$LIVE_HTACCESS"
-
-echo "Root .htaccess patched. Previous copy kept at $BACKUP"
-echo "NOTE: a docs deploy resets the in-flight block. That is how the exemption is removed at"
-echo "      GA, but it also means a mid-cycle docs deploy drops it - re-run this if so."
+echo "NOTE: a docs deploy resets the root in-flight block. That is how the exemption is"
+echo "      removed at GA, but a mid-cycle docs deploy drops it - re-run this if so."


### PR DESCRIPTION
Backport of #15027 to `b36.1.0`, following #15022. Cherry-picked cleanly — the script is byte-identical to the `latest` branch, and the verification suite was re-run against this copy.


## The bug

Measured on production with 36.1.0 in flight:

| Path | Served | Expected |
| --- | --- | --- |
| `/archive/36.1.0/` HTML | `no-cache` | ✅ |
| `/archive/36.1.0/scripts/gtm-init.js` | `no-cache` | ✅ |
| `/archive/36.1.0/_astro/design-system.BcXAtF3c.css` | `public, max-age=604800, s-maxage=31536000` | ❌ |
| `/charts/archive/14.1.0/_astro/design-system.BFonzYye.css` | `no-cache` | ✅ |

Apache merges `.htaccess` root-down and the deeper file wins on `Header set`. Archives from 36.0.0 ship their own `.htaccess`, and now that it is generated from the same source it carries the hashed-asset rule — which overrides the root's in-flight `no-cache` for anything under `/_astro/`.

That the archive-level file is in play is directly observable: the grid and charts archives serve *different* CSP headers from each other, so neither can be coming from the root.

Charts escaped only by accident. Its `.htaccess` comes from the charts repo, which has no hashed-asset rule, so nothing competed and the root rule applied. It will regress the moment charts picks the rule up.

The assumption in #15007 — "the archive's own copy does not compete" — was true for HTML and false for assets.

## The fix

The in-flight block is emitted *after* the hashed-asset rule, so patching an archive's own copy overrides it within that same file:

```
line 22: Header set Cache-Control "public, max-age=604800, ..."   <- hashed assets
line 30: Header set Cache-Control "no-cache" ... m#^/archive/36\.1\.0/#    <- wins
```

Each archive is now patched alongside the root. Targets discriminate on what the file actually holds rather than assuming:

| Target | Mode | |
| --- | --- | --- |
| `$GRID_ROOT_DIR/.htaccess` | required | missing markers is fatal |
| `archive/<grid>/.htaccess` | optional | patched when it has markers |
| `charts/archive/<charts>/.htaccess` | optional | patched when it has markers |

For the optional targets:

- **no file** — older archives ship none, nothing to patch
- **no markers, no hashed rule** — nothing to override, the root file covers it
- **no markers but has the hashed rule** — cannot be patched, so it **warns** and names the archive
- **markers** — patched

That third case is exactly where charts lands when it adopts the rule, so the regression announces itself rather than passing silently. It warns rather than fails on purpose: the archive is already deployed by the time this runs, and a cached content-addressed asset is a freshness annoyance rather than a correctness problem, so failing the upload would be the worse outcome.

Both rules go into every patched file. The charts line inside a grid archive's copy never fires — a request under `/archive/36.1.0/` cannot have a URI beginning `/charts/archive/` — so it is inert, and keeping one block shape means `clear` still round-trips byte-identically.

## Verification

Run against a fake remote filesystem with stubbed `ssh`/`scp`, so the real script executes unmodified:

| Case | Result |
| --- | --- |
| `set`, all files present | exit 0 — root and grid archive patched, charts warned |
| `clear`, versions match | exit 0 — both files byte-identical to the originals |
| `clear`, charts version mismatched | exit 1 — refuses, nothing changed |
| root file has no markers | exit 1 — fatal |
| no archive `.htaccess` at all | exit 0 — skipped |
| archive with neither markers nor rule | exit 0 — skipped with a note |

Note for whoever is testing 36.1.0: it is in flight with only the root patched, so re-running the patcher against production is what fixes the two `/_astro/` paths above.
