### PR TITLE
AG-13360 filters-custom-comparator

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/filter-advanced/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/filter-advanced/index.mdoc
@@ -156,6 +156,30 @@ For `number`, `date`, `dateString`, `dateTime` and `dateTimeString` Cell Data Ty
 - `includeBlanksInGreaterThan = true`
 - `includeBlanksInRange = true`
 
+For `date`, `dateString`, `dateTime` and `dateTimeString` Cell Data Types, the Date Filter's [`comparator`](./filter-date/#filter-comparator) also decides the column's comparisons here, including the [relative date options](#relative-date-options) below. This is how a column whose cells carry a time is compared by date alone. The comparator is given the cell value as the column holds it, and `isValidDate` gates every comparison alongside it:
+
+```{% frameworkTransform=true %}
+const gridOptions = {
+    columnDefs: [
+        {
+            field: 'date',
+            cellDataType: 'date',
+            filter: 'agDateColumnFilter',
+            filterParams: {
+                // ignore the time the cell carries, so `[Date] = 24/08/2008` matches the whole day
+                comparator: (filterLocalDateAtMidnight, cellValue) => {
+                    const cellDate = new Date(cellValue);
+                    cellDate.setHours(0, 0, 0, 0);
+                    return cellDate.getTime() - filterLocalDateAtMidnight.getTime();
+                },
+            },
+        },
+    ],
+}
+```
+
+It applies equally where the Date Filter is a child of a Multi Filter. A Set Filter column's `comparator` orders its values instead, and a custom filter component's `filterParams` are its own.
+
 These settings only apply when using the Client-Side Row Model. You need to implement support for these in your server-side filtering logic when using the Server-Side Row Model.
 
 ### Relative Date Options

--- a/documentation/ag-grid-docs/src/content/docs/filter-date/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/filter-date/index.mdoc
@@ -67,6 +67,8 @@ If using `Date` objects, the default date comparator assumes that the `Date`s do
 
 If you are not using Cell Data Types (and the cell value is not a `Date` object, which will also work automatically), then a `comparator` needs to be configured to allow the Date Filter to perform the date comparisons.
 
+A `comparator` set here also decides the column's comparisons in the [Advanced Filter](./filter-advanced/#filter-parameters), under the Client-Side Row Model.
+
 {% interfaceDocumentation interfaceName="IDateFilterParams" names=["comparator"] config={"description":"", "overrideBottomMargin":"1rem"} /%}
 
 The `comparator` function takes two parameters. The first parameter is a JavaScript `Date` object for the selected date in the filter (with the time set to midnight). The second parameter is the current value of the cell in the row being evaluated. The function must return:

--- a/packages/ag-grid-community/src/filter/filterDataTypeUtils.ts
+++ b/packages/ag-grid-community/src/filter/filterDataTypeUtils.ts
@@ -80,6 +80,25 @@ function isValidDate(value: any): boolean {
     return value instanceof Date && !isNaN(value.getTime());
 }
 
+// Merged onto `colDef.filterParams` by `setColDefPropsForDataType`, so nothing else tells one from the author's.
+const gridSuppliedFilterParams = new WeakSet<object>();
+
+function gridSupplied<T extends object>(fn: T): T {
+    gridSuppliedFilterParams.add(fn);
+    return fn;
+}
+
+// One identity for every `date` column; the `dateString` pair closes over its definition, so it registers per call.
+const gridSuppliedIsValidDate = gridSupplied(isValidDate);
+
+/**
+ * Whether a `filterParams` function is the grid's own for the cell data type, rather than the column author's.
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
+ */
+export function _isGridSuppliedFilterParam(value: unknown): boolean {
+    return typeof value === 'function' && gridSuppliedFilterParams.has(value);
+}
+
 type FilterParamsDefArgs = {
     formatValue: DataTypeFormatValueFunc;
     t: LocaleTextFunc;
@@ -145,9 +164,9 @@ const filterParamsForEachDataType: FilterParamsDefMap = {
         // A copy per column, so editing the list one colDef carries cannot reach the others.
         filterOptions: [...BOOLEAN_FILTER_OPTIONS],
     }),
-    date: () => ({ isValidDate }),
+    date: () => ({ isValidDate: gridSuppliedIsValidDate }),
     dateString: ({ dataTypeDefinition }) => ({
-        comparator: (filterDate: Date, cellValue: string | undefined) => {
+        comparator: gridSupplied((filterDate: Date, cellValue: string | undefined) => {
             const cellAsDate = (dataTypeDefinition as DateStringDataTypeDefinition).dateParser!(cellValue)!;
             if (cellValue == null || cellAsDate < filterDate) {
                 return -1;
@@ -156,10 +175,12 @@ const filterParamsForEachDataType: FilterParamsDefMap = {
                 return 1;
             }
             return 0;
-        },
-        isValidDate: (value: any) =>
-            typeof value === 'string' &&
-            isValidDate((dataTypeDefinition as DateStringDataTypeDefinition).dateParser!(value)),
+        }),
+        isValidDate: gridSupplied(
+            (value: any) =>
+                typeof value === 'string' &&
+                isValidDate((dataTypeDefinition as DateStringDataTypeDefinition).dateParser!(value))
+        ),
     }),
     dateTime: (args) => filterParamsForEachDataType.date(args),
     dateTimeString: (args) => filterParamsForEachDataType.dateString(args),

--- a/packages/ag-grid-community/src/filter/filterDataTypeUtils.ts
+++ b/packages/ag-grid-community/src/filter/filterDataTypeUtils.ts
@@ -83,7 +83,7 @@ function isValidDate(value: any): boolean {
 // Merged onto `colDef.filterParams` by `setColDefPropsForDataType`, so nothing else tells one from the author's.
 const gridSuppliedFilterParams = new WeakSet<object>();
 
-function gridSupplied<T extends object>(fn: T): T {
+function gridSupplied<T extends (...args: any[]) => any>(fn: T): T {
     gridSuppliedFilterParams.add(fn);
     return fn;
 }

--- a/packages/ag-grid-community/src/filter/provided/date/iDateFilter.ts
+++ b/packages/ag-grid-community/src/filter/provided/date/iDateFilter.ts
@@ -67,6 +67,7 @@ export interface IDateFilterParams extends IScalarFilterParams {
     /**
      * Required if the data for the column are not native JS `Date` objects.
      * If cell values can contain invalid dates, should also implement `isValidDate`.
+     * Also decides the column's comparisons in the Advanced Filter, under the Client-Side Row Model.
      */
     comparator?: IDateComparatorFunc;
     /**
@@ -107,6 +108,7 @@ export interface IDateFilterParams extends IScalarFilterParams {
      * If providing a `comparator` and cell values can contain invalid dates,
      * this can be implemented to allow invalid date values to be filtered out
      * (as the comparator only allows for greater than, less than and equals).
+     * Also gates the column's comparisons in the Advanced Filter, under the Client-Side Row Model.
      */
     isValidDate?: (value: any) => boolean;
     /**

--- a/packages/ag-grid-community/src/main-internal.ts
+++ b/packages/ag-grid-community/src/main-internal.ts
@@ -142,6 +142,7 @@ export {
     _getDefaultSimpleFilter,
     _getFilterParamsForDataType,
     _isGridSuppliedFilterOptions,
+    _isGridSuppliedFilterParam,
 } from './filter/filterDataTypeUtils';
 export { translateForFilter as _translateForFilter } from './filter/filterLocaleText';
 export {

--- a/packages/ag-grid-enterprise/src/advancedFilter/advancedFilterExpressionService.ts
+++ b/packages/ag-grid-enterprise/src/advancedFilter/advancedFilterExpressionService.ts
@@ -530,7 +530,7 @@ export class AdvancedFilterExpressionService extends BeanStub implements NamedBe
         let operators = isSetColumn
             ? addSetOperators(dataTypeOperators, (key) => this.translate(key))
             : dataTypeOperators;
-        // The shared table's, since the set-derived one offers those keys on top rather than instead.
+        // The shared table's: `addSetOperators` returns a table carrying no `defaultOperators` of its own.
         let activeOperators = dataTypeOperators.defaultOperators;
         // The set options come from the filter, not the data type, so a data type holding some of its own
         // back — a date column and its relative options — must not take these with them.
@@ -562,7 +562,7 @@ export class AdvancedFilterExpressionService extends BeanStub implements NamedBe
     /**
      * The params of the Date Filter a column filters through, if it filters through one at all: `comparator`
      * is also a Set Filter's list sort and a custom filter component's own parameter, neither of them a date
-     * comparison. A Multi Filter carries the Date Filter as a child, as `getColumnFilterOptions` reads it.
+     * comparison. A Multi Filter carries the Date Filter as one of its children.
      */
     private getDateFilterParams(
         column: AgColumn,
@@ -656,10 +656,14 @@ export class AdvancedFilterExpressionService extends BeanStub implements NamedBe
                 params = { valueConverter: (v: any) => v };
                 break;
         }
-        // A Multi Filter hands its Date Filter child that child's parameters alone, so the parent's own never
-        // stand in for the ones it omits.
-        const dateFilterParams = this.getDateFilterParams(column, baseCellDataType);
-        const source = dateFilterParams ?? column.colDef.filterParams;
+        // A Multi Filter configures each filter on its own child, so the child that does the comparing owns
+        // these too; the parent's never stand in for the ones that child omits.
+        const { filter, filterParams } = column.colDef;
+        const childParams =
+            filter === 'agMultiColumnFilter'
+                ? getMultiFilterChild(filterParams, _getDefaultSimpleFilter(baseCellDataType))?.filterParams
+                : undefined;
+        const source = childParams ?? filterParams;
         if (source) {
             for (let i = 0, len = COPIED_FILTER_PARAMS.length; i < len; ++i) {
                 const param = COPIED_FILTER_PARAMS[i];
@@ -669,6 +673,7 @@ export class AdvancedFilterExpressionService extends BeanStub implements NamedBe
                 }
             }
         }
+        const dateFilterParams = this.getDateFilterParams(column, baseCellDataType);
         if (dateFilterParams) {
             // What the grid supplies restates the parse `valueConverter` does, and a comparator skips that
             // conversion, so only where none is in play is the grid's own gate already covered.

--- a/packages/ag-grid-enterprise/src/advancedFilter/advancedFilterExpressionService.ts
+++ b/packages/ag-grid-enterprise/src/advancedFilter/advancedFilterExpressionService.ts
@@ -659,11 +659,10 @@ export class AdvancedFilterExpressionService extends BeanStub implements NamedBe
         // A Multi Filter configures each filter on its own child, so the child that does the comparing owns
         // these too; the parent's never stand in for the ones that child omits.
         const { filter, filterParams } = column.colDef;
-        const childParams =
+        const source =
             filter === 'agMultiColumnFilter'
                 ? getMultiFilterChild(filterParams, _getDefaultSimpleFilter(baseCellDataType))?.filterParams
-                : undefined;
-        const source = childParams ?? filterParams;
+                : filterParams;
         if (source) {
             for (let i = 0, len = COPIED_FILTER_PARAMS.length; i < len; ++i) {
                 const param = COPIED_FILTER_PARAMS[i];

--- a/packages/ag-grid-enterprise/src/advancedFilter/advancedFilterExpressionService.ts
+++ b/packages/ag-grid-enterprise/src/advancedFilter/advancedFilterExpressionService.ts
@@ -8,17 +8,24 @@ import type {
     ColumnModel,
     ColumnNameService,
     DataTypeService,
+    IDateFilterParams,
     JoinAdvancedFilterModel,
     NamedBean,
     SetAdvancedFilterModel,
     ValueService,
 } from 'ag-grid-community';
-import { BeanStub, _classifyFilterOptions, _toFiniteNumber } from 'ag-grid-community';
+import {
+    BeanStub,
+    _classifyFilterOptions,
+    _getDefaultSimpleFilter,
+    _isGridSuppliedFilterParam,
+    _toFiniteNumber,
+} from 'ag-grid-community';
 
 import { ADVANCED_FILTER_LOCALE_TEXT } from './advancedFilterLocaleText';
 import type { AutocompleteEntry, AutocompleteListParams } from './autocomplete/autocompleteParams';
 import { COL_FILTER_EXPRESSION_END_CHAR, COL_FILTER_EXPRESSION_START_CHAR } from './colFilterExpressionParser';
-import { createCustomOptionOperators, getColumnFilterOptions } from './customFilterOptions';
+import { createCustomOptionOperators, getColumnFilterOptions, getMultiFilterChild } from './customFilterOptions';
 import type {
     DataTypeFilterExpressionOperators,
     FilterExpressionEvaluatorParams,
@@ -82,6 +89,8 @@ const COPIED_FILTER_PARAMS: (keyof FilterExpressionEvaluatorParams<any>)[] = [
     'includeBlanksInRange',
     'inRangeInclusive',
 ];
+
+const DATE_FILTER = 'agDateColumnFilter';
 
 /** A column's operators and the keys it narrows them to, classified together from its one `filterOptions`. */
 interface ColumnOperators {
@@ -521,7 +530,7 @@ export class AdvancedFilterExpressionService extends BeanStub implements NamedBe
         let operators = isSetColumn
             ? addSetOperators(dataTypeOperators, (key) => this.translate(key))
             : dataTypeOperators;
-        // Only the data type's own table carries `defaultOperators`; a derived one does not.
+        // The shared table's, since the set-derived one offers those keys on top rather than instead.
         let activeOperators = dataTypeOperators.defaultOperators;
         // The set options come from the filter, not the data type, so a data type holding some of its own
         // back — a date column and its relative options — must not take these with them.
@@ -548,6 +557,30 @@ export class AdvancedFilterExpressionService extends BeanStub implements NamedBe
             }
         }
         return { operators, activeOperators };
+    }
+
+    /**
+     * The params of the Date Filter a column filters through, if it filters through one at all: `comparator`
+     * is also a Set Filter's list sort and a custom filter component's own parameter, neither of them a date
+     * comparison. A Multi Filter carries the Date Filter as a child, as `getColumnFilterOptions` reads it.
+     */
+    private getDateFilterParams(
+        column: AgColumn,
+        baseCellDataType: BaseCellDataType | undefined
+    ): IDateFilterParams | undefined {
+        // The four date types are exactly those the Date Filter is the default for, so the table owns the list.
+        if (
+            _getDefaultSimpleFilter(baseCellDataType) !== DATE_FILTER ||
+            this.advFilterSetSvc.isSetFilterColumn(column)
+        ) {
+            return undefined;
+        }
+        const { filter, filterParams } = column.colDef;
+        if (filter === 'agMultiColumnFilter') {
+            return getMultiFilterChild(filterParams, DATE_FILTER)?.filterParams;
+        }
+        // `filter: true` is the data type's default, which the guards above have established is the Date Filter.
+        return filter === true || filter === DATE_FILTER ? filterParams : undefined;
     }
 
     public getExpressionJoinOperators(): { AND: string; OR: string } {
@@ -589,12 +622,15 @@ export class AdvancedFilterExpressionService extends BeanStub implements NamedBe
         }
 
         const baseCellDataType = this.dataTypeSvc?.getBaseDataType(column);
+        // Only a converter that parses can stand in for a validity gate, so it is recorded where it is chosen.
+        let converterParses = false;
         switch (baseCellDataType) {
             case 'dateTimeString':
             case 'dateString':
                 params = {
                     valueConverter: this.dataTypeSvc?.getDateParserFunction(column) ?? ((v: any) => v),
                 };
+                converterParses = true;
                 break;
             case 'object':
                 // If there's a filter value getter, assume the value is already a string. Otherwise we need to format it.
@@ -620,15 +656,27 @@ export class AdvancedFilterExpressionService extends BeanStub implements NamedBe
                 params = { valueConverter: (v: any) => v };
                 break;
         }
-        const { filterParams } = column.colDef;
-        if (filterParams) {
+        // A Multi Filter hands its Date Filter child that child's parameters alone, so the parent's own never
+        // stand in for the ones it omits.
+        const dateFilterParams = this.getDateFilterParams(column, baseCellDataType);
+        const source = dateFilterParams ?? column.colDef.filterParams;
+        if (source) {
             for (let i = 0, len = COPIED_FILTER_PARAMS.length; i < len; ++i) {
                 const param = COPIED_FILTER_PARAMS[i];
-                const paramValue = filterParams[param];
+                const paramValue = source[param];
                 if (paramValue) {
                     params[param] = paramValue;
                 }
             }
+        }
+        if (dateFilterParams) {
+            // What the grid supplies restates the parse `valueConverter` does, and a comparator skips that
+            // conversion, so only where none is in play is the grid's own gate already covered.
+            const { comparator, isValidDate } = dateFilterParams;
+            const ownComparator = comparator && !_isGridSuppliedFilterParam(comparator) ? comparator : undefined;
+            const coveredByConversion = converterParses && !ownComparator;
+            params.comparator = ownComparator;
+            params.isValid = coveredByConversion && _isGridSuppliedFilterParam(isValidDate) ? undefined : isValidDate;
         }
         this.expressionEvaluatorParams[colId] = params;
 

--- a/packages/ag-grid-enterprise/src/advancedFilter/customFilterOptions.ts
+++ b/packages/ag-grid-enterprise/src/advancedFilter/customFilterOptions.ts
@@ -12,7 +12,7 @@ import type {
     FilterExpressionOperator,
     OperandsKind,
 } from './filterExpressionOperators';
-import { getEntries } from './filterExpressionOperators';
+import { freshOperand, getEntries } from './filterExpressionOperators';
 
 /** A list the column author wrote, as opposed to the one its data type supplies; an empty list narrows nothing. */
 function getAuthoredFilterOptions(filterParams: any): (string | IFilterOptionDef)[] | undefined {
@@ -76,11 +76,12 @@ function createCustomOptionOperator(
             operands = 'none';
             break;
         case 1:
-            evaluator = (value, _node, _params, operand1) => predicate([operand1], value);
+            evaluator = (value, _node, _params, operand1) => predicate([freshOperand(operand1)], value);
             operands = 'one';
             break;
         default:
-            evaluator = (value, _node, _params, operand1, operand2) => predicate([operand1, operand2], value);
+            evaluator = (value, _node, _params, operand1, operand2) =>
+                predicate([freshOperand(operand1), freshOperand(operand2)], value);
             operands = 'range';
             break;
     }

--- a/packages/ag-grid-enterprise/src/advancedFilter/customFilterOptions.ts
+++ b/packages/ag-grid-enterprise/src/advancedFilter/customFilterOptions.ts
@@ -1,6 +1,6 @@
 import type { LocaleTextFunc } from 'ag-stack';
 
-import type { AgColumn, IFilterOptionDef } from 'ag-grid-community';
+import type { AgColumn, IFilterOptionDef, IMultiFilterDef } from 'ag-grid-community';
 import {
     _getCustomOptionDisplayName,
     _getCustomOptionNumberOfInputs,
@@ -20,11 +20,23 @@ function getAuthoredFilterOptions(filterParams: any): (string | IFilterOptionDef
     return !filterOptions?.length || _isGridSuppliedFilterOptions(filterOptions) ? undefined : filterOptions;
 }
 
+/** The child a Multi Filter wraps for `filterName`, where that filter's own parameters live. */
+export function getMultiFilterChild(filterParams: any, filterName: string): IMultiFilterDef | undefined {
+    const filters: IMultiFilterDef[] | undefined = filterParams?.filters;
+    for (let i = 0, len = filters?.length ?? 0; i < len; ++i) {
+        const child = filters![i];
+        if (child?.filter === filterName) {
+            return child;
+        }
+    }
+    return undefined;
+}
+
 /** The options a column narrows itself to, or `undefined` where it narrows nothing of its own. */
 export function getColumnFilterOptions(column: AgColumn): (string | IFilterOptionDef)[] | undefined {
     const filterParams = column.colDef.filterParams;
     // A Multi Filter writes `filterOptions` on a child, so its own level is read only after them.
-    const filters: { filterParams?: any }[] | undefined = filterParams?.filters;
+    const filters: IMultiFilterDef[] | undefined = filterParams?.filters;
     for (let i = 0, len = filters?.length ?? 0; i < len; ++i) {
         const childOptions = getAuthoredFilterOptions(filters![i]?.filterParams);
         if (childOptions) {

--- a/packages/ag-grid-enterprise/src/advancedFilter/filterExpressionOperators.ts
+++ b/packages/ag-grid-enterprise/src/advancedFilter/filterExpressionOperators.ts
@@ -27,8 +27,8 @@ export interface FilterExpressionEvaluatorParams<ConvertedTValue, TValue = Conve
     valueConverter: (value: TValue, node: IRowNode) => ConvertedTValue;
 }
 
-/** The column filter maps its model per row, so a comparator is free to normalise the operand it is handed. */
-function freshOperand<T>(operand: T): T {
+/** The column filter maps its model per row, so author code is free to normalise the operand it is handed. */
+export function freshOperand<T>(operand: T): T {
     return operand instanceof Date ? (new Date(operand.getTime()) as T) : operand;
 }
 
@@ -447,7 +447,7 @@ const PRESET_DATE_OPERATOR_LOCALE_KEYS: Record<ISimpleFilterModelPresetType, key
         last24Months: 'advancedFilterLast24Months',
     };
 
-/** One cache for every date column, since a relative range depends on nothing but the clock. */
+/** One cache per data type table, since a relative range depends on nothing but the clock. */
 function addRelativeDateOperators(
     operators: { [operator: string]: FilterExpressionOperator<any> },
     translate: AdvancedFilterTranslate

--- a/packages/ag-grid-enterprise/src/advancedFilter/filterExpressionOperators.ts
+++ b/packages/ag-grid-enterprise/src/advancedFilter/filterExpressionOperators.ts
@@ -20,7 +20,16 @@ export interface FilterExpressionEvaluatorParams<ConvertedTValue, TValue = Conve
     includeBlanksInGreaterThan?: boolean;
     includeBlanksInRange?: boolean;
     inRangeInclusive?: boolean;
+    /** The column's own comparison, reading the cell value itself as the column filter's does. */
+    comparator?: (operand: ConvertedTValue, value: TValue) => number;
+    /** Gates every comparison, as it does in the column filter; a value it rejects matches only a negation. */
+    isValid?: (value: TValue) => boolean;
     valueConverter: (value: TValue, node: IRowNode) => ConvertedTValue;
+}
+
+/** The column filter maps its model per row, so a comparator is free to normalise the operand it is handed. */
+function freshOperand<T>(operand: T): T {
+    return operand instanceof Date ? (new Date(operand.getTime()) as T) : operand;
 }
 
 type FilterExpressionEvaluator<ConvertedTValue, TValue = ConvertedTValue> = (
@@ -211,6 +220,14 @@ interface ScalarFilterExpressionOperatorsParams<ConvertedTValue> extends FilterE
     relativeDates?: boolean;
 }
 
+/** Where the cell sits against the operand, as `comparator` reports it: the column filter's own mapping. */
+const isEqualTo = (result: number) => result === 0;
+const isNotEqualTo = (result: number) => result !== 0;
+const isAbove = (result: number) => result > 0;
+const isAtLeast = (result: number) => result >= 0;
+const isBelow = (result: number) => result < 0;
+const isAtMost = (result: number) => result <= 0;
+
 export class ScalarFilterExpressionOperators<
     ConvertedTValue extends number | Date | bigint,
     TValue = ConvertedTValue,
@@ -238,7 +255,8 @@ export class ScalarFilterExpressionOperators<
                         params,
                         operand1!,
                         !!params.includeBlanksInEquals,
-                        equals
+                        equals,
+                        isEqualTo
                     ),
                 operands: 'one',
             },
@@ -252,6 +270,7 @@ export class ScalarFilterExpressionOperators<
                         operand1!,
                         !!params.includeBlanksInNotEqual,
                         (v, o) => !equals(v, o),
+                        isNotEqualTo,
                         true
                     ),
                 operands: 'one',
@@ -265,7 +284,8 @@ export class ScalarFilterExpressionOperators<
                         params,
                         operand1!,
                         !!params.includeBlanksInGreaterThan,
-                        (v, o) => v > o
+                        (v, o) => v > o,
+                        isAbove
                     ),
                 operands: 'one',
             },
@@ -278,7 +298,8 @@ export class ScalarFilterExpressionOperators<
                         params,
                         operand1!,
                         !!params.includeBlanksInGreaterThan,
-                        (v, o) => v >= o
+                        (v, o) => v >= o,
+                        isAtLeast
                     ),
                 operands: 'one',
             },
@@ -291,7 +312,8 @@ export class ScalarFilterExpressionOperators<
                         params,
                         operand1!,
                         !!params.includeBlanksInLessThan,
-                        (v, o) => v < o
+                        (v, o) => v < o,
+                        isBelow
                     ),
                 operands: 'one',
             },
@@ -304,7 +326,8 @@ export class ScalarFilterExpressionOperators<
                         params,
                         operand1!,
                         !!params.includeBlanksInLessThan,
-                        (v, o) => v <= o
+                        (v, o) => v <= o,
+                        isAtMost
                     ),
                 operands: 'one',
             },
@@ -343,6 +366,17 @@ export class ScalarFilterExpressionOperators<
         if (value == null || _isBlank(value)) {
             return !!params.includeBlanksInRange;
         }
+        const { comparator, isValid } = params;
+        if (isValid && !isValid(value)) {
+            return false;
+        }
+        if (comparator) {
+            // The upper bound only where the lower one admits the row: the comparator is the column's own code.
+            const fromResult = comparator(freshOperand(from), value);
+            return params.inRangeInclusive
+                ? fromResult >= 0 && comparator(freshOperand(to), value) <= 0
+                : fromResult > 0 && comparator(freshOperand(to), value) < 0;
+        }
         const convertedValue = params.valueConverter(value, node);
         if (convertedValue == null) {
             return false;
@@ -359,12 +393,22 @@ export class ScalarFilterExpressionOperators<
         operand: ConvertedTValue,
         nullsMatch: boolean,
         expression: (value: ConvertedTValue, operand: ConvertedTValue) => boolean,
+        sign: (result: number) => boolean,
         isNegated?: boolean
     ): boolean {
         // A scalar has no use for a blank string, so it counts as absent — as it does in the column filter.
         // The `== null` half is what narrows `value`; `_isBlank` alone would not.
         if (value == null || _isBlank(value)) {
             return nullsMatch;
+        }
+        const { comparator, isValid } = params;
+        if (isValid && !isValid(value)) {
+            return !!isNegated;
+        }
+        // The column's own comparison reads the cell value, never a converted one: that is the whole reason
+        // a column with data the data type cannot read supplies one.
+        if (comparator) {
+            return sign(comparator(freshOperand(operand), value));
         }
         const convertedValue = params.valueConverter(value, node);
         // A value the data type cannot read is nothing to compare against, as the column filter's own validity
@@ -403,7 +447,7 @@ const PRESET_DATE_OPERATOR_LOCALE_KEYS: Record<ISimpleFilterModelPresetType, key
         last24Months: 'advancedFilterLast24Months',
     };
 
-/** One cache per data type, since a relative range depends on nothing but the clock. */
+/** One cache for every date column, since a relative range depends on nothing but the clock. */
 function addRelativeDateOperators(
     operators: { [operator: string]: FilterExpressionOperator<any> },
     translate: AdvancedFilterTranslate
@@ -416,7 +460,19 @@ function addRelativeDateOperators(
             displayValue: translate(PRESET_DATE_OPERATOR_LOCALE_KEYS[key]),
             evaluator: (value, node, params) => {
                 // A range has nothing to match a blank against, as the column filter has nothing either.
-                const convertedValue = value == null || _isBlank(value) ? null : params.valueConverter(value, node);
+                if (value == null || _isBlank(value)) {
+                    return false;
+                }
+                const { comparator, isValid } = params;
+                if (isValid && !isValid(value)) {
+                    return false;
+                }
+                if (comparator) {
+                    // A fresh pair each row, as the column filter builds one per comparison.
+                    const { fromTime, toTime } = cache.getRange(key, rangeFn);
+                    return comparator(new Date(fromTime), value) >= 0 && comparator(new Date(toTime), value) < 0;
+                }
+                const convertedValue = params.valueConverter(value, node);
                 if (convertedValue == null) {
                     return false;
                 }

--- a/testing/behavioural/src/filters/advanced-filter/advanced-filter-column-filter-parity.test.ts
+++ b/testing/behavioural/src/filters/advanced-filter/advanced-filter-column-filter-parity.test.ts
@@ -257,8 +257,8 @@ describe('Advanced Filter matches the column filter', () => {
         expect(getDisplayedIds(api as GridApi<TestRow>)).toEqual([0, 1]);
     });
 
-    // A `dateString` column's `comparator` and `isValidDate` are the grid's own, so the same gate keeps an
-    // unreadable date out of the comparison on both sides.
+    // Both sides refuse a date they cannot read, by different routes: the column filter through the grid's own
+    // `isValidDate`, the Advanced Filter through the parse its `valueConverter` already does.
     test('an unreadable date compares rather than throwing, in both', async () => {
         expect(await withColumnFilter('date', { filterType: 'date', type: 'equals', dateFrom: '2008-08-24' })).toEqual([
             0,
@@ -719,16 +719,21 @@ describe('Advanced Filter matches the column filter', () => {
 
         // A Set Filter's `comparator` orders its list — `(a, b)` over two cell values — so reading it as a
         // date comparison compares the wrong things. One that calls every pair equal would match every row.
-        test('a Set Filter column ignores its list `comparator`', async () => {
-            const columnDefs = timedDefs({ comparator: () => 0 }, 'agSetColumnFilter');
+        // `filter: true` is the reachable case: under enterprise it resolves to the Set Filter, so the name
+        // alone does not say which filter owns the parameter.
+        test.each(['agSetColumnFilter' as const, true as const])(
+            'a Set Filter column ignores its list `comparator` (`filter: %s`)',
+            async (filter) => {
+                const columnDefs = timedDefs({ comparator: () => 0 }, filter);
 
-            expect(
-                await timedAdvancedFilter(
-                    { filterType: 'date', colId: 'when', type: 'equals', filter: '2008-08-24' },
-                    columnDefs
-                )
-            ).toEqual([1]);
-        });
+                expect(
+                    await timedAdvancedFilter(
+                        { filterType: 'date', colId: 'when', type: 'equals', filter: '2008-08-24' },
+                        columnDefs
+                    )
+                ).toEqual([1]);
+            }
+        );
 
         // `comparator` is the Date Filter's key; a custom component's `filterParams` are its own, and the
         // ordinary `(a, b)` sort shape is the inverse of `IDateComparatorFunc`, so reading it flips every option.
@@ -877,6 +882,82 @@ describe('Advanced Filter matches the column filter', () => {
                     { filterType: 'date', colId: 'when', type: 'equals', filter: '2010-01-01' },
                     columnDefs,
                     rowData
+                )
+            ).toEqual(columnFilterIds);
+        });
+
+        // The child that does the comparing owns the comparison's settings whatever it filters on, so a number
+        // column reads them a level down exactly as a date one does.
+        test("a Multi Filter number column reads its number child's `inRangeInclusive`, in both", async () => {
+            const columnDefs = [
+                { field: 'id' },
+                {
+                    field: 'age',
+                    filter: 'agMultiColumnFilter',
+                    filterParams: {
+                        filters: [{ filter: 'agNumberColumnFilter', filterParams: { inRangeInclusive: true } }],
+                    },
+                },
+            ];
+            const rowData = [
+                { id: 0, age: 1 },
+                { id: 1, age: 2 },
+                { id: 2, age: 3 },
+                { id: 3, age: 4 },
+            ];
+
+            const columnFilterIds = await withColumnFilter(
+                'age',
+                {
+                    filterType: 'multi',
+                    filterModels: [{ filterType: 'number', type: 'inRange', filter: 1, filterTo: 3 }],
+                },
+                columnDefs,
+                rowData
+            );
+
+            expect(columnFilterIds).toEqual([0, 1, 2]); // both ends included
+            expect(
+                await withAdvancedFilter(
+                    { filterType: 'number', colId: 'age', type: 'inRange', filter: 1, filterTo: 3 },
+                    columnDefs,
+                    rowData
+                )
+            ).toEqual(columnFilterIds);
+        });
+
+        // A Custom Filter Option's predicate is author code too, and the column filter maps its operands inside
+        // the per-row comparison, so one that normalises what it is handed must see a fresh value each row.
+        test('a custom filter option predicate is given a fresh operand per row, in both', async () => {
+            const columnDefs = timedDefs({
+                filterOptions: [
+                    {
+                        displayKey: 'dayAfter',
+                        displayName: 'Day After',
+                        numberOfInputs: 1,
+                        predicate: ([filterValue]: any[], cellValue: any) => {
+                            filterValue.setDate(filterValue.getDate() + 1);
+                            return midnightComparator(filterValue, cellValue) === 0;
+                        },
+                    },
+                ],
+            });
+
+            const columnFilterIds = await timedColumnFilter(
+                { filterType: 'date', type: 'dayAfter', dateFrom: '2008-08-23' },
+                columnDefs
+            );
+
+            expect(columnFilterIds).toEqual([0, 1]); // the day after the operand, for every row
+            expect(
+                await timedAdvancedFilter(
+                    {
+                        filterType: 'date',
+                        colId: 'when',
+                        type: 'dayAfter',
+                        filter: '2008-08-23',
+                    } as ColumnAdvancedFilterModel,
+                    columnDefs
                 )
             ).toEqual(columnFilterIds);
         });

--- a/testing/behavioural/src/filters/advanced-filter/advanced-filter-column-filter-parity.test.ts
+++ b/testing/behavioural/src/filters/advanced-filter/advanced-filter-column-filter-parity.test.ts
@@ -7,16 +7,35 @@ import {
     uninstallFilterLayoutMock,
 } from 'ag-test-utils';
 
-import type { AdvancedFilterModel, ColumnAdvancedFilterModel, GridApi, GridOptions } from 'ag-grid-community';
+import type { AdvancedFilterModel, ColDef, ColumnAdvancedFilterModel, GridApi, GridOptions } from 'ag-grid-community';
 import {
     BigIntFilterModule,
     ClientSideRowModelModule,
+    CustomFilterModule,
     DateFilterModule,
     NumberFilterModule,
     TextFilterModule,
     setupAgTestIds,
 } from 'ag-grid-community';
-import { AdvancedFilterModule, SetFilterModule } from 'ag-grid-enterprise';
+import { AdvancedFilterModule, MultiFilterModule, SetFilterModule } from 'ag-grid-enterprise';
+
+/** A filter component that filters nothing: only its `filterParams` matter here. */
+class MinimalFilter {
+    public init(): void {}
+    public getGui(): HTMLElement {
+        return document.createElement('div');
+    }
+    public isFilterActive(): boolean {
+        return false;
+    }
+    public doesFilterPass(): boolean {
+        return true;
+    }
+    public getModel(): null {
+        return null;
+    }
+    public setModel(): void {}
+}
 
 interface TestRow {
     id: number;
@@ -59,6 +78,8 @@ describe('Advanced Filter matches the column filter', () => {
             DateFilterModule,
             BigIntFilterModule,
             SetFilterModule,
+            MultiFilterModule,
+            CustomFilterModule,
             AdvancedFilterModule,
             ClientSideRowModelModule,
         ],
@@ -72,8 +93,13 @@ describe('Advanced Filter matches the column filter', () => {
     afterEach(() => gridsManager.reset());
 
     /** The rows a column filter shows for `model`, applied to a grid with no Advanced Filter. */
-    async function withColumnFilter(colId: string, model: object, columnDefs = COLUMN_DEFS): Promise<number[]> {
-        const api = gridsManager.createGrid('columnFilterGrid', { columnDefs, rowData: ROW_DATA });
+    async function withColumnFilter(
+        colId: string,
+        model: object,
+        columnDefs: GridOptions['columnDefs'] = COLUMN_DEFS,
+        rowData: object[] = ROW_DATA
+    ): Promise<number[]> {
+        const api = gridsManager.createGrid('columnFilterGrid', { columnDefs, rowData });
         await asyncSetTimeout(0);
         await api.setColumnFilterModel(colId, model);
         api.onFilterChanged();
@@ -84,12 +110,12 @@ describe('Advanced Filter matches the column filter', () => {
     }
 
     /** The rows the Advanced Filter shows for the equivalent condition. */
-    async function withAdvancedFilter(model: AdvancedFilterModel, columnDefs = COLUMN_DEFS): Promise<number[]> {
-        const api = gridsManager.createGrid('advancedFilterGrid', {
-            columnDefs,
-            rowData: ROW_DATA,
-            enableAdvancedFilter: true,
-        });
+    async function withAdvancedFilter(
+        model: AdvancedFilterModel,
+        columnDefs: GridOptions['columnDefs'] = COLUMN_DEFS,
+        rowData: object[] = ROW_DATA
+    ): Promise<number[]> {
+        const api = gridsManager.createGrid('advancedFilterGrid', { columnDefs, rowData, enableAdvancedFilter: true });
         await asyncSetTimeout(0);
         api.setAdvancedFilterModel(model);
         api.onFilterChanged();
@@ -100,9 +126,9 @@ describe('Advanced Filter matches the column filter', () => {
     }
 
     /** Anchors the comparison: were either side to stop filtering, both would return every row and agree. */
-    function expectFiltered(ids: number[]): void {
+    function expectFiltered(ids: number[], total = ROW_DATA.length): void {
         expect(ids.length).toBeGreaterThan(0);
-        expect(ids.length).toBeLessThan(ROW_DATA.length);
+        expect(ids.length).toBeLessThan(total);
     }
 
     /**
@@ -231,8 +257,8 @@ describe('Advanced Filter matches the column filter', () => {
         expect(getDisplayedIds(api as GridApi<TestRow>)).toEqual([0, 1]);
     });
 
-    // The column filter's `isValid(cellValue)` gate keeps an unreadable date out of the comparison; the
-    // Advanced Filter has no equivalent and converts before it compares.
+    // A `dateString` column's `comparator` and `isValidDate` are the grid's own, so the same gate keeps an
+    // unreadable date out of the comparison on both sides.
     test('an unreadable date compares rather than throwing, in both', async () => {
         expect(await withColumnFilter('date', { filterType: 'date', type: 'equals', dateFrom: '2008-08-24' })).toEqual([
             0,
@@ -433,6 +459,485 @@ describe('Advanced Filter matches the column filter', () => {
 
             expect(await withAdvancedFilter({ ...model, filter: '9', filterTo: '10' })).toEqual([]);
             expect(await withAdvancedFilter({ ...model, filter: '10', filterTo: '9' })).toEqual([0, 1, 2, 3, 4, 5, 6]);
+        });
+    });
+
+    /**
+     * A date column's `filterParams.comparator` decides its comparisons in both filters. Cells carry a time
+     * here, which is what makes a day-only comparator change the answer rather than merely restate it.
+     */
+    describe('a date comparator', () => {
+        interface TimedRow {
+            id: number;
+            when: Date | null;
+        }
+
+        const TIMED_ROWS: TimedRow[] = [
+            { id: 0, when: new Date(2008, 7, 24, 13, 45) },
+            { id: 1, when: new Date(2008, 7, 24) },
+            { id: 2, when: new Date(2012, 7, 5, 9, 30) },
+            { id: 3, when: new Date(2020, 6, 23, 23, 59) },
+            { id: 4, when: null },
+        ];
+
+        /** The ticket's own comparator: compare the day, ignore the time the cell carries. */
+        function midnightComparator(filterDate: Date, cellValue: any): number {
+            const cellDate = new Date(cellValue);
+            cellDate.setHours(0, 0, 0, 0);
+            if (cellDate < filterDate) {
+                return -1;
+            }
+            if (cellDate > filterDate) {
+                return 1;
+            }
+            return 0;
+        }
+
+        function timedDefs(
+            filterParams: object,
+            filter: ColDef['filter'] = 'agDateColumnFilter'
+        ): GridOptions<TimedRow>['columnDefs'] {
+            return [{ field: 'id' }, { field: 'when', cellDataType: 'date', filter, filterParams }];
+        }
+
+        const timedColumnFilter = (
+            model: object,
+            columnDefs: GridOptions<TimedRow>['columnDefs'],
+            rowData: object[] = TIMED_ROWS
+        ) => withColumnFilter('when', model, columnDefs, rowData);
+
+        const timedAdvancedFilter = (
+            model: AdvancedFilterModel,
+            columnDefs: GridOptions<TimedRow>['columnDefs'],
+            rowData: object[] = TIMED_ROWS
+        ) => withAdvancedFilter(model, columnDefs, rowData);
+
+        // `greaterThanOrEqual` and `lessThanOrEqual` are not among the Date Filter's default options, so the
+        // column has to name them for there to be anything to compare the Advanced Filter against.
+        const comparatorParams = {
+            comparator: midnightComparator,
+            filterOptions: [
+                'equals',
+                'notEqual',
+                'greaterThan',
+                'greaterThanOrEqual',
+                'lessThan',
+                'lessThanOrEqual',
+                'inRange',
+                'blank',
+                'notBlank',
+            ],
+        };
+        const comparatorDefs = timedDefs(comparatorParams);
+
+        // The reported case: without the comparator only the cell that happens to sit at midnight matches.
+        test('`equals` matches every cell on the day, in both', async () => {
+            const columnFilterIds = await timedColumnFilter(
+                { filterType: 'date', type: 'equals', dateFrom: '2008-08-24' },
+                comparatorDefs
+            );
+
+            expect(columnFilterIds).toEqual([0, 1]);
+            expect(
+                await timedAdvancedFilter(
+                    { filterType: 'date', colId: 'when', type: 'equals', filter: '2008-08-24' },
+                    comparatorDefs
+                )
+            ).toEqual(columnFilterIds);
+        });
+
+        // Each option maps to a different sign of the comparator's result, so a mapping that drifts from the
+        // column filter's shows up as a different set of rows for that option alone.
+        test.each(['notEqual', 'greaterThan', 'greaterThanOrEqual', 'lessThan', 'lessThanOrEqual'])(
+            '`%s` filters the same rows as the Date Filter',
+            async (type) => {
+                // A day every option leaves some rows on either side of, and one the timed cell sits on.
+                const columnFilterIds = await timedColumnFilter(
+                    { filterType: 'date', type, dateFrom: '2012-08-05' },
+                    comparatorDefs
+                );
+
+                expectFiltered(columnFilterIds, TIMED_ROWS.length);
+                expect(
+                    await timedAdvancedFilter(
+                        { filterType: 'date', colId: 'when', type, filter: '2012-08-05' } as ColumnAdvancedFilterModel,
+                        comparatorDefs
+                    )
+                ).toEqual(columnFilterIds);
+            }
+        );
+
+        test('`inRange` takes both bounds through the comparator, in both', async () => {
+            const model = { type: 'inRange', dateFrom: '2008-08-24', dateTo: '2020-07-23' };
+            const advancedModel = {
+                filterType: 'date' as const,
+                colId: 'when',
+                type: 'inRange' as const,
+                filter: '2008-08-24',
+                filterTo: '2020-07-23',
+            };
+
+            const exclusiveIds = await timedColumnFilter({ filterType: 'date', ...model }, comparatorDefs);
+            expect(exclusiveIds).toEqual([2]); // both end days are excluded, times and all
+            expect(await timedAdvancedFilter(advancedModel, comparatorDefs)).toEqual(exclusiveIds);
+
+            const inclusiveDefs = timedDefs({ ...comparatorParams, inRangeInclusive: true });
+            const inclusiveIds = await timedColumnFilter({ filterType: 'date', ...model }, inclusiveDefs);
+            expect(inclusiveIds).toEqual([0, 1, 2, 3]);
+            expect(await timedAdvancedFilter(advancedModel, inclusiveDefs)).toEqual(inclusiveIds);
+        });
+
+        // A relative range is half-open, so which side each bound is compared on is what the day boundary pins.
+        // The comparator reads a cell as the day before it holds, which is what puts the raw value and the
+        // compared day on opposite sides of that boundary: converting instead of comparing picks the other row.
+        test('a relative date option compares its bounds through the comparator, in both', async () => {
+            const startOfToday = new Date();
+            startOfToday.setHours(0, 0, 0, 0);
+            const at = (dayOffset: number, hours: number) => {
+                const date = new Date(startOfToday);
+                date.setDate(date.getDate() + dayOffset);
+                date.setHours(hours, 0);
+                return date;
+            };
+            const rowData = [
+                { id: 0, when: at(0, 9) },
+                { id: 1, when: at(1, 9) },
+                { id: 2, when: at(2, 9) },
+            ];
+            const columnDefs = timedDefs({
+                comparator: (filterDate: Date, cellValue: any) => {
+                    const cellDate = new Date(cellValue);
+                    cellDate.setDate(cellDate.getDate() - 1);
+                    return midnightComparator(filterDate, cellDate);
+                },
+                filterOptions: ['today', 'equals'],
+            });
+
+            const columnFilterIds = await timedColumnFilter({ filterType: 'date', type: 'today' }, columnDefs, rowData);
+
+            expect(columnFilterIds).toEqual([1]); // tomorrow's cell is the one that reads as today
+            expect(
+                await timedAdvancedFilter({ filterType: 'date', colId: 'when', type: 'today' }, columnDefs, rowData)
+            ).toEqual(columnFilterIds);
+        });
+
+        // A comparator is handed whatever the cell holds, so `isValidDate` is what keeps a value it cannot
+        // read out of the comparison — the pairing the Date Filter's own documentation describes.
+        test('`isValidDate` keeps an unreadable cell out of every comparison but `notEqual`, in both', async () => {
+            const columnDefs = timedDefs({
+                ...comparatorParams,
+                isValidDate: (value: any) => value instanceof Date && !isNaN(+value),
+            });
+            const rowData = [
+                { id: 0, when: new Date(2008, 7, 24, 13, 45) },
+                { id: 1, when: new Date(NaN) },
+            ];
+
+            for (const [type, expected] of [
+                ['equals', [0]],
+                ['notEqual', [1]],
+                ['lessThanOrEqual', [0]],
+            ] as [string, number[]][]) {
+                const columnFilterIds = await timedColumnFilter(
+                    { filterType: 'date', type, dateFrom: '2008-08-24' },
+                    columnDefs,
+                    rowData
+                );
+                expect(columnFilterIds).toEqual(expected);
+                expect(
+                    await timedAdvancedFilter(
+                        { filterType: 'date', colId: 'when', type, filter: '2008-08-24' } as ColumnAdvancedFilterModel,
+                        columnDefs,
+                        rowData
+                    )
+                ).toEqual(columnFilterIds);
+            }
+
+            // `inRange` and the relative options gate through paths of their own. Both need a cell the
+            // comparator would otherwise admit, or the range excludes it anyway and the gate proves nothing.
+            const rangeDefs = timedDefs({
+                ...comparatorParams,
+                isValidDate: (value: any) => value.getFullYear() >= 1900,
+            });
+            const rangeRows = [
+                { id: 0, when: new Date(1899, 5, 15) },
+                { id: 1, when: new Date(2008, 7, 24) },
+            ];
+            const rangeModel = { type: 'inRange', dateFrom: '1899-01-01', dateTo: '2020-01-01' };
+
+            const rangeColumnIds = await timedColumnFilter({ filterType: 'date', ...rangeModel }, rangeDefs, rangeRows);
+            expect(rangeColumnIds).toEqual([1]); // 1899 sits inside the range and is refused by `isValidDate`
+            expect(
+                await timedAdvancedFilter(
+                    {
+                        filterType: 'date',
+                        colId: 'when',
+                        type: 'inRange',
+                        filter: '1899-01-01',
+                        filterTo: '2020-01-01',
+                    },
+                    rangeDefs,
+                    rangeRows
+                )
+            ).toEqual(rangeColumnIds);
+
+            const todayDefs = timedDefs({
+                ...comparatorParams,
+                isValidDate: (value: any) => value.getHours() !== 3,
+                filterOptions: ['today', 'equals'],
+            });
+            const todayAt = (hours: number) => {
+                const date = new Date();
+                date.setHours(hours, 0, 0, 0);
+                return date;
+            };
+            const todayRows = [
+                { id: 0, when: todayAt(10) },
+                { id: 1, when: todayAt(3) }, // today too, and refused by `isValidDate` alone
+            ];
+
+            const todayColumnIds = await timedColumnFilter({ filterType: 'date', type: 'today' }, todayDefs, todayRows);
+            expect(todayColumnIds).toEqual([0]);
+            expect(
+                await timedAdvancedFilter({ filterType: 'date', colId: 'when', type: 'today' }, todayDefs, todayRows)
+            ).toEqual(todayColumnIds);
+        });
+
+        test('a blank is still answered by `includeBlanksInEquals`, not by the comparator', async () => {
+            const columnDefs = timedDefs({ ...comparatorParams, includeBlanksInEquals: true });
+            const model = { type: 'equals', dateFrom: '2008-08-24' };
+
+            const columnFilterIds = await timedColumnFilter({ filterType: 'date', ...model }, columnDefs);
+            expect(columnFilterIds).toEqual([0, 1, 4]); // 4 holds a null date
+            expect(
+                await timedAdvancedFilter(
+                    { filterType: 'date', colId: 'when', type: 'equals', filter: '2008-08-24' },
+                    columnDefs
+                )
+            ).toEqual(columnFilterIds);
+        });
+
+        // A Set Filter's `comparator` orders its list — `(a, b)` over two cell values — so reading it as a
+        // date comparison compares the wrong things. One that calls every pair equal would match every row.
+        test('a Set Filter column ignores its list `comparator`', async () => {
+            const columnDefs = timedDefs({ comparator: () => 0 }, 'agSetColumnFilter');
+
+            expect(
+                await timedAdvancedFilter(
+                    { filterType: 'date', colId: 'when', type: 'equals', filter: '2008-08-24' },
+                    columnDefs
+                )
+            ).toEqual([1]);
+        });
+
+        // `comparator` is the Date Filter's key; a custom component's `filterParams` are its own, and the
+        // ordinary `(a, b)` sort shape is the inverse of `IDateComparatorFunc`, so reading it flips every option.
+        test('a custom filter component column ignores its own `comparator`', async () => {
+            const columnDefs = timedDefs({ comparator: (a: any, b: any) => (a > b ? 1 : -1) }, MinimalFilter);
+
+            expect(
+                await timedAdvancedFilter(
+                    { filterType: 'date', colId: 'when', type: 'greaterThan', filter: '2010-01-01' },
+                    columnDefs
+                )
+            ).toEqual([2, 3]);
+        });
+
+        // A Multi Filter carries the Date Filter as a child, so its comparator lives a level down.
+        test("a Multi Filter column reads its date child's `comparator`, in both", async () => {
+            const columnDefs = timedDefs(
+                { filters: [{ filter: 'agDateColumnFilter', filterParams: comparatorParams }] },
+                'agMultiColumnFilter'
+            );
+
+            const columnFilterIds = await timedColumnFilter(
+                { filterType: 'multi', filterModels: [{ filterType: 'date', type: 'equals', dateFrom: '2008-08-24' }] },
+                columnDefs
+            );
+
+            expect(columnFilterIds).toEqual([0, 1]); // the timed cell too, since the comparator drops its time
+            expect(
+                await timedAdvancedFilter(
+                    { filterType: 'date', colId: 'when', type: 'equals', filter: '2008-08-24' },
+                    columnDefs
+                )
+            ).toEqual(columnFilterIds);
+        });
+
+        // The child carries the rest of the comparison's configuration as well as the comparator.
+        test("a Multi Filter column reads its date child's `inRangeInclusive`, in both", async () => {
+            const columnDefs = timedDefs(
+                {
+                    filters: [
+                        {
+                            filter: 'agDateColumnFilter',
+                            filterParams: { ...comparatorParams, inRangeInclusive: true },
+                        },
+                    ],
+                },
+                'agMultiColumnFilter'
+            );
+            const model = { type: 'inRange', dateFrom: '2008-08-24', dateTo: '2020-07-23' };
+
+            const columnFilterIds = await timedColumnFilter(
+                { filterType: 'multi', filterModels: [{ filterType: 'date', ...model }] },
+                columnDefs
+            );
+
+            expect(columnFilterIds).toEqual([0, 1, 2, 3]); // both end days included, times and all
+            expect(
+                await timedAdvancedFilter(
+                    {
+                        filterType: 'date',
+                        colId: 'when',
+                        type: 'inRange',
+                        filter: '2008-08-24',
+                        filterTo: '2020-07-23',
+                    },
+                    columnDefs
+                )
+            ).toEqual(columnFilterIds);
+        });
+
+        // The Multi Filter hands a child that child's own parameters, so a flag set only on the parent reaches
+        // neither filter. Row 4 holds a null date and is what a leaked `includeBlanksInEquals` would admit.
+        test("a Multi Filter column leaves its parent's `includeBlanksInEquals` to the parent, in both", async () => {
+            const columnDefs = timedDefs(
+                {
+                    includeBlanksInEquals: true,
+                    filters: [{ filter: 'agDateColumnFilter', filterParams: comparatorParams }],
+                },
+                'agMultiColumnFilter'
+            );
+
+            const columnFilterIds = await timedColumnFilter(
+                { filterType: 'multi', filterModels: [{ filterType: 'date', type: 'equals', dateFrom: '2008-08-24' }] },
+                columnDefs
+            );
+
+            expect(columnFilterIds).toEqual([0, 1]);
+            expect(
+                await timedAdvancedFilter(
+                    { filterType: 'date', colId: 'when', type: 'equals', filter: '2008-08-24' },
+                    columnDefs
+                )
+            ).toEqual(columnFilterIds);
+        });
+
+        // A `date` column converts by identity, so the grid's own `isValidDate` is the only thing between an
+        // unreadable cell and `getTime()` being called on it.
+        test('a `date` column holding a cell that is not a date compares rather than throwing, in both', async () => {
+            const columnDefs = timedDefs({});
+            const rowData = [
+                { id: 0, when: new Date(2008, 7, 24) },
+                { id: 1, when: 'not a date' },
+            ];
+
+            const columnFilterIds = await timedColumnFilter(
+                { filterType: 'date', type: 'equals', dateFrom: '2008-08-24' },
+                columnDefs,
+                rowData
+            );
+
+            expect(columnFilterIds).toEqual([0]);
+            expect(
+                await timedAdvancedFilter(
+                    { filterType: 'date', colId: 'when', type: 'equals', filter: '2008-08-24' },
+                    columnDefs,
+                    rowData
+                )
+            ).toEqual(columnFilterIds);
+        });
+
+        // The column filter maps its model inside the per-row comparison, so a comparator that normalises the
+        // date it is handed gets a fresh one each time. One operand shared across rows accumulates the mutation.
+        test('a comparator that mutates the date it is handed is given a fresh one per row, in both', async () => {
+            const columnDefs = timedDefs({
+                comparator: (filterDate: Date, cellValue: any) => {
+                    filterDate.setDate(filterDate.getDate() + 1);
+                    return midnightComparator(filterDate, cellValue);
+                },
+                filterOptions: ['equals'],
+            });
+            const rowData = [
+                { id: 0, when: new Date(2010, 0, 1) },
+                { id: 1, when: new Date(2010, 0, 2) },
+                { id: 2, when: new Date(2010, 0, 3) },
+            ];
+
+            const columnFilterIds = await timedColumnFilter(
+                { filterType: 'date', type: 'equals', dateFrom: '2010-01-01' },
+                columnDefs,
+                rowData
+            );
+
+            expect(columnFilterIds).toEqual([1]); // the day after the operand, for every row
+            expect(
+                await timedAdvancedFilter(
+                    { filterType: 'date', colId: 'when', type: 'equals', filter: '2010-01-01' },
+                    columnDefs,
+                    rowData
+                )
+            ).toEqual(columnFilterIds);
+        });
+
+        // `isValidDate` is the column filter's gate whether or not a comparator sits beside it. The 1899 cell is
+        // the one it refuses, so every option but the negation loses it.
+        test.each([
+            { type: 'lessThan', expected: [] as number[] },
+            { type: 'equals', expected: [] as number[] },
+            { type: 'notEqual', expected: [0, 1] },
+        ])('`isValidDate` alone gates `$type`, in both', async ({ type, expected }) => {
+            const columnDefs = timedDefs({
+                isValidDate: (value: any) => value instanceof Date && value.getFullYear() >= 1900,
+            });
+            const rowData = [
+                { id: 0, when: new Date(1899, 0, 1) },
+                { id: 1, when: new Date(2012, 7, 5) },
+            ];
+
+            const columnFilterIds = await timedColumnFilter(
+                { filterType: 'date', type, dateFrom: '2000-01-01' },
+                columnDefs,
+                rowData
+            );
+
+            expect(columnFilterIds).toEqual(expected);
+            expect(
+                await timedAdvancedFilter(
+                    { filterType: 'date', colId: 'when', type, filter: '2000-01-01' } as ColumnAdvancedFilterModel,
+                    columnDefs,
+                    rowData
+                )
+            ).toEqual(columnFilterIds);
+        });
+
+        // The cell value reaches a comparator as the column holds it, which is the whole reason a column
+        // whose data the data type cannot read supplies one.
+        test('the comparator reads the cell value, not the value the data type converts it to', async () => {
+            const seen: unknown[] = [];
+            const defs = COLUMN_DEFS!.map((def) =>
+                (def as { field?: string }).field === 'date'
+                    ? {
+                          ...def,
+                          filterParams: {
+                              comparator: (filterDate: Date, cellValue: any) => {
+                                  seen.push(cellValue);
+                                  return midnightComparator(filterDate, new Date(cellValue));
+                              },
+                          },
+                      }
+                    : def
+            );
+
+            const advancedIds = await withAdvancedFilter(
+                { filterType: 'dateString', colId: 'date', type: 'equals', filter: '2008-08-24' },
+                defs
+            );
+
+            expect(advancedIds).toEqual([0]);
+            expect(seen.length).toBeGreaterThan(0);
+            expect(seen.every((value) => typeof value === 'string')).toBe(true);
         });
     });
 });

--- a/testing/behavioural/src/filters/advanced-filter/advanced-filter-column-filter-parity.test.ts
+++ b/testing/behavioural/src/filters/advanced-filter/advanced-filter-column-filter-parity.test.ts
@@ -886,6 +886,44 @@ describe('Advanced Filter matches the column filter', () => {
             ).toEqual(columnFilterIds);
         });
 
+        // A Multi Filter child that sets nothing is given nothing: falling back to the parent would reach a
+        // child that never asked for it. A number column shows it, having no grid-supplied child params to hide
+        // the fallback. `agTextColumnFilter` is the no-matching-child case, which must resolve the same way.
+        test.each([
+            { child: 'agNumberColumnFilter', name: 'a bare matching child' },
+            { child: 'agTextColumnFilter', name: 'no matching child' },
+        ])('a Multi Filter number column takes no parameters from its parent ($name), in both', async ({ child }) => {
+            const columnDefs = [
+                { field: 'id' },
+                {
+                    field: 'age',
+                    filter: 'agMultiColumnFilter',
+                    filterParams: { includeBlanksInEquals: true, filters: [{ filter: child }] },
+                },
+            ];
+            const rowData = [
+                { id: 0, age: 1 },
+                { id: 1, age: 2 },
+                { id: 2, age: null },
+            ];
+
+            const columnFilterIds = await withColumnFilter(
+                'age',
+                { filterType: 'multi', filterModels: [{ filterType: 'number', type: 'equals', filter: 1 }] },
+                columnDefs,
+                rowData
+            );
+
+            expect(columnFilterIds).toEqual([0]); // the blank row is not admitted by the parent's flag
+            expect(
+                await withAdvancedFilter(
+                    { filterType: 'number', colId: 'age', type: 'equals', filter: 1 },
+                    columnDefs,
+                    rowData
+                )
+            ).toEqual(columnFilterIds);
+        });
+
         // The child that does the comparing owns the comparison's settings whatever it filters on, so a number
         // column reads them a level down exactly as a date one does.
         test("a Multi Filter number column reads its number child's `inRangeInclusive`, in both", async () => {


### PR DESCRIPTION
<!-- base: latest -->

# AG-13360: Advanced Filter honours a date column's comparator

FIX AG-13360

A date column setting `filterParams.comparator` was compared by the Date Filter through that comparator and by the
Advanced Filter through `getTime()`, so the same condition on the same column returned different rows. A column
whose cells carry a time matched nothing at all for `=`.

| scope  | net lines |  lines changed | hunks | files changed |
| ------ | --------: | -------------: | ----: | ------------: |
| source |      +145 | 193 (+169 -24) |    38 |      6 edited |
| tests  |      +624 | 652 (+638 -14) |    10 |      1 edited |
| docs   |       +26 |       26 added |     2 |      2 edited |

## Behaviour change

Every one of these is a column the two filters already disagreed on, so each is a bug fix rather than a change of
a defensible behaviour, and each is visible to a column configured today.

- A date column setting `filterParams.comparator` or `isValidDate` returns different rows in the Advanced Filter.
- A Multi Filter column takes `inRangeInclusive`, the `includeBlanksIn*` flags and `caseSensitive` from the child
  matching its cell data type rather than from the parent level.
- A `date` or `dateTime` column holding a cell that is not a `Date` was throwing a `TypeError` from `equals`, and
  now compares as the Date Filter does.
- A Custom Filter Option whose `predicate` mutates the operand it is handed no longer carries that mutation into
  the rows that follow.

Under the Server-Side Row Model nothing changes: a comparator cannot travel in the filter model, so this is
Client-Side Row Model only, as the `includeBlanksIn*` flags already are.

## The column's comparator decides its comparisons ([AG-13360](https://ag-grid.atlassian.net/browse/AG-13360))

No new API: `comparator` joins the column filter parameters the Advanced Filter already reuses. For the `date`,
`dateString`, `dateTime` and `dateTimeString` cell data types it decides `equals`, `notEqual`, the four ordering
options, `inRange` and the relative date options, mapping its result as `ScalarFilterHandler` does and comparing
relative bounds half-open as `DateFilterHandler` does. It travels in the per-column evaluator parameters, beside
the `inRangeInclusive` and `includeBlanksIn*` flags the Advanced Filter already reads from `filterParams`, so no
column needs an operator table of its own.

It is handed the cell value as the column holds it, never a converted one: a column supplies a comparator
precisely because its data is not what the cell data type reads, and the grid-supplied `dateString` comparator
calls the column's own `dateParser` on that value.

Every operand handed to author code is rebuilt per row, for a comparator and for a Custom Filter Option's
`predicate` alike: the column filter maps its model inside the per-row comparison, so code that normalises what
it is given in place sees a fresh value each time rather than accumulating its own edits.

## Only the filter whose parameter it is

`comparator` is an overloaded `filterParams` key, so the column's resolved filter decides whether it is a date
comparison at all, rather than the cell data type alone. A Set Filter's `comparator` orders its list, `(a, b)`
over two cell values, and a custom filter component's `filterParams` are its own; neither is read here. Since the
ordinary sort shape is the inverse of `IDateComparatorFunc`, reading one would return the complement of every
ordering option. A Multi Filter configures each filter on its own child, so the comparison and the flags beside
it are read a level down, from the child matching the column's cell data type, as `getColumnFilterOptions`
already reads `filterOptions`. That child's parameters are read alone and never merged with the parent's, because
the Multi Filter hands its child exactly that level: a flag set only on the parent reaches neither filter.

The grid supplies a `comparator` to the `dateString` types that restates the parse `valueConverter` already does,
so it is left to the converter rather than taken; that keeps a single read of each cell per comparison.

## `isValidDate` gates comparisons on both sides

`isValidDate` is honoured whether or not a comparator sits beside it, as it is in the Date Filter: a value it
rejects matches no comparison and so matches every negation of one.

Which gate that is follows from what the conversion already covers. A comparator reads the cell instead of
converting it, so wherever one is in play the column's `isValidDate` is the only check left and applies whoever
supplied it. Without one, the `dateString` types are already gated by the parse their `valueConverter` performs,
so the grid's own restatement of it is skipped; `date` and `dateTime` convert by identity, so their gate is the
only thing standing between an unreadable cell and `getTime()` being called on it.
