### PR TITLE
SE-184 Remove Meta-ExternalAgent from the AI-crawler robots allow-group

### DIFF
--- a/documentation/ag-grid-docs/src/utils/robotsTxt.ts
+++ b/documentation/ag-grid-docs/src/utils/robotsTxt.ts
@@ -47,7 +47,6 @@ export const AI_CRAWLERS = [
     'Applebot-Extended',
     'CCBot',
     'Bytespider',
-    'Meta-ExternalAgent',
 ];
 
 // Public example pages we actively want AI to crawl and train on. Internal `/debug/` example


### PR DESCRIPTION
## Summary
- robots.txt names `Meta-ExternalAgent` in the AI-crawler allow group, but the edge already refuses ~99% of its requests (~98% from Meta's own verified network), so robots and the edge disagree.
- Meta publishes no machine-readable IP range list for this crawler (unlike GPTBot/PerplexityBot's JSON feeds), so making the edge allow it instead would mean self-maintaining an ASN-derived IP set with no authoritative source — an open-ended cost for a crawler that is training-only, with no citation or referral traffic back, unlike the other welcomed AI crawlers.
- Removes `Meta-ExternalAgent` from `AI_CRAWLERS` in `robotsTxt.ts`, matching robots.txt to what the edge already does. `Meta-ExternalFetcher`/`facebookexternalhit` (link previews) are untouched — they pass at the edge on other criteria already and were never in this list.

## Test plan
- [x] `yarn nx test ag-grid-docs` — 1054/1054 passing (the AI-group test iterates `AI_CRAWLERS` directly, so it now checks one fewer crawler with no fixture change needed)
- [x] `yarn nx lint ag-grid-docs` — clean