### PR TITLE
AG-18371: Privacy policy copy updates

### DIFF
--- a/documentation/ag-grid-docs/src/pages/community/beyond-the-prompt.astro
+++ b/documentation/ag-grid-docs/src/pages/community/beyond-the-prompt.astro
@@ -475,8 +475,8 @@ const markdownUrl = DISABLE_MARKDOWN_DOCS ? undefined : urlWithBaseUrl('/communi
                                 <label class={styles.notifyCheckbox} for="gdpr_47554">
                                     <input type="checkbox" id="gdpr_47554" name="gdpr[47554]" value="Y" />
                                     <span>
-                                        I'd like to receive product updates, news and marketing communications from AG
-                                        Grid and Bryntum by email. You can unsubscribe at any time.
+                                        Opt in to receive product updates, news, and marketing communications from AG
+                                        Grid and Bryntum. Unsubscribe at any time.
                                     </span>
                                 </label>
                                 <p class={styles.notifyGdprText}>

--- a/documentation/ag-grid-docs/src/pages/community/beyond-the-prompt.astro
+++ b/documentation/ag-grid-docs/src/pages/community/beyond-the-prompt.astro
@@ -474,15 +474,17 @@ const markdownUrl = DISABLE_MARKDOWN_DOCS ? undefined : urlWithBaseUrl('/communi
                             <div class={styles.notifyGdpr}>
                                 <label class={styles.notifyCheckbox} for="gdpr_47554">
                                     <input type="checkbox" id="gdpr_47554" name="gdpr[47554]" value="Y" />
-                                    <span>I am happy to receive emails from AG Grid</span>
+                                    <span>
+                                        I'd like to receive product updates, news and marketing communications from AG
+                                        Grid and Bryntum by email. You can unsubscribe at any time.
+                                    </span>
                                 </label>
                                 <p class={styles.notifyGdprText}>
-                                    You can unsubscribe at any time using the links available in our emails. By
-                                    submitting this form you acknowledge that AG Grid will process your data in
-                                    accordance with our
+                                    By submitting this form, your information will be processed in accordance with our
                                     <a href="https://www.ag-grid.com/privacy/" target="_blank" rel="noopener noreferrer"
-                                        >privacy policy</a
-                                    >.
+                                        >Privacy Policy</a
+                                    >. We will use it to respond to your enquiry and, where applicable, to manage our
+                                    commercial relationship with you.
                                 </p>
                             </div>
 

--- a/documentation/ag-grid-docs/src/utils/markdown-pages/buildPolicyMarkdown.test.ts
+++ b/documentation/ag-grid-docs/src/utils/markdown-pages/buildPolicyMarkdown.test.ts
@@ -48,10 +48,11 @@ describe('buildPolicyMarkdown', () => {
     it('renders the numbered policy body from the .mdoc, including its section headings', async () => {
         const output = await build('privacy');
         expect(output).toContain('# AG Grid Privacy Policy');
-        expect(output).toContain('Effective Date: 6 July 2022');
+        expect(output).toContain('Last Updated: 2 September 2026');
         expect(output).toContain('**Your privacy is important to us.**');
         expect(output).toContain('Introduction');
         expect(output).toContain('Marketing Communications');
+        expect(output).toContain('Purposes Of Processing And Lawful Bases');
     });
 
     it('carries the modern slavery statement’s financial year and version block', async () => {

--- a/external/ag-website-shared/src/components/consent-fields/ProcessingNotice.module.scss
+++ b/external/ag-website-shared/src/components/consent-fields/ProcessingNotice.module.scss
@@ -1,0 +1,7 @@
+@use 'design-system' as *;
+
+.processingNotice {
+    margin-bottom: $spacing-size-4;
+    font-size: var(--text-fs-sm);
+    color: var(--color-text-secondary);
+}

--- a/external/ag-website-shared/src/components/consent-fields/ProcessingNotice.tsx
+++ b/external/ag-website-shared/src/components/consent-fields/ProcessingNotice.tsx
@@ -1,0 +1,6 @@
+import type { FunctionComponent } from 'react';
+
+import styles from './ProcessingNotice.module.scss';
+import { PROCESSING_NOTICE } from './consentMessages';
+
+export const ProcessingNotice: FunctionComponent = () => <p className={styles.processingNotice}>{PROCESSING_NOTICE}</p>;

--- a/external/ag-website-shared/src/components/consent-fields/consentMessages.tsx
+++ b/external/ag-website-shared/src/components/consent-fields/consentMessages.tsx
@@ -5,7 +5,7 @@ import type { ReactElement } from 'react';
  * Consent copy shared by every web-to-lead form, so the wording stays identical
  * across the site. See AG-17996.
  */
-export const CONSENT_LABELS: Record<string, string> = {
+export const CONSENT_LABELS = {
     marketingEmail:
         "I'd like to receive product updates, news and marketing communications from AG Grid and Bryntum by email. You can unsubscribe at any time.",
     emailTracking: 'I consent to tracking of email opens and clicks',
@@ -14,7 +14,7 @@ export const CONSENT_LABELS: Record<string, string> = {
      * France and Italy, so visitors declare it themselves to reveal that checkbox.
      */
     franceOrItaly: 'I live in France or Italy',
-};
+} as const satisfies Record<string, string>;
 
 /** A statement, not a consent — must never be rendered as a checkbox. */
 export const PROCESSING_NOTICE: ReactElement = (

--- a/external/ag-website-shared/src/components/consent-fields/consentMessages.tsx
+++ b/external/ag-website-shared/src/components/consent-fields/consentMessages.tsx
@@ -5,16 +5,9 @@ import type { ReactElement } from 'react';
  * Consent copy shared by every web-to-lead form, so the wording stays identical
  * across the site. See AG-17996.
  */
-export const CONSENT_LABELS: Record<string, ReactElement | string> = {
-    dataProcessing: (
-        <>
-            I agree to my data being processed in accordance with the{' '}
-            <a href={PRIVACY_POLICY_URL} target="_blank" rel="noopener noreferrer">
-                Privacy Policy
-            </a>
-        </>
-    ),
-    marketingEmail: "I'd like to receive product updates and marketing emails",
+export const CONSENT_LABELS: Record<string, string> = {
+    marketingEmail:
+        "I'd like to receive product updates, news and marketing communications from AG Grid and Bryntum by email. You can unsubscribe at any time.",
     emailTracking: 'I consent to tracking of email opens and clicks',
     /**
      * Temporary stand-in for IP geolocation: email tracking consent only applies to
@@ -23,4 +16,14 @@ export const CONSENT_LABELS: Record<string, ReactElement | string> = {
     franceOrItaly: 'I live in France or Italy',
 };
 
-export const DATA_PROCESSING_CONSENT_REQUIRED = 'You must agree to the Privacy Policy to continue';
+/** A statement, not a consent — must never be rendered as a checkbox. */
+export const PROCESSING_NOTICE: ReactElement = (
+    <>
+        By submitting this form, your information will be processed in accordance with our{' '}
+        <a href={PRIVACY_POLICY_URL} target="_blank" rel="noopener noreferrer">
+            Privacy Policy
+        </a>
+        . We will use it to respond to your enquiry and, where applicable, to manage our commercial relationship with
+        you.
+    </>
+);

--- a/external/ag-website-shared/src/components/consent-fields/consentMessages.tsx
+++ b/external/ag-website-shared/src/components/consent-fields/consentMessages.tsx
@@ -7,7 +7,7 @@ import type { ReactElement } from 'react';
  */
 export const CONSENT_LABELS = {
     marketingEmail:
-        "I'd like to receive product updates, news and marketing communications from AG Grid and Bryntum by email. You can unsubscribe at any time.",
+        'Opt in to receive product updates, news, and marketing communications from AG Grid and Bryntum. Unsubscribe at any time.',
     emailTracking: 'I consent to tracking of email opens and clicks',
     /**
      * Temporary stand-in for IP geolocation: email tracking consent only applies to

--- a/external/ag-website-shared/src/components/contact-form/ContactForm.tsx
+++ b/external/ag-website-shared/src/components/contact-form/ContactForm.tsx
@@ -1,8 +1,6 @@
 import { ConsentCheckbox } from '@ag-website-shared/components/consent-fields/ConsentCheckbox';
-import {
-    CONSENT_LABELS,
-    DATA_PROCESSING_CONSENT_REQUIRED,
-} from '@ag-website-shared/components/consent-fields/consentMessages';
+import { ProcessingNotice } from '@ag-website-shared/components/consent-fields/ProcessingNotice';
+import { CONSENT_LABELS } from '@ag-website-shared/components/consent-fields/consentMessages';
 import type { CaptchaTicker } from '@ag-website-shared/components/contact-form/initCaptcha';
 import { initCaptcha } from '@ag-website-shared/components/contact-form/initCaptcha';
 import { Icon } from '@ag-website-shared/components/icon/Icon';
@@ -31,7 +29,7 @@ const {
     captchaSettingsKeyName,
 } = getIsProduction() ? contactFormData.production : contactFormData.default;
 
-const { dataProcessingConsentId, marketingEmailConsentId, emailTrackingConsentId, franceOrItalyId } = getIsProduction()
+const { marketingEmailConsentId, emailTrackingConsentId, franceOrItalyId } = getIsProduction()
     ? CONSENT_FIELD_IDS.production
     : CONSENT_FIELD_IDS.default;
 
@@ -318,16 +316,6 @@ export const ContactForm: FunctionComponent<Props> = ({
             )}
             <div className={styles.consents}>
                 <ConsentCheckbox
-                    id={dataProcessingConsentId}
-                    label={CONSENT_LABELS.dataProcessing}
-                    error={(errors as any)[dataProcessingConsentId]?.message as string}
-                    inputProps={{
-                        value: '1',
-                        ...register(dataProcessingConsentId, { required: DATA_PROCESSING_CONSENT_REQUIRED }),
-                    }}
-                />
-
-                <ConsentCheckbox
                     id={marketingEmailConsentId}
                     label={CONSENT_LABELS.marketingEmail}
                     inputProps={{ value: '1', ...register(marketingEmailConsentId) }}
@@ -360,6 +348,7 @@ export const ContactForm: FunctionComponent<Props> = ({
                     {captchaError && <p className="error">Please click on the reCAPTCHA checkbox</p>}
                 </div>
             </div>
+            <ProcessingNotice />
             <input
                 id="submit-contact-form"
                 className={classnames('button-primary', styles.submitButton, { disabled: isDisabled })}

--- a/external/ag-website-shared/src/components/policies/pages/privacy.astro
+++ b/external/ag-website-shared/src/components/policies/pages/privacy.astro
@@ -37,9 +37,10 @@ const content = POLICY_CONTENT.privacy;
                             <a href="#intro-privacy">Introduction</a>
                         </li>
                         <li>
-                            <a href="#data-what-why">
-                                What Do We Collect And For What Purpose And Ground We Process It
-                            </a>
+                            <a href="#data-what-why">What Data Do We Collect About You</a>
+                        </li>
+                        <li>
+                            <a href="#processing-purposes">Purposes Of Processing And Lawful Bases</a>
                         </li>
                         <li>
                             <a href="#data-how-we-collect">How We Collect Your Personal Data</a>

--- a/external/ag-website-shared/src/components/policies/policyContent.ts
+++ b/external/ag-website-shared/src/components/policies/policyContent.ts
@@ -28,12 +28,12 @@ export const POLICY_CONTENT = {
         metaTitle: 'Privacy Policy',
         description:
             'We take your privacy very seriously at AG Grid. This page outlines our privacy policy which we have updated in light of GDPR.',
-        meta: ['Effective Date: 6 July 2022'],
+        meta: ['Last Updated: 2 September 2026'],
         intro: [
-            "Welcome to AG Grid's Privacy Policy.",
+            'Welcome to the Privacy Policy of AG Grid Ltd (<strong>AG Grid</strong>).',
             '<strong>Your privacy is important to us.</strong>',
-            'At ag-grid, we are fully committed to protecting your personal data and complying with all data privacy laws.',
-            'This policy serves as a guide and reference point for how we may collect and use personal information, and the rights and choices available to all our visitors and customers.',
+            'At AG Grid, we are fully committed to protecting your personal data and complying with all data privacy laws.',
+            'This policy serves as a guide and reference point for how we may collect and use personal information, and the rights and choices available to all our website visitors and customers.',
             'We strongly recommend you read our policy and understand what we collect, how we collect it, what we do with it, how we protect it, and your rights regarding information, <strong>before</strong> you use or access any of our services.',
         ],
     },

--- a/external/ag-website-shared/src/components/trial-licence-form/TrialLicenceForm.tsx
+++ b/external/ag-website-shared/src/components/trial-licence-form/TrialLicenceForm.tsx
@@ -1,8 +1,6 @@
 import { ConsentCheckbox } from '@ag-website-shared/components/consent-fields/ConsentCheckbox';
-import {
-    CONSENT_LABELS,
-    DATA_PROCESSING_CONSENT_REQUIRED,
-} from '@ag-website-shared/components/consent-fields/consentMessages';
+import { ProcessingNotice } from '@ag-website-shared/components/consent-fields/ProcessingNotice';
+import { CONSENT_LABELS } from '@ag-website-shared/components/consent-fields/consentMessages';
 import { Icon } from '@ag-website-shared/components/icon/Icon';
 import { TRIAL_LICENCE_FORM_URL, ZI_FORM_ID } from '@constants';
 import { trackTrialLicenseFormError, trackTrialLicenseFormSuccess } from '@utils/analytics';
@@ -115,7 +113,6 @@ async function submitTrialLicenceFormData({
     lastName,
     email,
     company,
-    dataProcessingConsent,
     marketingEmailConsent,
     emailTrackingConsent,
     franceOrItaly,
@@ -125,7 +122,6 @@ async function submitTrialLicenceFormData({
     lastName: string;
     email: string;
     company: string;
-    dataProcessingConsent: boolean;
     marketingEmailConsent: boolean;
     emailTrackingConsent: boolean;
     franceOrItaly: boolean;
@@ -138,7 +134,6 @@ async function submitTrialLicenceFormData({
                 lastName,
                 email,
                 company,
-                dataProcessingConsent,
                 marketingEmailConsent,
                 emailTrackingConsent,
                 franceOrItaly,
@@ -174,9 +169,6 @@ function useTrialForm({ submitUrl }: Props) {
     } = useRequiredValidation();
     const lastNameError = wasValidated && validatedLastNameError ? validatedLastNameError : '';
 
-    const { checked: dataProcessingConsent, handleCheckedChange: handleDataProcessingConsentChange } = useCheckbox();
-    const dataProcessingConsentError = wasValidated && !dataProcessingConsent ? DATA_PROCESSING_CONSENT_REQUIRED : '';
-
     const { checked: marketingEmailConsent, handleCheckedChange: handleMarketingEmailConsentChange } = useCheckbox();
 
     const {
@@ -202,7 +194,7 @@ function useTrialForm({ submitUrl }: Props) {
             e.preventDefault();
             setWasValidated(true);
 
-            if (validatedEmailError || validatedFirstNameError || validatedLastNameError || !dataProcessingConsent) {
+            if (validatedEmailError || validatedFirstNameError || validatedLastNameError) {
                 setFormState('error');
                 return;
             }
@@ -220,7 +212,6 @@ function useTrialForm({ submitUrl }: Props) {
                     lastName,
                     email,
                     company,
-                    dataProcessingConsent,
                     marketingEmailConsent,
                     emailTrackingConsent,
                     franceOrItaly: isFranceOrItaly,
@@ -261,7 +252,6 @@ function useTrialForm({ submitUrl }: Props) {
             firstName,
             lastName,
             email,
-            dataProcessingConsent,
             marketingEmailConsent,
             emailTrackingConsent,
             isFranceOrItaly,
@@ -280,9 +270,6 @@ function useTrialForm({ submitUrl }: Props) {
         lastName,
         lastNameError,
         handleLastNameChange,
-        dataProcessingConsent,
-        dataProcessingConsentError,
-        handleDataProcessingConsentChange,
         marketingEmailConsent,
         handleMarketingEmailConsentChange,
         emailTrackingConsent,
@@ -306,9 +293,6 @@ export const TrialLicenceForm: FunctionComponent<Props> = ({ submitUrl }: Props)
         lastName,
         lastNameError,
         handleLastNameChange,
-        dataProcessingConsent,
-        dataProcessingConsentError,
-        handleDataProcessingConsentChange,
         marketingEmailConsent,
         handleMarketingEmailConsentChange,
         emailTrackingConsent,
@@ -317,7 +301,7 @@ export const TrialLicenceForm: FunctionComponent<Props> = ({ submitUrl }: Props)
         handleFranceOrItalyChange,
         handleFormSubmit,
     } = useTrialForm({ submitUrl });
-    const hasFormError = Boolean(emailError || firstNameError || lastNameError || dataProcessingConsentError);
+    const hasFormError = Boolean(emailError || firstNameError || lastNameError);
 
     return (
         <form id={ZI_FORM_ID} noValidate className={styles.trialForm} onSubmit={handleFormSubmit}>
@@ -377,18 +361,6 @@ export const TrialLicenceForm: FunctionComponent<Props> = ({ submitUrl }: Props)
 
             <div className={styles.consents}>
                 <ConsentCheckbox
-                    id="data-processing-consent"
-                    label={CONSENT_LABELS.dataProcessing}
-                    error={dataProcessingConsentError}
-                    inputProps={{
-                        name: 'data-processing-consent',
-                        checked: dataProcessingConsent,
-                        onChange: handleDataProcessingConsentChange,
-                        required: true,
-                    }}
-                />
-
-                <ConsentCheckbox
                     id="marketing-email-consent"
                     label={CONSENT_LABELS.marketingEmail}
                     inputProps={{
@@ -421,6 +393,8 @@ export const TrialLicenceForm: FunctionComponent<Props> = ({ submitUrl }: Props)
                     />
                 )}
             </div>
+
+            <ProcessingNotice />
 
             <div className={classnames(styles.actions, 'trial-licence-actions')}>
                 <button

--- a/external/ag-website-shared/src/components/trial-licence-form/TrialLicenceFormStudio.tsx
+++ b/external/ag-website-shared/src/components/trial-licence-form/TrialLicenceFormStudio.tsx
@@ -1,8 +1,6 @@
 import { ConsentCheckbox } from '@ag-website-shared/components/consent-fields/ConsentCheckbox';
-import {
-    CONSENT_LABELS,
-    DATA_PROCESSING_CONSENT_REQUIRED,
-} from '@ag-website-shared/components/consent-fields/consentMessages';
+import { ProcessingNotice } from '@ag-website-shared/components/consent-fields/ProcessingNotice';
+import { CONSENT_LABELS } from '@ag-website-shared/components/consent-fields/consentMessages';
 import { Icon } from '@ag-website-shared/components/icon/Icon';
 import { TRIAL_LICENCE_FORM_URL, ZI_FORM_ID } from '@constants';
 import { trackTrialLicenseFormError, trackTrialLicenseFormSuccess } from '@utils/analytics';
@@ -115,7 +113,6 @@ async function submitTrialLicenceFormData({
     lastName,
     email,
     company,
-    dataProcessingConsent,
     marketingEmailConsent,
     emailTrackingConsent,
     franceOrItaly,
@@ -125,7 +122,6 @@ async function submitTrialLicenceFormData({
     lastName: string;
     email: string;
     company: string;
-    dataProcessingConsent: boolean;
     marketingEmailConsent: boolean;
     emailTrackingConsent: boolean;
     franceOrItaly: boolean;
@@ -138,7 +134,6 @@ async function submitTrialLicenceFormData({
                 lastName,
                 email,
                 company,
-                dataProcessingConsent,
                 marketingEmailConsent,
                 emailTrackingConsent,
                 franceOrItaly,
@@ -174,9 +169,6 @@ function useTrialForm({ submitUrl }: Props) {
     } = useRequiredValidation();
     const lastNameError = wasValidated && validatedLastNameError ? validatedLastNameError : '';
 
-    const { checked: dataProcessingConsent, handleCheckedChange: handleDataProcessingConsentChange } = useCheckbox();
-    const dataProcessingConsentError = wasValidated && !dataProcessingConsent ? DATA_PROCESSING_CONSENT_REQUIRED : '';
-
     const { checked: marketingEmailConsent, handleCheckedChange: handleMarketingEmailConsentChange } = useCheckbox();
 
     const {
@@ -202,7 +194,7 @@ function useTrialForm({ submitUrl }: Props) {
             e.preventDefault();
             setWasValidated(true);
 
-            if (validatedEmailError || validatedFirstNameError || validatedLastNameError || !dataProcessingConsent) {
+            if (validatedEmailError || validatedFirstNameError || validatedLastNameError) {
                 setFormState('error');
                 return;
             }
@@ -220,7 +212,6 @@ function useTrialForm({ submitUrl }: Props) {
                     lastName,
                     email,
                     company,
-                    dataProcessingConsent,
                     marketingEmailConsent,
                     emailTrackingConsent,
                     franceOrItaly: isFranceOrItaly,
@@ -261,7 +252,6 @@ function useTrialForm({ submitUrl }: Props) {
             firstName,
             lastName,
             email,
-            dataProcessingConsent,
             marketingEmailConsent,
             emailTrackingConsent,
             isFranceOrItaly,
@@ -280,9 +270,6 @@ function useTrialForm({ submitUrl }: Props) {
         lastName,
         lastNameError,
         handleLastNameChange,
-        dataProcessingConsent,
-        dataProcessingConsentError,
-        handleDataProcessingConsentChange,
         marketingEmailConsent,
         handleMarketingEmailConsentChange,
         emailTrackingConsent,
@@ -306,9 +293,6 @@ export const TrialLicenceFormStudio: FunctionComponent<Props> = ({ submitUrl }: 
         lastName,
         lastNameError,
         handleLastNameChange,
-        dataProcessingConsent,
-        dataProcessingConsentError,
-        handleDataProcessingConsentChange,
         marketingEmailConsent,
         handleMarketingEmailConsentChange,
         emailTrackingConsent,
@@ -317,7 +301,7 @@ export const TrialLicenceFormStudio: FunctionComponent<Props> = ({ submitUrl }: 
         handleFranceOrItalyChange,
         handleFormSubmit,
     } = useTrialForm({ submitUrl });
-    const hasFormError = Boolean(emailError || firstNameError || lastNameError || dataProcessingConsentError);
+    const hasFormError = Boolean(emailError || firstNameError || lastNameError);
 
     return (
         <form id={ZI_FORM_ID} noValidate className={styles.trialForm} onSubmit={handleFormSubmit}>
@@ -374,18 +358,6 @@ export const TrialLicenceFormStudio: FunctionComponent<Props> = ({ submitUrl }: 
 
             <div className={styles.consents}>
                 <ConsentCheckbox
-                    id="data-processing-consent"
-                    label={CONSENT_LABELS.dataProcessing}
-                    error={dataProcessingConsentError}
-                    inputProps={{
-                        name: 'data-processing-consent',
-                        checked: dataProcessingConsent,
-                        onChange: handleDataProcessingConsentChange,
-                        required: true,
-                    }}
-                />
-
-                <ConsentCheckbox
                     id="marketing-email-consent"
                     label={CONSENT_LABELS.marketingEmail}
                     inputProps={{
@@ -418,6 +390,8 @@ export const TrialLicenceFormStudio: FunctionComponent<Props> = ({ submitUrl }: 
                     />
                 )}
             </div>
+
+            <ProcessingNotice />
 
             <div className={classnames(styles.actions, 'trial-licence-actions')}>
                 <button

--- a/external/ag-website-shared/src/constants.ts
+++ b/external/ag-website-shared/src/constants.ts
@@ -12,13 +12,11 @@ export const RECAPTCHA_URL = 'https://www.google.com/recaptcha/api.js';
  */
 export const CONSENT_FIELD_IDS = {
     default: {
-        dataProcessingConsentId: '00NS900000KbwBF',
         marketingEmailConsentId: '00NS900000KbwBI',
         emailTrackingConsentId: '00NS900000KbwBG',
         franceOrItalyId: '00NS900000KbwBH',
     },
     production: {
-        dataProcessingConsentId: '00NQ500000IfxTS',
         marketingEmailConsentId: '00NQ500000JApXt',
         emailTrackingConsentId: '00NQ500000JApXs',
         franceOrItalyId: '00NQ500000JD5zq',

--- a/external/ag-website-shared/src/content/policies/privacy.mdoc
+++ b/external/ag-website-shared/src/content/policies/privacy.mdoc
@@ -2,19 +2,21 @@
 
     ***
 
-    This privacy notice provides you with details of how we collect and process your personal data through your use of our [site](https://www.ag-grid.com/). By providing us with your data, you warrant to us that you are over 13 years of age. AG Grid Ltd is the data controller and we are responsible for your personal data (referred to as “we”, “us” or “our” in this privacy notice).
+    This privacy notice provides you with details of how we collect and process your personal data through your use of our **site**, when we communicate with you as a prospective customer and/or where you are a customer and your personal data is used to provide and administer our services. AG Grid is the data controller and we are responsible for your personal data (referred to as “we”, “us” or “our” in this privacy notice).
 
     #### **Contact Details**
 
     Our full details are:
 
     Full name of legal entity: **AG Grid Ltd**  
-    Email address: [info@ag-grid.com](mailto:info@ag-grid.com)  
+    Email address: [privacy@ag-grid.com](mailto:privacy@ag-grid.com)  
     Postal address: **AG Grid Ltd, 70 Wilson Street, London, EC2A 2DB, United Kingdom.**
 
-    It is very important that the information we hold about you is accurate and up to date. Please let us know if at any time your personal information changes by emailing us at [info@ag-grid.com](mailto:info@ag-grid.com).
+    It is very important that the information we hold about you is accurate and up to date. Please let us know if at any time your personal information changes by emailing us at [privacy@ag-grid.com](mailto:privacy@ag-grid.com).
 
-2.  ### What Data Do We Collect About You, For What Purpose And On What Ground We Process It {% id="data-what-why" %}
+    Our website and services are not targeted to children; if we become aware you are under the age of 13 we will delete any personal information about you that we hold.
+
+2.  ### What Data Do We Collect About You {% id="data-what-why" %}
 
     ***
 
@@ -22,79 +24,123 @@
 
     #### We may process the following categories of personal data about you:
 
-    **Communication Data** that includes any communication that you send to us whether that be through the contact form on our website, through email, text, social media messaging, social media posting or any other communication that you send us. We process this data for the purposes of communicating with you, for record keeping and for the establishment, pursuance or defence of legal claims. Our lawful ground for this processing is our legitimate interests which in this case are to reply to communications sent to us, to keep records and to establish, pursue or defend legal claims.
+    **Communication Data** that includes any communication that you send to us whether that be through the contact form on our website, through email, text, social media messaging, social media posting or any other communication that you send us.
 
-    **Customer Data** that includes data relating to any purchases of goods and/or services such as your name, title, billing address, delivery address email address, phone number, contact details, purchase details and your card details. We process this data to supply the goods and/or services you have purchased and to keep records of such transactions. Our lawful ground for this processing is the performance of a contract between you and us and/or taking steps at your request to enter into such a contract.
+    **Identity Data** that includes your name, title, email address, phone number, billing address, delivery address and other contact details. Where you are acting on behalf of your employer or another organisation, Identity Data may also include the name of that organisation and your role within it. In a business-to-business context, Identity Data will typically relate to an individual acting as a representative of a corporate customer.
 
-    **User Data** that includes data about how you use our website and any online services together with any data that you post for publication on our website or through other online services. We process this data to operate our website and ensure relevant content is provided to you, to ensure the security of our website, to maintain back- ups of our website and/or databases and to enable publication and administration of our website, other online services and business. Our lawful ground for this processing is our legitimate interests which in this case are to enable us to properly administer our website and our business.
+    **Transaction Data** that includes data relating to purchases of goods and/or services, such as details of the products or services purchased, order history, payment card details and billing information. In a business-to-business context, payment card details will typically relate to a corporate payment method rather than a personal card.
 
-    **Technical Data** that includes data about your use of our website and online services such as your IP address, your login data, details about your browser, length of visit to pages on our website, page views and navigation paths, details about the number of times you use our website, time zone settings and other technology on the devices you use to access our website. The source of this data is from our analytics tracking system. We process this data to analyse your use of our website and other online services, to administer and protect our business and website, to deliver relevant website content and advertisements to you and to understand the effectiveness of our advertising. Our lawful ground for this processing where essential cookies are used (those which are required to enable the website to function) is our legitimate interests which in this case are to enable us to properly administer our website and our business and to grow our business and to decide our marketing strategy. Where non-essential cookies, such as analytics or advertising cookies are used, we will rely on your consent obtained through the cookie banner to process your personal data.
+    **Lead Data** that includes information relating to your interest in our products or services, the source or channel through which you were identified as a prospective customer, company-level firmographic information obtained from third-party business data providers (such as company size, industry and revenue band), and any lead scoring or qualification status assigned to you.
 
-    **Marketing Data** that includes data about your preferences in receiving marketing from us and our third parties and your communication preferences. We process this data to enable you to partake in our promotions such as competitions, prize draws and free give-aways, to deliver relevant website content and advertisements to you and measure or understand the effectiveness of this advertising. Our lawful ground for this processing is our consent, where we have asked for it or legitimate interests, where you have previously purchased from us or expressed an interest in our services or products, which in this case are to study how customers use our products/services, to develop them, to grow our business and to decide our marketing strategy.
+    **User Data** that includes data about how you use our website and any online services together with any data that you post for publication on our website or through other online services.
 
-    We may use Customer Data, User Data, Technical Data and Marketing Data to deliver relevant website content and advertisements to you (including Facebook adverts or other display advertisements) and to measure or understand the effectiveness of the advertising we serve you. Our lawful ground for this processing your consent. We may also use such data to send other marketing communications to you. Our lawful ground for this processing is either consent or legitimate interests (namely to grow our business). **[NOTE SEE SECTION 4 BELOW]**
+    **Technical Data** that includes data about your use of our website and online services such as your IP address, your login data, details about your browser, length of visit to pages on our website, page views and navigation paths, details about the number of times you use our website, time zone settings and other technology on the devices you use to access our website. The source of this data is from our analytics tracking system.
+
+    **Marketing Data** that includes data about your preferences in receiving marketing from us and our third parties and your communication preferences.
 
     **Sensitive Data** We do not collect any Sensitive Data about you. Sensitive data refers to data that includes details about your race or ethnicity, religious or philosophical beliefs, sex life, sexual orientation, political opinions, trade union membership, information about your health and genetic and biometric data. We do not collect any information about criminal convictions and offences.
 
+3.  ### Purposes Of Processing And Lawful Bases {% id="processing-purposes" %}
+
+    ***
+
+    We set out below the purposes for which we process your personal data, the categories of data used for each purpose and the lawful basis on which we rely.
+
+    **Communicating with you**: When you contact us or we contact you, we process your Communication Data and Identity Data for the purposes of responding to your enquiries, corresponding with you and maintaining records of our communications. Our lawful ground for this processing is our legitimate interests, namely to reply to communications sent to us and to keep records of correspondence.
+
+    **Supplying our goods and services**: We process your Identity Data, Transaction Data and Communication Data to supply the goods and/or services you (or your employer or organisation) have purchased, to manage our relationship with you and to keep records of such transactions. Our lawful ground for this processing is the performance of a contract between you (or the organisation you represent) and us and/or taking steps at your request to enter into such a contract.
+
+    **Operating, administering and securing our website**: We process your User Data and Technical Data to operate our website and ensure relevant content is provided to you, to ensure the security of our website, to maintain back-ups of our website and/or databases and to enable publication and administration of our website, other online services and business. Our lawful ground for this processing is our legitimate interests, namely to enable us to properly administer our website and our business. Where essential cookies are used (those which are required to enable the website to function), our lawful ground is our legitimate interests. Where non-essential cookies, such as analytics or advertising cookies, are used, we will rely on your consent obtained through the cookie banner.
+
+    **Marketing and advertising**: We process your Identity Data, Lead Data, Marketing Data, User Data, Technical Data and Communication Data to deliver relevant website content and advertisements to you (including via social media platforms or other display advertisements) on behalf of AG Grid and its group companies, to measure or understand the effectiveness of our advertising, to enable you to partake in our promotions such as competitions, prize draws and free give-aways, and to send you marketing communications. See Section 5 for more information about Marketing including the lawful bases on which we rely.
+
+    **Record keeping and administration**: We process your Communication Data, Identity Data and Transaction Data to maintain appropriate business records. Our lawful ground for this processing is our legitimate interests, namely to ensure we maintain adequate records for internal administrative purposes and to comply with our legal and regulatory obligations.
+
+    **Establishment, pursuance or defence of legal claims**: We may process any category of your personal data where necessary for the establishment, pursuance or defence of legal claims. Our lawful ground for this processing is our legitimate interests, namely to protect and enforce our legal rights, your legal rights and the legal rights of others.
+
     Where we are required to collect personal data by law, or under the terms of the contract between us and you do not provide us with that data when requested, we may not be able to perform the contract (for example, to deliver goods or services to you). If you don’t provide us with the requested data, we may have to cancel a product or service you have ordered but if we do, we will notify you at the time.
 
-    We will only use your personal data for a purpose it was collected for or a reasonably compatible purpose if necessary. For more information on this please email us at [info@ag-grid.com](mailto:info@ag-grid.com). In case we need to use your details for an unrelated new purpose we will let you know and explain the legal grounds for processing.
+    We will only use your personal data for a purpose it was collected for or a reasonably compatible purpose if necessary. For more information on this please email us at [privacy@ag-grid.com](mailto:privacy@ag-grid.com). In case we need to use your details for an unrelated new purpose we will let you know and explain the legal grounds for processing.
 
     We may process your personal data without your knowledge or consent where this is required or permitted by law.
 
     We do not carry out automated decision making or any type of automated profiling.
 
-3.  ### How We Collect Your Personal Data {% id="data-how-we-collect" %}
+4.  ### How We Collect Your Personal Data {% id="data-how-we-collect" %}
 
     ***
 
-    We may collect data about you by you providing the data directly to us (for example by filling in forms on our site or by sending us emails). We may automatically collect certain data from you as you use our website by using cookies and similar technologies. Please see our [Cookie Policy](/cookies) for more details about this.
+    We may collect data about you by you providing the data directly to us (for example by filling in forms on our site or by sending us emails). We may automatically collect certain data from you as you use our website by using cookies and similar technologies. Please see our [**Cookie Policy**](/cookies) for more details about this.
 
     We may receive data from third parties such as analytics providers such as Google based outside the EU, advertising networks such as Facebook based outside the EU, such as search information providers such as Google based outside the EU, providers of technical, payment and delivery services, such as data brokers or aggregators.
 
     We may also receive data from publicly availably sources such as Companies House and the Electoral Register based inside the EU.
 
-4.  ### Marketing Communications {% id="marketing-comms" %}
+    We also receive data from our group companies, including Bryntum AB (Malmskillnadsgatan 44a, 111 57 Stockholm, Sweden; [dpo@bryntum.com](mailto:dpo@bryntum.com)) (**Bryntum**). When you enter your details into the Bryntum website (via contact, download and pricing forms), your Lead Data and Identity Data is transmitted to AG Grid. AG Grid and Bryntum are joint controllers for the collection of this information via the Bryntum website.
+
+    Bryntum provides its privacy notice to you at the point of collection at [https://bryntum.com/privacy-policy/](https://bryntum.com/privacy-policy/) which is the primary source of information about how your personal data is used by Bryntum. As Bryntum and AG Grid are joint controllers, you may also exercise your data subject rights against AG Grid directly by contacting us using the details in this privacy notice.
+
+    AG Grid uses the data it receives from Bryntum to conduct commercial follow-up regarding Bryntum’s products and services, to qualify leads (including by applying company-level firmographic information obtained from third-party business data providers, such as company size, industry and revenue band — no additional individual-level personal data is obtained from such providers) and to manage the commercial pipeline. AG Grid conducts these activities as an independent controller of your personal data and relies on legitimate interests (namely to optimise its marketing strategy and grow its business) to respond to specific requests for information from the Bryntum website.
+
+    AG Grid may also send individuals who have registered interest on the Bryntum website direct marketing communications about its own products and services and those of Bryntum, subject to obtaining your consent where required. See Section 5 for more information about our marketing activities and the lawful bases on which we rely.
+
+    We may also receive Identity Data from third-party business data providers (e.g. Zoominfo) who supply company-level firmographic information (such as company size, industry and revenue band) for the purposes of lead qualification. No additional individual-level personal data is obtained from such providers.
+
+5.  ### Marketing Communications {% id="marketing-comms" %}
 
     ***
 
-    Our lawful ground of processing your personal data to send you marketing communications is either your consent or our legitimate interests (namely to grow our business).
+    Our lawful ground for processing your personal data to send you marketing communications depends on the circumstances. Where you have given us your specific consent to receive marketing communications from us and our group companies, we will rely on that consent. You may have provided this consent on the Bryntum website at the time your personal data was collected.
 
-    Under the Privacy and Electronic Communications Regulations, we may send you marketing communications from us if:
-    - you made a purchase or asked for information from us about our goods or services or
-    - you agreed to receive marketing communications and in each case you have not opted out of receiving such communications since. Under these regulations, if you are a limited company, we may send you marketing emails without your consent. However you can still opt out of receiving marketing emails from us at any time.
+    Where you are:
+    - an existing customer who has previously purchased goods or services from us (or enquired about them); or
+    - an individual contacted in your capacity as an employee or representative of a company, and we are marketing our goods and services to that company (a corporate subscriber),
+
+    we may rely on our legitimate interests (namely to grow our business). In these cases you can still opt out of receiving marketing emails from us at any time.
+
+    The marketing you will receive from us will usually relate to our goods and services but where we think it may be of interest to you, you may also receive marketing that promotes the goods and services of Bryntum. Your personal data is not shared with Bryntum for this purpose. Marketing promoting Bryntum will be sent on the following bases:
+    - Where we rely on consent to send you marketing about AG Grid and group companies, we will send marketing relating to Bryntum on the basis of this consent.
+    - If we do not rely on your consent to send you marketing about AG Grid then we will only send you marketing about Bryntum if you have not opted out of our marketing messages and you are a corporate subscriber. In this case we will continue to rely on our legitimate interests (namely to grow our business) to send you marketing.
+
+    This is conducted in AG Grid’s capacity as Bryntum’s authorised commercial agent.
+
+    You can ask us to stop sending you marketing communications at any time by following the opt-out links on any marketing message sent to you or by emailing us at [info@ag-grid.com](mailto:info@ag-grid.com). If you opt out of receiving marketing communications, this does not affect the lawful processing of your personal data for other purposes (such as the performance of a contract or the provision of services you have requested).
 
     Before we share your personal data with any third party for their own marketing purposes we will get your express consent.
 
-    You can ask us or third parties to stop sending you marketing messages at any time by following the opt-out links on any marketing message sent to you or by emailing us at [info@ag-grid.com](mailto:info@ag-grid.com) at any time.
+    You can ask us or third parties to stop sending you marketing messages at any time by following the opt-out links on any marketing message sent to you or by emailing us at [privacy@ag-grid.com](mailto:privacy@ag-grid.com) at any time.
 
     If you opt out of receiving marketing communications this opt-out does not apply to personal data provided as a result of other transactions, such as purchases, warranty registrations etc.
 
-5.  ### Disclosures Of Your Personal Data {% id="data-disclosure" %}
+6.  ### Disclosures Of Your Personal Data {% id="data-disclosure" %}
 
     ***
 
     #### We may have to share your personal data with the parties set out below:
-    - Service providers who provide IT and system administration services.
-    - Professional advisers including lawyers, bankers, auditors and insurers
-    - Government bodies that require us to report processing activities.
+    - Service providers who provide IT and system administration services, including customer relationship management (CRM) platform providers, cloud hosting and infrastructure providers, and website analytics providers.
+    - Professional advisers including lawyers, bankers, auditors and insurers who provide consultancy, banking, legal, insurance and accounting services.
+    - Government and regulatory bodies, tax authorities and other authorities who require us to report processing activities or where disclosure is required by law.
+    - Our group companies, including Bryntum, in connection with the activities described in this privacy notice.
     - Third parties to whom we sell, transfer, or merge parts of our business or our assets.
+    - Third-party business data providers who supply company-level firmographic information for the purposes of lead qualification and marketing.
+    - Advertising networks and marketing platform providers who assist us in delivering and measuring the effectiveness of our advertising.
+    - Payment and delivery service providers who assist in fulfilling transactions.
 
-        We require all third parties to whom we transfer your data to respect the security of your personal data and to treat it in accordance with the law. We only allow such third parties to process your personal data for specified purposes and in accordance with our instructions.
+    We require all third parties to whom we transfer your data to respect the security of your personal data and to treat it in accordance with the law. We only allow such third parties to process your personal data for specified purposes and in accordance with our instructions.
 
-6.  ### International Transfers {% id="intl-transfers" %}
+7.  ### International Transfers {% id="intl-transfers" %}
 
     ***
 
-    Countries outside of the European Economic Area **(EEA)** do not always offer the same levels of protection to your personal data, so European law has prohibited transfers of personal data outside of the EEA unless the transfer meets certain criteria.
+    Countries outside of the United Kingdom and the European Economic Area (**EEA**) do not always offer the same levels of protection to your personal data, so data protection law restricts transfers of personal data outside of the UK and the EEA unless the transfer meets certain criteria.
 
-    Many of our third party service providers are based outside the European Economic Area **(EEA)** so their processing of your personal data will involve a transfer of data outside the EEA.
+    Some of our group companies and third-party service providers are based outside the United Kingdom. In particular, we receive personal data from Bryntum, which is based in Sweden (within the EEA). The transfer of personal data from the EEA to the United Kingdom is covered by the European Commission’s adequacy decision for the UK. We also have a subsidiary in the United States, and some of our service providers may process data in the United States or other countries outside the UK and the EEA.
 
-    Whenever we transfer your personal data out of the EEA, we do our best to ensure a similar degree of security of data by ensuring one of the following safeguards is in place:
-    - We will only transfer your personal data to countries that the European Commission have approved as providing an adequate level of protection for personal data by; or
-    - Where we use certain service providers, we may use specific contracts or codes of conduct or certification mechanisms approved by the European Commission which give personal data the same protection it has in Europe; or
+    Whenever we transfer your personal data outside of the UK or the EEA, we ensure that an appropriate safeguard is in place, including one or more of the following:
+    - the transfer of your personal data is to a country that have been recognised as providing an adequate level of protection for personal data (whether by the UK Government or the European Commission, as applicable); or
+    - we have entered into specific contracts approved for international transfers (such as the UK International Data Transfer Agreement or EU Standard Contractual Clauses), or other codes of conduct or certification mechanisms approved under applicable data protection law, which give personal data appropriate protection.
 
-7.  ### Data Security {% id="data-security" %}
+8.  ### Data Security {% id="data-security" %}
 
     ***
 
@@ -102,7 +148,7 @@
 
     We have procedures in place to deal with any suspected personal data breach and will notify you and any applicable regulator of a breach if we are legally required to.
 
-8.  ### Data Retention {% id="data-retention" %}
+9.  ### Data Retention {% id="data-retention" %}
 
     ***
 
@@ -110,36 +156,42 @@
 
     When deciding what the correct time is to keep the data for we look at its amount, nature and sensitivity, potential risk of harm from unauthorised use or disclosure, the processing purposes, if these can be achieved by other means and legal requirements.
 
-    For tax purposes the law requires us to keep basic information about our customers (including Contact, Identity, Financial and Transaction Data) for six years after they stop being customers.
+    For tax purposes the law requires us to keep basic information about our customers (including Identity Data, Communication Data and Transaction Data) for six years after they stop being customers.
 
     In some circumstances we may anonymise your personal data for research or statistical purposes in which case we may use this information indefinitely without further notice to you.
 
-9.  ### Your Legal Rights {% id="legal-rights" %}
+10. ### Your Legal Rights {% id="legal-rights" %}
 
     ***
 
-    Under data protection laws you have rights in relation to your personal data that include the right to request access, correction, erasure, restriction, transfer, to object to processing, to portability of data and (where the lawful ground of processing is consent) to withdraw consent.
+    Under data protection laws you have rights in relation to your personal data that include:
+    - **Right of access:** to request a copy of the personal data we hold about you
+    - **Right to rectification:** to request that we correct inaccurate or incomplete personal data
+    - **Right to erasure:** to request that we delete your personal data in certain circumstances
+    - **Right to restriction:** to request that we restrict our processing of your personal data in certain circumstances
+    - **Right to data portability:** to receive personal data you have provided to us in a structured, commonly used, and machine-readable format, or to have it transmitted to another controller, where processing is based on consent or contract
+    - **Right to object:** to object to processing based on legitimate interests, in which case we will cease that processing unless we can demonstrate compelling legitimate grounds that override your interests, rights, and freedoms, or unless the processing is necessary for the establishment, exercise, or defence of legal claims
+    - **Right to withdraw consent:** where processing is based on your consent, to withdraw that consent at any time without affecting the lawfulness of processing carried out before withdrawal
+    - **Rights in relation to automated decision-making:** not to be subject to decisions based solely on automated processing that produce legal or similarly significant effects on you, except where permitted by law
 
-    You can see more about these rights at: [https://ico.org.uk/for-organisations/guide-to-the-general-data-protection-regulation-gdpr/individual-rights/](https://ico.org.uk/for-organisations/guide-to-the-general-data-protection-regulation-gdpr/individual-rights/)
-
-    If you wish to exercise any of the rights set out above, please email us at [info@ag-grid.com](mailto:info@ag-grid.com).
-
-    You will not have to pay a fee to access your personal data (or to exercise any of the other rights). However, we may charge a reasonable fee if your request is clearly unfounded, repetitive or excessive or refuse to comply with your request in these circumstances.
+    If you wish to exercise any of the rights set out above, please email us at [privacy@ag-grid.com](mailto:privacy@ag-grid.com). You will not have to pay a fee to access your personal data (or to exercise any of the other rights). However, we may charge a reasonable fee if your request is clearly unfounded, repetitive or excessive or refuse to comply with your request in these circumstances.
 
     We may need to request specific information from you to help us confirm your identity and ensure your right to access your personal data (or to exercise any of your other rights). This is a security measure to ensure that personal data is not disclosed to any person who has no right to receive it. We may also contact you to ask you for further information in relation to your request to speed up our response.
 
     We try to respond to all legitimate requests within one month. Occasionally it may take us longer than a month if your request is particularly complex or you have made a number of requests. In this case, we will notify you.
 
-    If you are not happy with any aspect of how we collect and use your data, you have the right to complain to the Information Commissioner’s Office (ICO), the UK supervisory authority for data protection issues [(www.ico.org.uk)](https://www.ico.org.uk). We should be grateful if you would contact us first if you do have a complaint so that we can try to resolve it for you.
+    If you have concerns about how we handle your personal data, you have the right to complain to us using the contact details mentioned in Section 1. We will acknowledge your complaint within 30 days of receipt, investigate and respond to you without undue delay and keep you informed of progress. You also have the right to complain to the Information Commissioner’s Office (ICO), the UK supervisory authority for data protection issues [**(www.ico.org.uk)**](https://www.ico.org.uk). We should be grateful if you would contact us first if you do have a complaint so that we can try to resolve it for you.
 
-10. ### Third-Party Links {% id="third-party-links" %}
+    If you are located in the EEA, you have the right to lodge a complaint with the supervisory authority in your country of residence or place of work, or in the country where you consider an infringement of data protection law has occurred.
+
+11. ### Third-Party Links {% id="third-party-links" %}
 
     ***
 
     This website may include links to third-party websites, plug-ins and applications. Clicking on those links or enabling those connections may allow third parties to collect or share data about you. We do not control these third-party websites and are not responsible for their privacy statements. When you leave our website, we encourage you to read the privacy notice of every website you visit.
 
-11. ### Cookies {% id="cookies-privacy" %}
+12. ### Cookies {% id="cookies-privacy" %}
 
     ***
 
-    You can set your browser to refuse all or some browser cookies, or to alert you when websites set or access cookies. If you disable or refuse cookies, please note that some parts of this website may become inaccessible or not function properly. For more information about the cookies we use, please see: [Our Cookies Policy](/cookies).
+    You can set your browser to refuse all or some browser cookies, or to alert you when websites set or access cookies. If you disable or refuse cookies, please note that some parts of this website may become inaccessible or not function properly. For more information about the cookies we use, please see: [**Our Cookies Policy**](/cookies).


### PR DESCRIPTION
Replaces the privacy policy page copy with the v3 document from the ticket, and realigns the consent copy next to every user-submission form.

- Policy body goes from 11 to 12 sections: the old combined section 2 splits into "What Data Do We Collect About You" and a new "Purposes Of Processing And Lawful Bases". Section 2 keeps its `data-what-why` anchor so inbound deep links still resolve.
- The data-processing consent checkbox is replaced by a processing notice above the submit button, and the marketing consent wording now covers AG Grid and Bryntum in one checkbox.
- Processing is no longer consent-based, so the field is dropped from both submissions rather than auto-filled on the website — the blanket `true` is being applied in Salesforce instead, so it stays website-agnostic.

Needs checking before release:
- The source document has `[DATE]` as its Last Updated value; **2 September 2026** is assumed (in `policyContent.ts` and one test assertion).
- Staging submit on the contact and trial-licence forms, since the field is no longer sent. The trial-licence path goes via the `CreateLeadForTrialLK` cloud function, which isn't in this repo — worth confirming it doesn't require the dropped key.
- Source-document defects transcribed as-is: one stale `info@ag-grid.com` in section 5 where the rest uses `privacy@ag-grid.com`, and a near-duplicate opt-out paragraph. One "Brytum" typo was corrected to "Bryntum".
- Copy shared via `ag-website-shared`, so it reaches ag-charts and ag-studio on the next subrepo push.