### PR TITLE
AG-17950 PDF export documentation improvements (TC2-TC9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ AG Grid is available in two versions: Community & Enterprise.
 | [Row Grouping and Aggregation](https://www.ag-grid.com/javascript-data-grid/grouping/?utm_source=ag-grid-readme&utm_medium=repository&utm_campaign=github)     | ❌                | ✅                 |
 | [Pivoting](https://www.ag-grid.com/javascript-data-grid/pivoting/?utm_source=ag-grid-readme&utm_medium=repository&utm_campaign=github)                         | ❌                | ✅                 |
 | [Excel Export](https://www.ag-grid.com/javascript-data-grid/excel-export/?utm_source=ag-grid-readme&utm_medium=repository&utm_campaign=github)                 | ❌                | ✅                 |
+| [PDF Export](https://www.ag-grid.com/javascript-data-grid/pdf-export/?utm_source=ag-grid-readme&utm_medium=repository&utm_campaign=github)                     | ❌                | ✅                 |
 | [Clipboard Operations](https://www.ag-grid.com/javascript-data-grid/clipboard/?utm_source=ag-grid-readme&utm_medium=repository&utm_campaign=github)            | ❌                | ✅                 |
 | [Master/Detail](https://www.ag-grid.com/javascript-data-grid/master-detail/?utm_source=ag-grid-readme&utm_medium=repository&utm_campaign=github)               | ❌                | ✅                 |
 | [Tree Data](https://www.ag-grid.com/javascript-data-grid/tree-data/?utm_source=ag-grid-readme&utm_medium=repository&utm_campaign=github)                       | ❌                | ✅                 |

--- a/community-modules/locale/README.md
+++ b/community-modules/locale/README.md
@@ -114,6 +114,7 @@ AG Grid is available in two versions: Community & Enterprise.
 | [Row Grouping and Aggregation](https://www.ag-grid.com/javascript-data-grid/grouping/?utm_source=ag-grid-readme&utm_medium=repository&utm_campaign=github)     | ❌                | ✅                 |
 | [Pivoting](https://www.ag-grid.com/javascript-data-grid/pivoting/?utm_source=ag-grid-readme&utm_medium=repository&utm_campaign=github)                         | ❌                | ✅                 |
 | [Excel Export](https://www.ag-grid.com/javascript-data-grid/excel-export/?utm_source=ag-grid-readme&utm_medium=repository&utm_campaign=github)                 | ❌                | ✅                 |
+| [PDF Export](https://www.ag-grid.com/javascript-data-grid/pdf-export/?utm_source=ag-grid-readme&utm_medium=repository&utm_campaign=github)                     | ❌                | ✅                 |
 | [Clipboard Operations](https://www.ag-grid.com/javascript-data-grid/clipboard/?utm_source=ag-grid-readme&utm_medium=repository&utm_campaign=github)            | ❌                | ✅                 |
 | [Master/Detail](https://www.ag-grid.com/javascript-data-grid/master-detail/?utm_source=ag-grid-readme&utm_medium=repository&utm_campaign=github)               | ❌                | ✅                 |
 | [Tree Data](https://www.ag-grid.com/javascript-data-grid/tree-data/?utm_source=ag-grid-readme&utm_medium=repository&utm_campaign=github)                       | ❌                | ✅                 |

--- a/community-modules/styles/README.md
+++ b/community-modules/styles/README.md
@@ -114,6 +114,7 @@ AG Grid is available in two versions: Community & Enterprise.
 | [Row Grouping and Aggregation](https://www.ag-grid.com/javascript-data-grid/grouping/?utm_source=ag-grid-readme&utm_medium=repository&utm_campaign=github)     | ❌                | ✅                 |
 | [Pivoting](https://www.ag-grid.com/javascript-data-grid/pivoting/?utm_source=ag-grid-readme&utm_medium=repository&utm_campaign=github)                         | ❌                | ✅                 |
 | [Excel Export](https://www.ag-grid.com/javascript-data-grid/excel-export/?utm_source=ag-grid-readme&utm_medium=repository&utm_campaign=github)                 | ❌                | ✅                 |
+| [PDF Export](https://www.ag-grid.com/javascript-data-grid/pdf-export/?utm_source=ag-grid-readme&utm_medium=repository&utm_campaign=github)                     | ❌                | ✅                 |
 | [Clipboard Operations](https://www.ag-grid.com/javascript-data-grid/clipboard/?utm_source=ag-grid-readme&utm_medium=repository&utm_campaign=github)            | ❌                | ✅                 |
 | [Master/Detail](https://www.ag-grid.com/javascript-data-grid/master-detail/?utm_source=ag-grid-readme&utm_medium=repository&utm_campaign=github)               | ❌                | ✅                 |
 | [Tree Data](https://www.ag-grid.com/javascript-data-grid/tree-data/?utm_source=ag-grid-readme&utm_medium=repository&utm_campaign=github)                       | ❌                | ✅                 |

--- a/documentation/ag-grid-docs/src/content/docs-nav/nav.json
+++ b/documentation/ag-grid-docs/src/content/docs-nav/nav.json
@@ -1937,6 +1937,12 @@
                                 },
                                 {
                                     "type": "item",
+                                    "title": "Customising Content",
+                                    "path": "pdf-export-customising-content",
+                                    "isEnterprise": true
+                                },
+                                {
+                                    "type": "item",
                                     "title": "Images",
                                     "path": "pdf-export-images",
                                     "isEnterprise": true

--- a/documentation/ag-grid-docs/src/content/docs/pdf-export-columns/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/pdf-export-columns/index.mdoc
@@ -54,8 +54,6 @@ api.exportDataAsPdf({
 });
 ```
 
-When `columnWidth` is omitted, the exported Row Numbers column is sized automatically from its contents. A global or per-column `columnWidth` configuration can override this behaviour.
-
 The example below demonstrates header suppression, visible or hidden column selection, and Row Numbers export.
 
 {% gridExampleRunner title="PDF Export - Columns" name="pdf-export-columns" exampleHeight=350 /%}
@@ -69,7 +67,7 @@ The `columnWidth` option accepts:
 - A number to use a fixed width in points.
 - A callback to return a custom value for each column.
 
-When `columnWidth` is omitted, regular columns use `'grid'` and the Row Numbers column uses `'auto'`. A `columnWidth` value overrides those defaults; a callback result overrides the default for that column. Returning `null` or `undefined` from the callback uses the column's default mode.
+When `columnWidth` is omitted, columns use `'grid'`. A `columnWidth` value overrides that default; a callback result overrides the default for that column. Returning `null` or `undefined` from the callback uses the column's default mode.
 
 Auto widths are measured before page scaling. If the combined widths exceed the printable page width, every column is reduced proportionally. Smaller tables are not stretched. Horizontal pagination and automatically expanding the page size are not supported.
 

--- a/documentation/ag-grid-docs/src/content/docs/pdf-export-customising-content/_examples/pdf-customising-content/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/pdf-export-customising-content/_examples/pdf-customising-content/example.spec.ts
@@ -1,0 +1,28 @@
+import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
+import { readFile } from 'node:fs/promises';
+
+test.agExample(import.meta, () => {
+    test.eachFramework('applies the export callbacks to cells, groups and headers', async ({ page }) => {
+        await ensureGridReady(page);
+        await waitForGridContent(page);
+
+        const [download] = await Promise.all([
+            page.waitForEvent('download'),
+            page.getByRole('button', { name: 'Export to PDF' }).click(),
+        ]);
+        const downloadPath = await download.path();
+
+        expect(downloadPath).toBeTruthy();
+        if (!downloadPath) {
+            throw new Error('Expected PDF export to create a downloadable file.');
+        }
+
+        const pdfContent = await readFile(downloadPath, 'latin1');
+        expect(pdfContent.startsWith('%PDF-1.4')).toBe(true);
+        expect(pdfContent).toContain('(Region: EMEA) Tj');
+        expect(pdfContent).toContain('(CUSTOMER) Tj');
+        expect(pdfContent).toContain('(Customer Details \\(grouped\\)) Tj');
+        expect(pdfContent).toContain('(Not invoiced) Tj');
+        expect(pdfContent.trimEnd().endsWith('%%EOF')).toBe(true);
+    });
+});

--- a/documentation/ag-grid-docs/src/content/docs/pdf-export-customising-content/_examples/pdf-customising-content/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/pdf-export-customising-content/_examples/pdf-customising-content/example.spec.ts
@@ -22,7 +22,8 @@ test.agExample(import.meta, () => {
         expect(pdfContent).toContain('(Region: EMEA) Tj');
         expect(pdfContent).toContain('(CUSTOMER) Tj');
         expect(pdfContent).toContain('(Customer Details \\(grouped\\)) Tj');
-        expect(pdfContent).toContain('(Not invoiced) Tj');
+        // only the single missing order total is labelled, not every blank cell on the group rows
+        expect(pdfContent.split('(Not invoiced) Tj')).toHaveLength(2);
         expect(pdfContent.trimEnd().endsWith('%%EOF')).toBe(true);
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/pdf-export-customising-content/_examples/pdf-customising-content/index.html
+++ b/documentation/ag-grid-docs/src/content/docs/pdf-export-customising-content/_examples/pdf-customising-content/index.html
@@ -1,0 +1,6 @@
+<div class="example-wrapper">
+    <div class="controls">
+        <button onclick="onBtExport()">Export to PDF</button>
+    </div>
+    <div id="myGrid"></div>
+</div>

--- a/documentation/ag-grid-docs/src/content/docs/pdf-export-customising-content/_examples/pdf-customising-content/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/pdf-export-customising-content/_examples/pdf-customising-content/main.ts
@@ -1,0 +1,71 @@
+import type { GridApi, GridOptions } from 'ag-grid-community';
+import { ClientSideRowModelModule, ModuleRegistry, createGrid, enableDevValidations } from 'ag-grid-community';
+import { ContextMenuModule, PdfExportModule, RowGroupingModule } from 'ag-grid-enterprise';
+
+if (process.env.NODE_ENV !== 'production') {
+    // Enable extended validations only for development
+    enableDevValidations();
+}
+
+ModuleRegistry.registerModules([ClientSideRowModelModule, ContextMenuModule, RowGroupingModule, PdfExportModule]);
+
+interface OrderData {
+    region: string;
+    customer: string;
+    product: string;
+    quantity: number;
+    total: number | null;
+}
+
+const rowData: OrderData[] = [
+    { region: 'EMEA', customer: 'Aurora Systems', product: 'Wireless Keyboard', quantity: 12, total: 1794 },
+    { region: 'EMEA', customer: 'Baltic Analytics', product: 'Studio Monitor', quantity: 4, total: 2756 },
+    { region: 'Americas', customer: 'Northstar Labs', product: 'USB-C Dock', quantity: 8, total: 1752 },
+    { region: 'Americas', customer: 'Cedar Freight', product: 'Wireless Keyboard', quantity: 20, total: null },
+    { region: 'APAC', customer: 'Horizon Studio', product: 'Studio Monitor', quantity: 6, total: 4134 },
+    { region: 'APAC', customer: 'Kite Robotics', product: 'USB-C Dock', quantity: 3, total: 657 },
+];
+
+let gridApi: GridApi<OrderData>;
+
+const gridOptions: GridOptions<OrderData> = {
+    columnDefs: [
+        { field: 'region', rowGroup: true, hide: true },
+        {
+            headerName: 'Customer Details',
+            children: [
+                { field: 'customer', minWidth: 180 },
+                { field: 'product', minWidth: 180 },
+            ],
+        },
+        {
+            headerName: 'Order Details',
+            children: [
+                { field: 'quantity' },
+                { field: 'total', valueFormatter: (params) => (params.value == null ? '' : `$${params.value}`) },
+            ],
+        },
+    ],
+    defaultColDef: { flex: 1, minWidth: 110 },
+    autoGroupColumnDef: { headerName: 'Region', minWidth: 200 },
+    groupDefaultExpanded: -1,
+    rowData,
+    defaultPdfExportParams: {
+        columnWidth: 'auto',
+        processCellCallback: (params) => (params.value == null ? 'Not invoiced' : params.formatValue(params.value)),
+        processRowGroupCallback: (params) => `Region: ${params.node.key ?? ''}`,
+        processHeaderCallback: (params) => {
+            const { headerName } = params.column.getColDef();
+            return (headerName ?? params.column.getColId()).toUpperCase();
+        },
+        processGroupHeaderCallback: (params) => `${params.columnGroup.getColGroupDef()?.headerName ?? ''} (grouped)`,
+    },
+};
+
+function onBtExport() {
+    gridApi.exportDataAsPdf();
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    gridApi = createGrid(document.querySelector<HTMLElement>('#myGrid')!, gridOptions);
+});

--- a/documentation/ag-grid-docs/src/content/docs/pdf-export-customising-content/_examples/pdf-customising-content/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/pdf-export-customising-content/_examples/pdf-customising-content/main.ts
@@ -52,7 +52,10 @@ const gridOptions: GridOptions<OrderData> = {
     rowData,
     defaultPdfExportParams: {
         columnWidth: 'auto',
-        processCellCallback: (params) => (params.value == null ? 'Not invoiced' : params.formatValue(params.value)),
+        processCellCallback: (params) => {
+            const isMissingTotal = params.column.getColId() === 'total' && !params.node?.group && params.value == null;
+            return isMissingTotal ? 'Not invoiced' : params.formatValue(params.value);
+        },
         processRowGroupCallback: (params) => `Region: ${params.node.key ?? ''}`,
         processHeaderCallback: (params) => {
             const { headerName } = params.column.getColDef();

--- a/documentation/ag-grid-docs/src/content/docs/pdf-export-customising-content/_examples/pdf-customising-content/styles.css
+++ b/documentation/ag-grid-docs/src/content/docs/pdf-export-customising-content/_examples/pdf-customising-content/styles.css
@@ -1,0 +1,18 @@
+.example-wrapper {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+}
+
+.controls {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 8px;
+}
+
+#myGrid {
+    flex: 1 1 0px;
+    width: 100%;
+}

--- a/documentation/ag-grid-docs/src/content/docs/pdf-export-customising-content/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/pdf-export-customising-content/index.mdoc
@@ -1,0 +1,49 @@
+---
+title: "PDF Export - Customising Content"
+enterprise: true
+---
+
+Exported values follow the grid's Value Getters and Value Formatters. Export callbacks replace the resulting text without changing the grid.
+
+## Customising Cell and Row Group Values
+
+Cell and row group values can be customised for PDF export using the following function params, either in a call to the `exportDataAsPdf` API method or in `defaultPdfExportParams`.
+
+```{% frameworkTransform=true %}
+gridApi.exportDataAsPdf({
+    processCellCallback(params) {
+        return params.value == null ? 'Not invoiced' : params.formatValue(params.value);
+    },
+    processRowGroupCallback(params) {
+        return `Region: ${params.node.key ?? ''}`;
+    },
+});
+```
+
+Row group indentation is applied independently of `processRowGroupCallback`, so the returned text does not need to account for it.
+
+{% interfaceDocumentation interfaceName="PdfExportParams" overrideSrc="pdf-export/pdf.json" names=["processCellCallback", "processRowGroupCallback"] config={"description":""} /%}
+
+## Customising Column Headers and Group Header Values
+
+Column headers and column-group headers can be customised using the following function params.
+
+```{% frameworkTransform=true %}
+gridApi.exportDataAsPdf({
+    processHeaderCallback(params) {
+        const { headerName } = params.column.getColDef();
+        return (headerName ?? params.column.getColId()).toUpperCase();
+    },
+    processGroupHeaderCallback(params) {
+        return `${params.columnGroup.getColGroupDef()?.headerName ?? ''} (grouped)`;
+    },
+});
+```
+
+{% interfaceDocumentation interfaceName="PdfExportParams" overrideSrc="pdf-export/pdf.json" names=["processHeaderCallback", "processGroupHeaderCallback"] config={"description":""} /%}
+
+The following example applies all four callbacks. The exported PDF has row groups prefixed with `Region: `, upper-case column headers, column-group headers suffixed with `(grouped)`, and the missing order total replaced with `Not invoiced`.
+
+{% gridExampleRunner title="PDF Export - Customising Content" name="pdf-customising-content" /%}
+
+These callbacks return text. To style the result, use `processStyleCallback` as described in [PDF Export - Styles](./pdf-export-styles/); its `value` is the final exported string.

--- a/documentation/ag-grid-docs/src/content/docs/pdf-export-customising-content/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/pdf-export-customising-content/index.mdoc
@@ -12,7 +12,8 @@ Cell and row group values can be customised for PDF export using the following f
 ```{% frameworkTransform=true %}
 gridApi.exportDataAsPdf({
     processCellCallback(params) {
-        return params.value == null ? 'Not invoiced' : params.formatValue(params.value);
+        const isMissingTotal = params.column.getColId() === 'total' && !params.node?.group && params.value == null;
+        return isMissingTotal ? 'Not invoiced' : params.formatValue(params.value);
     },
     processRowGroupCallback(params) {
         return `Region: ${params.node.key ?? ''}`;

--- a/documentation/ag-grid-docs/src/content/docs/pdf-export-extra-content/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/pdf-export-extra-content/index.mdoc
@@ -90,24 +90,6 @@ const defaultPdfExportParams = {
 
 {% gridExampleRunner title="PDF Cover Page" name="pdf-cover-page" exampleHeight=520 /%}
 
-## Customising Exported Values
-
-```{% frameworkTransform=true %}
-api.exportDataAsPdf({
-    processCellCallback: (params) => params.formatValue(params.value),
-    processHeaderCallback: (params) => params.column.getColDef().headerName ?? params.column.getColId(),
-    processGroupHeaderCallback: (params) => params.columnGroup.getColGroupDef()?.headerName ?? '',
-    processRowGroupCallback: (params) => `Group: ${params.node.key ?? ''}`,
-});
-```
-
-- `processCellCallback` customises body cell text.
-- `processHeaderCallback` customises column header text.
-- `processGroupHeaderCallback` customises column-group header text.
-- `processRowGroupCallback` customises row-group text. Group indentation is applied independently.
-
-These callbacks return text. To style the processed result, use `processStyleCallback`; its `value` is the final exported string.
-
 ## Additional Content
 
 Use `prependContent`, `appendContent`, or `getCustomContentBelowRow` to add content that is not displayed in the grid. Strings create full-width rows. Use `PdfCell[][]` for explicit spans and styling.
@@ -120,7 +102,7 @@ See [PDF Export - Master Detail](./pdf-export-master-detail/) for an example tha
 
 ### Export Options
 
-{% interfaceDocumentation interfaceName="PdfExportParams" overrideSrc="pdf-export/pdf.json" names=["documentTitle", "documentTitleStyle", "documentSubtitle", "documentSubtitleStyle", "coverPage", "headerFooterConfig", "processCellCallback", "processHeaderCallback", "processGroupHeaderCallback", "processRowGroupCallback", "prependContent", "appendContent", "getCustomContentBelowRow"] config={"description":""} /%}
+{% interfaceDocumentation interfaceName="PdfExportParams" overrideSrc="pdf-export/pdf.json" names=["documentTitle", "documentTitleStyle", "documentSubtitle", "documentSubtitleStyle", "coverPage", "headerFooterConfig", "prependContent", "appendContent", "getCustomContentBelowRow"] config={"description":""} /%}
 
 ### PdfDocumentHeadingStyle
 

--- a/documentation/ag-grid-docs/src/content/docs/pdf-export/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/pdf-export/index.mdoc
@@ -23,7 +23,7 @@ Set `suppressPdfExport=true` to disable both `exportDataAsPdf()` and `getDataAsP
 
 The export uses the current column order and visibility, together with the filtered, sorted, and grouped row data. Exported values are produced independently of the rendered grid cells, using Value Getters and, by default, [Value Formatters](./value-formatters/#formatting-for-export).
 
-By default, regular columns use their current grid widths and the Row Numbers column is sized from its exported content. Columns are proportionally reduced when their combined width exceeds the printable page width. Cells remain on one line unless wrapping is enabled, and table headers repeat when a table continues onto another page.
+By default, columns use their current width in the grid. Columns are proportionally reduced when their combined width exceeds the printable page width. Cells remain on one line unless wrapping is enabled, and table headers repeat when a table continues onto another page.
 
 PDF Export uses the built-in PDF Base 14 fonts with WinAnsi encoding by default. Register static TrueType font families to export Unicode text or use right-to-left text layout.
 

--- a/documentation/ag-grid-docs/src/content/docs/toolbar/_examples/built-in-items/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/toolbar/_examples/built-in-items/example.spec.ts
@@ -11,6 +11,16 @@ test.agExample(import.meta, () => {
         await expect(toolbar.locator(':scope > .ag-toolbar-button-wrapper')).toHaveCount(2);
     });
 
+    test.eachFramework('Export toolbar item offers CSV, Excel and PDF', async ({ page }) => {
+        await waitForGridContent(page);
+
+        await page.locator('.ag-toolbar-button-wrapper', { hasText: 'Export' }).click();
+
+        await expect(page.locator('.ag-menu-option-text', { hasText: 'CSV Export' })).toBeVisible();
+        await expect(page.locator('.ag-menu-option-text', { hasText: 'Excel Export' })).toBeVisible();
+        await expect(page.locator('.ag-menu-option-text', { hasText: 'PDF Export' })).toBeVisible();
+    });
+
     test.eachFramework('Typing into quick filter reduces displayed rows', async ({ agIdFor, page }) => {
         await waitForGridContent(page);
 

--- a/documentation/ag-grid-docs/src/content/docs/toolbar/_examples/built-in-items/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/toolbar/_examples/built-in-items/main.ts
@@ -10,7 +10,7 @@ import {
     createGrid,
     enableDevValidations,
 } from 'ag-grid-community';
-import { ContextMenuModule, ExcelExportModule, FindModule, ToolbarModule } from 'ag-grid-enterprise';
+import { ContextMenuModule, ExcelExportModule, FindModule, PdfExportModule, ToolbarModule } from 'ag-grid-enterprise';
 
 if (process.env.NODE_ENV !== 'production') {
     // Enable extended validations only for development
@@ -26,6 +26,7 @@ ModuleRegistry.registerModules([
     CsvExportModule,
     ExcelExportModule,
     FindModule,
+    PdfExportModule,
     QuickFilterModule,
     ToolbarModule,
 ]);
@@ -61,9 +62,9 @@ const gridOptions: GridOptions<IOlympicData> = {
                 icon: 'save',
                 alignment: 'right',
                 label: 'Export',
-                tooltip: 'Export as CSV or Excel',
+                tooltip: 'Export as CSV, Excel or PDF',
                 toolbarItemParams: {
-                    menuItems: ['csvExport', 'excelExport'],
+                    menuItems: ['csvExport', 'excelExport', 'pdfExport'],
                 },
             },
         ],

--- a/documentation/ag-grid-docs/src/content/docs/toolbar/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/toolbar/index.mdoc
@@ -30,9 +30,9 @@ const gridOptions = {
                 icon: 'save',
                 alignment: 'right',
                 label: 'Download',
-                tooltip: 'Download as CSV or Excel',
+                tooltip: 'Download as CSV, Excel or PDF',
                 toolbarItemParams: {
-                    menuItems: ['csvExport', 'excelExport'],
+                    menuItems: ['csvExport', 'excelExport', 'pdfExport'],
                 },
             },
         ],
@@ -98,7 +98,7 @@ const gridOptions = {
                 toolbarItem: 'agMenuToolbarItem',
                 icon: 'save',
                 toolbarItemParams: {
-                    menuItems: ['csvExport', 'excelExport'],
+                    menuItems: ['csvExport', 'excelExport', 'pdfExport'],
                 },
             },
         ],

--- a/documentation/ag-grid-docs/src/content/docs/value-formatters/_examples/use-value-formatter-for-export/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/value-formatters/_examples/use-value-formatter-for-export/main.ts
@@ -12,6 +12,7 @@ import {
     ColumnMenuModule,
     ContextMenuModule,
     ExcelExportModule,
+    PdfExportModule,
 } from 'ag-grid-enterprise';
 
 if (process.env.NODE_ENV !== 'production') {
@@ -24,6 +25,7 @@ ModuleRegistry.registerModules([
     ClientSideRowModelModule,
     ClipboardModule,
     ExcelExportModule,
+    PdfExportModule,
     ColumnMenuModule,
     ContextMenuModule,
     CellSelectionModule,

--- a/documentation/ag-grid-docs/src/content/docs/value-formatters/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/value-formatters/index.mdoc
@@ -58,6 +58,7 @@ Using the value formatter for export applies to the following features:
 - [Copy Range Down](./cell-selection/#copy-cell-range-down)
 - [CSV Export](./csv-export/)
 - [Excel Export](./excel-export-customising-content/)
+- [PDF Export](./pdf-export/)
 
 Using a value formatter for export is normally used in conjunction with [Using a Value Parser for Import](./value-parsers/#use-value-parser-for-import), where a [Value Parser](./value-parsers/) is defined that does the reverse of the value formatter.
 
@@ -73,3 +74,4 @@ Note that if any of the following conditions are true, then `useValueFormatterFo
 - If `processCellCallback` is provided when using CSV export.
 - If `processCellCallback` or [Excel Data Types](./excel-export-data-types/) are provided when using Excel export.
 - If the underlying value is a number when using Excel export. To export formatted number values to Excel, please use the [Excel Data Type](./excel-export-data-types/#strings-number-and-booleans) feature.
+- If `processCellCallback` is provided when using PDF export.

--- a/external/ag-website-shared/src/content/license-features/gridFeaturesMatrix.json
+++ b/external/ag-website-shared/src/content/license-features/gridFeaturesMatrix.json
@@ -430,6 +430,15 @@
             },
             {
                 "label": {
+                    "name": "PDF Export",
+                    "link": "grid:./pdf-export/"
+                },
+                "community": false,
+                "enterprise": true,
+                "chartsGrid": true
+            },
+            {
+                "label": {
                     "name": "Clipboard Operations",
                     "link": "grid:./clipboard/"
                 },

--- a/packages/ag-grid-angular/README.md
+++ b/packages/ag-grid-angular/README.md
@@ -114,6 +114,7 @@ AG Grid is available in two versions: Community & Enterprise.
 | [Row Grouping and Aggregation](https://www.ag-grid.com/angular-data-grid/grouping/?utm_source=ag-grid-angular-readme&utm_medium=repository&utm_campaign=github)     | ❌                | ✅                 |
 | [Pivoting](https://www.ag-grid.com/angular-data-grid/pivoting/?utm_source=ag-grid-angular-readme&utm_medium=repository&utm_campaign=github)                         | ❌                | ✅                 |
 | [Excel Export](https://www.ag-grid.com/angular-data-grid/excel-export/?utm_source=ag-grid-angular-readme&utm_medium=repository&utm_campaign=github)                 | ❌                | ✅                 |
+| [PDF Export](https://www.ag-grid.com/angular-data-grid/pdf-export/?utm_source=ag-grid-angular-readme&utm_medium=repository&utm_campaign=github)                     | ❌                | ✅                 |
 | [Clipboard Operations](https://www.ag-grid.com/angular-data-grid/clipboard/?utm_source=ag-grid-angular-readme&utm_medium=repository&utm_campaign=github)            | ❌                | ✅                 |
 | [Master/Detail](https://www.ag-grid.com/angular-data-grid/master-detail/?utm_source=ag-grid-angular-readme&utm_medium=repository&utm_campaign=github)               | ❌                | ✅                 |
 | [Tree Data](https://www.ag-grid.com/angular-data-grid/tree-data/?utm_source=ag-grid-angular-readme&utm_medium=repository&utm_campaign=github)                       | ❌                | ✅                 |

--- a/packages/ag-grid-angular/projects/ag-grid-angular/README.md
+++ b/packages/ag-grid-angular/projects/ag-grid-angular/README.md
@@ -114,6 +114,7 @@ AG Grid is available in two versions: Community & Enterprise.
 | [Row Grouping and Aggregation](https://www.ag-grid.com/angular-data-grid/grouping/?utm_source=ag-grid-angular-readme&utm_medium=repository&utm_campaign=github)     | ❌                | ✅                 |
 | [Pivoting](https://www.ag-grid.com/angular-data-grid/pivoting/?utm_source=ag-grid-angular-readme&utm_medium=repository&utm_campaign=github)                         | ❌                | ✅                 |
 | [Excel Export](https://www.ag-grid.com/angular-data-grid/excel-export/?utm_source=ag-grid-angular-readme&utm_medium=repository&utm_campaign=github)                 | ❌                | ✅                 |
+| [PDF Export](https://www.ag-grid.com/angular-data-grid/pdf-export/?utm_source=ag-grid-angular-readme&utm_medium=repository&utm_campaign=github)                     | ❌                | ✅                 |
 | [Clipboard Operations](https://www.ag-grid.com/angular-data-grid/clipboard/?utm_source=ag-grid-angular-readme&utm_medium=repository&utm_campaign=github)            | ❌                | ✅                 |
 | [Master/Detail](https://www.ag-grid.com/angular-data-grid/master-detail/?utm_source=ag-grid-angular-readme&utm_medium=repository&utm_campaign=github)               | ❌                | ✅                 |
 | [Tree Data](https://www.ag-grid.com/angular-data-grid/tree-data/?utm_source=ag-grid-angular-readme&utm_medium=repository&utm_campaign=github)                       | ❌                | ✅                 |

--- a/packages/ag-grid-community/README.md
+++ b/packages/ag-grid-community/README.md
@@ -114,6 +114,7 @@ AG Grid is available in two versions: Community & Enterprise.
 | [Row Grouping and Aggregation](https://www.ag-grid.com/javascript-data-grid/grouping/?utm_source=ag-grid-readme&utm_medium=repository&utm_campaign=github)     | ❌                | ✅                 |
 | [Pivoting](https://www.ag-grid.com/javascript-data-grid/pivoting/?utm_source=ag-grid-readme&utm_medium=repository&utm_campaign=github)                         | ❌                | ✅                 |
 | [Excel Export](https://www.ag-grid.com/javascript-data-grid/excel-export/?utm_source=ag-grid-readme&utm_medium=repository&utm_campaign=github)                 | ❌                | ✅                 |
+| [PDF Export](https://www.ag-grid.com/javascript-data-grid/pdf-export/?utm_source=ag-grid-readme&utm_medium=repository&utm_campaign=github)                     | ❌                | ✅                 |
 | [Clipboard Operations](https://www.ag-grid.com/javascript-data-grid/clipboard/?utm_source=ag-grid-readme&utm_medium=repository&utm_campaign=github)            | ❌                | ✅                 |
 | [Master/Detail](https://www.ag-grid.com/javascript-data-grid/master-detail/?utm_source=ag-grid-readme&utm_medium=repository&utm_campaign=github)               | ❌                | ✅                 |
 | [Tree Data](https://www.ag-grid.com/javascript-data-grid/tree-data/?utm_source=ag-grid-readme&utm_medium=repository&utm_campaign=github)                       | ❌                | ✅                 |

--- a/packages/ag-grid-community/src/interfaces/iPdfCreator.ts
+++ b/packages/ag-grid-community/src/interfaces/iPdfCreator.ts
@@ -121,6 +121,7 @@ export interface PdfImage {
 export interface PdfTextStyle {
     /**
      * Font size in points.
+     * @default 10 in body cells, 11 in header cells, 9 in page headers and footers
      */
     fontSize?: number;
     /**
@@ -170,19 +171,22 @@ export interface PdfCellStyle extends PdfTextStyle {
     borderColor?: string;
     /**
      * Border width in points.
-     * Defaults to 1 when `borderColor` is set, otherwise 0.
+     * @default 1 when borderColor is set, otherwise 0
      */
     borderWidth?: number;
     /**
      * Padding inside the cell in points. A number applies to all sides.
+     * @default 4
      */
     padding?: number | PdfMargin;
     /**
      * Horizontal alignment for the cell text.
+     * @default 'left'
      */
     alignment?: PdfTextAlignment;
     /**
      * Whether text should wrap onto multiple lines. Wrapped content increases the row height as required.
+     * @default false
      */
     wrapText?: boolean;
     /**

--- a/packages/ag-grid-community/src/interfaces/iPdfCreator.ts
+++ b/packages/ag-grid-community/src/interfaces/iPdfCreator.ts
@@ -121,7 +121,9 @@ export interface PdfImage {
 export interface PdfTextStyle {
     /**
      * Font size in points.
-     * @default 10 in body cells, 11 in header cells, 9 in page headers and footers
+     * The default depends on where the style is used: see `defaultCellStyle`,
+     * `defaultHeaderStyle`, `documentTitleStyle`, `documentSubtitleStyle`,
+     * `headerFooterConfig` and `watermark`.
      */
     fontSize?: number;
     /**
@@ -176,12 +178,14 @@ export interface PdfCellStyle extends PdfTextStyle {
     borderWidth?: number;
     /**
      * Padding inside the cell in points. A number applies to all sides.
-     * @default 4
+     * The default depends on where the style is used: see `defaultCellStyle`,
+     * `documentTitleStyle` and `documentSubtitleStyle`.
      */
     padding?: number | PdfMargin;
     /**
      * Horizontal alignment for the cell text.
-     * @default 'left'
+     * The default depends on where the style is used: see `defaultCellStyle`,
+     * `documentTitleStyle` and `documentSubtitleStyle`.
      */
     alignment?: PdfTextAlignment;
     /**
@@ -390,7 +394,10 @@ interface PdfHeaderFooterContentBase {
      * When omitted, array entries default to left, centre, and right in order.
      */
     position?: 'Left' | 'Center' | 'Right';
-    /** Text styling for this entry. */
+    /**
+     * Text styling for this entry.
+     * Unset properties default to 9 points with no padding, aligned to the entry position.
+     */
     style?: PdfTextStyle;
 }
 
@@ -434,7 +441,10 @@ export interface PdfWatermark {
      * @default 'all'
      */
     pages?: PdfWatermarkPageSelection;
-    /** Text styling for the watermark. */
+    /**
+     * Text styling for the watermark.
+     * When `fontSize` is unset, it is scaled from the page size.
+     */
     style?: PdfTextStyle;
 }
 
@@ -494,6 +504,9 @@ export interface PdfExportParams extends ExportParams<PdfCustomContent>, PdfFile
     documentTitle?: string;
     /**
      * Styling for the visible document title.
+     * Unset properties default to centred text, with padding and a bottom margin
+     * separating it from the content below, at a font size derived from the header
+     * font size.
      */
     documentTitleStyle?: PdfDocumentHeadingStyle;
     /**
@@ -502,6 +515,9 @@ export interface PdfExportParams extends ExportParams<PdfCustomContent>, PdfFile
     documentSubtitle?: string;
     /**
      * Styling for the visible document subtitle.
+     * Unset properties default to centred text, with padding and a bottom margin
+     * separating it from the content below, at a font size derived from the header
+     * font size.
      */
     documentSubtitleStyle?: PdfDocumentHeadingStyle;
     /**
@@ -553,13 +569,15 @@ export interface PdfExportParams extends ExportParams<PdfCustomContent>, PdfFile
      * Default style applied to every body cell, including custom content rows.
      * Grid styles, row and cell styles, and `processStyleCallback` results
      * override these values.
-     * When no style is provided, body cells use `Helvetica` at 10 points.
+     * When no style is provided, body cells use `Helvetica` at 10 points,
+     * 4 points of padding and left-aligned text.
      */
     defaultCellStyle?: PdfCellStyle;
     /**
      * Default style applied to header and group-header cells.
      * Each unset property inherits from `defaultCellStyle`; values set here
-     * take precedence. If neither style sets `fontSize`, headers use 11 points.
+     * take precedence. If neither style sets `fontSize`, headers use 11 points
+     * and the same 4 points of padding and left-aligned text as body cells.
      * If no font weight is inherited or set, headers use the bold variant of
      * the resolved body font.
      */

--- a/packages/ag-grid-community/src/interfaces/iPdfCreator.ts
+++ b/packages/ag-grid-community/src/interfaces/iPdfCreator.ts
@@ -562,10 +562,10 @@ export interface PdfExportParams extends ExportParams<PdfCustomContent>, PdfFile
     defaultHeaderStyle?: PdfCellStyle;
     /**
      * Controls exported column widths. Use `auto` to size from exported content, `grid` to use the
-     * current grid width, a number for a width in points, or a callback for per-column control.
+     * current column width in the grid, a number for a width in points, or a callback for
+     * per-column control.
      * Widths are proportionally reduced when their total exceeds the printable page width.
-     * By default, current grid widths are used except for the Row Numbers column, which is sized
-     * from its exported content.
+     * By default, columns use their current width in the grid.
      */
     columnWidth?: PdfColumnWidth | PdfColumnWidthCallback;
     /**

--- a/packages/ag-grid-react/README.md
+++ b/packages/ag-grid-react/README.md
@@ -114,6 +114,7 @@ AG Grid is available in two versions: Community & Enterprise.
 | [Row Grouping and Aggregation](https://www.ag-grid.com/react-data-grid/grouping/?utm_source=ag-grid-react-readme&utm_medium=repository&utm_campaign=github)     | ❌                | ✅                 |
 | [Pivoting](https://www.ag-grid.com/react-data-grid/pivoting/?utm_source=ag-grid-react-readme&utm_medium=repository&utm_campaign=github)                         | ❌                | ✅                 |
 | [Excel Export](https://www.ag-grid.com/react-data-grid/excel-export/?utm_source=ag-grid-react-readme&utm_medium=repository&utm_campaign=github)                 | ❌                | ✅                 |
+| [PDF Export](https://www.ag-grid.com/react-data-grid/pdf-export/?utm_source=ag-grid-react-readme&utm_medium=repository&utm_campaign=github)                     | ❌                | ✅                 |
 | [Clipboard Operations](https://www.ag-grid.com/react-data-grid/clipboard/?utm_source=ag-grid-react-readme&utm_medium=repository&utm_campaign=github)            | ❌                | ✅                 |
 | [Master/Detail](https://www.ag-grid.com/react-data-grid/master-detail/?utm_source=ag-grid-react-readme&utm_medium=repository&utm_campaign=github)               | ❌                | ✅                 |
 | [Tree Data](https://www.ag-grid.com/react-data-grid/tree-data/?utm_source=ag-grid-react-readme&utm_medium=repository&utm_campaign=github)                       | ❌                | ✅                 |

--- a/packages/ag-grid-vue3/README.md
+++ b/packages/ag-grid-vue3/README.md
@@ -114,6 +114,7 @@ AG Grid is available in two versions: Community & Enterprise.
 | [Row Grouping and Aggregation](https://www.ag-grid.com/vue-data-grid/grouping/?utm_source=ag-grid-vue3-readme&utm_medium=repository&utm_campaign=github)     | ❌                | ✅                 |
 | [Pivoting](https://www.ag-grid.com/vue-data-grid/pivoting/?utm_source=ag-grid-vue3-readme&utm_medium=repository&utm_campaign=github)                         | ❌                | ✅                 |
 | [Excel Export](https://www.ag-grid.com/vue-data-grid/excel-export/?utm_source=ag-grid-vue3-readme&utm_medium=repository&utm_campaign=github)                 | ❌                | ✅                 |
+| [PDF Export](https://www.ag-grid.com/vue-data-grid/pdf-export/?utm_source=ag-grid-vue3-readme&utm_medium=repository&utm_campaign=github)                     | ❌                | ✅                 |
 | [Clipboard Operations](https://www.ag-grid.com/vue-data-grid/clipboard/?utm_source=ag-grid-vue3-readme&utm_medium=repository&utm_campaign=github)            | ❌                | ✅                 |
 | [Master/Detail](https://www.ag-grid.com/vue-data-grid/master-detail/?utm_source=ag-grid-vue3-readme&utm_medium=repository&utm_campaign=github)               | ❌                | ✅                 |
 | [Tree Data](https://www.ag-grid.com/vue-data-grid/tree-data/?utm_source=ag-grid-vue3-readme&utm_medium=repository&utm_campaign=github)                       | ❌                | ✅                 |

--- a/packages/ag-stack/README.md
+++ b/packages/ag-stack/README.md
@@ -114,6 +114,7 @@ AG Grid is available in two versions: Community & Enterprise.
 | [Row Grouping and Aggregation](https://www.ag-grid.com/javascript-data-grid/grouping/?utm_source=ag-grid-readme&utm_medium=repository&utm_campaign=github)     | ❌                | ✅                 |
 | [Pivoting](https://www.ag-grid.com/javascript-data-grid/pivoting/?utm_source=ag-grid-readme&utm_medium=repository&utm_campaign=github)                         | ❌                | ✅                 |
 | [Excel Export](https://www.ag-grid.com/javascript-data-grid/excel-export/?utm_source=ag-grid-readme&utm_medium=repository&utm_campaign=github)                 | ❌                | ✅                 |
+| [PDF Export](https://www.ag-grid.com/javascript-data-grid/pdf-export/?utm_source=ag-grid-readme&utm_medium=repository&utm_campaign=github)                     | ❌                | ✅                 |
 | [Clipboard Operations](https://www.ag-grid.com/javascript-data-grid/clipboard/?utm_source=ag-grid-readme&utm_medium=repository&utm_campaign=github)            | ❌                | ✅                 |
 | [Master/Detail](https://www.ag-grid.com/javascript-data-grid/master-detail/?utm_source=ag-grid-readme&utm_medium=repository&utm_campaign=github)               | ❌                | ✅                 |
 | [Tree Data](https://www.ag-grid.com/javascript-data-grid/tree-data/?utm_source=ag-grid-readme&utm_medium=repository&utm_campaign=github)                       | ❌                | ✅                 |


### PR DESCRIPTION
Works through the documentation improvements listed on [AG-17950](https://ag-grid.atlassian.net/browse/AG-17950), except TC1 which is on a separate branch so it does not block these.

| TC | Change |
| --- | --- |
| TC2 | `columnWidth` describes `grid` as the current column width in the grid |
| TC3 | `pdfExport` added to the Quick Access Toolbar export menu, with an example test |
| TC4 | PDF Export listed in Value Formatters > Formatting for Export, and `PdfExportModule` registered in that example |
| TC5 | PDF Export row in the licence-pricing feature matrix |
| TC6 | PDF Export row in the repository and package README feature tables |
| TC7 | Row Numbers sizing detail removed from the `columnWidth` description and the column-width prose |
| TC8 | `@default` tags added for the PDF cell and text style properties whose defaults were undocumented or prose-only |
| TC9 | Export callbacks moved to a new PDF Export > Customising Content page, mirroring Excel Export, with an example covering all four callbacks |

Notes for review:

- TC3 needs no grid code: the toolbar menu resolves stock items through the same mapper as the context menu, so `pdfExport` works once `PdfExportModule` is registered.
- TC4 was a question on the ticket. PDF export extracts values through the same serializing session as CSV and Excel, so `useValueFormatterForExport` already applied to it and the page was wrong by omission.
- TC7 removes the Row Numbers sizing detail from the API description only. The `exportRowNumbers` opt-in stays documented, as that column is not exported by default.
- TC8 leaves properties resolved from the theme, from font metrics or from exported content untagged, as they have no fixed default.
- TC9 omits an equivalent of Excel's Custom Metadata section, as PDF exposes no arbitrary metadata properties.

Verification: `./checks.sh` and `yarn nx format` clean; 120 PDF docs e2e tests pass across all frameworks, including 5 new ones for the Customising Content example and 5 for the toolbar export menu; `./behave.sh --project ag-grid-docs` passes, covering the licence-pricing feature link check.

`yarn nx validate-examples ag-grid-docs` fails on `latest` as well as here, because `documentation/ag-grid-docs/tsconfig.examples.json` does not exist and never has. Unrelated to this branch and worth its own ticket.