### PR TITLE
AG-3390 Allow the blog newsletter's Mailchimp JSONP subscribe call in script-src

### DIFF
--- a/documentation/ag-grid-docs/src/utils/htaccess/cspRules.test.ts
+++ b/documentation/ag-grid-docs/src/utils/htaccess/cspRules.test.ts
@@ -127,6 +127,24 @@ describe('cspRules', () => {
         });
     });
 
+    describe('blog scope (reverse-proxied Ghost blog)', () => {
+        it('allows the Mailchimp newsletter signup end to end', () => {
+            const blog = getCspDirectives({ env: 'production', scope: 'blog' });
+            // The signup form loads mc-validate.js, which submits via jQuery JSONP — a
+            // <script src> pointing at /subscribe/post-json on the list-manage origin —
+            // so that origin needs script-src on top of the base form-action entry.
+            expect(blog['script-src']).toContain('https://s3.amazonaws.com/downloads.mailchimp.com/js/mc-validate.js');
+            expect(blog['script-src']).toContain('https://ag-grid.us11.list-manage.com');
+            expect(blog['form-action']).toContain('https://ag-grid.us11.list-manage.com');
+        });
+
+        it('does not leak the blog script hosts into the site scope', () => {
+            const site = getCspDirectives({ env: 'production', scope: 'site' });
+            expect(site['script-src']).not.toContain('https://ag-grid.us11.list-manage.com');
+            expect(site['script-src']).not.toContain('https://platform.twitter.com');
+        });
+    });
+
     describe('Enzuzo cookie-consent banner (replaces OneTrust)', () => {
         it('allows the banner bundle in script-src and its APIs in connect-src', () => {
             const site = getCspDirectives({ env: 'production', scope: 'site' });

--- a/documentation/ag-grid-docs/src/utils/htaccess/cspRules.ts
+++ b/documentation/ag-grid-docs/src/utils/htaccess/cspRules.ts
@@ -385,6 +385,10 @@ const BLOG_SCRIPT_HOSTS = [
     'https://platform.twitter.com', // embedded tweets (widgets.js)
     'https://widget.spreaker.com', // podcast embeds
     'https://s3.amazonaws.com/downloads.mailchimp.com/js/mc-validate.js',
+    // The newsletter signup form submits via mc-validate's jQuery JSONP: the subscribe
+    // call is loaded as a <script src> pointing at /subscribe/post-json on this origin,
+    // so it needs script-src on top of the form-action entry in the base policy.
+    'https://ag-grid.us11.list-manage.com',
 ];
 
 const BLOG_STYLE_HOSTS = ['https://cdn-images.mailchimp.com']; // Mailchimp embed stylesheet


### PR DESCRIPTION
## What

Submitting the newsletter form on https://www.ag-grid.com/blog/newsletter/ is blocked by the blog CSP:

> Loading the script 'https://ag-grid.us11.list-manage.com/subscribe/post-json?...' violates the following Content Security Policy directive: "script-src ..."

Mailchimp's `mc-validate.js` (already allowed) submits the subscription as jQuery JSONP — a `<script src>` pointing at `/subscribe/post-json` on `ag-grid.us11.list-manage.com`. That origin was only in `form-action`, not `script-src`, so the load was blocked.

## Changes

- Add `https://ag-grid.us11.list-manage.com` to `BLOG_SCRIPT_HOSTS` — blog scope only, the site policy is unchanged.
- Add blog-scope tests: the Mailchimp signup path end to end, and that the blog script hosts do not leak into the site scope.

## Deployment note

The blog CSP is served from the vhost (the blog is reverse-proxied, so it never reads the generated `.htaccess`) — the live header changes only once the fragment from `generate-csp.ts` (`getBlogVhostHeaderFragment`) is regenerated and re-placed on the vhost.