### PR TITLE
AG-8950 pre refactor

### DIFF
--- a/packages/ag-grid-enterprise/src/advancedFilter/advancedFilterExpressionService.ts
+++ b/packages/ag-grid-enterprise/src/advancedFilter/advancedFilterExpressionService.ts
@@ -183,7 +183,7 @@ export class AdvancedFilterExpressionService extends BeanStub implements NamedBe
     private expressionJoinOperators: { AND: string; OR: string };
     private expressionEvaluatorParams: { [colId: string]: FilterExpressionEvaluatorParams<any> } = Object.create(null);
     /** Keyed by data type as well as column: a model's `filterType` need not be the column's current one. */
-    private columnExpressionOperators: { [dataType: string]: WeakMap<AgColumn, ColumnOperators> } = Object.create(null);
+    private columnExpressionOperators = new WeakMap<AgColumn, { [dataType: string]: ColumnOperators }>();
 
     public postConstruct(): void {
         this.expressionJoinOperators = this.generateExpressionJoinOperators();
@@ -445,16 +445,16 @@ export class AdvancedFilterExpressionService extends BeanStub implements NamedBe
         if (!column) {
             return { operators: dataTypeOperators, activeOperators: dataTypeOperators.defaultOperators };
         }
-        const byDataType = this.columnExpressionOperators;
-        let forDataType = byDataType[baseCellDataType!];
-        if (!forDataType) {
-            forDataType = new WeakMap();
-            byDataType[baseCellDataType!] = forDataType;
+        const byColumn = this.columnExpressionOperators;
+        let byDataType = byColumn.get(column);
+        if (!byDataType) {
+            byDataType = Object.create(null) as { [dataType: string]: ColumnOperators };
+            byColumn.set(column, byDataType);
         }
-        let columnOperators = forDataType.get(column);
+        let columnOperators = byDataType[baseCellDataType!];
         if (!columnOperators) {
             columnOperators = this.createColumnOperators(dataTypeOperators, column);
-            forDataType.set(column, columnOperators);
+            byDataType[baseCellDataType!] = columnOperators;
         }
         return columnOperators;
     }
@@ -473,7 +473,13 @@ export class AdvancedFilterExpressionService extends BeanStub implements NamedBe
         const operators = customOptions.size
             ? createCustomOptionOperators(dataTypeOperators, customOptions, localeTextFunc)
             : dataTypeOperators;
-        const activeOperators = [...offered.keys()].filter((key) => _getOwn(operators.operators, key));
+        const operatorsByKey = operators.operators;
+        const activeOperators: string[] = [];
+        for (const key of offered.keys()) {
+            if (_getOwn(operatorsByKey, key)) {
+                activeOperators.push(key);
+            }
+        }
         return {
             operators,
             activeOperators: activeOperators.length ? activeOperators : dataTypeOperators.defaultOperators,
@@ -610,6 +616,6 @@ export class AdvancedFilterExpressionService extends BeanStub implements NamedBe
         this.columnAutocompleteEntries = null;
         this.columnNameToIdMap = Object.create(null);
         this.expressionEvaluatorParams = Object.create(null);
-        this.columnExpressionOperators = Object.create(null);
+        this.columnExpressionOperators = new WeakMap();
     }
 }

--- a/packages/ag-grid-enterprise/src/advancedFilter/autocomplete/agAutocomplete.ts
+++ b/packages/ag-grid-enterprise/src/advancedFilter/autocomplete/agAutocomplete.ts
@@ -66,7 +66,6 @@ export class AgAutocomplete extends Component<AgAutocompleteEvent> {
     private autocompleteListParams: AutocompleteListParams;
     private lastPosition: number = 0;
     private valid: boolean = true;
-    private validationMessage: string | null;
     private listAriaLabel: string;
     private listGenerator?: (value: string | null, position: number) => AutocompleteListParams;
     private validator?: (value: string | null) => string | null;
@@ -248,7 +247,7 @@ export class AgAutocomplete extends Component<AgAutocompleteEvent> {
         if (!this.validator) {
             return;
         }
-        const validationMessage = (this.validationMessage = this.validator(value));
+        const validationMessage = this.validator(value);
         this.eAutocompleteInput.getInputElement().setCustomValidity(validationMessage ?? '');
         this.valid = !validationMessage;
         this.dispatchLocalEvent<AutocompleteValidChangedEvent>({

--- a/packages/ag-grid-enterprise/src/advancedFilter/autocomplete/agAutocompleteList.ts
+++ b/packages/ag-grid-enterprise/src/advancedFilter/autocomplete/agAutocompleteList.ts
@@ -210,7 +210,7 @@ export class AgAutocompleteList extends AgPopupComponent<
         const selectedValue = this.selectedValue;
         if (!matches.length && selectedValue && forceLastSelection?.(selectedValue, searchString)) {
             matches = [selectedValue];
-            topIndex = -1;
+            topIndex = 0;
         }
 
         this.autocompleteEntries = matches;

--- a/packages/ag-grid-enterprise/src/advancedFilter/autocomplete/agAutocompleteList.ts
+++ b/packages/ag-grid-enterprise/src/advancedFilter/autocomplete/agAutocompleteList.ts
@@ -2,7 +2,6 @@ import {
     AgPopupComponent,
     RefPlaceholder,
     _exists,
-    _fuzzySuggestions,
     _isVisible,
     _setAriaActiveDescendant,
     _setAriaSelected,
@@ -57,6 +56,8 @@ export class AgAutocompleteList extends AgPopupComponent<
 
     // as the user moves the mouse, the selectedValue changes
     private selectedValue: AutocompleteEntry;
+    /** Where `selectedValue` sits, so a list is not searched on every mousemove. */
+    private selectedIndex = -1;
 
     private searchString = '';
     private lastAutoListHeight: number | null = null;
@@ -65,7 +66,6 @@ export class AgAutocompleteList extends AgPopupComponent<
         private readonly params: {
             autocompleteEntries: AutocompleteEntry[];
             onConfirmed: () => void;
-            useFuzzySearch?: boolean;
             useStartsWithSearch?: boolean;
             autoSizeList?: boolean;
             maxVisibleItems?: number;
@@ -104,10 +104,10 @@ export class AgAutocompleteList extends AgPopupComponent<
     }
 
     public getActiveOptionId(): string | null {
-        const selectedValue = this.selectedValue;
-        const index = selectedValue ? this.autocompleteEntries.indexOf(selectedValue) : -1;
+        const index = this.selectedIndex;
 
-        return index >= 0 ? this.getOptionId(index) : null;
+        // The cached position is only good while it still holds the selection, the entries having changed.
+        return index >= 0 && this.autocompleteEntries[index] === this.selectedValue ? this.getOptionId(index) : null;
     }
 
     public getListId(): string {
@@ -121,7 +121,8 @@ export class AgAutocompleteList extends AgPopupComponent<
             return;
         }
 
-        const oldIndex = this.autocompleteEntries.indexOf(this.selectedValue);
+        const cachedIndex = this.selectedIndex;
+        const oldIndex = this.autocompleteEntries[cachedIndex] === this.selectedValue ? cachedIndex : -1;
         let nextIndex = 0;
         if (oldIndex >= 0) {
             nextIndex = key === KeyCode.UP ? oldIndex - 1 : oldIndex + 1;
@@ -145,90 +146,77 @@ export class AgAutocompleteList extends AgPopupComponent<
         this.updateSearchInList();
     }
 
+    /**
+     * Entries holding the search string, and the index of the one to suggest: the shortest starting with
+     * it, otherwise the shortest holding it, the first offered winning a tie. `-1` where nothing matched.
+     */
     private runContainsSearch(
         searchString: string,
-        searchStrings: string[]
-    ): { topMatch: string | undefined; allMatches: string[] } {
-        let topMatch: string | undefined;
-        let topMatchStartsWithSearchString = false;
+        entries: AutocompleteEntry[]
+    ): { matches: AutocompleteEntry[]; topIndex: number } {
         const lowerCaseSearchString = searchString.toLocaleLowerCase();
-        const allMatches = searchStrings.filter((string) => {
-            const lowerCaseString = string.toLocaleLowerCase();
-            const index = lowerCaseString.indexOf(lowerCaseSearchString);
-            const startsWithSearchString = index === 0;
-            const isMatch = index >= 0;
-            // top match is shortest value that starts with the search string, otherwise shortest value that includes the search string
-            if (
-                isMatch &&
-                (!topMatch ||
-                    (!topMatchStartsWithSearchString && startsWithSearchString) ||
-                    (topMatchStartsWithSearchString === startsWithSearchString && string.length < topMatch.length))
-            ) {
-                topMatch = string;
-                topMatchStartsWithSearchString = startsWithSearchString;
+        const matches: AutocompleteEntry[] = [];
+        let topIndex = -1;
+        let topLength = 0;
+        let topStartsWith = false;
+        for (let i = 0, len = entries.length; i < len; ++i) {
+            const entry = entries[i];
+            const text = entry.displayValue ?? entry.key;
+            const index = text.toLocaleLowerCase().indexOf(lowerCaseSearchString);
+            if (index < 0) {
+                continue;
             }
-            return isMatch;
-        });
-        if (!topMatch && allMatches.length) {
-            topMatch = allMatches[0];
+            const startsWith = index === 0;
+            if (
+                topIndex < 0 ||
+                (!topStartsWith && startsWith) ||
+                (topStartsWith === startsWith && text.length < topLength)
+            ) {
+                topIndex = matches.length;
+                topLength = text.length;
+                topStartsWith = startsWith;
+            }
+            matches.push(entry);
         }
-        return { topMatch, allMatches };
+        return { matches, topIndex };
     }
 
-    private runStartsWithSearch(
-        searchString: string,
-        searchStrings: string[]
-    ): { topMatch: string | undefined; allMatches: string[] } {
+    private runStartsWithSearch(searchString: string, entries: AutocompleteEntry[]): AutocompleteEntry[] {
         const lowerCaseSearchString = searchString.toLocaleLowerCase();
-        const allMatches = searchStrings.filter((string) =>
-            string.toLocaleLowerCase().startsWith(lowerCaseSearchString)
-        );
-        const topMatch = allMatches[0];
-        return { topMatch, allMatches };
+        const matches: AutocompleteEntry[] = [];
+        for (let i = 0, len = entries.length; i < len; ++i) {
+            const entry = entries[i];
+            const text = entry.displayValue ?? entry.key;
+            if (text.toLocaleLowerCase().startsWith(lowerCaseSearchString)) {
+                matches.push(entry);
+            }
+        }
+        return matches;
     }
 
-    private runSearch() {
-        const { autocompleteEntries, useFuzzySearch, useStartsWithSearch, forceLastSelection } = this.params;
-        const searchStrings = autocompleteEntries.map((v) => v.displayValue ?? v.key);
+    /** One pass, producing the list to show and the row to suggest together, per keystroke. */
+    private runSearch(): void {
+        const { autocompleteEntries, useStartsWithSearch, forceLastSelection } = this.params;
+        const searchString = this.searchString;
 
-        let matchingStrings: string[];
-        let topSuggestion: string | undefined;
-        if (useFuzzySearch) {
-            matchingStrings = _fuzzySuggestions({
-                inputValue: this.searchString,
-                allSuggestions: searchStrings,
-                hideIrrelevant: true,
-            }).values;
-            topSuggestion = matchingStrings.length ? matchingStrings[0] : undefined;
+        let matches: AutocompleteEntry[];
+        let topIndex = 0;
+        if (useStartsWithSearch) {
+            matches = this.runStartsWithSearch(searchString, autocompleteEntries);
         } else {
-            const matches = useStartsWithSearch
-                ? this.runStartsWithSearch(this.searchString, searchStrings)
-                : this.runContainsSearch(this.searchString, searchStrings);
-            matchingStrings = matches.allMatches;
-            topSuggestion = matches.topMatch;
+            ({ matches, topIndex } = this.runContainsSearch(searchString, autocompleteEntries));
         }
 
-        let filteredEntries = autocompleteEntries.filter(({ key, displayValue }) =>
-            matchingStrings.includes(displayValue ?? key)
-        );
-        if (
-            !filteredEntries.length &&
-            this.selectedValue &&
-            forceLastSelection?.(this.selectedValue, this.searchString)
-        ) {
-            filteredEntries = [this.selectedValue];
+        const selectedValue = this.selectedValue;
+        if (!matches.length && selectedValue && forceLastSelection?.(selectedValue, searchString)) {
+            matches = [selectedValue];
+            topIndex = -1;
         }
-        this.autocompleteEntries = filteredEntries;
+
+        this.autocompleteEntries = matches;
         this.refreshVirtualList();
         this.updateListHeight();
-
-        if (!topSuggestion) {
-            return;
-        }
-
-        const topSuggestionIndex = matchingStrings.indexOf(topSuggestion);
-
-        this.checkSetSelectedValue(topSuggestionIndex);
+        this.checkSetSelectedValue(topIndex);
     }
 
     private updateSearchInList(): void {
@@ -278,6 +266,8 @@ export class AgAutocompleteList extends AgPopupComponent<
 
     private setSelectedValue(index: number): void {
         const value = this.autocompleteEntries[index];
+        // An empty list has no row to point at, so the position stays unset rather than naming row 0.
+        this.selectedIndex = value === undefined ? -1 : index;
 
         if (this.selectedValue === value) {
             this.refreshRenderedRowsAria();
@@ -325,11 +315,15 @@ export class AgAutocompleteList extends AgPopupComponent<
         return `${this.getListId()}-option-${index}`;
     }
 
-    private createRowComponent(value: AutocompleteEntry, listItemElement: HTMLElement): AutocompleteRowComponent {
+    private createRowComponent(
+        value: AutocompleteEntry,
+        listItemElement: HTMLElement,
+        rowIndex: number
+    ): AutocompleteRowComponent {
         const customRow = this.params.rowComponentCreator?.(value, value === this.selectedValue);
         if (customRow) {
             this.createBean(customRow);
-            this.updateRowAriaProperties(customRow, listItemElement, this.autocompleteEntries.indexOf(value));
+            this.updateRowAriaProperties(customRow, listItemElement, rowIndex);
             return customRow;
         }
 
@@ -337,7 +331,7 @@ export class AgAutocompleteList extends AgPopupComponent<
 
         this.createBean(row);
         row.setState(value.displayValue ?? value.key, value === this.selectedValue);
-        this.updateRowAriaProperties(row, listItemElement, this.autocompleteEntries.indexOf(value));
+        this.updateRowAriaProperties(row, listItemElement, rowIndex);
 
         return row;
     }

--- a/packages/ag-grid-enterprise/src/agStack/agVirtualList.ts
+++ b/packages/ag-grid-enterprise/src/agStack/agVirtualList.ts
@@ -82,7 +82,7 @@ export class AgVirtualList<
 
     protected model: VirtualListModel;
     private readonly renderedRows = new Map<number, { rowComponent: C; eDiv: HTMLDivElement; value: V }>();
-    private componentCreator: (value: V, listItemElement: HTMLElement) => C;
+    private componentCreator: (value: V, listItemElement: HTMLElement, rowIndex: number) => C;
     private componentUpdater: (value: V, component: C) => void;
     private rowHeight = 20;
     private pageSize = -1;
@@ -358,7 +358,9 @@ export class AgVirtualList<
         return false;
     }
 
-    public setComponentCreator(componentCreator: (value: V, listItemElement: HTMLElement) => C): void {
+    public setComponentCreator(
+        componentCreator: (value: V, listItemElement: HTMLElement, rowIndex: number) => C
+    ): void {
         this.componentCreator = componentCreator;
     }
 
@@ -513,7 +515,7 @@ export class AgVirtualList<
         eDiv.style.height = `${rowHeight}px`;
         eDiv.style.top = `${rowHeight * rowIndex}px`;
 
-        const rowComponent = this.componentCreator(value, eDiv);
+        const rowComponent = this.componentCreator(value, eDiv, rowIndex);
 
         rowComponent.addGuiEventListener('focusin', () => (this.lastFocusedRowIndex = rowIndex));
 

--- a/testing/behavioural/src/filters/advanced-filter/advanced-filter-autocomplete.test.ts
+++ b/testing/behavioural/src/filters/advanced-filter/advanced-filter-autocomplete.test.ts
@@ -279,6 +279,45 @@ describe('Advanced Filter - Autocomplete Interaction', () => {
                 └── LEAF id:5 athlete:"" age:null date:"2024-01-01" hasGold:true country:""
             `);
         });
+
+        test('suggests the shortest column starting with the search string, else the shortest containing it', async () => {
+            const api = gridsManager.createGrid('grid1', {
+                columnDefs: [
+                    { field: 'location', filter: true },
+                    { field: 'order', filter: true },
+                    { field: 'won', filter: true },
+                ],
+                rowData: [{ location: 'Rome', order: 1, won: 'yes' }],
+                enableAdvancedFilter: true,
+            });
+            await new GridColumns(api, `top suggestion rule setup`).checkColumns(`
+                CENTER
+                ├── location "Location" width:200
+                ├── order "Order" width:200
+                └── won "Won" width:200
+            `);
+            await asyncSetTimeout(0);
+            const input = getInput(getGridElement(api)! as HTMLElement);
+
+            // All three hold 'o'; only Order starts with it, so length does not decide.
+            typeInto(input, '[o');
+            await asyncSetTimeout(0);
+            selectAutocomplete(input);
+            await asyncSetTimeout(0);
+            expect(input.value).toContain('[Order]');
+
+            const nativeInputValueSetter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')!.set!;
+            nativeInputValueSetter.call(input, '');
+            input.dispatchEvent(new Event('input', { bubbles: true }));
+            await asyncSetTimeout(0);
+
+            // Location and Won hold 'on' and neither starts with it, so the shortest wins.
+            typeInto(input, '[on');
+            await asyncSetTimeout(0);
+            selectAutocomplete(input);
+            await asyncSetTimeout(0);
+            expect(input.value).toContain('[Won]');
+        });
     });
 
     describe('Operator autocomplete', () => {

--- a/testing/behavioural/src/filters/advanced-filter/advanced-filter-autocomplete.test.ts
+++ b/testing/behavioural/src/filters/advanced-filter/advanced-filter-autocomplete.test.ts
@@ -1,3 +1,4 @@
+import { waitFor } from '@testing-library/dom';
 import { GridColumns, GridRows, TestGridsManager, asyncSetTimeout } from 'ag-test-utils';
 
 import type { GridApi, GridOptions } from 'ag-grid-community';
@@ -78,6 +79,15 @@ function pressKey(input: HTMLInputElement, key: string): void {
 /** Returns true if the autocomplete list popup is present in the DOM. */
 function isAutocompleteOpen(): boolean {
     return document.querySelector('.ag-autocomplete-list-popup') !== null;
+}
+
+/** Asserts which row the autocomplete list advertises as active; `null` for none. */
+function expectActiveOption(index: number | null): void {
+    const list = document.querySelector('.ag-autocomplete-list-popup .ag-virtual-list-container');
+    if (!list) {
+        throw new Error('Autocomplete list not found');
+    }
+    expect(list.getAttribute('aria-activedescendant')).toBe(index === null ? null : `${list.id}-option-${index}`);
 }
 
 /**
@@ -812,6 +822,37 @@ describe('Advanced Filter - Autocomplete Interaction', () => {
                     ├── LEAF id:4 athlete:"Li Wei" age:28 date:null hasGold:null country:null
                     └── LEAF id:5 athlete:"" age:null date:"2024-01-01" hasGold:true country:""
                 `);
+        });
+
+        test('retaining a non-first selection keeps it as the active descendant', async () => {
+            const api = gridsManager.createGrid('grid1', DEFAULT_OPTIONS);
+            await new GridColumns(api, `retaining a non-first selection setup`).checkColumns(`
+                CENTER
+                ├── athlete "Athlete" width:200
+                ├── age "Age" width:200
+                ├── date "Date" width:200
+                ├── hasGold "Has Gold" width:200
+                └── country "Country" width:200
+            `);
+            await asyncSetTimeout(0);
+            const input = getInput(getGridElement(api)! as HTMLElement);
+
+            typeInto(input, '[');
+            await asyncSetTimeout(0);
+            expectActiveOption(0);
+
+            // Columns are listed alphabetically, so this moves onto Athlete — not the row a reset would pick.
+            pressKey(input, 'ArrowDown');
+            await asyncSetTimeout(0);
+            expectActiveOption(1);
+
+            // The trailing space matches no column, so the list keeps the last selection as its only row.
+            typeInto(input, '[Athlete ');
+            await waitFor(() => expectActiveOption(0));
+
+            selectAutocomplete(input);
+            await asyncSetTimeout(0);
+            expect(input.value).toContain('[Athlete]');
         });
     });
 


### PR DESCRIPTION
<!-- base: latest -->

# Advanced Filter autocomplete and operator lookup

Groundwork for Set Filter support in the Advanced Filter. None of it is Set Filter specific, so it lands
first.

| scope  | net lines | lines changed | hunks | files changed |
| ------ | --------: | ------------: | ----: | ------------: |
| source |        +1 | 181 (+91 -90) |    35 |      4 edited |
| tests  |       +80 |      80 added |     4 |      1 edited |

## The autocomplete search was quadratic in the matches

`AgAutocompleteList.runSearch` built an array of every entry's text, filtered that to the matching strings,
then filtered the entries by testing each one's text for membership of the match array. That is
O(entries x matches), on every keystroke. It is now a single pass returning the entries to show and the row to
suggest together.

One keystroke in the column autocomplete, headless Chromium, where the entries are the filterable columns:

| entries | keystroke            |   before |  after |
| ------: | -------------------- | -------: | -----: |
|   2 000 | matches every entry  |   2.55ms | 0.30ms |
|   2 000 | narrows to a handful |   0.23ms | 0.17ms |
|  20 000 | matches every entry  | 245.93ms | 0.84ms |
|  20 000 | narrows to a handful |   2.73ms | 0.56ms |

Ten times the entries cost 96x before and 2.8x after.

Three list scans go with it. `AgVirtualList` hands its component creator the row index it already has, rather
than the creator recovering it with `indexOf`, and the list records where its selection sits instead of
searching for it in `getActiveOptionId`, which `onMouseMove` reaches at pointer rate.

The suggestion rule is unchanged and now has a test: the shortest entry starting with the search string,
otherwise the shortest holding it.

## `useFuzzySearch` is dead

`AgAutocompleteList` has three construction sites (`formulaInputAutocompleteFeature`, `calculatedColumnForm`,
`agAutocomplete`), none of which sets the flag, and the class is exported from no entry point. Its sibling
`useStartsWithSearch` is set by the formula input, so only this arm is dead. It put a Levenshtein pass in front
of the two cheap search arms on every keystroke.

`AgAutocomplete.validationMessage`, assigned by `validate` and read nowhere, goes with it.

## Operator tables are keyed by column, then data type

`columnExpressionOperators` was an object of data types holding a `WeakMap` each. It is now one `WeakMap` from
column to a record keyed by data type.

The data type stays in the key rather than collapsing to `WeakMap<AgColumn, ColumnOperators>`.
`getModelOperator` resolves against `model.filterType`, which is public API, so a model restored from storage
or set through `setAdvancedFilterModel` can name a data type the column no longer has, and a single-slot cache
would hand that entry back to the column's own lookup.

`createColumnOperators` builds its narrowed key list in one loop, instead of materialising the offered keys, a
filtered copy and a closure.
