### PR TITLE
SE-184 Allow Meta-ExternalAgent to train, per the log-analysis recommendation

### DIFF
--- a/documentation/ag-grid-docs/src/utils/robotsTxt.ts
+++ b/documentation/ag-grid-docs/src/utils/robotsTxt.ts
@@ -46,6 +46,7 @@ export const AI_CRAWLERS = [
     'Applebot-Extended',
     'CCBot',
     'Bytespider',
+    'Meta-ExternalAgent',
 ];
 
 // Public example pages we actively want AI to crawl and train on. Internal `/debug/` example


### PR DESCRIPTION
## What

Reverts SE-184's earlier removal of `Meta-ExternalAgent` from the AI-crawler robots allow-group (#15076/#15077 depending on branch).

## Why

SE-184's original scoping recommended removing Meta-ExternalAgent from robots.txt rather than building an edge IP-allowlist, on the premise that Meta publishes no machine-readable crawler IP list. That premise is correct (verified: Meta's only crawler-verification method is checking the source IP against AS32934 via WHOIS, not a static range file), but a subsequent review on the ticket (Nick Redding) flagged that removing it from the named AI group doesn't actually close training access — Meta falls through to `User-agent: *`, which still carries `Allow: /` and `ai-train=yes`, so the robots/edge mismatch the ticket exists to fix was still present, just relocated.

**Decision:** honour the open-training stance (SE-78) for Meta same as the other named AI crawlers, matching log-analysis's original recommendation to allow at the edge rather than close training. This PR is robots' half of that; the edge half is a separate, non-code change to the `block-nonbrowser-except-ai-assistants` WAF rule (applied via AWS Console, not managed in this repo).

## Companion PR

This same change targets both `latest` and `b36.1.0` (mirroring how the original SE-184 removal was applied to both branches as #15076/#15077).

## Testing

- `AI_CRAWLERS` is a single flat array consumed identically by both robots groups; no test asserted its absence, so nothing else needs updating.
- Live verification pending this deploying + the WAF-side change landing (tracked on SE-184).