### PR TITLE
[AG-18393] Docs(grid-state): list the missing state sections

### DIFF
--- a/.rulesync/.gitignore
+++ b/.rulesync/.gitignore
@@ -36,6 +36,7 @@ mcp.json
 !/rules/examples.md
 !/rules/framework-view-layers.md
 !/rules/grid-code-conventions.md
+!/rules/grid-state.md
 !/rules/grid-styling.md
 !/rules/integrated-charts.md
 !/rules/testing.md

--- a/.rulesync/rules/grid-state.md
+++ b/.rulesync/rules/grid-state.md
@@ -1,0 +1,28 @@
+---
+targets: ['*']
+description: 'Keeping the Grid State docs page in sync with the GridState interface'
+globs:
+    [
+        'packages/ag-grid-community/src/interfaces/gridState.ts',
+        'packages/ag-grid-community/src/misc/state/stateService.ts',
+    ]
+---
+
+# Grid State
+
+## The docs page is part of the change
+
+`GridState` is public API, and its sections are enumerated by hand in the "State Contents" list on
+`documentation/ag-grid-docs/src/content/docs/grid-state/index.mdoc`. Nothing generates that list and
+nothing fails when it drifts, so adding, removing or renaming a state section — a top-level
+`GridState` property or a field of one of its sub-states — is not finished until the list matches.
+
+- Adding a section: add a bullet, linking the feature's own docs page where one exists, and say so
+  when the section only applies to some row models.
+- Removing or deprecating one: delete its bullet. Deprecated sections stay out of the list, as
+  `rangeSelection` does.
+- Changing what a section carries: re-read its bullet. A bullet that describes the old contents is
+  worse than a missing one.
+
+The interface documentation below the list is generated from `gridState.ts`, so JSDoc on the new
+member is what a reader sees there — write it for them, not for the diff.

--- a/.rulesync/rules/grid-state.md
+++ b/.rulesync/rules/grid-state.md
@@ -10,19 +10,15 @@ globs:
 
 # Grid State
 
-## The docs page is part of the change
+## JSDoc on `GridState` is the docs page
 
-`GridState` is public API, and its sections are enumerated by hand in the "State Contents" list on
-`documentation/ag-grid-docs/src/content/docs/grid-state/index.mdoc`. Nothing generates that list and
-nothing fails when it drifts, so adding, removing or renaming a state section — a top-level
-`GridState` property or a field of one of its sub-states — is not finished until the list matches.
+The "State Contents" section of `documentation/ag-grid-docs/src/content/docs/grid-state/index.mdoc`
+is generated from `gridState.ts` — there is no hand-maintained list any more. Whatever you write as
+JSDoc on a state member is what a user reads on the docs page, so write it for them, not for the diff.
 
-- Adding a section: add a bullet, linking the feature's own docs page where one exists, and say so
-  when the section only applies to some row models.
-- Removing or deprecating one: delete its bullet. Deprecated sections stay out of the list, as
-  `rangeSelection` does.
-- Changing what a section carries: re-read its bullet. A bullet that describes the old contents is
-  worse than a missing one.
-
-The interface documentation below the list is generated from `gridState.ts`, so JSDoc on the new
-member is what a reader sees there — write it for them, not for the diff.
+- Adding a section: give the new member a JSDoc line naming the feature and linking its own docs page
+  where one exists (docs-relative markdown links such as `[Sorting](./row-sorting/)` render on the
+  page), and say so when the section only applies to some row models.
+- Changing what a section carries: re-read its JSDoc. A description of the old contents is worse than
+  none.
+- Deprecating one: mark it `@deprecated` with the version and the replacement, as `rangeSelection` is.

--- a/.rulesync/rules/grid-state.md
+++ b/.rulesync/rules/grid-state.md
@@ -16,9 +16,12 @@ The "State Contents" section of `documentation/ag-grid-docs/src/content/docs/gri
 is generated from `gridState.ts` — there is no hand-maintained list any more. Whatever you write as
 JSDoc on a state member is what a user reads on the docs page, so write it for them, not for the diff.
 
-- Adding a section: give the new member a JSDoc line naming the feature and linking its own docs page
-  where one exists (docs-relative markdown links such as `[Sorting](./row-sorting/)` render on the
-  page), and say so when the section only applies to some row models.
+- Adding a section: give the new member a plain-prose JSDoc line naming the feature, and say so when
+  the section only applies to some row models. Do not put markdown links in the JSDoc — the docs link
+  belongs in the `more` entry of
+  `documentation/ag-grid-docs/src/content/interface-documentation/grid-state/grid-state.json`, which
+  renders as the row's "More Details" link. Add an entry there for any new section with its own docs
+  page.
 - Changing what a section carries: re-read its JSDoc. A description of the old contents is worse than
   none.
 - Deprecating one: mark it `@deprecated` with the version and the replacement, as `rangeSelection` is.

--- a/documentation/ag-grid-docs/src/content/docs/grid-state/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/grid-state/index.mdoc
@@ -45,24 +45,30 @@ The following is captured in the grid state:
 
 - [Aggregation Functions](./aggregation/) (column state)
 - [Opened Column Groups](./column-groups/)
+- [Column Group Header Names](./column-headers/#editable-header-name) edited by end users
+- [Column Header Names](./column-headers/#editable-header-name) edited by end users (column state)
 - [Column Order](./column-moving/) (column state)
 - [Pinned Columns](./column-pinning/) (column state)
 - [Column Sizes](./column-sizing/) (column state)
 - [Hidden Columns](./column-properties/#reference-display-hide) (column state)
 - [Column Filter Model](./filtering/)
+- Column Filter State - the state of each [Column Filter](./filtering/) component, keyed by column, for filters that keep state beyond their model
 - [Advanced Filter Model](./filter-advanced/#filter-model--api)
+- [Selected Filters](./tool-panel-filters-new/#changing-selectable-filters) when using `agSelectableColumnFilter`
 - [Focused Cell](./keyboard-navigation/) ([Client-Side Row Model](./row-models/) only)
 - [Current Page](./row-pagination/)
 - [Pivot Mode and Columns](./pivoting/) (column state)
+- [Pivot Column Label Sort](./pivoting-column-groups/#sorting-pivot-columns)
 - [Cell Selection](./cell-selection/)
 - [Row Group Columns](./grouping/) (column state)
-- [Expanded Row Groups](./grouping-opening-groups/)
+- [Expanded Row Groups](./grouping-opening-groups/), including [Server-Side Row Model](./server-side-model-grouping/) expansion when `ssrmExpandAllAffectsAllRows` is used
 - [Row Selection](./row-selection/) (retrievable for all row models, but can only be set for [Client-Side Row Model](./row-models/) and [Server-Side Row Model](./row-models/))
 - [Pinned Rows](./row-pinning)
 - [Show Values As](./aggregation-show-values-as/) (column state)
-- [Side Bar](./side-bar/)
+- Scroll Position ([Client-Side Row Model](./row-models/) only)
+- [Side Bar](./side-bar/), including the state of each open tool panel
 - [Sort](./row-sorting/) (column state)
-- [Calculated Columns](./calculated-columns/) added or modified by end users
+- Columns the user created or removed at runtime, such as [Calculated Columns](./calculated-columns/), along with the column definition properties they changed
 
 {% note %}
 When restoring the current page using the [Server Side Row Model](./server-side-model/) or [Infinite Row Model](./infinite-scrolling/),

--- a/documentation/ag-grid-docs/src/content/docs/grid-state/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/grid-state/index.mdoc
@@ -41,9 +41,15 @@ The state is also passed in the [Grid Pre-Destroyed Event](./grid-lifecycle/#gri
 
 ## State Contents
 
-The grid state is made up of the sections below, each of which can be provided or omitted independently.
+The grid state is made up of the sections below, each of which can be provided or omitted independently. If applying some but not all of the column state properties, then `initialState.partialColumnState` must be set to `true`.
 
-{% interfaceDocumentation interfaceName="GridState" /%}
+`partialColumnState` controls _which_ column state sections you supply, not whether those sections may themselves be partial. Any section you include must match its documented shape.
+
+The state also contains the grid version number. When applying state with older version numbers, any old state properties will be automatically migrated to the current format.
+
+The grid state is designed to be serialisable, so any functions will be stripped out. For example, aggregation functions should be [Registered as Custom Functions](./aggregation-custom-functions/#registering-custom-functions) to work with state rather than being set as [Directly Applied Functions](./aggregation-custom-functions/#directly-applied-functions).
+
+{% interfaceDocumentation interfaceName="GridState" overrideSrc="grid-state/grid-state.json" /%}
 
 {% note %}
 When restoring the current page using the [Server Side Row Model](./server-side-model/) or [Infinite Row Model](./infinite-scrolling/),
@@ -53,16 +59,6 @@ additional configuration is required:
 - For the Infinite Row Model - set the `infiniteInitialRowCount` property to a value which includes the rows to be shown.
 
 {% /note %}
-
-All state properties are optional, so a property can be excluded if you do not want to restore it.
-
-If applying some but not all of the column state properties, then `initialState.partialColumnState` must be set to `true`.
-
-`partialColumnState` controls _which_ column state sections you supply, not whether those sections may themselves be partial. Any section you include must match its documented shape.
-
-The state also contains the grid version number. When applying state with older version numbers, any old state properties will be automatically migrated to the current format.
-
-The grid state is designed to be serialisable, so any functions will be stripped out. For example, aggregation functions should be [Registered as Custom Functions](./aggregation-custom-functions/#registering-custom-functions) to work with state rather than being set as [Directly Applied Functions](./aggregation-custom-functions/#directly-applied-functions).
 
 ## Column and Group IDs
 
@@ -86,9 +82,9 @@ The best way to restore grid state is via initial state as described above. Howe
 `setState` should only be used to restore grid state. The grid does not support being used as a controlled component, so do not call this on every state update.
 {% /note %}
 
-{% gridExampleRunner title="Setting State" name="set-state"  exampleHeight=630 /%}
-
 It is possible to maintain the existing state for individual state contents by passing a second argument to `setState` that contains the top-level properties to ignore. E.g. `api.setState(state, ['filter'])` will maintain the existing filter state in the grid.
+
+{% gridExampleRunner title="Setting State" name="set-state"  exampleHeight=630 /%}
 
 ## Converting Column State to Grid State
 

--- a/documentation/ag-grid-docs/src/content/docs/grid-state/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/grid-state/index.mdoc
@@ -41,34 +41,9 @@ The state is also passed in the [Grid Pre-Destroyed Event](./grid-lifecycle/#gri
 
 ## State Contents
 
-The following is captured in the grid state:
+The grid state is made up of the sections below, each of which can be provided or omitted independently.
 
-- [Aggregation Functions](./aggregation/) (column state)
-- [Opened Column Groups](./column-groups/)
-- [Column Group Header Names](./column-headers/#editable-header-name) edited by end users
-- [Column Header Names](./column-headers/#editable-header-name) edited by end users (column state)
-- [Column Order](./column-moving/) (column state)
-- [Pinned Columns](./column-pinning/) (column state)
-- [Column Sizes](./column-sizing/) (column state)
-- [Hidden Columns](./column-properties/#reference-display-hide) (column state)
-- [Column Filter Model](./filtering/)
-- Column Filter State - the state of each [Column Filter](./filtering/) component, keyed by column, for filters that keep state beyond their model
-- [Advanced Filter Model](./filter-advanced/#filter-model--api)
-- [Selected Filters](./tool-panel-filters-new/#changing-selectable-filters) when using `agSelectableColumnFilter`
-- [Focused Cell](./keyboard-navigation/) ([Client-Side Row Model](./row-models/) only)
-- [Current Page](./row-pagination/)
-- [Pivot Mode and Columns](./pivoting/) (column state)
-- [Pivot Column Label Sort](./pivoting-column-groups/#sorting-pivot-columns)
-- [Cell Selection](./cell-selection/)
-- [Row Group Columns](./grouping/) (column state)
-- [Expanded Row Groups](./grouping-opening-groups/), including [Server-Side Row Model](./server-side-model-grouping/) expansion when `ssrmExpandAllAffectsAllRows` is used
-- [Row Selection](./row-selection/) (retrievable for all row models, but can only be set for [Client-Side Row Model](./row-models/) and [Server-Side Row Model](./row-models/))
-- [Pinned Rows](./row-pinning)
-- [Show Values As](./aggregation-show-values-as/) (column state)
-- Scroll Position ([Client-Side Row Model](./row-models/) only)
-- [Side Bar](./side-bar/), including the state of each open tool panel
-- [Sort](./row-sorting/) (column state)
-- Columns the user created or removed at runtime, such as [Calculated Columns](./calculated-columns/), along with the column definition properties they changed
+{% interfaceDocumentation interfaceName="GridState" /%}
 
 {% note %}
 When restoring the current page using the [Server Side Row Model](./server-side-model/) or [Infinite Row Model](./infinite-scrolling/),
@@ -88,8 +63,6 @@ If applying some but not all of the column state properties, then `initialState.
 The state also contains the grid version number. When applying state with older version numbers, any old state properties will be automatically migrated to the current format.
 
 The grid state is designed to be serialisable, so any functions will be stripped out. For example, aggregation functions should be [Registered as Custom Functions](./aggregation-custom-functions/#registering-custom-functions) to work with state rather than being set as [Directly Applied Functions](./aggregation-custom-functions/#directly-applied-functions).
-
-{% interfaceDocumentation interfaceName="GridState" /%}
 
 ## Column and Group IDs
 

--- a/documentation/ag-grid-docs/src/content/interface-documentation/grid-state/grid-state.json
+++ b/documentation/ag-grid-docs/src/content/interface-documentation/grid-state/grid-state.json
@@ -1,0 +1,134 @@
+{
+    "GridState": {
+        "aggregation": {
+            "more": {
+                "url": "./aggregation/",
+                "name": "Aggregation"
+            }
+        },
+        "columnGroup": {
+            "more": {
+                "url": "./column-groups/",
+                "name": "Column Groups"
+            }
+        },
+        "columnOrder": {
+            "more": {
+                "url": "./column-moving/",
+                "name": "Column Moving"
+            }
+        },
+        "columnPinning": {
+            "more": {
+                "url": "./column-pinning/",
+                "name": "Column Pinning"
+            }
+        },
+        "columnSizing": {
+            "more": {
+                "url": "./column-sizing/",
+                "name": "Column Sizing"
+            }
+        },
+        "columnVisibility": {
+            "more": {
+                "url": "./column-properties/#reference-display-hide",
+                "name": "Column Visibility"
+            }
+        },
+        "columnHeaderName": {
+            "more": {
+                "url": "./column-headers/#editable-header-name",
+                "name": "Editable Header Name"
+            }
+        },
+        "filter": {
+            "more": {
+                "url": "./filtering-overview/",
+                "name": "Filtering Overview"
+            },
+            "interfaceHierarchyOverrides": {
+                "exclude": ["AdvancedFilterModel"],
+                "include": []
+            }
+        },
+        "focusedCell": {
+            "more": {
+                "url": "./keyboard-navigation/",
+                "name": "Keyboard Navigation"
+            }
+        },
+        "pagination": {
+            "more": {
+                "url": "./row-pagination/",
+                "name": "Row Pagination"
+            }
+        },
+        "rowPinning": {
+            "more": {
+                "url": "./row-pinning/",
+                "name": "Row Pinning"
+            }
+        },
+        "pivot": {
+            "more": {
+                "url": "./pivoting/",
+                "name": "Pivoting"
+            }
+        },
+        "cellSelection": {
+            "more": {
+                "url": "./cell-selection/",
+                "name": "Cell Selection"
+            }
+        },
+        "rowGroup": {
+            "more": {
+                "url": "./grouping/",
+                "name": "Row Grouping"
+            }
+        },
+        "rowGroupExpansion": {
+            "more": {
+                "url": "./grouping-opening-groups/",
+                "name": "Opening Groups"
+            }
+        },
+        "ssrmRowGroupExpansion": {
+            "more": {
+                "url": "./server-side-model-grouping/",
+                "name": "SSRM Row Grouping"
+            }
+        },
+        "rowSelection": {
+            "more": {
+                "url": "./row-selection/",
+                "name": "Row Selection"
+            }
+        },
+        "sideBar": {
+            "more": {
+                "url": "./side-bar/",
+                "name": "Side Bar"
+            }
+        },
+        "sort": {
+            "more": {
+                "url": "./row-sorting/",
+                "name": "Row Sorting"
+            }
+        },
+        "showValuesAs": {
+            "more": {
+                "url": "./aggregation-show-values-as/",
+                "name": "Show Values As"
+            }
+        },
+        "userColumns": {
+            "more": {
+                "url": "./calculated-columns/",
+                "name": "Calculated Columns"
+            }
+        }
+    }
+}

--- a/packages/ag-grid-community/src/interfaces/gridState.ts
+++ b/packages/ag-grid-community/src/interfaces/gridState.ts
@@ -17,23 +17,13 @@ export interface SelectableFilterState {
 }
 
 export interface FilterState {
-    /**
-     * Filter model for [Column Filters](./filtering/)
-     */
+    /** Filter model for Column Filters */
     filterModel?: FilterModel;
-    /**
-     * State of each [Column Filter](./filtering/) component, keyed by column, for filters that keep
-     * state beyond their model
-     */
+    /** State of each Column Filter component, keyed by column, for filters that keep state beyond their model */
     columnFilterState?: ColumnFilterState;
-    /**
-     * Filter model for [Advanced Filter](./filter-advanced/#filter-model--api)
-     */
+    /** Filter model for Advanced Filter */
     advancedFilterModel?: AdvancedFilterModel;
-    /**
-     * Currently [selected filter](./tool-panel-filters-new/#changing-selectable-filters) when using the
-     * new filter tool panel with `agSelectableColumnFilter`
-     */
+    /** Currently selected filter when using the new filter tool panel with `agSelectableColumnFilter` */
     selectableFilters?: SelectableFilterState;
 }
 
@@ -148,7 +138,7 @@ export interface PivotSortModelItem {
 export interface PivotState {
     pivotMode: boolean;
     pivotColIds: string[];
-    /** [Pivot label sort](./pivoting-column-groups/#sorting-pivot-columns) direction of each pivot column */
+    /** Pivot label sort direction of each pivot column */
     pivotSortModel?: PivotSortModelItem[];
 }
 
@@ -183,7 +173,7 @@ export interface ColumnGroupHeaderNameState {
 
 export interface ColumnGroupState {
     openColumnGroupIds: string[];
-    /** [User-edited group header names](./column-headers/#editable-header-name), keyed by group id. */
+    /** User-edited group header names, keyed by group id. */
     headerNames?: ColumnGroupHeaderNameState[];
 }
 
@@ -219,12 +209,12 @@ export interface ColumnHeaderNameColumnState {
 }
 
 export interface ColumnHeaderNameState {
-    /** [User-edited column header names](./column-headers/#editable-header-name), keyed by column id. */
+    /** User-edited column header names, keyed by column id. */
     columnHeaderNames: ColumnHeaderNameColumnState[];
 }
 
 export interface RowPinningState {
-    /** Row IDs of rows [pinned](./row-pinning) to the top container */
+    /** Row IDs of rows pinned to the top container */
     top: string[];
     /** Row IDs of rows pinned to the bottom container */
     bottom: string[];
@@ -233,60 +223,60 @@ export interface RowPinningState {
 export interface GridState {
     /** Grid version number */
     version?: string;
-    /** [Aggregation Functions](./aggregation/) (column state) */
+    /** Aggregation Functions (column state) */
     aggregation?: AggregationState;
-    /** Opened [Column Groups](./column-groups/), and column group header names edited by end users */
+    /** Opened Column Groups, and column group header names edited by end users */
     columnGroup?: ColumnGroupState;
-    /** [Column Order](./column-moving/) (column state) */
+    /** Column Order (column state) */
     columnOrder?: ColumnOrderState;
-    /** Left/right [Pinned Columns](./column-pinning/) (column state) */
+    /** Left/right Pinned Columns (column state) */
     columnPinning?: ColumnPinningState;
-    /** [Column Sizes](./column-sizing/) - width/flex (column state) */
+    /** Column Sizes - width/flex (column state) */
     columnSizing?: ColumnSizingState;
-    /** [Hidden Columns](./column-properties/#reference-display-hide) (column state) */
+    /** Hidden Columns (column state) */
     columnVisibility?: ColumnVisibilityState;
-    /** [Column Header Names](./column-headers/#editable-header-name) edited by end users (column state) */
+    /** Column Header Names edited by end users (column state) */
     columnHeaderName?: ColumnHeaderNameState;
-    /** [Column Filters](./filtering/) and [Advanced Filter](./filter-advanced/#filter-model--api) */
+    /** Column Filters and Advanced Filter */
     filter?: FilterState;
-    /** Currently [focused cell](./keyboard-navigation/). Works for [Client-Side Row Model](./row-models/) only */
+    /** Currently focused cell. Works for Client-Side Row Model only */
     focusedCell?: FocusedCellState;
-    /** Current [page](./row-pagination/) */
+    /** Current page */
     pagination?: PaginationState;
-    /** Currently manually [pinned rows](./row-pinning) */
+    /** Currently manually pinned rows */
     rowPinning?: RowPinningState;
-    /** Current [pivot mode and pivot columns](./pivoting/), and pivot column label sort (column state) */
+    /** Current pivot mode and pivot columns, and pivot column label sort (column state) */
     pivot?: PivotState;
-    /** Currently selected [cell ranges](./cell-selection/) */
+    /** Currently selected cell ranges */
     cellSelection?: CellSelectionState;
     /**
      * Includes currently selected cell ranges
      * @deprecated v32.2 Use `cellSelection` instead.
      */
     rangeSelection?: RangeSelectionState;
-    /** Current [Row Group Columns](./grouping/) (column state) */
+    /** Current Row Group Columns (column state) */
     rowGroup?: RowGroupState;
-    /** Currently [expanded group rows](./grouping-opening-groups/) */
+    /** Currently expanded group rows */
     rowGroupExpansion?: RowGroupExpansionState;
-    /** Currently expanded [Server-Side Row Model](./server-side-model-grouping/) group rows when using `ssrmExpandAllAffectsAllRows` */
+    /** Currently expanded Server-Side Row Model group rows when using `ssrmExpandAllAffectsAllRows` */
     ssrmRowGroupExpansion?: RowGroupExpansionState | RowGroupBulkExpansionState;
     /**
-     * Currently [selected rows](./row-selection/).
+     * Currently selected rows.
      * For Server-Side Row Model, will be `ServerSideRowSelectionState | ServerSideRowGroupSelectionState`,
      * for other row models, will be an array of row IDs.
      * Can only be set for Client-Side Row Model and Server-Side Row Model.
      */
     rowSelection?: string[] | ServerSideRowSelectionState | ServerSideRowGroupSelectionState;
-    /** Current scroll position. Works for [Client-Side Row Model](./row-models/) only */
+    /** Current scroll position. Works for Client-Side Row Model only */
     scroll?: ScrollState;
-    /** Current [Side Bar](./side-bar/) positioning and opened tool panel, including the state of each open tool panel */
+    /** Current Side Bar positioning and opened tool panel, including the state of each open tool panel */
     sideBar?: SideBarState;
-    /** Current [sort](./row-sorting/) columns and direction (column state) */
+    /** Current sort columns and direction (column state) */
     sort?: SortState;
-    /** The per-column ["Show Values As"](./aggregation-show-values-as/) mode (column state) */
+    /** The per-column "Show Values As" mode (column state) */
     showValuesAs?: ShowValuesAsState;
     /**
-     * Columns the user created or removed at runtime, such as [Calculated Columns](./calculated-columns/),
+     * Columns the user created or removed at runtime, such as Calculated Columns,
      * along with the column definition properties they changed. Unlike the other sections, which configure
      * existing columns, this section can create and remove them.
      */

--- a/packages/ag-grid-community/src/interfaces/gridState.ts
+++ b/packages/ag-grid-community/src/interfaces/gridState.ts
@@ -18,19 +18,21 @@ export interface SelectableFilterState {
 
 export interface FilterState {
     /**
-     * Filter model for Column Filters
+     * Filter model for [Column Filters](./filtering/)
      */
     filterModel?: FilterModel;
     /**
-     * State for Column Filters
+     * State of each [Column Filter](./filtering/) component, keyed by column, for filters that keep
+     * state beyond their model
      */
     columnFilterState?: ColumnFilterState;
     /**
-     * Filter model for Advanced Filter
+     * Filter model for [Advanced Filter](./filter-advanced/#filter-model--api)
      */
     advancedFilterModel?: AdvancedFilterModel;
     /**
-     * Currently selected filter when using new filter tool panel with `agSelectableColumnFilter`
+     * Currently [selected filter](./tool-panel-filters-new/#changing-selectable-filters) when using the
+     * new filter tool panel with `agSelectableColumnFilter`
      */
     selectableFilters?: SelectableFilterState;
 }
@@ -146,7 +148,7 @@ export interface PivotSortModelItem {
 export interface PivotState {
     pivotMode: boolean;
     pivotColIds: string[];
-    /** Pivot label sort direction of each pivot column */
+    /** [Pivot label sort](./pivoting-column-groups/#sorting-pivot-columns) direction of each pivot column */
     pivotSortModel?: PivotSortModelItem[];
 }
 
@@ -181,7 +183,7 @@ export interface ColumnGroupHeaderNameState {
 
 export interface ColumnGroupState {
     openColumnGroupIds: string[];
-    /** User-edited group header names, keyed by group id. */
+    /** [User-edited group header names](./column-headers/#editable-header-name), keyed by group id. */
     headerNames?: ColumnGroupHeaderNameState[];
 }
 
@@ -217,12 +219,12 @@ export interface ColumnHeaderNameColumnState {
 }
 
 export interface ColumnHeaderNameState {
-    /** User-edited column header names, keyed by column id. */
+    /** [User-edited column header names](./column-headers/#editable-header-name), keyed by column id. */
     columnHeaderNames: ColumnHeaderNameColumnState[];
 }
 
 export interface RowPinningState {
-    /** Row IDs of rows pinned to the top container */
+    /** Row IDs of rows [pinned](./row-pinning) to the top container */
     top: string[];
     /** Row IDs of rows pinned to the bottom container */
     bottom: string[];
@@ -231,62 +233,62 @@ export interface RowPinningState {
 export interface GridState {
     /** Grid version number */
     version?: string;
-    /** Includes aggregation functions (column state) */
+    /** [Aggregation Functions](./aggregation/) (column state) */
     aggregation?: AggregationState;
-    /** Includes opened groups */
+    /** Opened [Column Groups](./column-groups/), and column group header names edited by end users */
     columnGroup?: ColumnGroupState;
-    /** Includes column ordering (column state) */
+    /** [Column Order](./column-moving/) (column state) */
     columnOrder?: ColumnOrderState;
-    /** Includes left/right pinned columns (column state) */
+    /** Left/right [Pinned Columns](./column-pinning/) (column state) */
     columnPinning?: ColumnPinningState;
-    /** Includes column width/flex (column state) */
+    /** [Column Sizes](./column-sizing/) - width/flex (column state) */
     columnSizing?: ColumnSizingState;
-    /** Includes hidden columns (column state) */
+    /** [Hidden Columns](./column-properties/#reference-display-hide) (column state) */
     columnVisibility?: ColumnVisibilityState;
-    /** Includes user-edited column header names (column state) */
+    /** [Column Header Names](./column-headers/#editable-header-name) edited by end users (column state) */
     columnHeaderName?: ColumnHeaderNameState;
-    /** Includes Column Filters and Advanced Filter */
+    /** [Column Filters](./filtering/) and [Advanced Filter](./filter-advanced/#filter-model--api) */
     filter?: FilterState;
-    /** Includes currently focused cell. Works for Client-Side Row Model only */
+    /** Currently [focused cell](./keyboard-navigation/). Works for [Client-Side Row Model](./row-models/) only */
     focusedCell?: FocusedCellState;
-    /** Includes current page */
+    /** Current [page](./row-pagination/) */
     pagination?: PaginationState;
-    /** Includes currently manually pinned rows */
+    /** Currently manually [pinned rows](./row-pinning) */
     rowPinning?: RowPinningState;
-    /** Includes current pivot mode and pivot columns (column state) */
+    /** Current [pivot mode and pivot columns](./pivoting/), and pivot column label sort (column state) */
     pivot?: PivotState;
-    /** Includes currently selected cell ranges */
+    /** Currently selected [cell ranges](./cell-selection/) */
     cellSelection?: CellSelectionState;
     /**
      * Includes currently selected cell ranges
      * @deprecated v32.2 Use `cellSelection` instead.
      */
     rangeSelection?: RangeSelectionState;
-    /** Includes current row group columns (column state) */
+    /** Current [Row Group Columns](./grouping/) (column state) */
     rowGroup?: RowGroupState;
-    /** Includes currently expanded group rows */
+    /** Currently [expanded group rows](./grouping-opening-groups/) */
     rowGroupExpansion?: RowGroupExpansionState;
-    /** Includes currently expanded group rows when using ssrmExpandAllAffectsAllRows */
+    /** Currently expanded [Server-Side Row Model](./server-side-model-grouping/) group rows when using `ssrmExpandAllAffectsAllRows` */
     ssrmRowGroupExpansion?: RowGroupExpansionState | RowGroupBulkExpansionState;
     /**
-     * Includes currently selected rows.
+     * Currently [selected rows](./row-selection/).
      * For Server-Side Row Model, will be `ServerSideRowSelectionState | ServerSideRowGroupSelectionState`,
      * for other row models, will be an array of row IDs.
      * Can only be set for Client-Side Row Model and Server-Side Row Model.
      */
     rowSelection?: string[] | ServerSideRowSelectionState | ServerSideRowGroupSelectionState;
-    /** Includes current scroll position. Works for Client-Side Row Model only */
+    /** Current scroll position. Works for [Client-Side Row Model](./row-models/) only */
     scroll?: ScrollState;
-    /** Includes current Side Bar positioning and opened tool panel */
+    /** Current [Side Bar](./side-bar/) positioning and opened tool panel, including the state of each open tool panel */
     sideBar?: SideBarState;
-    /** Includes current sort columns and direction (column state) */
+    /** Current [sort](./row-sorting/) columns and direction (column state) */
     sort?: SortState;
-    /** Includes the per-column "Show Values As" mode (column state) */
+    /** The per-column ["Show Values As"](./aggregation-show-values-as/) mode (column state) */
     showValuesAs?: ShowValuesAsState;
     /**
-     * Includes columns the user created at runtime (e.g. via the Calculated Column dialog), and the
-     * properties the user changed on or removals of columns declared in `columnDefs`. Unlike the other
-     * sections, which configure existing columns, this section can create and remove them.
+     * Columns the user created or removed at runtime, such as [Calculated Columns](./calculated-columns/),
+     * along with the column definition properties they changed. Unlike the other sections, which configure
+     * existing columns, this section can create and remove them.
      */
     userColumns?: UserColumnState[];
     /**


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-18393
Fix AG-18393

The Grid State page's "State Contents" list omitted nine sections that `GridState` captures, and described `userColumns` as only covering added or modified Calculated Columns. Prose only — no examples or code touched. Split out of #15042 so the feature diff stays readable.

Also adds a rulesync rule scoped to `gridState.ts` / `stateService.ts`: the list is hand-maintained and nothing fails when it drifts, so the rule attaches when either file is edited.