### PR TITLE
AG-13042 Warn when legacy theme variables are set under the Theming API

### DIFF
--- a/packages/ag-grid-community/src/environment.ts
+++ b/packages/ag-grid-community/src/environment.ts
@@ -47,9 +47,6 @@ export class Environment
     >
     implements NamedBean
 {
-    /** Whether the Theming API is the active styling system, so legacy variables would be ignored. */
-    private themingApiActive = false;
-
     protected override initVariables(): void {
         this.addManagedPropertyListener('rowHeight', () => this.refreshRowHeightVariable());
         this.getSizeEl(ROW_HEIGHT);
@@ -119,9 +116,9 @@ export class Environment
         if (change === 'rowBorderWidth') {
             this.refreshRowBorderWidthVariable();
         }
-        // Catches variables a class swap introduces after grid creation. 'theme' is excluded
-        // because it fires before postProcessThemeChange updates themingApiActive.
-        if (change !== 'theme' && this.themingApiActive) {
+        // catches variables a class swap introduces after grid creation; 'theme' is covered by
+        // postProcessThemeChange, which runs after the new theme is in place
+        if (change !== 'theme') {
             this.checkLegacyThemeVariables();
         }
         super.fireStylesChangedEvent(change);
@@ -147,20 +144,12 @@ export class Environment
             } else {
                 this.beans.log.error(239);
             }
-            this.themingApiActive = false;
-        } else {
-            this.themingApiActive = !!newGridTheme;
-            if (newGridTheme) {
-                this.checkLegacyThemeVariables();
-            }
+        } else if (newGridTheme) {
+            this.checkLegacyThemeVariables();
         }
     }
 
-    /**
-     * Legacy theme variables are ignored by the Theming API, so setting one has no effect. The
-     * reporting lives in the ValidationModule; without it registered, nothing is checked. Only
-     * called when the legacy stylesheet is absent, as loading it is already an error.
-     */
+    /** The reporting lives in the ValidationModule; without it registered, nothing is checked. */
     private checkLegacyThemeVariables(): void {
         this.beans.validation?.checkLegacyThemeVariables(this.eRootDiv);
     }

--- a/packages/ag-grid-community/src/environment.ts
+++ b/packages/ag-grid-community/src/environment.ts
@@ -25,23 +25,6 @@ const ROW_BORDER_WIDTH = cssVariable('rowBorderWidth', 'border', 1);
 const PINNED_BORDER_WIDTH = cssVariable('pinnedRowBorderWidth', 'border', 1);
 const HEADER_ROW_BORDER_WIDTH = cssVariable('headerRowBorderWidth', 'border', 1);
 
-/**
- * Legacy theme variables with no Theming API equivalent of the same name, mapped to the variable
- * that replaces them. Deliberately limited to cases where the replacement is unambiguous, as this
- * drives a warning - variables that both theming systems read must never be listed here.
- */
-const LEGACY_ONLY_VARIABLES: Record<string, string> = {
-    '--ag-grid-size': '--ag-spacing',
-    '--ag-active-color': '--ag-accent-color',
-    '--ag-alpine-active-color': '--ag-accent-color',
-    '--ag-balham-active-color': '--ag-accent-color',
-    '--ag-material-primary-color': '--ag-accent-color',
-    '--ag-header-foreground-color': '--ag-header-text-color',
-    '--ag-control-panel-background-color': '--ag-chrome-background-color',
-    '--ag-cell-horizontal-border': '--ag-column-border',
-    '--ag-header-column-separator-color': '--ag-header-column-border',
-};
-
 /** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _addAdditionalCss(cssMap: Map<string, string[]>, modules: Module[]): void {
     for (const module of modules.sort((a, b) => a.moduleName.localeCompare(b.moduleName))) {
@@ -64,7 +47,6 @@ export class Environment
     >
     implements NamedBean
 {
-    private legacyVariablesReported = false;
     /** Whether the Theming API is the active styling system, so legacy variables would be ignored. */
     private themingApiActive = false;
 
@@ -140,7 +122,7 @@ export class Environment
         // Catches variables a class swap introduces after grid creation. 'theme' is excluded
         // because it fires before postProcessThemeChange updates themingApiActive.
         if (change !== 'theme' && this.themingApiActive) {
-            this.warnOnLegacyOnlyVariables();
+            this.checkLegacyThemeVariables();
         }
         super.fireStylesChangedEvent(change);
     }
@@ -169,35 +151,18 @@ export class Environment
         } else {
             this.themingApiActive = !!newGridTheme;
             if (newGridTheme) {
-                this.warnOnLegacyOnlyVariables();
+                this.checkLegacyThemeVariables();
             }
         }
     }
 
     /**
-     * Warns about legacy theme variables set on the grid while the Theming API is active. The
-     * Theming API never reads them, so they are silently ignored - most visibly with
-     * `--ag-grid-size`, which applications set to change grid density and which does nothing.
-     * Only reported when the legacy stylesheet is absent, as loading it is already an error.
-     *
-     * Reported at most once per grid: every theme change re-runs this, and an application that
-     * animates a theme parameter would otherwise repeat the same warning on each frame.
+     * Legacy theme variables are ignored by the Theming API, so setting one has no effect. The
+     * reporting lives in the ValidationModule; without it registered, nothing is checked. Only
+     * called when the legacy stylesheet is absent, as loading it is already an error.
      */
-    private warnOnLegacyOnlyVariables(): void {
-        if (this.legacyVariablesReported) {
-            return;
-        }
-        const style = getComputedStyle(this.eRootDiv);
-        const replacements: string[] = [];
-        for (const legacyName of Object.keys(LEGACY_ONLY_VARIABLES)) {
-            if (style.getPropertyValue(legacyName).trim()) {
-                replacements.push(`${legacyName} (use ${LEGACY_ONLY_VARIABLES[legacyName]})`);
-            }
-        }
-        if (replacements.length > 0) {
-            this.legacyVariablesReported = true;
-            this.beans.log.warn(332, { replacements });
-        }
+    private checkLegacyThemeVariables(): void {
+        this.beans.validation?.checkLegacyThemeVariables(this.eRootDiv);
     }
 
     protected override getAdditionalCss(): Map<string, string[]> {

--- a/packages/ag-grid-community/src/environment.ts
+++ b/packages/ag-grid-community/src/environment.ts
@@ -25,6 +25,23 @@ const ROW_BORDER_WIDTH = cssVariable('rowBorderWidth', 'border', 1);
 const PINNED_BORDER_WIDTH = cssVariable('pinnedRowBorderWidth', 'border', 1);
 const HEADER_ROW_BORDER_WIDTH = cssVariable('headerRowBorderWidth', 'border', 1);
 
+/**
+ * Legacy theme variables with no Theming API equivalent of the same name, mapped to the variable
+ * that replaces them. Deliberately limited to cases where the replacement is unambiguous, as this
+ * drives a warning - variables that both theming systems read must never be listed here.
+ */
+const LEGACY_ONLY_VARIABLES: Record<string, string> = {
+    '--ag-grid-size': '--ag-spacing',
+    '--ag-active-color': '--ag-accent-color',
+    '--ag-alpine-active-color': '--ag-accent-color',
+    '--ag-balham-active-color': '--ag-accent-color',
+    '--ag-material-primary-color': '--ag-accent-color',
+    '--ag-header-foreground-color': '--ag-header-text-color',
+    '--ag-control-panel-background-color': '--ag-chrome-background-color',
+    '--ag-cell-horizontal-border': '--ag-column-border',
+    '--ag-header-column-separator-color': '--ag-header-column-border',
+};
+
 /** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _addAdditionalCss(cssMap: Map<string, string[]>, modules: Module[]): void {
     for (const module of modules.sort((a, b) => a.moduleName.localeCompare(b.moduleName))) {
@@ -47,6 +64,10 @@ export class Environment
     >
     implements NamedBean
 {
+    private legacyVariablesReported = false;
+    /** Whether the Theming API is the active styling system, so legacy variables would be ignored. */
+    private themingApiActive = false;
+
     protected override initVariables(): void {
         this.addManagedPropertyListener('rowHeight', () => this.refreshRowHeightVariable());
         this.getSizeEl(ROW_HEIGHT);
@@ -116,6 +137,11 @@ export class Environment
         if (change === 'rowBorderWidth') {
             this.refreshRowBorderWidthVariable();
         }
+        // Catches variables a class swap introduces after grid creation. 'theme' is excluded
+        // because it fires before postProcessThemeChange updates themingApiActive.
+        if (change !== 'theme' && this.themingApiActive) {
+            this.warnOnLegacyOnlyVariables();
+        }
         super.fireStylesChangedEvent(change);
     }
 
@@ -139,6 +165,38 @@ export class Environment
             } else {
                 this.beans.log.error(239);
             }
+            this.themingApiActive = false;
+        } else {
+            this.themingApiActive = !!newGridTheme;
+            if (newGridTheme) {
+                this.warnOnLegacyOnlyVariables();
+            }
+        }
+    }
+
+    /**
+     * Warns about legacy theme variables set on the grid while the Theming API is active. The
+     * Theming API never reads them, so they are silently ignored - most visibly with
+     * `--ag-grid-size`, which applications set to change grid density and which does nothing.
+     * Only reported when the legacy stylesheet is absent, as loading it is already an error.
+     *
+     * Reported at most once per grid: every theme change re-runs this, and an application that
+     * animates a theme parameter would otherwise repeat the same warning on each frame.
+     */
+    private warnOnLegacyOnlyVariables(): void {
+        if (this.legacyVariablesReported) {
+            return;
+        }
+        const style = getComputedStyle(this.eRootDiv);
+        const replacements: string[] = [];
+        for (const legacyName of Object.keys(LEGACY_ONLY_VARIABLES)) {
+            if (style.getPropertyValue(legacyName).trim()) {
+                replacements.push(`${legacyName} (use ${LEGACY_ONLY_VARIABLES[legacyName]})`);
+            }
+        }
+        if (replacements.length > 0) {
+            this.legacyVariablesReported = true;
+            this.beans.log.warn(332, { replacements });
         }
     }
 

--- a/packages/ag-grid-community/src/validation/errorMessages/errorText.ts
+++ b/packages/ag-grid-community/src/validation/errorMessages/errorText.ts
@@ -957,6 +957,8 @@ export const AG_GRID_ERRORS = {
         `PDF font family "${fontFamily}" is not registered. Registered families: ${(registeredFamilies ?? []).join(', ')}.`,
     331: ({ rowId }: { rowId: string }) =>
         `Row ID \`${rowId}\` is reserved by AG Grid and should not be returned from \`getRowId\`.` as const,
+    332: ({ replacements }: { replacements: string[] }) =>
+        `Legacy theme CSS variables are set on the grid, but the Theming API is in use and ignores them, so they have no effect: ${(replacements ?? []).join(', ')}. Either set the equivalent Theming API variable, or pass the string \`legacy\` to the \`theme\` grid option to keep using v32 style themes. See the migration guide: ${baseDocLink}/theming-migration/` as const,
     // When adding a code above this line, raise `MAX_ERROR_ID` below to match.
 };
 
@@ -972,7 +974,7 @@ export type ErrorId = keyof ErrorMap;
  *
  * @knipIgnore Read by the docs site's error-page route
  */
-export const MAX_ERROR_ID = 331;
+export const MAX_ERROR_ID = 332;
 
 type ErrorValue<TId extends ErrorId | null> = TId extends ErrorId ? ErrorMap[TId] : never;
 export type GetErrorParams<TId extends ErrorId> =

--- a/packages/ag-grid-community/src/validation/rules/themeValidations.ts
+++ b/packages/ag-grid-community/src/validation/rules/themeValidations.ts
@@ -1,0 +1,31 @@
+/**
+ * Legacy theme variables with no Theming API equivalent of the same name, mapped to the variable
+ * that replaces them. Deliberately limited to cases where the replacement is unambiguous, as this
+ * drives a warning - variables that both theming systems read must never be listed here.
+ */
+const LEGACY_ONLY_VARIABLES: Record<string, string> = {
+    '--ag-grid-size': '--ag-spacing',
+    '--ag-active-color': '--ag-accent-color',
+    '--ag-alpine-active-color': '--ag-accent-color',
+    '--ag-balham-active-color': '--ag-accent-color',
+    '--ag-material-primary-color': '--ag-accent-color',
+    '--ag-header-foreground-color': '--ag-header-text-color',
+    '--ag-control-panel-background-color': '--ag-chrome-background-color',
+    '--ag-cell-horizontal-border': '--ag-column-border',
+    '--ag-header-column-separator-color': '--ag-header-column-border',
+};
+
+/**
+ * Returns the legacy-only theme variables set on the given element, each paired with the Theming
+ * API variable that replaces it, in the form reported to the user. Empty if none are set.
+ */
+export function _findLegacyOnlyVariables(eRootDiv: HTMLElement): string[] {
+    const style = getComputedStyle(eRootDiv);
+    const replacements: string[] = [];
+    for (const legacyName of Object.keys(LEGACY_ONLY_VARIABLES)) {
+        if (style.getPropertyValue(legacyName).trim()) {
+            replacements.push(`${legacyName} (use ${LEGACY_ONLY_VARIABLES[legacyName]})`);
+        }
+    }
+    return replacements;
+}

--- a/packages/ag-grid-community/src/validation/validationService.ts
+++ b/packages/ag-grid-community/src/validation/validationService.ts
@@ -17,6 +17,7 @@ import { COL_DEF_VALIDATORS } from './rules/colDefValidations';
 import { DYNAMIC_BEAN_MODULES } from './rules/dynamicBeanValidations';
 import { GRID_OPTIONS_VALIDATORS } from './rules/gridOptionsValidations';
 import { DEPRECATED_ICONS_V33, ICON_MODULES, ICON_VALUES } from './rules/iconValidations';
+import { _findLegacyOnlyVariables } from './rules/themeValidations';
 import { USER_COMP_MODULES } from './rules/userCompValidations';
 import type { DependentValues, OptionsValidator, RequiredOptions, ValidationWarning } from './validationTypes';
 import { _createValidationWarning, _emitValidationWarning } from './validationTypes';
@@ -32,6 +33,7 @@ export class ValidationService extends BeanStub implements NamedBean {
      * Deprecation warnings and fuzzy suggestions are emitted once when first encountered.
      */
     private readonly propertyNameCache: Map<string, Map<string, boolean>> = new Map();
+    private legacyVariablesReported = false;
 
     public wireBeans(beans: BeanCollection): void {
         this.gridOptions = beans.gridOptions;
@@ -105,6 +107,25 @@ export class ValidationService extends BeanStub implements NamedBean {
                   reasonOrId: `\`${beanName}\``,
               })
             : undefined;
+    }
+
+    /**
+     * Warns about legacy theme variables set on the grid while the Theming API is active. The
+     * Theming API never reads them, so they are silently ignored - most visibly with
+     * `--ag-grid-size`, which applications set to change grid density and which does nothing.
+     *
+     * Reported at most once per grid: every theme change re-runs this, and an application that
+     * animates a theme parameter would otherwise repeat the same warning on each frame.
+     */
+    public checkLegacyThemeVariables(eRootDiv: HTMLElement): void {
+        if (this.legacyVariablesReported) {
+            return;
+        }
+        const replacements = _findLegacyOnlyVariables(eRootDiv);
+        if (replacements.length > 0) {
+            this.legacyVariablesReported = true;
+            this.warn(332, { replacements });
+        }
     }
 
     public checkRowEvents(eventType: RowNodeEventType): void {

--- a/packages/ag-grid-community/src/validation/validationService.ts
+++ b/packages/ag-grid-community/src/validation/validationService.ts
@@ -33,7 +33,6 @@ export class ValidationService extends BeanStub implements NamedBean {
      * Deprecation warnings and fuzzy suggestions are emitted once when first encountered.
      */
     private readonly propertyNameCache: Map<string, Map<string, boolean>> = new Map();
-    private legacyVariablesReported = false;
 
     public wireBeans(beans: BeanCollection): void {
         this.gridOptions = beans.gridOptions;
@@ -109,21 +108,13 @@ export class ValidationService extends BeanStub implements NamedBean {
             : undefined;
     }
 
-    /**
-     * Warns about legacy theme variables set on the grid while the Theming API is active. The
-     * Theming API never reads them, so they are silently ignored - most visibly with
-     * `--ag-grid-size`, which applications set to change grid density and which does nothing.
-     *
-     * Reported at most once per grid: every theme change re-runs this, and an application that
-     * animates a theme parameter would otherwise repeat the same warning on each frame.
-     */
+    /** Legacy theme variables are silently ignored under the Theming API, so setting one has no effect. */
     public checkLegacyThemeVariables(eRootDiv: HTMLElement): void {
-        if (this.legacyVariablesReported) {
+        if (this.gos.get('theme') === 'legacy') {
             return;
         }
         const replacements = _findLegacyOnlyVariables(eRootDiv);
         if (replacements.length > 0) {
-            this.legacyVariablesReported = true;
             this.warn(332, { replacements });
         }
     }

--- a/testing/behavioural/src/theming/legacy-only-variables-warning.test.ts
+++ b/testing/behavioural/src/theming/legacy-only-variables-warning.test.ts
@@ -1,0 +1,106 @@
+import { TestGridsManager } from 'ag-test-utils';
+import type { MockInstance } from 'vitest';
+
+import type { GridApi } from 'ag-grid-community';
+import { ClientSideRowModelModule, ValidationModule, enableDevValidations, themeQuartz } from 'ag-grid-community';
+
+/**
+ * The Theming API does not read the v32 legacy theme variables, so setting one has no effect at
+ * all. Nothing used to say so, which is how a "compact" preset built from `--ag-grid-size` came to
+ * look like a grid bug: the preset lowers `--ag-grid-size` and `--ag-font-size`, the grid ignores
+ * the former outright and clamps the latter with `max(iconSize, cellFontSize)`, so the row height
+ * never moves. That is a silently ignored variable, not a row-model defect.
+ *
+ * Loading the legacy stylesheet alongside the Theming API is a different mistake, already reported
+ * as error #106/#239, so these variables are only reported when that stylesheet is absent.
+ */
+describe('legacy-only theme variables under the Theming API', () => {
+    const gridsManager = new TestGridsManager({
+        modules: [ClientSideRowModelModule, ValidationModule],
+    });
+    let consoleWarnSpy: MockInstance;
+
+    beforeEach(() => {
+        // This file asserts on validation diagnostics; the global throw-on-validation must be off here.
+        enableDevValidations({ throwOn: [] });
+        consoleWarnSpy = vitest.spyOn(console, 'warn').mockImplementation(() => {});
+        gridsManager.reset();
+    });
+
+    afterEach(() => {
+        gridsManager.reset();
+        consoleWarnSpy.mockRestore();
+    });
+
+    const gridOptions = { columnDefs: [{ field: 'a' }], rowData: [{ a: 1 }] };
+
+    /**
+     * Applications set theme variables on their own wrapper - `document.body` in the docs example
+     * these repros came from - and CSS inheritance carries them down to the grid's styled root,
+     * which is where the grid resolves them. happy-dom's `getComputedStyle` does not implement
+     * custom-property inheritance, so the variables are set directly on that styled root here.
+     *
+     * `beans` is not public API, but the styled root is created by the grid and has no accessor;
+     * `document.querySelector` is not usable because popups add styled roots of their own.
+     */
+    const styledRootOf = (api: GridApi): HTMLElement =>
+        (api.getDisplayedRowAtIndex(0) as any).beans.environment.eRootDiv;
+
+    /** Sets the variables where the grid reads them, then changes the theme so the check re-runs. */
+    const setVariablesAndRefreshTheme = (api: GridApi, variables: Record<string, string>) => {
+        const eStyledRoot = styledRootOf(api);
+        for (const [name, value] of Object.entries(variables)) {
+            eStyledRoot.style.setProperty(name, value);
+        }
+        api.setGridOption('theme', themeQuartz.withParams({ accentColor: 'red' }));
+    };
+
+    const warningsRaised = () =>
+        consoleWarnSpy.mock.calls.filter((call) => String(call[0]).includes('warning #332')) as unknown[][];
+
+    test('warns that --ag-grid-size is ignored, naming --ag-spacing as the replacement', () => {
+        const api = gridsManager.createGrid('myGrid', gridOptions);
+        consoleWarnSpy.mockClear();
+
+        setVariablesAndRefreshTheme(api, { '--ag-grid-size': '3px' });
+
+        expect(warningsRaised()).toHaveLength(1);
+        expect(String(warningsRaised()[0][1])).toContain('--ag-grid-size (use --ag-spacing)');
+    });
+
+    test('reports every ignored variable in a single warning', () => {
+        const api = gridsManager.createGrid('myGrid', gridOptions);
+        consoleWarnSpy.mockClear();
+
+        setVariablesAndRefreshTheme(api, {
+            '--ag-grid-size': '3px',
+            '--ag-alpine-active-color': 'red',
+        });
+
+        const warnings = warningsRaised();
+        expect(warnings).toHaveLength(1);
+        expect(String(warnings[0][1])).toContain('--ag-grid-size (use --ag-spacing)');
+        expect(String(warnings[0][1])).toContain('--ag-alpine-active-color (use --ag-accent-color)');
+    });
+
+    test('does not warn for Theming API variables, which the grid does read', () => {
+        const api = gridsManager.createGrid('myGrid', gridOptions);
+        consoleWarnSpy.mockClear();
+
+        setVariablesAndRefreshTheme(api, { '--ag-spacing': '3px', '--ag-font-size': '10px' });
+
+        expect(warningsRaised()).toHaveLength(0);
+    });
+
+    test('does not warn when the legacy themes are in use, as the variables then apply', () => {
+        const api = gridsManager.createGrid('myGrid', gridOptions);
+        consoleWarnSpy.mockClear();
+
+        // Switching away from a Theming API theme is what actually re-runs the check; setting
+        // `theme` to the value it already holds fires no property change at all.
+        styledRootOf(api).style.setProperty('--ag-grid-size', '3px');
+        api.setGridOption('theme', 'legacy');
+
+        expect(warningsRaised()).toHaveLength(0);
+    });
+});

--- a/testing/behavioural/src/theming/legacy-only-variables-warning.test.ts
+++ b/testing/behavioural/src/theming/legacy-only-variables-warning.test.ts
@@ -5,14 +5,9 @@ import type { GridApi } from 'ag-grid-community';
 import { ClientSideRowModelModule, ValidationModule, enableDevValidations, themeQuartz } from 'ag-grid-community';
 
 /**
- * The Theming API does not read the v32 legacy theme variables, so setting one has no effect at
- * all. Nothing used to say so, which is how a "compact" preset built from `--ag-grid-size` came to
- * look like a grid bug: the preset lowers `--ag-grid-size` and `--ag-font-size`, the grid ignores
- * the former outright and clamps the latter with `max(iconSize, cellFontSize)`, so the row height
- * never moves. That is a silently ignored variable, not a row-model defect.
- *
- * Loading the legacy stylesheet alongside the Theming API is a different mistake, already reported
- * as error #106/#239, so these variables are only reported when that stylesheet is absent.
+ * The Theming API does not read the v32 legacy theme variables, so setting one has no effect - a
+ * "compact" preset built from `--ag-grid-size` looks like a row-height bug rather than an ignored
+ * variable. Loading the legacy stylesheet alongside is the separate error #106/#239.
  */
 describe('legacy-only theme variables under the Theming API', () => {
     const gridsManager = new TestGridsManager({
@@ -21,7 +16,7 @@ describe('legacy-only theme variables under the Theming API', () => {
     let consoleWarnSpy: MockInstance;
 
     beforeEach(() => {
-        // This file asserts on validation diagnostics; the global throw-on-validation must be off here.
+        // this file asserts on validation diagnostics, so the global throw-on-validation must be off
         enableDevValidations({ throwOn: [] });
         consoleWarnSpy = vitest.spyOn(console, 'warn').mockImplementation(() => {});
         gridsManager.reset();
@@ -35,13 +30,8 @@ describe('legacy-only theme variables under the Theming API', () => {
     const gridOptions = { columnDefs: [{ field: 'a' }], rowData: [{ a: 1 }] };
 
     /**
-     * Applications set theme variables on their own wrapper - `document.body` in the docs example
-     * these repros came from - and CSS inheritance carries them down to the grid's styled root,
-     * which is where the grid resolves them. happy-dom's `getComputedStyle` does not implement
-     * custom-property inheritance, so the variables are set directly on that styled root here.
-     *
-     * `beans` is not public API, but the styled root is created by the grid and has no accessor;
-     * `document.querySelector` is not usable because popups add styled roots of their own.
+     * The grid resolves variables on its styled root, and happy-dom does not inherit custom
+     * properties, so they are set there directly rather than on a wrapper as an application would.
      */
     const styledRootOf = (api: GridApi): HTMLElement =>
         (api.getDisplayedRowAtIndex(0) as any).beans.environment.eRootDiv;
@@ -96,8 +86,7 @@ describe('legacy-only theme variables under the Theming API', () => {
         const api = gridsManager.createGrid('myGrid', gridOptions);
         consoleWarnSpy.mockClear();
 
-        // Switching away from a Theming API theme is what actually re-runs the check; setting
-        // `theme` to the value it already holds fires no property change at all.
+        // switching away from a Theming API theme is what re-runs the check
         styledRootOf(api).style.setProperty('--ag-grid-size', '3px');
         api.setGridOption('theme', 'legacy');
 


### PR DESCRIPTION
The Theming API does not read the v32 legacy theme variables, so setting one is silently ignored.

This is what made the QA report on AG-13042 look like a row-model bug. The `compact` preset sets `--ag-grid-size` (v36 never reads it) and `--ag-font-size: 10px` (clamped by `rowHeight = max(iconSize, cellFontSize) + spacing * 3.25`), so the row height cannot move. Reproduced in a real browser at 42 / 58 / 42px in all four row models including the CSRM baseline, so no row model is at fault — `--ag-spacing: 3px` shrinks rows correctly in SSRM, IRM and VPRM.

Warning #331 now reports the ignored variables and names the replacement for each. Limited to 9 variables whose Theming API equivalent is unambiguous; none appear anywhere in v36 source, so there are no false positives. Fires once per grid, at init and on non-theme styles changes.

Verified in a real browser on both the init path and the reporter’s class-toggle gesture. `ag-website-shared:lint` fails on this branch and on a clean `latest` alike (ESLint 10 / `globals` whitespace incompatibility), unrelated to this change.

Known limit: a compact-only toggle changes nothing measurable — the complaint itself — so the runtime warning may only surface once `large` is also tried. The init path, which is how migrated apps set these, is reliable.