### PR TITLE
AG-10819-fixes

### DIFF
--- a/community-modules/styles/src/internal/base/parts/_advanced-filter.scss
+++ b/community-modules/styles/src/internal/base/parts/_advanced-filter.scss
@@ -258,14 +258,20 @@
         cursor: default;
     }
 
+    .ag-advanced-filter-builder-virtual-list-viewport {
+        scrollbar-width: thin;
+    }
+
     .ag-advanced-filter-builder-virtual-list-container {
         top: var(--ag-grid-size);
+        overflow: visible;
     }
 
     .ag-advanced-filter-builder-virtual-list-item {
         display: flex;
         cursor: default;
         height: var(--ag-list-item-height);
+        min-width: max-content;
 
         &:hover {
             background-color: var(--ag-row-hover-color);

--- a/community-modules/styles/src/internal/base/parts/_common-structural.scss
+++ b/community-modules/styles/src/internal/base/parts/_common-structural.scss
@@ -1397,6 +1397,12 @@
         width: 100%;
     }
 
+    // lets a rendered row report the width its content wants, so the list can grow to it
+    :where(.ag-virtual-list-grow-to-content) .ag-virtual-list-item {
+        min-width: 100%;
+        width: max-content;
+    }
+
     // /**
     //  ****************************
     //  * Floating Top and Bottom

--- a/documentation/ag-grid-docs/playwright.config.ts
+++ b/documentation/ag-grid-docs/playwright.config.ts
@@ -2,6 +2,19 @@ import { defineConfig, devices } from '@playwright/test';
 
 import { wafBypassSecret } from './src/utils/grid/test/wafBypass';
 
+// The dev server takes its port from `PORT`, but `docs-e2e.sh` runs Playwright directly rather than through Nx,
+// so Nx's own dotenv loading never reaches here and a moved port would be tested at the one it moved off.
+// Neither file is required, and an already-set variable wins, so the shell still overrides both.
+for (const envFile of ['../../.env.local', '../../.env']) {
+    try {
+        process.loadEnvFile(new URL(envFile, import.meta.url));
+    } catch {
+        // absent in a checkout that has not overridden anything
+    }
+}
+
+const LOCAL_PORT = process.env.PORT || '4610';
+
 const PRE_34_VERSION = process.env.PRE_34_VERSION;
 
 const PREV_URL = PRE_34_VERSION && `https://www.ag-grid.com/archive/${PRE_34_VERSION}/`;
@@ -12,7 +25,7 @@ const BASE_URL = process.env.BASE_URL;
 // unless it ends in a slash, so a URL passed without one would silently lose the prefix.
 const withTrailingSlash = (url: string): string => (url.endsWith('/') ? url : `${url}/`);
 
-const baseURL = withTrailingSlash(BASE_URL || PREV_URL || PROD_URL || 'https://localhost:4610');
+const baseURL = withTrailingSlash(BASE_URL || PREV_URL || PROD_URL || `https://localhost:${LOCAL_PORT}`);
 
 const LOCAL_HOSTNAMES = ['localhost', '127.0.0.1', '[::1]'];
 

--- a/documentation/ag-grid-docs/src/content/docs/filter-advanced/_examples/built-in-filter-options/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/filter-advanced/_examples/built-in-filter-options/example.spec.ts
@@ -95,4 +95,32 @@ test.agExample(import.meta, () => {
         await applyExpression(page, `[Date] is between ("${daysAgo(30)}", "${daysAgo(1)}")`);
         await expectDates(page, (date) => date <= daysAgo(30) || date >= daysAgo(1));
     });
+
+    // Needs a real browser: the picker is sized from the pill, so only layout says whether the options still fit.
+    test.eachFramework('should size the builder operator dropdown to its longest option', async ({ page }) => {
+        await ensureGridReady(page);
+        await waitForGridContent(page);
+
+        await applyExpression(page, '[Date] is in last 7 days');
+        await page.getByRole('button', { name: 'Builder' }).click();
+        await page.getByRole('combobox', { name: 'Option' }).click();
+
+        const picker = page.locator('.ag-rich-select-list');
+        await expect(picker).toBeVisible();
+        await expect(page.locator('.ag-rich-select-row')).not.toHaveCount(0);
+
+        const { pickerWidth, overflowing } = await picker.evaluate((ePicker) => ({
+            pickerWidth: ePicker.clientWidth,
+            // Row width against the picker's content box, so no border or scroll offset has to be accounted for.
+            overflowing: [...ePicker.querySelectorAll('.ag-rich-select-row')]
+                .filter((row) => row.getBoundingClientRect().width > ePicker.clientWidth)
+                .map((row) => row.textContent),
+        }));
+
+        // Two assertions because each catches a different half. Sizing the picker from the pill leaves it at
+        // `pillSelectMinWidth`, so only the width discriminates there; laying the rows out at their content
+        // width without resizing the popup keeps every row untruncated, so only their right edges do.
+        expect(pickerWidth).toBeGreaterThan(140);
+        expect(overflowing).toEqual([]);
+    });
 });

--- a/documentation/ag-grid-docs/src/content/docs/filter-advanced/_examples/custom-filter-options/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/filter-advanced/_examples/custom-filter-options/example.spec.ts
@@ -107,4 +107,32 @@ test.agExample(import.meta, () => {
             expect(dates.filter((date) => date <= '2008-08-20' || date >= '2008-08-25')).toEqual([]);
         }).toPass();
     });
+
+    // A two-input condition is wider than the Builder, so its buttons are only reachable by scrolling.
+    test.eachFramework('should keep a condition wider than the builder reachable', async ({ page }) => {
+        await ensureGridReady(page);
+        await waitForGridContent(page);
+
+        await applyExpression(page, '[Date] Between (Exclusive) ("2008-08-20", "2008-08-25")');
+        await page.getByRole('button', { name: 'Builder' }).click();
+
+        const viewport = page.locator('.ag-advanced-filter-builder .ag-virtual-list-viewport');
+        await expect(viewport).toBeVisible();
+        const viewportBox = (await viewport.boundingBox())!;
+
+        // Scrolled by wheel rather than `scrollIntoViewIfNeeded`, which also scrolls `overflow: hidden`
+        // ancestors and so passes on a list the user cannot move at all.
+        await page.mouse.move(viewportBox.x + viewportBox.width / 2, viewportBox.y + viewportBox.height / 2);
+        await page.mouse.wheel(viewportBox.width, 0);
+
+        const removeButton = page
+            .locator('.ag-advanced-filter-builder-virtual-list-item', { hasText: 'Between (Exclusive)' })
+            .getByRole('button', { name: 'Remove' });
+        await expect(removeButton).toBeVisible();
+        await expect(async () => {
+            const buttonBox = (await removeButton.boundingBox())!;
+            expect(buttonBox.x).toBeGreaterThanOrEqual(viewportBox.x);
+            expect(buttonBox.x + buttonBox.width).toBeLessThanOrEqual(viewportBox.x + viewportBox.width);
+        }).toPass({ timeout: 5_000 });
+    });
 });

--- a/documentation/ag-grid-docs/src/content/docs/filter-advanced/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/filter-advanced/index.mdoc
@@ -201,22 +201,15 @@ The Advanced Filter names each of them as a phrase, where the Date Filter names 
 | is in last 12 months | `last12Months` |
 | is in last 24 months | `last24Months` |
 
-They take no value, so an expression is the column and the option alone, and the filter model holds only the option key:
-
-```text
-[Date] is in last year
-```
+They take no value, so an expression is the column and the option alone — `[Date] is in last year` — and the filter model holds only the option key:
 
 ```js
 const advancedFilterModel = { filterType: 'date', colId: 'date', type: 'lastYear' };
 ```
 
 Taking no value also means one cannot be a bound of `is between`. Write a span of consecutive options as a join
-of them, which stays relative where a written pair of dates would not:
-
-```text
-[Date] is yesterday OR [Date] is today OR [Date] is tomorrow
-```
+of them — `[Date] is yesterday OR [Date] is today OR [Date] is tomorrow` — which stays relative where a written
+pair of dates would not.
 
 The option stays relative to the current date rather than being resolved to fixed dates when it is applied, so a saved filter model means the same thing whenever it is restored. With the Server-Side Row Model the option key reaches the server with no values, as the Date Filter's does — see [Preset Date Range Filters](./server-side-model-filtering/#preset-date-range-filters).
 
@@ -258,12 +251,7 @@ const gridOptions = {
 }
 ```
 
-An option is written in an expression under its `displayName`, or its [localised](./localisation/) text where the `displayKey` has an entry, followed by as many values as it takes. An option whose name is blank once resolved is written under its `displayKey` instead, so it stays usable. Two values are separated by a comma, and are conventionally wrapped in brackets, which are optional:
-
-```text
-[Age] Even Numbers
-[Age] Between (Exclusive) (30, 40)
-```
+An option is written in an expression under its `displayName`, or its [localised](./localisation/) text where the `displayKey` has an entry, followed by as many values as it takes. An option whose name is blank once resolved is written under its `displayKey` instead, so it stays usable. Two values are separated by a comma, and are conventionally wrapped in brackets, which are optional — `[Age] Even Numbers`, `[Age] Between (Exclusive) (30, 40)`.
 
 Each value is quoted according to its Cell Data Type, as for the built-in options: `number` and `bigint` values are unquoted, all others are quoted. A value that would otherwise end early — one containing a space or a closing bracket, starting with a quote, or holding the comma that separates a pair — is quoted whatever its type. A `number` or `bigint` value that contains both kinds of quote cannot be wrapped in either, so it is written as the plain number instead.
 

--- a/packages/ag-grid-community/src/interfaces/iAdvancedFilterBuilderParams.ts
+++ b/packages/ag-grid-community/src/interfaces/iAdvancedFilterBuilderParams.ts
@@ -26,7 +26,7 @@ export interface IAdvancedFilterBuilderParams {
     pillSelectMinWidth?: number;
     /**
      * Max width in pixels of the Advanced Filter Builder pill select popup.
-     * @default 200
+     * Unset, the popup grows to its widest option, bounded by the width of the Advanced Filter Builder.
      */
     pillSelectMaxWidth?: number;
     /**

--- a/packages/ag-grid-enterprise/src/advancedFilter/advanced-filter.css
+++ b/packages/ag-grid-enterprise/src/advancedFilter/advanced-filter.css
@@ -262,7 +262,13 @@
     cursor: default;
 }
 
+.ag-advanced-filter-builder-virtual-list-viewport {
+    scrollbar-width: thin;
+}
+
 .ag-advanced-filter-builder-virtual-list-container {
+    --ag-internal-virtual-list-overflow: visible;
+
     top: var(--ag-spacing);
 }
 
@@ -270,6 +276,7 @@
     display: flex;
     cursor: default;
     height: var(--ag-list-item-height);
+    min-width: max-content;
 }
 
 .ag-advanced-filter-builder-virtual-list-item:hover {

--- a/packages/ag-grid-enterprise/src/advancedFilter/builder/advancedFilterBuilderComp.ts
+++ b/packages/ag-grid-enterprise/src/advancedFilter/builder/advancedFilterBuilderComp.ts
@@ -391,7 +391,7 @@ export class AdvancedFilterBuilderComp extends Component<AdvancedFilterBuilderEv
     ): AdvancedFilterBuilderItemComp | AdvancedFilterBuilderItemAddComp {
         const itemComp = this.createBean(
             item.filterModel
-                ? new AdvancedFilterBuilderItemComp(item, this.dragFeature, focusWrapper)
+                ? new AdvancedFilterBuilderItemComp(item, this.dragFeature, focusWrapper, this.getGui())
                 : new AdvancedFilterBuilderItemAddComp(item, focusWrapper)
         );
 

--- a/packages/ag-grid-enterprise/src/advancedFilter/builder/advancedFilterBuilderItemComp.ts
+++ b/packages/ag-grid-enterprise/src/advancedFilter/builder/advancedFilterBuilderItemComp.ts
@@ -120,7 +120,8 @@ export class AdvancedFilterBuilderItemComp extends TabGuardComp<AdvancedFilterBu
     constructor(
         public readonly item: AdvancedFilterBuilderItem,
         private readonly dragFeature: AdvancedFilterBuilderDragFeature,
-        private readonly focusWrapper: HTMLElement
+        private readonly focusWrapper: HTMLElement,
+        private readonly eBuilder: HTMLElement
     ) {
         super(AdvancedFilterBuilderItemElement);
     }
@@ -390,9 +391,7 @@ export class AdvancedFilterBuilderItemComp extends TabGuardComp<AdvancedFilterBu
         };
         if (params.isSelect) {
             const { getEditorParams, pickerAriaLabelKey, pickerAriaLabelValue, displayValue } = params;
-            const advancedFilterBuilderParams = this.gos.get('advancedFilterBuilderParams');
-            const minPickerWidth = `${advancedFilterBuilderParams?.pillSelectMinWidth ?? 140}px`;
-            const maxPickerWidth = `${advancedFilterBuilderParams?.pillSelectMaxWidth ?? 200}px`;
+            const { pillSelectMinWidth, pillSelectMaxWidth } = this.gos.get('advancedFilterBuilderParams') ?? {};
             const comp = this.createBean(
                 new SelectPillComp({
                     pickerAriaLabelKey,
@@ -405,8 +404,9 @@ export class AdvancedFilterBuilderItemComp extends TabGuardComp<AdvancedFilterBu
                     valueFormatter: (value: AutocompleteEntry) =>
                         value == null ? '' : (value.displayValue ?? value.key),
                     variableWidth: true,
-                    minPickerWidth,
-                    maxPickerWidth,
+                    minPickerWidth: pillSelectMinWidth ?? 140,
+                    maxPickerWidth: pillSelectMaxWidth,
+                    eBuilder: this.eBuilder,
                     getEditorParams,
                     wrapperClassName: cssClass,
                     ariaLabel,

--- a/packages/ag-grid-enterprise/src/advancedFilter/builder/selectPillComp.ts
+++ b/packages/ag-grid-enterprise/src/advancedFilter/builder/selectPillComp.ts
@@ -1,4 +1,4 @@
-import { _setAriaLabel, _setAriaLabelledBy } from 'ag-stack';
+import { _getInnerWidth, _setAriaLabel, _setAriaLabelledBy } from 'ag-stack';
 
 import type { ElementParams, RichSelectParams } from 'ag-grid-community';
 import { AgInputTextFieldSelector, _stopPropagationForAgGrid } from 'ag-grid-community';
@@ -10,6 +10,9 @@ interface SelectPillParams extends RichSelectParams<AutocompleteEntry> {
     getEditorParams: () => { values?: any[] };
     wrapperClassName: string;
     ariaLabel: string;
+    /** Caps how wide the picker may grow: wider than the builder itself and a dropdown reads as a second panel. */
+    eBuilder: HTMLElement;
+    maxPickerWidth?: number;
 }
 
 const SelectPillElement: ElementParams = {
@@ -84,7 +87,29 @@ export class SelectPillComp extends AgRichSelect<AutocompleteEntry> {
             };
             this.value = value;
         }
-        return super.createPickerComponent();
+
+        const listComponent = super.createPickerComponent();
+        // Opening reseeds the picker's width from `minPickerWidth`, so both the cap and the arming are per-open.
+        const maxWidth = Math.min(this.params.maxPickerWidth ?? Infinity, _getInnerWidth(this.params.eBuilder));
+        listComponent.setContentWidthCallback((width) => this.growPickerToContent(width, maxWidth));
+        return listComponent;
+    }
+
+    /** The pill's width reflects the current value, not the options it lists, so size the picker from the rows. */
+    private growPickerToContent(width: number, maxWidth: number): boolean {
+        const ePicker = this.pickerComponent?.getGui();
+        if (!ePicker) {
+            return true; // nothing was measured, which is not the same as no room left
+        }
+
+        const target = Math.min(width, maxWidth);
+        // The seeded `min-width` is the floor, so reading it back is what keeps a narrower row from shrinking it.
+        if (target > parseFloat(ePicker.style.minWidth || '0')) {
+            ePicker.style.minWidth = `${target}px`;
+            this.alignPickerToComponent();
+        }
+
+        return target < maxWidth;
     }
 
     protected override onEnterKeyDown(event: KeyboardEvent): void {

--- a/packages/ag-grid-enterprise/src/agStack/agVirtualList.css
+++ b/packages/ag-grid-enterprise/src/agStack/agVirtualList.css
@@ -17,7 +17,8 @@
 }
 
 .ag-virtual-list-container {
-    overflow: hidden;
+    /* a variable rather than a rule to override, so a list needing its rows to overflow does not fight the cascade */
+    overflow: var(--ag-internal-virtual-list-overflow, hidden);
     position: relative;
 }
 
@@ -25,4 +26,10 @@
     height: var(--ag-list-item-height);
     position: absolute;
     width: 100%;
+}
+
+/* lets a rendered row report the width its content wants, so the list can grow to it */
+:where(.ag-virtual-list-grow-to-content) .ag-virtual-list-item {
+    min-width: 100%;
+    width: max-content;
 }

--- a/packages/ag-grid-enterprise/src/widgets/agRichSelectList.test.ts
+++ b/packages/ag-grid-enterprise/src/widgets/agRichSelectList.test.ts
@@ -20,6 +20,48 @@ function createList<TValue>(params?: Partial<RichSelectParams<TValue>>) {
     return { list, wrapper };
 }
 
+const GROW_CLASS = 'ag-virtual-list-grow-to-content';
+
+/**
+ * A list whose rendered rows report `rowWidths`, and whose own box is `boxWidth` wide with a 2px border, so the
+ * width the callback receives is `max(rowWidths) + 2`. `draw()` runs one `drawVirtualRows` pass over them.
+ */
+function createMeasurableList(rowWidths: number[], boxWidth = 500) {
+    const { list } = createList<string>();
+    const gui = list.getGui() as HTMLElement;
+
+    Object.defineProperty(gui, 'getBoundingClientRect', { value: () => ({ width: boxWidth }), configurable: true });
+    Object.defineProperty(gui, 'clientWidth', { value: boxWidth - 2, configurable: true });
+
+    (list as any).forEachRenderedRow = (callback: (cmp: any, idx: number) => void) => {
+        rowWidths.forEach((width, idx) =>
+            callback(
+                {
+                    getCompId: () => `${idx}`,
+                    getValue: () => 'value',
+                    toggleHighlighted: vi.fn(),
+                    updateSelected: vi.fn(),
+                    getGui: () => ({ getBoundingClientRect: () => ({ width }) }),
+                },
+                idx
+            )
+        );
+    };
+    (list as any).refresh = vi.fn();
+    (list as any).ensureIndexVisible = vi.fn();
+    list.setCurrentList(rowWidths.map((_, idx) => `row-${idx}`));
+
+    const virtualListPrototype = Object.getPrototypeOf(Object.getPrototypeOf(list));
+    const drawSpy = vi.spyOn(virtualListPrototype, 'drawVirtualRows').mockImplementation(() => {});
+
+    return {
+        list,
+        gui,
+        draw: () => (list as any).drawVirtualRows(true),
+        restore: () => drawSpy.mockRestore(),
+    };
+}
+
 describe('AgRichSelectList', () => {
     it('clears active option attributes when highlight is removed', () => {
         const { list, wrapper } = createList<string>();
@@ -215,6 +257,68 @@ describe('AgRichSelectList', () => {
         (list as any).onGuiScroll();
 
         expect(callback).toHaveBeenCalled();
+    });
+
+    it('reports the widest rendered row plus the width its own border takes', () => {
+        const { list, draw, restore } = createMeasurableList([120, 180.4, 90]);
+        const reportContentWidth = vi.fn().mockReturnValue(true);
+
+        try {
+            list.setContentWidthCallback(reportContentWidth);
+            draw();
+        } finally {
+            restore();
+        }
+
+        expect(reportContentWidth).toHaveBeenCalledTimes(1);
+        expect(reportContentWidth).toHaveBeenCalledWith(183);
+    });
+
+    it('lays rows out at their content width only while armed', () => {
+        const { list, gui, draw, restore } = createMeasurableList([120]);
+
+        try {
+            expect(gui.classList.contains(GROW_CLASS)).toBe(false);
+
+            list.setContentWidthCallback(vi.fn().mockReturnValue(true));
+            expect(gui.classList.contains(GROW_CLASS)).toBe(true);
+
+            draw();
+            expect(gui.classList.contains(GROW_CLASS)).toBe(true);
+        } finally {
+            restore();
+        }
+    });
+
+    it('stops measuring and restores elision once the callback reports no room left', () => {
+        const { list, gui, draw, restore } = createMeasurableList([120]);
+        const reportContentWidth = vi.fn().mockReturnValue(false);
+
+        try {
+            list.setContentWidthCallback(reportContentWidth);
+            draw();
+            draw();
+        } finally {
+            restore();
+        }
+
+        expect(reportContentWidth).toHaveBeenCalledTimes(1);
+        expect(gui.classList.contains(GROW_CLASS)).toBe(false);
+    });
+
+    it('stays armed when a draw renders no rows, so a later draw can still measure', () => {
+        const { list, gui, draw, restore } = createMeasurableList([]);
+        const reportContentWidth = vi.fn().mockReturnValue(false);
+
+        try {
+            list.setContentWidthCallback(reportContentWidth);
+            draw();
+        } finally {
+            restore();
+        }
+
+        expect(reportContentWidth).not.toHaveBeenCalled();
+        expect(gui.classList.contains(GROW_CLASS)).toBe(true);
     });
 
     it('announces loading and no-matches state transitions', () => {

--- a/packages/ag-grid-enterprise/src/widgets/agRichSelectList.ts
+++ b/packages/ag-grid-enterprise/src/widgets/agRichSelectList.ts
@@ -41,6 +41,7 @@ export class AgRichSelectList<TValue, TEventType extends string = AgRichSelectLi
     private eStateCompLabel: HTMLElement;
     private eLoadingIcon: Element | undefined;
     private loadMoreRowsCallback?: (direction?: VerticalDirection) => void;
+    private contentWidthCallback?: (width: number) => boolean;
     private loadMoreRowsThreshold = 10;
     private stateAnnouncementCallback?: (value: string) => void;
     private readonly valueFormatter: (value: TValue | TValue[] | null | undefined) => string;
@@ -199,6 +200,41 @@ export class AgRichSelectList<TValue, TEventType extends string = AgRichSelectLi
         this.refreshSelectedItems();
         if (this.lastRowHovered !== -1) {
             this.updateRenderedHighlightState(this.lastRowHovered);
+        }
+        // Measured last: the refreshes above write classes on these same rows, and reading before them thrashes.
+        this.reportContentWidth();
+    }
+
+    /**
+     * Opts the list into reporting the width its rows want. Rows are laid out at their content width to be
+     * measurable, which stops them eliding, so the callback returning false ends both.
+     */
+    public setContentWidthCallback(callback: (width: number) => boolean): void {
+        this.contentWidthCallback = callback;
+        this.getGui().classList.add('ag-virtual-list-grow-to-content');
+    }
+
+    /** Only rendered rows can be measured, so scrolling to a wider one is what reveals it. */
+    private reportContentWidth(): void {
+        const callback = this.contentWidthCallback;
+        if (!callback) {
+            return;
+        }
+
+        let widest = 0;
+        this.forEachRenderedRow((comp) => {
+            widest = Math.max(widest, comp.getGui().getBoundingClientRect().width);
+        });
+        if (widest === 0) {
+            return;
+        }
+
+        const eGui = this.getGui();
+        // clientWidth drops the border and any vertical scrollbar, which the picker still has to fit. Taken off
+        // the fractional rect rather than offsetWidth, so a sub-pixel border cannot round the allowance away.
+        if (!callback(Math.ceil(widest + eGui.getBoundingClientRect().width - eGui.clientWidth))) {
+            this.contentWidthCallback = undefined;
+            eGui.classList.remove('ag-virtual-list-grow-to-content');
         }
     }
 


### PR DESCRIPTION
<!-- base: latest -->

# AG-10819 + AG-10029: Advanced Filter Builder overflow fixes

FIX AG-10819
FIX AG-10029

Two ways the Builder lost content too wide for its box. Fixed together because they meet in the same stylesheet.

| scope  | net lines | lines changed | hunks | files changed |
| ------ | --------: | ------------: | ----: | ------------: |
| source |       +75 |  97 (+86 -11) |    15 |      7 edited |
| tests  |      +104 |     104 added |     2 |      1 edited |
| docs   |       +57 |  91 (+74 -17) |     7 |      4 edited |
| other  |       +12 |      12 added |     4 |      2 edited |

## Builder rows size to their content ([AG-10819](https://ag-grid.atlassian.net/browse/AG-10819))

An option taking two inputs makes a row wider than the fixed-width panel, so its add and remove buttons were
clipped away with no way to reach them: `[Date] Between (Exclusive) ("2008-08-20", "2008-08-25")` needs 734px in
a 698px viewport. Rows take `min-width: max-content` and the Builder's own list container stops clipping, so the
overflow reaches the viewport's scrollbar, which takes `scrollbar-width: thin` to match the paging panel and
status bar.

The shared virtual list's `overflow: hidden` becomes `var(--ag-internal-virtual-list-overflow, hidden)` and the
Builder's container sets that variable. A custom property set on the element wins whatever order the two
stylesheets register in, so the shared rule keeps its selector and its specificity and no other virtual list is
affected. Legacy themes emit the advanced filter part after the shared one, so there the plain declaration
already wins and the variable is not needed.

**Behaviour change:** a pill whose text is wider than the panel now widens its row instead of eliding. A long
column or option name scrolls the Builder where it previously truncated one pill and kept its tooltip.

## Pill dropdowns size to their options ([AG-10029](https://ag-grid.atlassian.net/browse/AG-10029))

The picker was sized from the pill showing the current value, not from the options in it. With `is between`
selected the pill is narrow, the picker fell back to its 140px minimum, and the 122px of content that leaves
cannot fit `is in last 24 months`; selecting a wider value first gave 159px and it fitted. The picker now grows
to the widest row the list has rendered and keeps that width for as long as it is open, capped at the Builder's
width, past which rows elide and keep their tooltip. Only rendered rows are measured, so list length costs
nothing. The cap is on width rather than position: the picker is a popup anchored to its pill, so a capped one
opened from an indented pill still extends past the panel edge.

Growing is opt-in. `AgRichSelectList` lays its rows out at their content width only once
`setContentWidthCallback` has been called, and `SelectPillComp` is its only caller, so every other rich select
keeps sizing from its wrapper.

**Behaviour change:** `pillSelectMaxWidth` no longer defaults to 200px. Unset, a dropdown grows to its widest
option, capped at the Builder's width; set `advancedFilterBuilderParams.pillSelectMaxWidth` to restore a fixed
cap.

A list that scrolls rather than grows would be wrong here, and vice versa: the panel is a fixed size holding
controls that must be reachable, while the dropdown is a transient popup holding text that must be readable.

## Docs e2e honours a moved dev-server port

`docs-e2e.sh` runs Playwright directly rather than through Nx, so it never saw the `PORT` the `dev` target takes
its port from, and tested `4610` whatever the server was serving. The Playwright config now reads the workspace
`.env.local` then `.env`, first value winning as Nx does, and defaults its local base URL from `PORT`. That lets
several checkouts serve the docs side by side, each with one gitignored line, and it removes a way for an e2e run
to pass against a port nothing under test is listening on.

## Advanced Filter expressions are highlighted as TypeScript ([AG-10029](https://ag-grid.atlassian.net/browse/AG-10029))

A fenced block on the docs site is highlighted as the reader's framework language whatever the fence declares,
so `[Date] is in last year` rendered with `in` in the keyword colour. The three expression blocks on the
Advanced Filter page become inline code, as `[Age] is between (21, 38)` already is.
