### PR TITLE
AG-17659 fix-for-custom-renderers

### DIFF
--- a/packages/ag-grid-enterprise/src/setFilter/setFilterHandler.ts
+++ b/packages/ag-grid-enterprise/src/setFilter/setFilterHandler.ts
@@ -15,7 +15,7 @@ import type {
     SetFilterModelValue,
     ValueFormatterParams,
 } from 'ag-grid-community';
-import { BeanStub, _addGridCommonParams, _isClientSideRowModel } from 'ag-grid-community';
+import { BeanStub, _addGridCommonParams, _isBlank, _isClientSideRowModel } from 'ag-grid-community';
 
 import { CsrmValuesExtractor } from './csrmValueExtractor';
 import type { SetFilterModelTreeItem } from './iSetDisplayValueModel';
@@ -480,10 +480,17 @@ export class SetFilterHandler<TValue = string>
                 return;
             }
             this.noValueFormatterSupplied = true;
-            // ref data is handled by ValueService
-            if (!isRefData) {
-                valueFormatter = (params) => _toStringOrNull(params.value)!;
-            }
+            // Naming the blank here, not at render time, is what keeps a supplied formatter able to override it.
+            valueFormatter = (params) => {
+                const value = params.value;
+                if (_isBlank(value)) {
+                    return translateForSetFilter(this, 'blanks');
+                }
+                // ref data is handled by ValueService
+                return isRefData
+                    ? this.beans.valueSvc.formatValue(params.column as AgColumn, null, value, undefined, false)!
+                    : _toStringOrNull(value)!;
+            };
         }
         this.valueFormatter = valueFormatter;
     }

--- a/packages/ag-grid-enterprise/src/setFilter/setFilterListItem.ts
+++ b/packages/ag-grid-enterprise/src/setFilter/setFilterListItem.ts
@@ -401,6 +401,10 @@ export class SetFilterListItem<V> extends Component<SetFilterListItemEvent> {
         } else {
             formattedValue = this.getFormattedValue(column as AgColumn, value);
         }
+        // A formatter answering nothing for a blank declined to name it, so the label and a cellRenderer agree here.
+        if (formattedValue == null && value == null) {
+            formattedValue = this.translate('blanks');
+        }
         this.formattedValue = formattedValue;
 
         this.setTooltipAndCellRendererParams(value, formattedValue);
@@ -483,7 +487,7 @@ export class SetFilterListItem<V> extends Component<SetFilterListItemEvent> {
 
     private renderCellWithoutCellRenderer(): void {
         const { valueFormatted, value } = this.cellRendererParams;
-        let valueToRender = (valueFormatted == null ? value : valueFormatted) ?? this.translate('blanks');
+        let valueToRender = valueFormatted == null ? value : valueFormatted;
         if (typeof valueToRender !== 'string') {
             this.beans.log.warn(208);
             valueToRender = '';

--- a/packages/ag-grid-enterprise/src/setFilter/setFilterUtils.ts
+++ b/packages/ag-grid-enterprise/src/setFilter/setFilterUtils.ts
@@ -38,15 +38,14 @@ export function setFilterNullIfBlank<T>(value?: T): T | null {
     return value == null || _isBlank(value) ? null : value;
 }
 
-/** `refData` answers '' for a key it cannot map, but a formatter owns its own output. */
+/** The Set Filter formats with its own formatter only, never the column's. */
 export function setFilterFormattedValue(
     beans: BeanCollection,
     column: AgColumn,
     value: unknown,
     valueFormatter: ((params: ValueFormatterParams) => string) | undefined
 ): string | null {
-    const formattedValue = beans.valueSvc.formatValue(column, null, value, valueFormatter, false);
-    return !valueFormatter && formattedValue === '' && _isBlank(value) ? null : formattedValue;
+    return beans.valueSvc.formatValue(column, null, value, valueFormatter, false);
 }
 
 export function translateForSetFilter(

--- a/testing/behavioural/src/filters/advanced-filter/advanced-filter-set-autocomplete.test.ts
+++ b/testing/behavioural/src/filters/advanced-filter/advanced-filter-set-autocomplete.test.ts
@@ -140,6 +140,40 @@ describe('Advanced Filter - Set Filter autocomplete rendering', () => {
         expect(document.querySelectorAll('.ag-autocomplete-list em').length).toBe(2);
         expect(document.querySelectorAll('.ag-autocomplete-list b').length).toBe(0);
     });
+
+    test('a blank reaches a cell renderer named, the same spelling the list offers', async () => {
+        const api = await gridsManager.createGridAndWait('grid1', {
+            ...DEFAULT_OPTIONS,
+            columnDefs: [
+                { field: 'athlete' },
+                {
+                    field: 'country',
+                    filter: 'agSetColumnFilter',
+                    filterParams: {
+                        cellRenderer: (p: { valueFormatted?: string | null }) => `<em>${p.valueFormatted || ''}</em>`,
+                    },
+                },
+            ],
+        });
+        const af = AdvancedFilterHarness.get(api);
+
+        await af.type('[Country] is any of [');
+
+        expect(af.autocompleteEntries()).toEqual([
+            '(Blanks)',
+            'Jamaica',
+            'Poland',
+            'United Kingdom',
+            'United States',
+        ]);
+        expect(Array.from(document.querySelectorAll('.ag-autocomplete-list em')).map((el) => el.textContent)).toEqual([
+            '(Blanks)',
+            'Jamaica',
+            'Poland',
+            'United Kingdom',
+            'United States',
+        ]);
+    });
 });
 
 describe('Advanced Filter - Set Filter editing a written list', () => {

--- a/testing/behavioural/src/filters/advanced-filter/advanced-filter-set-autocomplete.test.ts
+++ b/testing/behavioural/src/filters/advanced-filter/advanced-filter-set-autocomplete.test.ts
@@ -159,13 +159,7 @@ describe('Advanced Filter - Set Filter autocomplete rendering', () => {
 
         await af.type('[Country] is any of [');
 
-        expect(af.autocompleteEntries()).toEqual([
-            '(Blanks)',
-            'Jamaica',
-            'Poland',
-            'United Kingdom',
-            'United States',
-        ]);
+        expect(af.autocompleteEntries()).toEqual(['(Blanks)', 'Jamaica', 'Poland', 'United Kingdom', 'United States']);
         expect(Array.from(document.querySelectorAll('.ag-autocomplete-list em')).map((el) => el.textContent)).toEqual([
             '(Blanks)',
             'Jamaica',

--- a/testing/behavioural/src/filters/filter-behaviour/set-filter-values.test.ts
+++ b/testing/behavioural/src/filters/filter-behaviour/set-filter-values.test.ts
@@ -511,15 +511,15 @@ describe('Set Filter — value model & UI (coverage)', () => {
         expect(filter.setFilterItemLabels()).toEqual(['(Select All)', '(Blanks)', 'Ada']);
     });
 
-    // A custom cellRenderer replaces the label, so it needs the same blank signal the built-in label gets.
-    test('a custom filterParams.cellRenderer is told a blank is blank', async () => {
+    // The blanks label is a formatted value, so it reaches a custom cellRenderer like any other label.
+    test('a custom filterParams.cellRenderer is given the blanks label on every untyped column', async () => {
         const seen: unknown[] = [];
         class LabelRenderer {
             private eGui!: HTMLElement;
             public init(params: ISetFilterCellRendererParams): void {
-                seen.push(params.valueFormatted);
+                seen.push(params.value);
                 this.eGui = document.createElement('span');
-                this.eGui.textContent = params.valueFormatted ?? 'MISSING';
+                this.eGui.textContent = params.valueFormatted || '<empty>';
             }
             public getGui(): HTMLElement {
                 return this.eGui;
@@ -528,23 +528,126 @@ describe('Set Filter — value model & UI (coverage)', () => {
                 return false;
             }
         }
+        const cellRenderer = { cellRenderer: LabelRenderer } as ISetFilterParams;
+
+        const api: GridApi = await gridsManager.createGridAndWait('grid1', {
+            columnDefs: [
+                { field: 'country', filter: 'agSetColumnFilter', refData: { it: 'Italy' }, filterParams: cellRenderer },
+                { field: 'name', filter: 'agSetColumnFilter', filterParams: cellRenderer },
+                { field: 'age', cellDataType: 'number', filter: 'agSetColumnFilter', filterParams: cellRenderer },
+            ],
+            rowData: [
+                { country: 'it', name: 'Ada', age: 42 },
+                { country: null, name: null, age: null },
+            ],
+        });
+
+        expect((await ColumnFilterHarness.open(api, 'country')).setFilterItemLabels()).toEqual([
+            '(Select All)',
+            '(Blanks)',
+            'Italy',
+        ]);
+        expect((await ColumnFilterHarness.open(api, 'name')).setFilterItemLabels()).toEqual([
+            '(Select All)',
+            '(Blanks)',
+            'Ada',
+        ]);
+        expect((await ColumnFilterHarness.open(api, 'age')).setFilterItemLabels()).toEqual([
+            '(Select All)',
+            '(Blanks)',
+            '42',
+        ]);
+        // The key stays null, so a renderer that wants to treat a blank differently still can.
+        expect(seen).toContain(null);
+    });
+
+    // Returning nothing declines to name the blank, so the grid names it for the renderer as it does for the label.
+    test('a filterParams.valueFormatter answering nothing leaves the blank named for a cellRenderer too', async () => {
+        class LabelRenderer {
+            private eGui!: HTMLElement;
+            public init(params: ISetFilterCellRendererParams): void {
+                this.eGui = document.createElement('span');
+                this.eGui.textContent = params.valueFormatted || '<empty>';
+            }
+            public getGui(): HTMLElement {
+                return this.eGui;
+            }
+            public refresh(): boolean {
+                return false;
+            }
+        }
+        // The reference-data value-handler docs example: a lookup that misses answers `undefined`.
+        const valueFormatter = ({ value }: ValueFormatterParams) => ({ cb: 'Cadet Blue' })[value as string];
 
         const api: GridApi = await gridsManager.createGridAndWait('grid1', {
             columnDefs: [
                 {
-                    field: 'country',
+                    field: 'colour',
                     filter: 'agSetColumnFilter',
-                    refData: { it: 'Italy' },
-                    filterParams: { cellRenderer: LabelRenderer } as ISetFilterParams,
+                    filterParams: { valueFormatter, cellRenderer: LabelRenderer } as ISetFilterParams,
                 },
+                { field: 'other', filter: 'agSetColumnFilter', filterParams: { valueFormatter } as ISetFilterParams },
             ],
-            rowData: [{ country: 'it' }, { country: null }],
+            rowData: [
+                { colour: 'cb', other: 'cb' },
+                { colour: null, other: null },
+            ],
         });
 
-        const filter = await ColumnFilterHarness.open(api, 'country');
-        expect(filter.setFilterItemLabels()).toEqual(['(Select All)', 'MISSING', 'Italy']);
-        // The blank arrives as nullish rather than '', which is what lets a renderer tell it apart.
-        expect(seen).toContain(null);
+        expect((await ColumnFilterHarness.open(api, 'colour')).setFilterItemLabels()).toEqual([
+            '(Select All)',
+            '(Blanks)',
+            'Cadet Blue',
+        ]);
+        // The built-in label has always named it; the cellRenderer now agrees.
+        expect((await ColumnFilterHarness.open(api, 'other')).setFilterItemLabels()).toEqual([
+            '(Select All)',
+            '(Blanks)',
+            'Cadet Blue',
+        ]);
+    });
+
+    test('a supplied filterParams.valueFormatter still owns the blank label, cellRenderer or not', async () => {
+        class LabelRenderer {
+            private eGui!: HTMLElement;
+            public init(params: ISetFilterCellRendererParams): void {
+                this.eGui = document.createElement('span');
+                this.eGui.textContent = params.valueFormatted || '<empty>';
+            }
+            public getGui(): HTMLElement {
+                return this.eGui;
+            }
+            public refresh(): boolean {
+                return false;
+            }
+        }
+        const valueFormatter = ({ value }: ValueFormatterParams) => (value == null ? 'nothing here' : String(value));
+
+        const api: GridApi = await gridsManager.createGridAndWait('grid1', {
+            columnDefs: [
+                { field: 'name', filter: 'agSetColumnFilter', filterParams: { valueFormatter } as ISetFilterParams },
+                {
+                    field: 'other',
+                    filter: 'agSetColumnFilter',
+                    filterParams: { valueFormatter, cellRenderer: LabelRenderer } as ISetFilterParams,
+                },
+            ],
+            rowData: [
+                { name: 'Ada', other: 'Ada' },
+                { name: null, other: null },
+            ],
+        });
+
+        expect((await ColumnFilterHarness.open(api, 'name')).setFilterItemLabels()).toEqual([
+            '(Select All)',
+            'nothing here',
+            'Ada',
+        ]);
+        expect((await ColumnFilterHarness.open(api, 'other')).setFilterItemLabels()).toEqual([
+            '(Select All)',
+            'nothing here',
+            'Ada',
+        ]);
     });
 
     // The filter summary resolves the label independently of the Filter List.


### PR DESCRIPTION
<!-- base: latest -->
# AG-17659: Set Filter names a blank for a custom cellRenderer

FIX AG-17659

A Set Filter's blank entry read `(Blanks)` only where the grid rendered the label itself. A column supplying `filterParams.cellRenderer` was handed nothing to show, so the entry rendered empty. The Reference Data documentation examples supply one.

The previous PR fixed for the general case without formatters and custom components, this fixes also with formatters and custom components

| scope  | net lines |  lines changed | hunks | files changed |
| ------ | --------: | -------------: | ----: | ------------: |
| source |       +10 |    28 (+19 -9) |     6 |      3 edited |
| tests  |      +137 | 161 (+149 -12) |     9 |      2 edited |

## The blanks label is a formatted value ([AG-17659](https://ag-grid.atlassian.net/browse/AG-17659))

For every `cellDataType` the grid owns, `setFilterParamsForEachDataType` installs a default `filterParams.valueFormatter` that answers `(Blanks)`, so `date`, `dateString`, `object` and `boolean` columns already gave that label to whatever rendered the entry. `text`, `number`, `bigint` and `refData` columns get no such formatter, and only the built-in label applied the fallback, so a custom cellRenderer on those columns received nothing.

The Set Filter's own synthesised formatter now names the blank, matching the typed columns. It is installed only when no formatter was supplied, so `filterParams.valueFormatter` still decides the label for any column that provides one. `params.value` stays null, which is what lets a renderer treat a blank differently.

A refData column keeps its mapping by delegating a present value back to `ValueService`, the only path that consults `colDef.refData`.

Since this covers every column at the point the formatter is resolved, it also reaches `cellDataType: false`, which the per-data-type table cannot describe. It supersedes the refData branch in `setFilterFormattedValue`, which is removed.

## A formatter answering nothing leaves the blank unnamed ([AG-17659](https://ag-grid.atlassian.net/browse/AG-17659))

A supplied `filterParams.valueFormatter` that returns `undefined` for a value it cannot map declined to name the blank rather than choosing an empty label. The built-in label already fell back to `(Blanks)` in that case; a custom cellRenderer was handed the `undefined`.

Resolving that fallback once in `SetFilterListItem.render` gives the label and the cell renderer the same string. A formatter returning `''` still keeps its empty label, since only a nullish answer counts as declining.

The Advanced Filter's value list resolves its labels through `SetFilterHandler.getFormattedValue`, which named blanks already; the added autocomplete case characterises that parity rather than changing it.
