### PR TITLE
SE-183 Disallow the changelog and pipeline search parameter in robots.txt

### DIFF
--- a/documentation/ag-grid-docs/src/utils/robotsTxt.test.ts
+++ b/documentation/ag-grid-docs/src/utils/robotsTxt.test.ts
@@ -20,7 +20,7 @@ const INTERNAL_EXAMPLE_DISALLOWS = [
     '/charts/debug/gallery-examples',
 ];
 // Non-example blocks that always apply.
-const OTHER_DISALLOWS = ['/debug/', '/*-data-grid/*-test/', '/404'];
+const OTHER_DISALLOWS = ['/debug/', '/*-data-grid/*-test/', '/404', '/*searchQuery='];
 // Everything the AI group must still enforce (internal fixtures + other blocks).
 const AI_KEPT_DISALLOWS = [...INTERNAL_EXAMPLE_DISALLOWS, ...OTHER_DISALLOWS];
 const DISALLOW_PATHS = [...PUBLIC_EXAMPLE_DISALLOWS, ...AI_KEPT_DISALLOWS];

--- a/documentation/ag-grid-docs/src/utils/sitemapPages.test.ts
+++ b/documentation/ag-grid-docs/src/utils/sitemapPages.test.ts
@@ -1,0 +1,10 @@
+import { getSitemapIgnorePaths } from './sitemapPages';
+
+describe('getSitemapIgnorePaths', () => {
+    test('includes the searchQuery wildcard unmodified by the trailing-slash mapping', async () => {
+        const ignorePaths = await getSitemapIgnorePaths();
+
+        expect(ignorePaths).toContain('/*searchQuery=');
+        expect(ignorePaths).not.toContain('/*searchQuery=/');
+    });
+});

--- a/documentation/ag-grid-docs/src/utils/sitemapPages.ts
+++ b/documentation/ag-grid-docs/src/utils/sitemapPages.ts
@@ -26,7 +26,7 @@ export async function getSitemapIgnorePaths() {
     ];
     const folderPaths = ignorePaths.map(addTrailingSlash);
 
-    return folderPaths.concat(urlWithBaseUrl('/404'));
+    return folderPaths.concat(urlWithBaseUrl('/404'), urlWithBaseUrl('/*searchQuery='));
 }
 
 export async function getSitemapAllowPaths() {


### PR DESCRIPTION
## Summary
- Bingbot makes ~12,800 requests to `/changelog/?searchQuery=...` (~19% of Bing's crawl of the site) — low-value search-result duplicates of the changelog, already protected from indexing by a canonical to `/changelog/` but not from being crawled. `/pipeline/` uses the same client-side `searchQuery` param via the same `useSearchQuery` hook.
- Adds `/*searchQuery=` to `getSitemapIgnorePaths()` in `sitemapPages.ts`, appended after the `.map(addTrailingSlash)` step (alongside `/404`) so the trailing-slash mapping doesn't corrupt the wildcard pattern into `/*searchQuery=/`.
- `robotsTxt.ts` already builds the AI-crawler group from the same disallow list as the wildcard group (filtering only `/example/i` paths for AI), so this one addition covers both robots groups without duplication.
- Updated `robotsTxt.test.ts`'s `OTHER_DISALLOWS` fixture to include the new path, which the existing wildcard/AI-group assertions pick up automatically.

## Test plan
- [x] `yarn nx test ag-grid-docs` — 1054/1054 passing
- [x] `yarn nx lint ag-grid-docs` — clean
- [x] `yarn nx run ag-grid-docs:build-tsc` — pre-existing failures in `ag-grid-community` confirmed present on `latest` without this change (unrelated)