### PR TITLE
[AG-18402] Fix(column-sizing): debounce viewport-driven continuous auto-size

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/column-sizing/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/column-sizing/index.mdoc
@@ -217,7 +217,7 @@ Every strategy re-runs when the displayed columns change and when the grid is re
 - `fitCellContents` re-runs on any change to the row data, and on viewport changes, because both change what there is to measure — scrolling is what brings new cell content into view.
 - The width-distribution strategies, `fitGridWidth` and `fitProvidedWidth`, are arithmetic over the current column set, so scrolling cannot change their result. They re-run on new data, a page change, and a scrollbar appearing or disappearing — the changes to the width there is to share out.
 
-Triggers arriving in the same frame are coalesced into a single re-size, and viewport changes are debounced, so scrolling re-sizes once the scroll settles rather than on every frame.
+Triggers arriving in the same frame are coalesced into a single re-size. Viewport and grid-size changes are debounced on top of that, so scrolling and resizing the grid re-size once the gesture settles rather than on every frame.
 
 Provide `shouldAutoSizeColumns` to take control of each re-size. It is called first, with the eligible `columns` and a `reason` of `'dataChanged'`, `'columnsChanged'`, `'viewportChanged'` or `'gridSizeChanged'`. Return `false` to skip that re-size, leaving the widths untouched. The callback has no effect unless `continuous` is `true`.
 

--- a/documentation/ag-grid-docs/src/content/docs/column-sizing/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/column-sizing/index.mdoc
@@ -217,7 +217,7 @@ Every strategy re-runs when the displayed columns change and when the grid is re
 - `fitCellContents` re-runs on any change to the row data, and on viewport changes, because both change what there is to measure — scrolling is what brings new cell content into view.
 - The width-distribution strategies, `fitGridWidth` and `fitProvidedWidth`, are arithmetic over the current column set, so scrolling cannot change their result. They re-run on new data, a page change, and a scrollbar appearing or disappearing — the changes to the width there is to share out.
 
-Triggers arriving in the same frame are coalesced into a single re-size.
+Triggers arriving in the same frame are coalesced into a single re-size, and viewport changes are debounced, so scrolling re-sizes once the scroll settles rather than on every frame.
 
 Provide `shouldAutoSizeColumns` to take control of each re-size. It is called first, with the eligible `columns` and a `reason` of `'dataChanged'`, `'columnsChanged'`, `'viewportChanged'` or `'gridSizeChanged'`. Return `false` to skip that re-size, leaving the widths untouched. The callback has no effect unless `continuous` is `true`.
 

--- a/packages/ag-grid-community/src/columnAutosize/columnAutosizeService.ts
+++ b/packages/ag-grid-community/src/columnAutosize/columnAutosizeService.ts
@@ -42,10 +42,11 @@ const UI_MENU_SOURCES: ReadonlySet<ColumnEventType> = new Set(['columnMenu', 'co
 type AutoSizeReason = AutoSizeColumnsTriggerParams['reason'];
 
 /**
- * Matches `SCROLL_END_TIMEOUT`, so viewport re-sizes settle when the grid considers scrolling finished
- * rather than jittering once per frame through a scroll.
+ * Matches `SCROLL_END_TIMEOUT`, so a re-size driven by a gesture that streams events — a scroll, a
+ * resize drag — settles when the grid considers that gesture finished, rather than jittering once per
+ * frame throughout it.
  */
-const CONTINUOUS_VIEWPORT_DEBOUNCE = 150;
+const CONTINUOUS_STREAMING_DEBOUNCE = 150;
 
 /** Escalating waits for a continuous re-size that arrived before the grid had a width. */
 const CONTINUOUS_RETRY_DELAYS: readonly number[] = [0, 100, 500];
@@ -74,10 +75,10 @@ export class ColumnAutosizeService extends BeanStub implements NamedBean {
     private continuousRetries = 0;
     private continuousRetryScheduled = false;
 
-    private readonly scheduleViewportAutoSize = _debounce(
+    private readonly runDebouncedContinuousAutoSize = _debounce(
         this,
-        () => this.scheduleContinuousAutoSize('viewportChanged'),
-        CONTINUOUS_VIEWPORT_DEBOUNCE
+        () => this.scheduleContinuousAutoSize(),
+        CONTINUOUS_STREAMING_DEBOUNCE
     );
 
     public postConstruct(): void {
@@ -694,7 +695,8 @@ export class ColumnAutosizeService extends BeanStub implements NamedBean {
             cellValueChanged: () => this.scheduleContinuousAutoSize('dataChanged'),
             displayedColumnsChanged: () => this.scheduleContinuousAutoSize('columnsChanged'),
             newColumnsLoaded: () => this.scheduleContinuousAutoSize('columnsChanged'),
-            gridSizeChanged: () => this.scheduleContinuousAutoSize('gridSizeChanged'),
+            // a resize drag streams one event per frame, so it settles like a scroll does
+            gridSizeChanged: () => this.scheduleDebouncedContinuousAutoSize('gridSizeChanged'),
             // a scrollbar appearing or disappearing changes the width there is to work with. A row count
             // change is the usual cause, and a transaction reports neither `newData` nor `newPage`, so for
             // the width-distribution strategies this is the only signal that one happened
@@ -714,20 +716,32 @@ export class ColumnAutosizeService extends BeanStub implements NamedBean {
 
         this.addManagedEventListeners({
             // horizontal virtualisation renders new columns, which are then measurable for the first time
-            virtualColumnsChanged: () => this.scheduleViewportAutoSize(),
-            viewportChanged: () => this.scheduleViewportAutoSize(),
+            virtualColumnsChanged: () => this.scheduleDebouncedContinuousAutoSize('viewportChanged'),
+            viewportChanged: () => this.scheduleDebouncedContinuousAutoSize('viewportChanged'),
             bodyScroll: (event: BodyScrollEvent) => {
                 if (event.direction === 'horizontal') {
-                    this.scheduleViewportAutoSize();
+                    this.scheduleDebouncedContinuousAutoSize('viewportChanged');
                 }
             },
         });
     }
 
+    /**
+     * Holds a re-size off until the triggers stop arriving, for the gestures that stream them — a scroll,
+     * a resize drag. The reason is recorded as it arrives, so a gesture overlapping another still reports
+     * the most significant of them once the run lands.
+     */
+    private scheduleDebouncedContinuousAutoSize(reason: AutoSizeReason): void {
+        (this.pendingReasons ??= new Set()).add(reason);
+        this.runDebouncedContinuousAutoSize();
+    }
+
     /** Coalesces every trigger in the current frame into at most one evaluation. */
-    private scheduleContinuousAutoSize(reason: AutoSizeReason): void {
+    private scheduleContinuousAutoSize(reason?: AutoSizeReason): void {
         const pendingReasons = (this.pendingReasons ??= new Set());
-        pendingReasons.add(reason);
+        if (reason) {
+            pendingReasons.add(reason);
+        }
 
         // a run in flight picks these up on completion, so no nested run may start
         if (this.continuousRunning || this.continuousFrameScheduled) {

--- a/packages/ag-grid-community/src/columnAutosize/columnAutosizeService.ts
+++ b/packages/ag-grid-community/src/columnAutosize/columnAutosizeService.ts
@@ -1,4 +1,4 @@
-import { _getInnerWidth, _removeFromArray, _requestAnimationFrame } from 'ag-stack';
+import { _debounce, _getInnerWidth, _removeFromArray, _requestAnimationFrame } from 'ag-stack';
 
 import { dispatchColumnResizedEvent } from '../columns/columnEventUtils';
 import { getWidthOfColsInList, isSpecialCol } from '../columns/columnUtils';
@@ -41,6 +41,12 @@ const UI_MENU_SOURCES: ReadonlySet<ColumnEventType> = new Set(['columnMenu', 'co
 
 type AutoSizeReason = AutoSizeColumnsTriggerParams['reason'];
 
+/**
+ * Matches `SCROLL_END_TIMEOUT`, so viewport re-sizes settle when the grid considers scrolling finished
+ * rather than jittering once per frame through a scroll.
+ */
+const CONTINUOUS_VIEWPORT_DEBOUNCE = 150;
+
 /** Escalating waits for a continuous re-size that arrived before the grid had a width. */
 const CONTINUOUS_RETRY_DELAYS: readonly number[] = [0, 100, 500];
 
@@ -67,6 +73,12 @@ export class ColumnAutosizeService extends BeanStub implements NamedBean {
     private pendingReasons: Set<AutoSizeReason> | null = null;
     private continuousRetries = 0;
     private continuousRetryScheduled = false;
+
+    private readonly scheduleViewportAutoSize = _debounce(
+        this,
+        () => this.scheduleContinuousAutoSize('viewportChanged'),
+        CONTINUOUS_VIEWPORT_DEBOUNCE
+    );
 
     public postConstruct(): void {
         const { gos } = this;
@@ -702,11 +714,11 @@ export class ColumnAutosizeService extends BeanStub implements NamedBean {
 
         this.addManagedEventListeners({
             // horizontal virtualisation renders new columns, which are then measurable for the first time
-            virtualColumnsChanged: () => this.scheduleContinuousAutoSize('viewportChanged'),
-            viewportChanged: () => this.scheduleContinuousAutoSize('viewportChanged'),
+            virtualColumnsChanged: () => this.scheduleViewportAutoSize(),
+            viewportChanged: () => this.scheduleViewportAutoSize(),
             bodyScroll: (event: BodyScrollEvent) => {
                 if (event.direction === 'horizontal') {
-                    this.scheduleContinuousAutoSize('viewportChanged');
+                    this.scheduleViewportAutoSize();
                 }
             },
         });

--- a/packages/ag-grid-community/src/interfaces/autoSize.ts
+++ b/packages/ag-grid-community/src/interfaces/autoSize.ts
@@ -70,6 +70,7 @@ export interface ContinuousAutoSizeOptions<TData = any, TContext = any> {
      * that, `fitCellContents` responds to any row data change and to viewport changes, because both change
      * what there is to measure, while the width-distribution strategies respond to new data, a page change
      * and a scrollbar appearing or disappearing — the changes to the width there is to share out.
+     * Viewport-driven re-sizes are debounced, so a scroll re-sizes once it settles rather than per frame.
      *
      * A column the user has resized themselves is left alone and treated as fixed width — a header drag, a
      * keyboard resize or a double-click auto-size — as is one given an explicit width through

--- a/packages/ag-grid-community/src/interfaces/autoSize.ts
+++ b/packages/ag-grid-community/src/interfaces/autoSize.ts
@@ -70,7 +70,8 @@ export interface ContinuousAutoSizeOptions<TData = any, TContext = any> {
      * that, `fitCellContents` responds to any row data change and to viewport changes, because both change
      * what there is to measure, while the width-distribution strategies respond to new data, a page change
      * and a scrollbar appearing or disappearing — the changes to the width there is to share out.
-     * Viewport-driven re-sizes are debounced, so a scroll re-sizes once it settles rather than per frame.
+     * Viewport and grid-size changes are debounced, so scrolling or resizing the grid re-sizes once the
+     * gesture settles rather than once per frame.
      *
      * A column the user has resized themselves is left alone and treated as fixed width — a header drag, a
      * keyboard resize or a double-click auto-size — as is one given an explicit width through

--- a/testing/behavioural/src/columns/column-autosize-continuous.test.ts
+++ b/testing/behavioural/src/columns/column-autosize-continuous.test.ts
@@ -315,6 +315,24 @@ describe('Continuous Column Autosize', () => {
             expect(reasons).toEqual(['dataChanged']);
         });
 
+        /**
+         * The viewport triggers are debounced so that a scroll re-sizes once it settles; a real scroll is
+         * not drivable in happy-dom, so the debounce itself is covered by the docs e2e suite. This pins the
+         * other half of that change: a data change must still be sized within the frame, not held back.
+         */
+        test('a data change is not held back by the viewport debounce', async () => {
+            const { api, reasons } = createGridRecordingReasons();
+            await expectWidth(api, 'eligible', MEASURED_WIDTH);
+            await flushScheduledResize();
+            reasons.length = 0;
+
+            api.setGridOption('rowData', LONGER_DATA);
+            // sampled well inside the viewport debounce, so a data change caught by it would be missed here
+            await flushScheduledResize();
+
+            expect(reasons).toContain('dataChanged');
+        });
+
         test('the strategy stays one-shot when `continuous` is omitted', async () => {
             const api = createGrid({
                 autoSizeStrategy: { type: 'fitCellContents', skipHeader: true },

--- a/testing/behavioural/src/columns/column-autosize-continuous.test.ts
+++ b/testing/behavioural/src/columns/column-autosize-continuous.test.ts
@@ -15,7 +15,7 @@
 import { waitFor } from '@testing-library/dom';
 import { DragEventDispatcher, TestGridsManager, asyncSetTimeout } from 'ag-test-utils';
 
-import type { AutoSizeColumnsTriggerParams, ColDef, GridApi, GridOptions } from 'ag-grid-community';
+import type { AgEvent, AutoSizeColumnsTriggerParams, ColDef, GridApi, GridOptions } from 'ag-grid-community';
 import { AlignedGridsModule, ClientSideRowModelModule, ColumnAutoSizeModule } from 'ag-grid-community';
 
 /** The width every eligible column lands on once measured: `minWidth` beats the 20px happy-dom measurement. */
@@ -41,6 +41,18 @@ describe('Continuous Column Autosize', () => {
      */
     // eslint-disable-next-line no-restricted-syntax -- samples past the continuous-resize scheduling frame; every assertion that follows it is negative
     const flushScheduledResize = (): Promise<void> => asyncSetTimeout(50);
+
+    /**
+     * Shorter than the 150ms debounce the streaming triggers settle on
+     * (`CONTINUOUS_STREAMING_DEBOUNCE` in `columnAutosizeService.ts`), so a trigger sent after this wait
+     * still lands inside the window opened by the previous one and postpones it again.
+     */
+    // eslint-disable-next-line no-restricted-syntax -- samples inside the continuous-resize debounce window, which is the behaviour under test
+    const insideDebounceWindow = (): Promise<void> => asyncSetTimeout(40);
+
+    /** Stands in for an internal trigger the grid would dispatch itself, payload and all. */
+    const dispatchGridEvent = (api: GridApi, event: { type: string } & Record<string, unknown>): void =>
+        api.dispatchEvent(event as AgEvent);
 
     const expectWidth = (api: GridApi, colId: string, width: number): Promise<void> =>
         waitFor(() => expect(widthOf(api, colId)).toBe(width));
@@ -316,21 +328,75 @@ describe('Continuous Column Autosize', () => {
         });
 
         /**
-         * The viewport triggers are debounced so that a scroll re-sizes once it settles; a real scroll is
-         * not drivable in happy-dom, so the debounce itself is covered by the docs e2e suite. This pins the
-         * other half of that change: a data change must still be sized within the frame, not held back.
+         * A real scroll is not drivable in happy-dom — there is no laid-out body viewport to scroll — so
+         * the debounce is driven through the `viewportChanged` event the row renderer would dispatch as
+         * new rows come into view, which is what makes a scroll re-size at all.
          */
-        test('a data change is not held back by the viewport debounce', async () => {
+        test('a stream of viewport triggers re-sizes once, after the triggers stop', async () => {
+            const { api, reasons } = createGridRecordingReasons();
+            await expectWidth(api, 'eligible', MEASURED_WIDTH);
+            await flushScheduledResize();
+            reasons.length = 0;
+
+            // a scroll's worth of triggers, each arriving inside the 150ms debounce window of the last
+            for (let firstRow = 0; firstRow < 5; firstRow++) {
+                dispatchGridEvent(api, { type: 'viewportChanged', firstRow, lastRow: firstRow + 10 });
+                await insideDebounceWindow();
+            }
+
+            // 200ms of triggers so far, and every one of them still postponed
+            expect(reasons).toEqual([]);
+
+            await waitFor(() => expect(reasons).toEqual(['viewportChanged']));
+        });
+
+        /** A data change must still be sized within the frame, rather than held back by the debounce. */
+        test('a data change is not held back by the debounce', async () => {
             const { api, reasons } = createGridRecordingReasons();
             await expectWidth(api, 'eligible', MEASURED_WIDTH);
             await flushScheduledResize();
             reasons.length = 0;
 
             api.setGridOption('rowData', LONGER_DATA);
-            // sampled well inside the viewport debounce, so a data change caught by it would be missed here
+            // sampled well inside the debounce window, so a data change caught by it would be missed here
             await flushScheduledResize();
 
             expect(reasons).toContain('dataChanged');
+        });
+
+        /**
+         * A resize drag streams `gridSizeChanged` the way a scroll streams viewport changes, so it settles
+         * on the same debounce — for the width-distribution strategies too, which is where the widths visibly
+         * chase the drag.
+         */
+        test('a stream of grid-size triggers re-sizes once, after the triggers stop', async () => {
+            const reasons: string[] = [];
+            const api = createGrid({
+                columnDefs: [
+                    { colId: 'a', field: 'a' },
+                    { colId: 'b', field: 'b' },
+                ],
+                autoSizeStrategy: {
+                    type: 'fitGridWidth',
+                    continuous: true,
+                    shouldAutoSizeColumns: ({ reason }) => {
+                        reasons.push(reason);
+                        return true;
+                    },
+                },
+            });
+            await waitFor(() => expect(reasons.length).toBeGreaterThan(0));
+            await flushScheduledResize();
+            reasons.length = 0;
+
+            for (let i = 0; i < 5; i++) {
+                dispatchGridEvent(api, { type: 'gridSizeChanged', clientWidth: 400 + i, clientHeight: 300 });
+                await insideDebounceWindow();
+            }
+
+            expect(reasons).toEqual([]);
+
+            await waitFor(() => expect(reasons).toEqual(['gridSizeChanged']));
         });
 
         test('the strategy stays one-shot when `continuous` is omitted', async () => {


### PR DESCRIPTION
Continuous `fitCellContents` auto-sizing re-sized columns once per animation frame while scrolling, because `viewportChanged` fires as new rows render — the grid visibly jitters, more so with `animateColumnResizing`.

Debounces the three viewport triggers (`viewportChanged`, `virtualColumnsChanged`, horizontal `bodyScroll`) by 150ms, matching `SCROLL_END_TIMEOUT`, so a scroll re-sizes once it settles. Data, column and grid-size triggers keep the existing per-frame path.

https://ag-grid.atlassian.net/browse/AG-18402