### PR TITLE
AG-18408 Add a continuous auto-sizing example to the column sizing docs

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/column-sizing/_examples/continuous-auto-size-in-action/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/column-sizing/_examples/continuous-auto-size-in-action/example.spec.ts
@@ -8,6 +8,29 @@ async function waitForWidths(page: Page): Promise<void> {
     await expect(page.locator('.ag-animate-autosize')).toHaveCount(0);
 }
 
+/** The page's first-row number in the paging summary, which changes as soon as the new page lands. */
+function firstRowOnPage(page: Page) {
+    return page.locator('.ag-paging-row-summary-panel-number').first();
+}
+
+/**
+ * Whether this page's content has moved any column off `initialWidths`. The re-size is asynchronous even
+ * once the rows are rendered, so the widths are polled rather than sampled once — a page that leaves them
+ * alone costs the settle window before it is ruled out, which is why that window is kept short.
+ */
+async function widthsChangedFrom(page: Page, initialWidths: number[]): Promise<boolean> {
+    try {
+        await expect
+            .poll(async () => (await columnWidths(page)).some((width, index) => width !== initialWidths[index]), {
+                timeout: 2000,
+            })
+            .toBe(true);
+        return true;
+    } catch {
+        return false;
+    }
+}
+
 async function columnWidths(page: Page): Promise<number[]> {
     const widths: number[] = [];
     for (const colId of COLUMNS) {
@@ -36,13 +59,18 @@ test.agExample(import.meta, () => {
 
         const initialWidths = await columnWidths(page);
 
+        // the first page whose content is wide enough somewhere to move a column off its initial width
         let changed = false;
         for (let i = 0; i < 5 && !changed; i++) {
+            // the previous page's rows are still on screen right after the click, so wait on the page
+            // number rather than on row content, which would match before the new page had rendered
+            const previousFirstRow = await firstRowOnPage(page).textContent();
             await page.getByRole('button', { name: 'Next Page' }).click();
+            await expect(firstRowOnPage(page)).not.toHaveText(previousFirstRow ?? '');
             await waitForGridContent(page);
             await waitForWidths(page);
-            const widths = await columnWidths(page);
-            changed = widths.some((width, index) => width !== initialWidths[index]);
+
+            changed = await widthsChangedFrom(page, initialWidths);
         }
 
         expect(changed).toBe(true);

--- a/documentation/ag-grid-docs/src/content/docs/column-sizing/_examples/continuous-auto-size-in-action/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/column-sizing/_examples/continuous-auto-size-in-action/example.spec.ts
@@ -1,0 +1,50 @@
+import { expect, test, waitForGridContent } from '@utils/grid/test-utils';
+import type { Page } from 'playwright/test';
+
+const COLUMNS = ['athlete', 'age', 'country', 'sport', 'year', 'date', 'gold', 'silver', 'bronze', 'total'];
+
+/** Settle the width animation so measurements are stable. */
+async function waitForWidths(page: Page): Promise<void> {
+    await expect(page.locator('.ag-animate-autosize')).toHaveCount(0);
+}
+
+async function columnWidths(page: Page): Promise<number[]> {
+    const widths: number[] = [];
+    for (const colId of COLUMNS) {
+        const box = await page.locator(`.ag-header-cell[col-id="${colId}"]`).first().boundingBox();
+        widths.push(box?.width ?? 0);
+    }
+    return widths;
+}
+
+test.agExample(import.meta, () => {
+    test.eachFramework('renders every grouped column sized to its contents', async ({ page }) => {
+        await waitForGridContent(page);
+        await waitForWidths(page);
+
+        await expect(page.locator('.ag-header-group-cell-label')).toHaveText(['Competitor', 'Event', 'Medals']);
+
+        const widths = await columnWidths(page);
+        expect(widths.every((width) => width > 0)).toBe(true);
+        // the narrow numeric columns must not be padded out to the default width
+        expect(Math.min(...widths)).toBeLessThan(150);
+    });
+
+    test.eachFramework('changing page re-fits the columns to the new page contents', async ({ page }) => {
+        await waitForGridContent(page);
+        await waitForWidths(page);
+
+        const initialWidths = await columnWidths(page);
+
+        let changed = false;
+        for (let i = 0; i < 5 && !changed; i++) {
+            await page.getByRole('button', { name: 'Next Page' }).click();
+            await waitForGridContent(page);
+            await waitForWidths(page);
+            const widths = await columnWidths(page);
+            changed = widths.some((width, index) => width !== initialWidths[index]);
+        }
+
+        expect(changed).toBe(true);
+    });
+});

--- a/documentation/ag-grid-docs/src/content/docs/column-sizing/_examples/continuous-auto-size-in-action/index.html
+++ b/documentation/ag-grid-docs/src/content/docs/column-sizing/_examples/continuous-auto-size-in-action/index.html
@@ -1,0 +1,1 @@
+<div id="myGrid" style="height: 100%"></div>

--- a/documentation/ag-grid-docs/src/content/docs/column-sizing/_examples/continuous-auto-size-in-action/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/column-sizing/_examples/continuous-auto-size-in-action/main.ts
@@ -41,9 +41,6 @@ const gridOptions: GridOptions<IOlympicData> = {
         type: 'fitCellContents',
         continuous: true,
     },
-    // `fitCellContents` can only measure the columns that are rendered, so every column has to be
-    // rendered for all ten to re-fit around each page's content rather than only once scrolled into view
-    suppressColumnVirtualisation: true,
 };
 
 // setup the grid after the page has finished loading

--- a/documentation/ag-grid-docs/src/content/docs/column-sizing/_examples/continuous-auto-size-in-action/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/column-sizing/_examples/continuous-auto-size-in-action/main.ts
@@ -41,6 +41,9 @@ const gridOptions: GridOptions<IOlympicData> = {
         type: 'fitCellContents',
         continuous: true,
     },
+    // `fitCellContents` can only measure the columns that are rendered, so every column has to be
+    // rendered for all ten to re-fit around each page's content rather than only once scrolled into view
+    suppressColumnVirtualisation: true,
 };
 
 // setup the grid after the page has finished loading

--- a/documentation/ag-grid-docs/src/content/docs/column-sizing/_examples/continuous-auto-size-in-action/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/column-sizing/_examples/continuous-auto-size-in-action/main.ts
@@ -1,0 +1,54 @@
+import type { ColGroupDef, GridApi, GridOptions } from 'ag-grid-community';
+import {
+    ClientSideRowModelModule,
+    ColumnAutoSizeModule,
+    ModuleRegistry,
+    PaginationModule,
+    createGrid,
+    enableDevValidations,
+} from 'ag-grid-community';
+
+if (process.env.NODE_ENV !== 'production') {
+    // Enable extended validations only for development
+    enableDevValidations();
+}
+
+ModuleRegistry.registerModules([ColumnAutoSizeModule, PaginationModule, ClientSideRowModelModule]);
+
+const columnDefs: ColGroupDef<IOlympicData>[] = [
+    {
+        headerName: 'Competitor',
+        children: [{ field: 'athlete' }, { field: 'age' }, { field: 'country' }],
+    },
+    {
+        headerName: 'Event',
+        children: [{ field: 'sport' }, { field: 'year' }, { field: 'date' }],
+    },
+    {
+        headerName: 'Medals',
+        children: [{ field: 'gold' }, { field: 'silver' }, { field: 'bronze' }, { field: 'total' }],
+    },
+];
+
+let gridApi: GridApi<IOlympicData>;
+
+const gridOptions: GridOptions<IOlympicData> = {
+    columnDefs: columnDefs,
+    pagination: true,
+    paginationPageSize: 20,
+    paginationPageSizeSelector: [20, 50, 100],
+    autoSizeStrategy: {
+        type: 'fitCellContents',
+        continuous: true,
+    },
+};
+
+// setup the grid after the page has finished loading
+document.addEventListener('DOMContentLoaded', () => {
+    const gridDiv = document.querySelector<HTMLElement>('#myGrid')!;
+    gridApi = createGrid(gridDiv, gridOptions);
+
+    fetch('https://www.ag-grid.com/example-assets/olympic-winners.json')
+        .then((response) => response.json())
+        .then((data: IOlympicData[]) => gridApi!.setGridOption('rowData', data));
+});

--- a/documentation/ag-grid-docs/src/content/docs/column-sizing/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/column-sizing/index.mdoc
@@ -219,6 +219,10 @@ Every strategy re-runs when the displayed columns change and when the grid is re
 
 Triggers arriving in the same frame are coalesced into a single re-size.
 
+The example below uses `fitCellContents` continuously over a grouped, paginated grid. Move between pages, or change the page size, and the columns re-fit to the content of the rows now on screen — the medal columns stay narrow while "Athlete" and "Sport" grow and shrink around the longest names on each page.
+
+{% gridExampleRunner title="Continuous Auto-Sizing in Action" name="continuous-auto-size-in-action" /%}
+
 Provide `shouldAutoSizeColumns` to take control of each re-size. It is called first, with the eligible `columns` and a `reason` of `'dataChanged'`, `'columnsChanged'`, `'viewportChanged'` or `'gridSizeChanged'`. Return `false` to skip that re-size, leaving the widths untouched. The callback has no effect unless `continuous` is `true`.
 
 ### Column Width Ownership


### PR DESCRIPTION
Adds a `continuous-auto-size-in-action` example to the Continuous Auto-Sizing section of the column sizing docs: ~10 columns under three column groups, the full olympic-winners dataset and pagination, with `fitCellContents` + `continuous: true` so the columns re-fit as you page through.

https://ag-grid.atlassian.net/browse/AG-18408