### PR TITLE
Say one line, and do not fail a release for a no-op clear

### DIFF
--- a/scripts/deployments/prep_and_archive/patchUncachedArchives.sh
+++ b/scripts/deployments/prep_and_archive/patchUncachedArchives.sh
@@ -14,7 +14,8 @@ if [ "$#" -lt 3 ]
     echo "For example: ./scripts/deployments/prep_and_archive/patchUncachedArchives.sh 36.1.0 14.1.0 user@host clear"
     echo ""
     echo "Nothing has to clear this: a production docs deploy emits an empty in-flight block,"
-    echo "so going live restores normal caching on its own."
+    echo "so going live restores normal caching on its own. That cuts both ways - a docs deploy"
+    echo "mid-cycle drops the exemption too, so re-run this if one lands before GA."
     echo ""
     echo "Requires \$SSH_FILE, \$SSH_PORT and \$GRID_ROOT_DIR, as the other deploy scripts do."
     exit 1
@@ -87,7 +88,18 @@ then
     patchFailed "Could not fetch the live root .htaccess.";
 fi
 
-node "$PATCHER" "$LIVE_HTACCESS" "$ACTION" "$VERSION" "$CHARTS_VERSION" || patchFailed "Patching failed."
+BEFORE=$(cksum < "$LIVE_HTACCESS")
+OUTCOME=$(node "$PATCHER" "$LIVE_HTACCESS" "$ACTION" "$VERSION" "$CHARTS_VERSION") || patchFailed "Patching failed."
+
+# A clear that finds nothing of ours leaves the file untouched. Stop here rather than
+# uploading it back: the write cannot fail a release it was never going to change, and a
+# stale invocation cannot overwrite a newer state it never looked at.
+if [ "$(cksum < "$LIVE_HTACCESS")" = "$BEFORE" ]
+then
+    rm -f "$LIVE_HTACCESS";
+    echo "$GRID_ROOT_DIR/$REMOTE: $OUTCOME";
+    exit 0;
+fi
 
 # Keep a timestamped copy on the box, so a bad patch is one cp away from being undone without
 # needing this script or a deploy.
@@ -109,4 +121,4 @@ then
 fi
 rm -f "$LIVE_HTACCESS"
 
-echo "$GRID_ROOT_DIR/$REMOTE updated - previous copy at $BACKUP"
+echo "$GRID_ROOT_DIR/$REMOTE: $OUTCOME (previous copy at $BACKUP)"

--- a/scripts/deployments/prep_and_archive/patchUncachedArchives.sh
+++ b/scripts/deployments/prep_and_archive/patchUncachedArchives.sh
@@ -82,7 +82,6 @@ function patchFailed {
     exit 1;
 }
 
-echo "scp -i $SSH_LOCATION -P $SSH_PORT $CURRENT_HOST:$GRID_ROOT_DIR/$REMOTE -> local"
 if ! scp -i $SSH_LOCATION -P $SSH_PORT $CURRENT_HOST:$GRID_ROOT_DIR/$REMOTE "$LIVE_HTACCESS"
 then
     patchFailed "Could not fetch the live root .htaccess.";
@@ -92,7 +91,6 @@ node "$PATCHER" "$LIVE_HTACCESS" "$ACTION" "$VERSION" "$CHARTS_VERSION" || patch
 
 # Keep a timestamped copy on the box, so a bad patch is one cp away from being undone without
 # needing this script or a deploy.
-echo "ssh -i $SSH_LOCATION -p $SSH_PORT $CURRENT_HOST \"cp $GRID_ROOT_DIR/$REMOTE $BACKUP\""
 if ! ssh -i $SSH_LOCATION -p $SSH_PORT $CURRENT_HOST "cp $GRID_ROOT_DIR/$REMOTE $BACKUP"
 then
     patchFailed "Could not back up the live root .htaccess.";
@@ -101,7 +99,6 @@ fi
 # Upload beside the live file and rename over it: scp writes in place, so an interrupted
 # transfer straight onto .htaccess would leave the site with a truncated one. mv within the
 # same directory is atomic, so a reader sees either the old file or the new one.
-echo "scp -i $SSH_LOCATION -P $SSH_PORT local -> $CURRENT_HOST:$STAGED"
 if ! scp -i $SSH_LOCATION -P $SSH_PORT "$LIVE_HTACCESS" $CURRENT_HOST:$STAGED
 then
     patchFailed "Could not upload the patched root .htaccess.";
@@ -112,6 +109,4 @@ then
 fi
 rm -f "$LIVE_HTACCESS"
 
-echo "Root .htaccess patched. Previous copy kept at $BACKUP"
-echo "NOTE: a docs deploy resets the in-flight block. That is how the exemption is removed at"
-echo "      GA, but it also means a mid-cycle docs deploy drops it - re-run this if so."
+echo "$GRID_ROOT_DIR/$REMOTE updated - previous copy at $BACKUP"

--- a/scripts/uncached-archives.mjs
+++ b/scripts/uncached-archives.mjs
@@ -58,17 +58,23 @@ const versionIn = (prefix) => {
 const current = { grid: versionIn(GRID_PREFIX), charts: versionIn(CHARTS_PREFIX) };
 const show = (g, c) => (g || c ? `grid ${g ?? 'none'}, charts ${c ?? 'none'}` : 'nothing in flight');
 
-console.log(`current: ${show(current.grid, current.charts)}`);
 if (!action) {
+    console.log(show(current.grid, current.charts));
     process.exit(0);
 }
 
+// clear is a no-op, not a failure, when there is nothing of ours to clear. It runs from a
+// release step that must not fail the build for finding the block already in the state it
+// wants - and a cycle that has moved on to other versions is not this step's to end.
 if (action === 'clear' && (current.grid !== grid || current.charts !== charts)) {
-    console.error(
-        `\nREFUSING: ${show(current.grid, current.charts)} is in flight, not grid ${grid}, charts ${charts}.`
-    );
-    console.error('clear only ends the cycle it was given, so a stale GA step cannot end a newer one.');
-    process.exit(1);
+    if (!current.grid && !current.charts) {
+        console.log('nothing in flight - nothing to clear');
+    } else {
+        console.log(
+            `left alone: ${show(current.grid, current.charts)} is in flight, not grid ${grid}, charts ${charts}`
+        );
+    }
+    process.exit(0);
 }
 
 const after = action === 'set' ? [rule(GRID_PREFIX, grid), rule(CHARTS_PREFIX, charts)] : [];
@@ -78,21 +84,14 @@ const tail = source.slice(e);
 const next = head + (after.length ? '\n' + after.join('\n') : '') + '\n' + tail;
 
 if (next === source) {
-    console.log('\nAlready in that state - nothing to do.');
+    console.log(`already ${action === 'set' ? `set: grid ${grid}, charts ${charts}` : 'clear'}`);
     process.exit(0);
 }
 // next is built from source's own head and tail, so this guards the construction, not a diff.
 if (!next.startsWith(head) || !next.endsWith(tail)) {
-    console.error('\nREFUSING: the change would touch bytes outside the marker block.');
+    console.error('REFUSING: the change would touch bytes outside the marker block.');
     process.exit(1);
 }
 
-console.log('\nchanges, all inside the marker block:');
-before.filter((l) => !after.includes(l)).forEach((l) => console.log(`  - ${l}`));
-after.filter((l) => !before.includes(l)).forEach((l) => console.log(`  + ${l}`));
-console.log(
-    `\n${head.split('\n').length - 1} lines before the block and ${tail.split('\n').length - 1} after it are unchanged.`
-);
-
 writeFileSync(file, next);
-console.log(`\napplied to ${file}`);
+console.log(action === 'set' ? `set grid ${grid}, charts ${charts}` : `cleared grid ${grid}, charts ${charts}`);


### PR DESCRIPTION
A GA step running `clear` when nothing was in flight failed the build:

```
[14:45:13][Step 11/14] REFUSING: nothing in flight is in flight, not grid 36.1.0, charts 14.1.0.
[14:45:13][Step 11/14] clear only ends the cycle it was given, so a stale GA step cannot end a newer one.
```

Two problems: it exited non-zero for something that is not an error, and it was far too loud for a build log. (The mangled sentence was the empty-state string being interpolated into a template that assumed a version.)

## clear is now idempotent

Finding the block already in the state it wants, or finding a cycle that has moved on to other versions, is reported and exits **0**. Neither is that step's problem to solve.

The guard itself is unchanged — a mismatched `clear` still leaves the block alone, so a stale GA step still cannot end a newer cycle. Only the failure mode changed.

## One line per outcome

| Invocation | Output | Exit |
| --- | --- | --- |
| *(no action)* | `grid 36.1.0, charts 14.1.0` | 0 |
| `set 36.1.0 14.1.0` | `set grid 36.1.0, charts 14.1.0` | 0 |
| `set` again, unchanged | `already set: grid 36.1.0, charts 14.1.0` | 0 |
| `clear 36.1.0 14.1.0`, matching | `cleared grid 36.1.0, charts 14.1.0` | 0 |
| `clear`, nothing in flight | `nothing in flight - nothing to clear` | **0** |
| `clear`, other versions set | `left alone: grid 36.1.0, charts 14.1.0 is in flight, not grid 36.2.0, charts 14.1.0` | **0** |

`set` loses the change listing, the unchanged-line counts and the `applied to <path>` trailer. The wrapper loses its three echoed `ssh`/`scp` command lines and the two-line trailing note. A successful run is one line per file.

## Real failures stay loud

Checked explicitly, since making `clear` lenient must not make anything else lenient:

```
no marker block      exit 1
bad version          exit 2
unknown action       exit 2
missing charts arg   exit 2
```

`set` → `clear` still round-trips the file byte-for-byte.
