### PR TITLE
AG-17659 fix ref data editing

### DIFF
--- a/packages/ag-grid-community/src/edit/cellEditors/checkboxCellEditor.ts
+++ b/packages/ag-grid-community/src/edit/cellEditors/checkboxCellEditor.ts
@@ -23,6 +23,8 @@ export class CheckboxCellEditor extends AgAbstractCellEditor<ICellEditorParams<a
     }
 
     protected readonly eEditor: GridCheckbox = RefPlaceholder;
+    /** Read off the widget, which cannot hold `null`, so an untouched commit would narrow it to `undefined`. */
+    private seededValue: boolean | undefined | this = this;
 
     public initialiseEditor(params: ICellEditorParams<any, boolean>): void {
         this.agSetEditValue(params.value);
@@ -39,11 +41,13 @@ export class CheckboxCellEditor extends AgAbstractCellEditor<ICellEditorParams<a
         this.params.value = value;
         const isSelected = value ?? undefined;
         this.eEditor.setValue(isSelected, true);
+        this.seededValue = this.eEditor.getValue();
         this.setAriaLabel(isSelected);
     }
 
-    public getValue(): boolean | undefined {
-        return this.eEditor.getValue();
+    public getValue(): boolean | null | undefined {
+        const value = this.eEditor.getValue();
+        return value === this.seededValue ? this.params.value : value;
     }
 
     public focusIn(): void {

--- a/packages/ag-grid-community/src/edit/cellEditors/dateCellEditor.ts
+++ b/packages/ag-grid-community/src/edit/cellEditors/dateCellEditor.ts
@@ -1,5 +1,5 @@
 import type { LocaleTextFunc } from 'ag-stack';
-import { _exists, _serialiseDate } from 'ag-stack';
+import { _exists, _parseDateTimeFromString, _serialiseDate } from 'ag-stack';
 
 import { AgInputDateFieldSelector } from '../../agWidgets/agInputDateField';
 import type { DataTypeService } from '../../columns/dataTypeService';
@@ -58,46 +58,51 @@ class DateCellEditorInput implements CellEditorInput<Date, IDateCellEditorParams
         }
     }
 
-    public getValidationErrors(): string[] | null {
+    public getValidationErrors(untouched: boolean): string[] | null {
         const eInput = this.eEditor.getInputElement();
-        const value = eInput.valueAsDate;
+        // Not `valueAsDate`: it is null for the `datetime-local` input `includeTime` switches to.
+        const value = _parseDateTimeFromString(eInput.value);
 
         const { params } = this;
-        const { min, max, getValidationErrors } = params;
-        let internalErrors: string[] | null = [];
-        const translate = this.getLocaleTextFunc();
-
-        if (value instanceof Date && !isNaN(value.getTime())) {
-            if (min) {
-                const minValue = min instanceof Date ? min : new Date(min);
-                if (value < minValue) {
-                    const minDateString = minValue.toLocaleDateString();
-                    internalErrors.push(
-                        translate('minDateValidation', `Date must be after ${minDateString}`, [minDateString])
-                    );
-                }
-            }
-
-            if (max) {
-                const maxValue = max instanceof Date ? max : new Date(max);
-                if (value > maxValue) {
-                    const maxDateString = maxValue.toLocaleDateString();
-                    internalErrors.push(
-                        translate('maxDateValidation', `Date must be before ${maxDateString}`, [maxDateString])
-                    );
-                }
-            }
-        }
-
-        if (!internalErrors.length) {
-            internalErrors = null;
-        }
+        const { getValidationErrors } = params;
+        const internalErrors = this.getInternalValidationErrors(value);
 
         if (getValidationErrors) {
-            return getValidationErrors({ value, cellEditorParams: params, internalErrors });
+            const graded = untouched ? params.value : value;
+            return getValidationErrors({ value: graded, cellEditorParams: params, internalErrors });
         }
 
         return internalErrors;
+    }
+
+    private getInternalValidationErrors(date: Date | null): string[] | null {
+        if (!date) {
+            return null;
+        }
+
+        const { min, max } = this.params;
+        const translate = this.getLocaleTextFunc();
+        const errors: string[] = [];
+
+        // Bounds parse with the same parser as the input, or a `yyyy-mm-dd` string would be read as UTC
+        // and compared against a local-time entry.
+        if (min) {
+            const minValue = min instanceof Date ? min : _parseDateTimeFromString(min);
+            if (minValue && date < minValue) {
+                const minDateString = minValue.toLocaleDateString();
+                errors.push(translate('minDateValidation', `Date must be after ${minDateString}`, [minDateString]));
+            }
+        }
+
+        if (max) {
+            const maxValue = max instanceof Date ? max : _parseDateTimeFromString(max);
+            if (maxValue && date > maxValue) {
+                const maxDateString = maxValue.toLocaleDateString();
+                errors.push(translate('maxDateValidation', `Date must be before ${maxDateString}`, [maxDateString]));
+            }
+        }
+
+        return errors.length ? errors : null;
     }
 
     public flushInput(): void {

--- a/packages/ag-grid-community/src/edit/cellEditors/dateStringCellEditor.ts
+++ b/packages/ag-grid-community/src/edit/cellEditors/dateStringCellEditor.ts
@@ -63,7 +63,7 @@ class DateStringCellEditorInput implements CellEditorInput<string, IDateStringCe
         }
     }
 
-    public getValidationErrors(): string[] | null {
+    public getValidationErrors(untouched: boolean): string[] | null {
         const { eEditor, params } = this;
         const date = _parseDateTimeFromString(eEditor.getInputElement().value) ?? undefined;
         const value = this.formatDate(date);
@@ -74,7 +74,7 @@ class DateStringCellEditorInput implements CellEditorInput<string, IDateStringCe
         }
 
         return params.getValidationErrors({
-            value: this.parseEditorValue(value),
+            value: untouched ? params.value : this.parseEditorValue(value),
             cellEditorParams: params,
             internalErrors,
         });

--- a/packages/ag-grid-community/src/edit/cellEditors/iCellEditorInput.ts
+++ b/packages/ag-grid-community/src/edit/cellEditors/iCellEditorInput.ts
@@ -9,7 +9,8 @@ export interface CellEditorInput<TValue, P extends ICellEditorParams, I extends 
     init(eInput: I, params: P): void;
     getValue(): TValue | null | undefined;
     getStartValue(): string | null | undefined;
-    getValidationErrors(): string[] | null;
+    /** When `untouched`, the widget still holds its seed, so `params.value` is what a commit would write. */
+    getValidationErrors(untouched: boolean): string[] | null;
     setCaret?(): void;
     /** Commit any buffered input to the field's value before the grid reads it on stop (e.g. a Firefox date segment). */
     flushInput?(): void;

--- a/packages/ag-grid-community/src/edit/cellEditors/iTextCellEditor.ts
+++ b/packages/ag-grid-community/src/edit/cellEditors/iTextCellEditor.ts
@@ -5,7 +5,8 @@ export interface ITextCellEditorParams<TData = any, TValue = any, TContext = any
     extends ICellEditorParams<TData, TValue, TContext>, IAutoCompleteComponentParams {
     /** If `true`, the editor will use the provided `colDef.valueFormatter` to format the value displayed in the editor.
      * Used when the cell value needs formatting prior to editing, such as when using reference data and you
-     * want to display text rather than code. */
+     * want to display text rather than code. Nothing reverses the mapping on commit, so this needs a
+     * `colDef.valueParser` that turns the formatted text back into the stored value. */
     useFormatter: boolean;
 
     /**

--- a/packages/ag-grid-community/src/edit/cellEditors/largeTextCellEditor.ts
+++ b/packages/ag-grid-community/src/edit/cellEditors/largeTextCellEditor.ts
@@ -25,6 +25,8 @@ export class LargeTextCellEditor extends AgAbstractCellEditor<ILargeTextEditorPa
     private cachedRaw: unknown = this;
     /** Memoised parse result for `cachedRaw`. Returned by `getValue()` when the raw input is unchanged across repeated validation/sync passes within an edit session. */
     private cachedParsed: any;
+    /** Read off the widget, not from `getStartValue`, because the widget normalises what it is given. */
+    private seededText: string | null | undefined | this = this;
 
     constructor() {
         super(LargeTextCellElement, [AgInputTextAreaSelector]);
@@ -46,6 +48,7 @@ export class LargeTextCellEditor extends AgAbstractCellEditor<ILargeTextEditorPa
             .setRows(rows || 10);
 
         let startValue: string | null | undefined;
+        let seeded = false;
 
         // cellStartedEdit is only false if we are doing fullRow editing
         if (cellStartedEdit) {
@@ -57,6 +60,7 @@ export class LargeTextCellEditor extends AgAbstractCellEditor<ILargeTextEditorPa
                 startValue = eventKey;
             } else {
                 startValue = this.getStartValue(params);
+                seeded = true;
 
                 if (eventKey !== KeyCode.F2) {
                     this.highlightAllOnFocus = true;
@@ -65,11 +69,13 @@ export class LargeTextCellEditor extends AgAbstractCellEditor<ILargeTextEditorPa
         } else {
             this.focusAfterAttached = false;
             startValue = this.getStartValue(params);
+            seeded = true;
         }
 
         if (startValue != null) {
             eEditor.setValue(startValue, true);
         }
+        this.seededText = seeded ? eEditor.getValue() : this;
 
         this.addGuiEventListener('keydown', this.onKeyDown.bind(this));
         this.activateTabIndex();
@@ -84,6 +90,7 @@ export class LargeTextCellEditor extends AgAbstractCellEditor<ILargeTextEditorPa
         this.params.value = value;
         const startValue = this.getStartValue(this.params);
         this.eEditor.setValue(startValue ?? '', true);
+        this.seededText = this.eEditor.getValue();
     }
 
     private onKeyDown(event: KeyboardEvent): void {
@@ -121,6 +128,9 @@ export class LargeTextCellEditor extends AgAbstractCellEditor<ILargeTextEditorPa
         const { value } = params;
         const editorValue = eEditor.getValue();
 
+        if (editorValue === this.seededText) {
+            return value;
+        }
         if (!_exists(editorValue) && !_exists(value)) {
             return value;
         }

--- a/packages/ag-grid-community/src/edit/cellEditors/numberCellEditor.ts
+++ b/packages/ag-grid-community/src/edit/cellEditors/numberCellEditor.ts
@@ -58,7 +58,7 @@ class NumberCellEditorInput implements CellEditorInput<number, INumberCellEditor
         }
     }
 
-    public getValidationErrors(): string[] | null {
+    public getValidationErrors(untouched: boolean): string[] | null {
         const { params } = this;
         const { min, max, getValidationErrors } = params;
 
@@ -88,7 +88,7 @@ class NumberCellEditorInput implements CellEditorInput<number, INumberCellEditor
 
         if (getValidationErrors) {
             return getValidationErrors({
-                value,
+                value: untouched ? params.value : this.parseRaw(this.eEditor.getValue(true)),
                 cellEditorParams: params,
                 internalErrors,
             });
@@ -104,8 +104,11 @@ class NumberCellEditorInput implements CellEditorInput<number, INumberCellEditor
     }
 
     public getValue(): number | null | undefined {
-        const { eEditor, params } = this;
-        const value = eEditor.getValue();
+        return this.parseRaw(this.eEditor.getValue(true));
+    }
+
+    private parseRaw(value: string | null | undefined): number | null | undefined {
+        const { params } = this;
         if (!_exists(value) && !_exists(params.value)) {
             return params.value;
         }

--- a/packages/ag-grid-community/src/edit/cellEditors/selectCellEditor.ts
+++ b/packages/ag-grid-community/src/edit/cellEditors/selectCellEditor.ts
@@ -36,6 +36,12 @@ export class SelectCellEditor<TValue = any> extends AgAbstractCellEditor<SelectC
 
     protected readonly eEditor: GridSelect<TValue> = RefPlaceholder;
     private startedByEnter: boolean = false;
+    /** Read off the widget, which falls back to `values[0]` when the stored value is not an option,
+     * so an untouched commit would write that option over it. */
+    private seededValue: TValue | null | undefined | this = this;
+    /** Picking the fallback option leaves the widget on its seed, so equality alone cannot tell a
+     * deliberate choice from an untouched editor. */
+    private picked: boolean = false;
 
     constructor() {
         super(SelectCellElement, [AgSelectSelector]);
@@ -70,6 +76,7 @@ export class SelectCellEditor<TValue = any> extends AgAbstractCellEditor<SelectC
         } else if (params.values.length) {
             eEditor.setValue(params.values[0], true);
         }
+        this.seededValue = eEditor.getValue();
 
         const { valueListGap, valueListMaxWidth, valueListMaxHeight } = params;
 
@@ -85,14 +92,16 @@ export class SelectCellEditor<TValue = any> extends AgAbstractCellEditor<SelectC
             eEditor.setPickerMaxWidth(valueListMaxWidth);
         }
 
-        // we don't want to add this if full row editing, otherwise selecting will stop the
-        // full row editing.
-        if (gos.get('editType') !== 'fullRow') {
-            this.addManagedListeners(this.eEditor, {
-                selectedItem: (e: AgSelectSelectedItemEvent) =>
-                    params.stopEditing(e.keyboardEvent == null, e.keyboardEvent),
-            });
-        }
+        // selecting must not stop a full row edit, but it still counts as a deliberate pick.
+        const stopsOnSelect = gos.get('editType') !== 'fullRow';
+        this.addManagedListeners(this.eEditor, {
+            selectedItem: (e: AgSelectSelectedItemEvent) => {
+                this.picked = true;
+                if (stopsOnSelect) {
+                    params.stopEditing(e.keyboardEvent == null, e.keyboardEvent);
+                }
+            },
+        });
     }
 
     public afterGuiAttached() {
@@ -116,10 +125,13 @@ export class SelectCellEditor<TValue = any> extends AgAbstractCellEditor<SelectC
     public agSetEditValue(value: TValue | null | undefined): void {
         this.params.value = value;
         this.eEditor.setValue(value ?? undefined, true);
+        this.seededValue = this.eEditor.getValue();
+        this.picked = false;
     }
 
     public getValue(): TValue | null | undefined {
-        return this.eEditor.getValue();
+        const value = this.eEditor.getValue();
+        return !this.picked && value === this.seededValue ? this.params.value : value;
     }
 
     public override isPopup() {

--- a/packages/ag-grid-community/src/edit/cellEditors/simpleCellEditor.ts
+++ b/packages/ag-grid-community/src/edit/cellEditors/simpleCellEditor.ts
@@ -12,6 +12,9 @@ export class SimpleCellEditor<
 > extends AgAbstractCellEditor<ICellEditorParams, TValue, string> {
     private highlightAllOnFocus: boolean;
     private focusAfterAttached: boolean;
+    /** Read off the element, not from `getStartValue`: the widget normalises what it is given, and
+     * withholds its value entirely while the input breaks a native bound. */
+    private seededText: string | this = this;
     protected readonly eEditor: I = RefPlaceholder;
 
     constructor(protected cellEditorInput: CellEditorInput<TValue, P, I>) {
@@ -36,6 +39,7 @@ export class SimpleCellEditor<
         cellEditorInput.init(eEditor, params);
         let startValue: string | null | undefined;
         let shouldSetStartValue = true;
+        let seeded = false;
 
         // cellStartedEdit is only false if we are doing fullRow editing
         if (cellStartedEdit) {
@@ -51,6 +55,7 @@ export class SimpleCellEditor<
                 }
             } else {
                 startValue = cellEditorInput.getStartValue();
+                seeded = true;
 
                 if (eventKey !== KeyCode.F2) {
                     this.highlightAllOnFocus = true;
@@ -59,11 +64,13 @@ export class SimpleCellEditor<
         } else {
             this.focusAfterAttached = false;
             startValue = cellEditorInput.getStartValue();
+            seeded = true;
         }
 
         if (shouldSetStartValue && startValue != null) {
             eEditor.setStartValue(startValue);
         }
+        this.seededText = seeded ? eEditor.getInputElement().value : this;
 
         this.addGuiEventListener('keydown', (event: KeyboardEvent) => {
             const { key } = event;
@@ -113,14 +120,19 @@ export class SimpleCellEditor<
         this.cellEditorInput.flushInput?.();
     }
 
+    private isUntouched(): boolean {
+        return this.eEditor.getInputElement().value === this.seededText;
+    }
+
     public getValue(): TValue | null | undefined {
-        return this.cellEditorInput.getValue();
+        return this.isUntouched() ? this.params.value : this.cellEditorInput.getValue();
     }
 
     public override agSetEditValue(value: TValue | null | undefined): void {
         this.params.value = value;
         const startValue = this.cellEditorInput.getStartValue();
         this.eEditor.setStartValue(startValue ?? null);
+        this.seededText = this.eEditor.getInputElement().value;
     }
 
     public override isPopup() {
@@ -132,6 +144,6 @@ export class SimpleCellEditor<
     }
 
     public getValidationErrors(): string[] | null {
-        return this.cellEditorInput.getValidationErrors();
+        return this.cellEditorInput.getValidationErrors(this.isUntouched());
     }
 }

--- a/packages/ag-grid-community/src/edit/cellEditors/textCellEditor.ts
+++ b/packages/ag-grid-community/src/edit/cellEditors/textCellEditor.ts
@@ -48,10 +48,10 @@ class TextCellEditorInput<TValue = any> implements CellEditorInput<
         }
     }
 
-    public getValidationErrors(): string[] | null {
+    public getValidationErrors(untouched: boolean): string[] | null {
         const { params } = this;
         const { maxLength, getValidationErrors } = params;
-        const value = this.getValue();
+        const value = untouched ? params.value : this.getValue();
 
         const translate = this.getLocaleTextFunc();
 
@@ -91,8 +91,7 @@ class TextCellEditorInput<TValue = any> implements CellEditorInput<
 
     public getStartValue(): string | null | undefined {
         const params = this.params;
-        const formatValue = params.useFormatter || params.column.getColDef().refData;
-        return formatValue ? params.formatValue(params.value) : (params.value as any);
+        return params.useFormatter ? params.formatValue(params.value) : (params.value as any);
     }
 
     public setCaret(): void {

--- a/packages/ag-grid-enterprise/src/formula/editor/formulaCellEditor.ts
+++ b/packages/ag-grid-enterprise/src/formula/editor/formulaCellEditor.ts
@@ -17,6 +17,8 @@ export class FormulaCellEditor<TData = any, TValue = any, TContext = any> extend
     private cachedRaw: unknown = this;
     /** Memoised parse result for `cachedRaw`. Returned by `getValue()` when the raw input is unchanged across repeated validation/sync passes within an edit session. */
     private cachedParsed: any;
+    /** Read off the widget, not from `getStartValue`, because the widget normalises what it is given. */
+    private seededText: string | null | undefined | this = this;
 
     constructor() {
         super({ tag: 'div', cls: 'ag-cell-edit-wrapper' });
@@ -37,6 +39,7 @@ export class FormulaCellEditor<TData = any, TValue = any, TContext = any> extend
         // replicate the provided editors’ behaviour: if we started from a printable key, seed with that;
         // backspace/delete clears; otherwise use the existing value.
         let startValue: string | null | undefined;
+        let seeded = false;
         if (cellStartedEdit) {
             this.focusAfterAttached = true;
             if (eventKey === KeyCode.BACKSPACE || eventKey === KeyCode.DELETE) {
@@ -45,14 +48,17 @@ export class FormulaCellEditor<TData = any, TValue = any, TContext = any> extend
                 startValue = eventKey;
             } else {
                 startValue = this.getStartValue(params);
+                seeded = true;
             }
         } else {
             startValue = this.getStartValue(params);
+            seeded = true;
         }
 
         const initialValue = startValue == null ? '' : String(startValue);
         this.eEditor.setEditingCellRef(params.column, params.rowIndex);
         this.eEditor.setValue(initialValue, true);
+        this.seededText = seeded ? this.eEditor.getCurrentValue() : this;
     }
 
     private onFormulaInputKeyDown(event: KeyboardEvent, onKeyDown: (event: KeyboardEvent) => void) {
@@ -95,6 +101,7 @@ export class FormulaCellEditor<TData = any, TValue = any, TContext = any> extend
         this.params.value = value;
         const startValue = this.getStartValue(this.params);
         this.eEditor.setValue(startValue ?? '', true);
+        this.seededText = this.eEditor.getCurrentValue();
     }
 
     public override isPopup(): boolean {
@@ -125,6 +132,10 @@ export class FormulaCellEditor<TData = any, TValue = any, TContext = any> extend
         // commit in their intended type.
         if (typeof rawValue === 'string' && this.isFormulaText(rawValue)) {
             return rawValue;
+        }
+
+        if (rawValue === this.seededText) {
+            return value;
         }
 
         if (rawValue == null && value == null) {

--- a/packages/ag-grid-enterprise/src/richSelect/richSelectCellEditor.ts
+++ b/packages/ag-grid-enterprise/src/richSelect/richSelectCellEditor.ts
@@ -31,6 +31,9 @@ export class RichSelectCellEditor<TData = any, TValue = any, TContext = any> ext
     private cachedRaw: unknown = this;
     /** Memoised parse result for `cachedRaw`. Returned by `getValue()` when the raw input is unchanged across repeated validation/sync passes within an edit session. */
     private cachedParsed: any;
+    /** Recorded rather than read back, because this widget stores the value by identity and normalises
+     * only `undefined` to `null` on the way in. */
+    private seededValue: TValue | null | undefined | this = this;
 
     constructor() {
         super({ tag: 'div', cls: 'ag-cell-edit-wrapper' });
@@ -50,6 +53,7 @@ export class RichSelectCellEditor<TData = any, TValue = any, TContext = any> ext
         const richSelect = this.createManagedBean(new AgRichSelect<TValue>(richSelectParams));
 
         this.eEditor = richSelect;
+        this.seededValue = this.params.value;
         richSelect.addCss('ag-cell-editor');
         this.appendChild(richSelect);
 
@@ -428,10 +432,14 @@ export class RichSelectCellEditor<TData = any, TValue = any, TContext = any> ext
     public agSetEditValue(value: TValue | null | undefined): void {
         this.params.value = value;
         this.eEditor.setValue(value ?? null, true);
+        this.seededValue = value ?? null;
     }
 
     public getValue(): any {
         const value = this.eEditor.getValue();
+        if (value === this.seededValue) {
+            return this.params.value;
+        }
         if (Object.is(this.cachedRaw, value)) {
             return this.cachedParsed;
         }

--- a/testing/behavioural/src/cell-editing/cell-editing.test.ts
+++ b/testing/behavioural/src/cell-editing/cell-editing.test.ts
@@ -11,13 +11,14 @@ import {
 } from 'ag-test-utils';
 import type { EditorFormControl } from 'ag-test-utils';
 
-import type { CellValueChangedEvent, ColDef, NewValueParams } from 'ag-grid-community';
+import type { CellValueChangedEvent, ColDef, GridApi, NewValueParams } from 'ag-grid-community';
 import {
     CheckboxEditorModule,
     DateEditorModule,
     LargeTextEditorModule,
     NumberEditorModule,
     RenderApiModule,
+    SelectEditorModule,
     TextEditorModule,
     ValueCacheModule,
     agTestIdFor,
@@ -65,6 +66,7 @@ describe('Cell Editing Start', () => {
             DateEditorModule,
             LargeTextEditorModule,
             CheckboxEditorModule,
+            SelectEditorModule,
         ],
     });
 
@@ -328,6 +330,584 @@ describe('Cell Editing Start', () => {
             await waitFor(() => expect(cell).toHaveTextContent(expectedText as any));
 
             expect(api.getCellEditorInstances()).toHaveLength(0);
+        });
+    });
+
+    describe('refData start value', () => {
+        const refData = { cb: 'Cadet Blue', bw: 'Burlywood', fg: 'Forest Green' };
+
+        const openEditor = async (api: GridApi, field: string, rowId: string) => {
+            const gridDiv = getGridElement(api)! as HTMLElement;
+            const cell = await waitFor(() => getByTestId(gridDiv, agTestIdFor.cell(rowId, field)));
+            await userEvent.dblClick(cell);
+            return waitForInput(gridDiv, cell);
+        };
+
+        test('the text editor opens on the stored code, not the mapped label', async () => {
+            const api = await gridMgr.createGridAndWait('myGrid', {
+                columnDefs: [{ field: 'colour', refData }],
+                rowData: [{ colour: 'bw' }, { colour: 'cb' }],
+                defaultColDef: { editable: true },
+            });
+
+            expectInputValue(await openEditor(api, 'colour', '0'), 'bw');
+            await userEvent.keyboard('{Escape}');
+            await waitFor(() => expect(api.getEditingCells()).toHaveLength(0));
+
+            expectInputValue(await openEditor(api, 'colour', '1'), 'cb');
+        });
+
+        test('committing an untouched editor leaves the stored code alone', async () => {
+            const api = await gridMgr.createGridAndWait('myGrid', {
+                columnDefs: [{ field: 'colour', refData }],
+                rowData: [{ colour: 'bw' }, { colour: 'cb' }],
+                defaultColDef: { editable: true },
+            });
+
+            const eventTracker = new EditEventTracker(api);
+
+            await openEditor(api, 'colour', '0');
+            await userEvent.keyboard('{Enter}');
+            await waitFor(() => expect(api.getEditingCells()).toHaveLength(0));
+
+            await openEditor(api, 'colour', '1');
+            await userEvent.keyboard('{Enter}');
+            await waitFor(() => expect(api.getEditingCells()).toHaveLength(0));
+
+            expect(eventTracker.counts.cellValueChanged).toBe(0);
+            await new GridRows(api, 'codes survive an untouched edit', { useFormatter: false }).check(`
+                ROOT id:ROOT_NODE_ID
+                ├── LEAF id:0 colour:"bw"
+                └── LEAF id:1 colour:"cb"
+            `);
+        });
+
+        test('typing a code still commits it, and the cell renders the mapped label', async () => {
+            const api = await gridMgr.createGridAndWait('myGrid', {
+                columnDefs: [{ field: 'colour', refData }],
+                rowData: [{ colour: 'bw' }],
+                defaultColDef: { editable: true },
+            });
+
+            const input = await openEditor(api, 'colour', '0');
+            await userEvent.clear(input);
+            await userEvent.keyboard('fg');
+            await userEvent.keyboard('{Enter}');
+            await waitFor(() => expect(api.getEditingCells()).toHaveLength(0));
+
+            await new GridRows(api, 'typed code committed', { useFormatter: false }).check(`
+                ROOT id:ROOT_NODE_ID
+                └── LEAF id:0 colour:"fg"
+            `);
+            const gridDiv = getGridElement(api)! as HTMLElement;
+            await waitFor(() =>
+                expect(getByTestId(gridDiv, agTestIdFor.cell('0', 'colour'))).toHaveTextContent('Forest Green')
+            );
+        });
+
+        // The counterpart to the untouched case: an emptied input differs from the seed, so it
+        // must still commit, or the guard would swallow a deliberate clear.
+        test('clearing the input still writes a blank', async () => {
+            const api = await gridMgr.createGridAndWait('myGrid', {
+                columnDefs: [{ field: 'colour', refData }],
+                rowData: [{ colour: 'bw' }],
+                defaultColDef: { editable: true },
+            });
+
+            const input = await openEditor(api, 'colour', '0');
+            await userEvent.clear(input);
+            await userEvent.keyboard('{Enter}');
+            await waitFor(() => expect(api.getEditingCells()).toHaveLength(0));
+
+            await new GridRows(api, 'cleared refData cell', { useFormatter: false }).check(`
+                ROOT id:ROOT_NODE_ID
+                └── LEAF id:0 colour:""
+            `);
+        });
+
+        test('useFormatter still opens on the mapped label', async () => {
+            const api = await gridMgr.createGridAndWait('myGrid', {
+                columnDefs: [
+                    {
+                        field: 'colour',
+                        refData,
+                        cellEditor: 'agTextCellEditor',
+                        cellEditorParams: { useFormatter: true },
+                    },
+                ],
+                rowData: [{ colour: 'bw' }],
+                defaultColDef: { editable: true },
+            });
+
+            expectInputValue(await openEditor(api, 'colour', '0'), 'Burlywood');
+        });
+    });
+
+    // Opening an editor and committing without touching it must never report a change.
+    describe('untouched edit writes nothing', () => {
+        test.each([
+            { field: 'number', popup: false },
+            { field: 'string1', popup: false },
+            { field: 'string2', popup: true },
+            { field: 'date', popup: false },
+            { field: 'dateStr', popup: false },
+            { field: 'boolean', popup: false },
+        ])('$field', async ({ field, popup }) => {
+            const api = await gridMgr.createGridAndWait('myGrid', {
+                columnDefs,
+                rowData,
+                defaultColDef: { editable: true },
+            });
+            const eventTracker = new EditEventTracker(api);
+            const gridDiv = getGridElement(api)! as HTMLElement;
+
+            const cell = await waitFor(() => getByTestId(gridDiv, agTestIdFor.cell('0', field)));
+            await userEvent.dblClick(cell);
+            await waitForInput(gridDiv, cell, { popup });
+            await userEvent.keyboard('{Enter}');
+            await waitFor(() => expect(api.getEditingCells()).toHaveLength(0));
+
+            expect(eventTracker.counts.cellValueChanged).toBe(0);
+        });
+
+        // Characterisation: the inferred number data type supplies the parser that restores the type,
+        // so a text editor over a numeric column was never at risk here.
+        test('text editor on a numeric column keeps the number', async () => {
+            const api = await gridMgr.createGridAndWait('myGrid', {
+                columnDefs: [{ field: 'n', cellEditor: 'agTextCellEditor' }],
+                rowData: [{ n: 5 }],
+                defaultColDef: { editable: true },
+            });
+            const eventTracker = new EditEventTracker(api);
+            const gridDiv = getGridElement(api)! as HTMLElement;
+
+            const cell = await waitFor(() => getByTestId(gridDiv, agTestIdFor.cell('0', 'n')));
+            await userEvent.dblClick(cell);
+            await waitForInput(gridDiv, cell);
+            await userEvent.keyboard('{Enter}');
+            await waitFor(() => expect(api.getEditingCells()).toHaveLength(0));
+
+            expect(eventTracker.counts.cellValueChanged).toBe(0);
+            expect(api.getDisplayedRowAtIndex(0)!.data.n).toBe(5);
+        });
+
+        // The widget normalises what it is given, so the seed has to be read back off it rather than
+        // assumed: precision truncates 5.6789 to 5.67 and nothing would report the change.
+        test('number editor with precision keeps the full stored value', async () => {
+            const api = await gridMgr.createGridAndWait('myGrid', {
+                columnDefs: [{ field: 'n', cellEditor: 'agNumberCellEditor', cellEditorParams: { precision: 2 } }],
+                rowData: [{ n: 5.6789 }],
+                defaultColDef: { editable: true },
+            });
+            const eventTracker = new EditEventTracker(api);
+            const gridDiv = getGridElement(api)! as HTMLElement;
+
+            const cell = await waitFor(() => getByTestId(gridDiv, agTestIdFor.cell('0', 'n')));
+            await userEvent.dblClick(cell);
+            await waitForInput(gridDiv, cell);
+            api.stopEditing();
+            await waitFor(() => expect(api.getEditingCells()).toHaveLength(0));
+
+            expect(api.getDisplayedRowAtIndex(0)!.data.n).toBe(5.6789);
+            expect(eventTracker.counts.cellValueChanged).toBe(0);
+        });
+
+        test('full row editing commits nothing for untouched cells', async () => {
+            const api = await gridMgr.createGridAndWait('myGrid', {
+                // No popup editor: warning #98 forbids agLargeTextCellEditor under fullRow.
+                columnDefs: columnDefs.filter((c) => c.field !== 'string2'),
+                rowData,
+                defaultColDef: { editable: true },
+                editType: 'fullRow',
+            });
+            const eventTracker = new EditEventTracker(api);
+            const gridDiv = getGridElement(api)! as HTMLElement;
+
+            const cell = await waitFor(() => getByTestId(gridDiv, agTestIdFor.cell('0', 'string1')));
+            await userEvent.dblClick(cell);
+            await waitForInput(gridDiv, cell);
+            api.stopEditing();
+            await waitFor(() => expect(api.getEditingCells()).toHaveLength(0));
+
+            expect(eventTracker.counts.cellValueChanged).toBe(0);
+        });
+
+        // The parser is what makes this discriminating: `setDataValue(..., 'edit')` hands the editor a
+        // model value, so committing it must not run the column parser over it a second time.
+        test('re-seeding an open editor still commits nothing', async () => {
+            const api = await gridMgr.createGridAndWait('myGrid', {
+                columnDefs: [
+                    {
+                        field: 'a',
+                        cellEditor: 'agTextCellEditor',
+                        valueParser: (p) => String(p.newValue).toUpperCase(),
+                    },
+                ],
+                rowData: [{ a: 'one' }],
+                defaultColDef: { editable: true },
+            });
+            const gridDiv = getGridElement(api)! as HTMLElement;
+
+            const cell = await waitFor(() => getByTestId(gridDiv, agTestIdFor.cell('0', 'a')));
+            await userEvent.dblClick(cell);
+            await waitForInput(gridDiv, cell);
+
+            const node = api.getDisplayedRowAtIndex(0)!;
+            node.setDataValue('a', 'two', 'edit');
+            await waitFor(() => expect(api.getCellEditorInstances()[0]?.getValue()).toBe('two'));
+
+            api.stopEditing();
+            await waitFor(() => expect(api.getEditingCells()).toHaveLength(0));
+            expect(node.data.a).toBe('two');
+        });
+
+        test('validation grades the value that will be committed', async () => {
+            const seen: unknown[] = [];
+            const api = await gridMgr.createGridAndWait('myGrid', {
+                columnDefs: [
+                    {
+                        field: 'a',
+                        cellEditor: 'agTextCellEditor',
+                        valueParser: (p) => String(p.newValue).toUpperCase(),
+                        cellEditorParams: {
+                            getValidationErrors: ({ value }: { value: unknown }) => {
+                                seen.push(value);
+                                return null;
+                            },
+                        },
+                    },
+                ],
+                rowData: [{ a: 'abc' }],
+                defaultColDef: { editable: true },
+            });
+            const gridDiv = getGridElement(api)! as HTMLElement;
+
+            const cell = await waitFor(() => getByTestId(gridDiv, agTestIdFor.cell('0', 'a')));
+            await userEvent.dblClick(cell);
+            await waitForInput(gridDiv, cell);
+            api.stopEditing();
+            await waitFor(() => expect(api.getEditingCells()).toHaveLength(0));
+
+            expect(api.getDisplayedRowAtIndex(0)!.data.a).toBe('abc');
+            expect(seen).not.toHaveLength(0);
+            expect(seen.every((v) => v === 'abc')).toBe(true);
+        });
+
+        // The number widget withholds its value while the input breaks a native bound, so two
+        // different out-of-range entries both read as empty and an edit between them looks untouched.
+        // A custom callback may accept those values, which is what makes the state reachable.
+        test('an edit between two values outside min is committed', async () => {
+            const seen: unknown[] = [];
+            const api = await gridMgr.createGridAndWait('myGrid', {
+                columnDefs: [
+                    {
+                        field: 'n',
+                        cellEditor: 'agNumberCellEditor',
+                        cellEditorParams: {
+                            min: 0,
+                            getValidationErrors: ({ value }: { value: unknown }) => {
+                                seen.push(value);
+                                return null;
+                            },
+                        },
+                    },
+                ],
+                rowData: [{ n: -1 }],
+                defaultColDef: { editable: true },
+            });
+            const gridDiv = getGridElement(api)! as HTMLElement;
+
+            const cell = await waitFor(() => getByTestId(gridDiv, agTestIdFor.cell('0', 'n')));
+            await userEvent.dblClick(cell);
+            const input = (await waitForInput(gridDiv, cell)) as HTMLInputElement;
+            await userEvent.clear(input);
+            await userEvent.type(input, '-2');
+            api.stopEditing();
+            await waitFor(() => expect(api.getEditingCells()).toHaveLength(0));
+
+            expect(api.getDisplayedRowAtIndex(0)!.data.n).toBe(-2);
+            expect(seen.at(-1)).toBe(-2);
+        });
+
+        test('number validation grades the preserved value, not the truncated one', async () => {
+            const seen: unknown[] = [];
+            const api = await gridMgr.createGridAndWait('myGrid', {
+                columnDefs: [
+                    {
+                        field: 'n',
+                        cellEditor: 'agNumberCellEditor',
+                        cellEditorParams: {
+                            precision: 2,
+                            getValidationErrors: ({ value }: { value: unknown }) => {
+                                seen.push(value);
+                                return null;
+                            },
+                        },
+                    },
+                ],
+                rowData: [{ n: 5.6789 }],
+                defaultColDef: { editable: true },
+            });
+            const gridDiv = getGridElement(api)! as HTMLElement;
+
+            const cell = await waitFor(() => getByTestId(gridDiv, agTestIdFor.cell('0', 'n')));
+            await userEvent.dblClick(cell);
+            await waitForInput(gridDiv, cell);
+            api.stopEditing();
+            await waitFor(() => expect(api.getEditingCells()).toHaveLength(0));
+
+            expect(api.getDisplayedRowAtIndex(0)!.data.n).toBe(5.6789);
+            expect(seen).not.toHaveLength(0);
+            expect(seen.every((v) => v === 5.6789)).toBe(true);
+        });
+
+        test('date string validation grades the preserved value, not the reparsed one', async () => {
+            const seen: unknown[] = [];
+            const api = await gridMgr.createGridAndWait('myGrid', {
+                columnDefs: [
+                    {
+                        field: 'd',
+                        cellEditor: 'agDateStringCellEditor',
+                        valueParser: (p) => `parsed:${p.newValue}`,
+                        cellEditorParams: {
+                            getValidationErrors: ({ value }: { value: unknown }) => {
+                                seen.push(value);
+                                return null;
+                            },
+                        },
+                    },
+                ],
+                rowData: [{ d: '2025-01-01' }],
+                defaultColDef: { editable: true },
+            });
+            const gridDiv = getGridElement(api)! as HTMLElement;
+
+            const cell = await waitFor(() => getByTestId(gridDiv, agTestIdFor.cell('0', 'd')));
+            await userEvent.dblClick(cell);
+            await waitForInput(gridDiv, cell);
+            api.stopEditing();
+            await waitFor(() => expect(api.getEditingCells()).toHaveLength(0));
+
+            expect(api.getDisplayedRowAtIndex(0)!.data.d).toBe('2025-01-01');
+            expect(seen).not.toHaveLength(0);
+            expect(seen.every((v) => v === '2025-01-01')).toBe(true);
+        });
+
+        // `valueAsDate` is null for the `datetime-local` input `includeTime` switches to, which left
+        // both options unenforced and handed the callback null instead of the entered date.
+        test('date min and max are enforced when includeTime is set', async () => {
+            const seen: { value: unknown; internalErrors: string[] | null }[] = [];
+            const api = await gridMgr.createGridAndWait('myGrid', {
+                columnDefs: [
+                    {
+                        field: 'd',
+                        cellEditor: 'agDateCellEditor',
+                        cellEditorParams: {
+                            includeTime: true,
+                            min: new Date(2025, 1, 1),
+                            getValidationErrors: (p: { value: unknown; internalErrors: string[] | null }) => {
+                                seen.push({ value: p.value, internalErrors: p.internalErrors });
+                                return null;
+                            },
+                        },
+                    },
+                ],
+                rowData: [{ d: new Date(2025, 1, 10, 9, 0) }],
+                defaultColDef: { editable: true },
+            });
+            const gridDiv = getGridElement(api)! as HTMLElement;
+
+            const cell = await waitFor(() => getByTestId(gridDiv, agTestIdFor.cell('0', 'd')));
+            await userEvent.dblClick(cell);
+            const input = (await waitForInput(gridDiv, cell)) as HTMLInputElement;
+            expect(input.type).toBe('datetime-local');
+            input.value = '2025-01-15T08:15';
+            input.dispatchEvent(new Event('input', { bubbles: true }));
+            api.stopEditing();
+            await waitFor(() => expect(api.getEditingCells()).toHaveLength(0));
+
+            const last = seen.at(-1)!;
+            expect(last.internalErrors).toEqual([expect.stringContaining('Date must be after')]);
+            expect(last.value).toEqual(new Date(2025, 0, 15, 8, 15));
+        });
+
+        // The plain `date` control for the case above: it always worked, so it proves the
+        // includeTime test is discriminating rather than asserting a shared no-op.
+        test('date min and max are enforced without includeTime', async () => {
+            const seen: (string[] | null)[] = [];
+            const api = await gridMgr.createGridAndWait('myGrid', {
+                columnDefs: [
+                    {
+                        field: 'd',
+                        cellEditor: 'agDateCellEditor',
+                        cellEditorParams: {
+                            min: new Date(2025, 1, 1),
+                            getValidationErrors: (p: { internalErrors: string[] | null }) => {
+                                seen.push(p.internalErrors);
+                                return null;
+                            },
+                        },
+                    },
+                ],
+                rowData: [{ d: new Date(2025, 1, 10) }],
+                defaultColDef: { editable: true },
+            });
+            const gridDiv = getGridElement(api)! as HTMLElement;
+
+            const cell = await waitFor(() => getByTestId(gridDiv, agTestIdFor.cell('0', 'd')));
+            await userEvent.dblClick(cell);
+            const input = (await waitForInput(gridDiv, cell)) as HTMLInputElement;
+            expect(input.type).toBe('date');
+            input.value = '2025-01-15';
+            input.dispatchEvent(new Event('input', { bubbles: true }));
+            api.stopEditing();
+            await waitFor(() => expect(api.getEditingCells()).toHaveLength(0));
+
+            expect(seen.at(-1)).toEqual([expect.stringContaining('Date must be after')]);
+        });
+
+        // A normalising parser is the discriminating input: without one, every editor round-trips
+        // the value unchanged and an untouched commit looks correct whether or not it is guarded.
+        test.each([
+            { name: 'text', cellEditor: 'agTextCellEditor', popup: false },
+            { name: 'largeText', cellEditor: 'agLargeTextCellEditor', popup: true },
+        ])('$name editor does not run a normalising parser on an untouched commit', async ({ cellEditor, popup }) => {
+            const api = await gridMgr.createGridAndWait('myGrid', {
+                columnDefs: [
+                    {
+                        field: 'a',
+                        cellEditor,
+                        cellEditorPopup: popup,
+                        valueParser: (p) => String(p.newValue).toUpperCase(),
+                    },
+                ],
+                rowData: [{ a: 'abc' }],
+                defaultColDef: { editable: true },
+            });
+            const eventTracker = new EditEventTracker(api);
+            const gridDiv = getGridElement(api)! as HTMLElement;
+
+            const cell = await waitFor(() => getByTestId(gridDiv, agTestIdFor.cell('0', 'a')));
+            await userEvent.dblClick(cell);
+            await waitForInput(gridDiv, cell, { popup });
+            api.stopEditing();
+            await waitFor(() => expect(api.getEditingCells()).toHaveLength(0));
+
+            expect(api.getDisplayedRowAtIndex(0)!.data.a).toBe('abc');
+            expect(eventTracker.counts.cellValueChanged).toBe(0);
+        });
+
+        test('largeText editor still commits a typed value through the parser', async () => {
+            const api = await gridMgr.createGridAndWait('myGrid', {
+                columnDefs: [
+                    {
+                        field: 'a',
+                        cellEditor: 'agLargeTextCellEditor',
+                        cellEditorPopup: true,
+                        valueParser: (p) => String(p.newValue).toUpperCase(),
+                    },
+                ],
+                rowData: [{ a: 'abc' }],
+                defaultColDef: { editable: true },
+            });
+            const gridDiv = getGridElement(api)! as HTMLElement;
+
+            const cell = await waitFor(() => getByTestId(gridDiv, agTestIdFor.cell('0', 'a')));
+            await userEvent.dblClick(cell);
+            const input = await waitForInput(gridDiv, cell, { popup: true });
+            await userEvent.clear(input as HTMLElement);
+            await userEvent.type(input as HTMLElement, 'xyz');
+            api.stopEditing();
+            await waitFor(() => expect(api.getEditingCells()).toHaveLength(0));
+
+            expect(api.getDisplayedRowAtIndex(0)!.data.a).toBe('XYZ');
+        });
+
+        // The widget cannot hold null, so reading the value back off it narrowed the stored null.
+        test('checkbox editor keeps a null value on an untouched commit', async () => {
+            const api = await gridMgr.createGridAndWait('myGrid', {
+                columnDefs: [{ field: 'a', cellEditor: 'agCheckboxCellEditor' }],
+                rowData: [{ a: null }],
+                defaultColDef: { editable: true },
+            });
+            const eventTracker = new EditEventTracker(api);
+
+            api.startEditingCell({ rowIndex: 0, colKey: 'a' });
+            await waitFor(() => expect(api.getEditingCells()).toHaveLength(1));
+            api.stopEditing();
+            await waitFor(() => expect(api.getEditingCells()).toHaveLength(0));
+
+            expect(api.getDisplayedRowAtIndex(0)!.data.a).toBeNull();
+            expect(eventTracker.counts.cellValueChanged).toBe(0);
+        });
+
+        // The dropdown falls back to values[0] when the stored value is not an option, which is a
+        // display concern; committing it without touching the picker wrote that option over the data.
+        test('select editor keeps a value that is not in the list on an untouched commit', async () => {
+            const api = await gridMgr.createGridAndWait('myGrid', {
+                columnDefs: [
+                    { field: 'a', cellEditor: 'agSelectCellEditor', cellEditorParams: { values: ['x', 'y'] } },
+                ],
+                rowData: [{ a: 'zzz' }],
+                defaultColDef: { editable: true },
+            });
+            const eventTracker = new EditEventTracker(api);
+
+            api.startEditingCell({ rowIndex: 0, colKey: 'a' });
+            await waitFor(() => expect(api.getEditingCells()).toHaveLength(1));
+            api.stopEditing();
+            await waitFor(() => expect(api.getEditingCells()).toHaveLength(0));
+
+            expect(api.getDisplayedRowAtIndex(0)!.data.a).toBe('zzz');
+            expect(eventTracker.counts.cellValueChanged).toBe(0);
+        });
+
+        test('select editor still commits a value chosen from the list', async () => {
+            const api = await gridMgr.createGridAndWait('myGrid', {
+                columnDefs: [
+                    { field: 'a', cellEditor: 'agSelectCellEditor', cellEditorParams: { values: ['x', 'y'] } },
+                ],
+                rowData: [{ a: 'zzz' }],
+                defaultColDef: { editable: true },
+            });
+
+            api.startEditingCell({ rowIndex: 0, colKey: 'a' });
+            await waitFor(() => expect(api.getEditingCells()).toHaveLength(1));
+            const [editor] = api.getCellEditorInstances() as unknown as [{ agSetEditValue?: (v: unknown) => void }];
+            editor?.agSetEditValue?.('y');
+            api.stopEditing();
+            await waitFor(() => expect(api.getEditingCells()).toHaveLength(0));
+
+            expect(api.getDisplayedRowAtIndex(0)!.data.a).toBe('y');
+        });
+
+        test('useFormatter without a valueParser', async () => {
+            const api = await gridMgr.createGridAndWait('myGrid', {
+                columnDefs: [
+                    {
+                        field: 'colour',
+                        valueFormatter: (p) => ({ bw: 'Burlywood' })[p.value as string] ?? '',
+                        cellEditor: 'agTextCellEditor',
+                        cellEditorParams: { useFormatter: true },
+                    },
+                ],
+                rowData: [{ colour: 'bw' }],
+                defaultColDef: { editable: true },
+            });
+            const eventTracker = new EditEventTracker(api);
+            const gridDiv = getGridElement(api)! as HTMLElement;
+
+            const cell = await waitFor(() => getByTestId(gridDiv, agTestIdFor.cell('0', 'colour')));
+            await userEvent.dblClick(cell);
+            await waitForInput(gridDiv, cell);
+            await userEvent.keyboard('{Enter}');
+            await waitFor(() => expect(api.getEditingCells()).toHaveLength(0));
+
+            expect(eventTracker.counts.cellValueChanged).toBe(0);
+            await new GridRows(api, 'useFormatter untouched edit', { useFormatter: false }).check(`
+                ROOT id:ROOT_NODE_ID
+                └── LEAF id:0 colour:"bw"
+            `);
         });
     });
 

--- a/testing/behavioural/src/cell-editing/rich-select/rich-select-editor.test.ts
+++ b/testing/behavioural/src/cell-editing/rich-select/rich-select-editor.test.ts
@@ -532,4 +532,37 @@ describe('Rich Select cell editor', () => {
             expect(api.getFocusedCell()?.rowIndex).toBe(0);
         });
     });
+
+    // Opening and closing without picking must leave the stored value alone, so a `parseValue`
+    // supplied for committed picks does not rewrite it.
+    test('an untouched editor commits the stored value without running parseValue', async () => {
+        const api = await createGrid({
+            columnDefs: [baseColDef({ parseValue: (v: unknown) => `${String(v)}!` })],
+            rowData: [{ id: '0', a: 'Alpha' }],
+            getRowId: (p) => p.data.id,
+        });
+        const gridDiv = getGridElement(api)! as HTMLElement;
+        await openEditor(api, gridDiv, 0, 'a');
+
+        api.stopEditing();
+        await waitFor(() => expect(api.getEditingCells()).toHaveLength(0));
+        expect(getAllRows(api)[0].data.a).toBe('Alpha');
+    });
+
+    // `setDataValue(..., 'edit')` hands the editor a model value, and the widget normalises an
+    // `undefined` push to `null`, so the seed has to be what was pushed rather than what it holds.
+    test('an undefined value pushed into an open editor commits as undefined', async () => {
+        const api = await createGrid({
+            columnDefs: [baseColDef()],
+            rowData: [{ id: '0', a: 'Alpha' }],
+            getRowId: (p) => p.data.id,
+        });
+        const gridDiv = getGridElement(api)! as HTMLElement;
+        await openEditor(api, gridDiv, 0, 'a');
+
+        getAllRows(api)[0].setDataValue('a', undefined, 'edit');
+        api.stopEditing();
+        await waitFor(() => expect(api.getEditingCells()).toHaveLength(0));
+        expect(getAllRows(api)[0].data.a).toBeUndefined();
+    });
 });

--- a/testing/behavioural/src/cell-editing/select/select-editor.test.ts
+++ b/testing/behavioural/src/cell-editing/select/select-editor.test.ts
@@ -143,4 +143,39 @@ describe('Select cell editor', () => {
             expect(api.getFocusedCell()?.rowIndex).toBe(0);
         });
     });
+
+    describe('untouched commit', () => {
+        // The picker shows `values[0]` when the stored value is not an option, so an untouched commit
+        // must keep the stored value; picking that same option is a real choice and must commit.
+        test('opening and closing without picking keeps a value that is not in the list', async () => {
+            const api = await createGrid({
+                columnDefs: [baseColDef({ values: ['x', 'y'] })],
+                rowData: [{ id: '0', a: 'zzz' }],
+                getRowId: (p) => p.data.id,
+            });
+
+            await openEditor(api, 0, 'a');
+            api.stopEditing();
+
+            await waitFor(() => expect(api.getEditingCells()).toHaveLength(0));
+            expect(getAllRows(api)[0].data.a).toBe('zzz');
+        });
+
+        test('explicitly picking the fallback option commits it', async () => {
+            const api = await createGrid({
+                columnDefs: [baseColDef({ values: ['x', 'y'] })],
+                rowData: [{ id: '0', a: 'zzz' }],
+                getRowId: (p) => p.data.id,
+            });
+
+            await openEditor(api, 0, 'a');
+            const option = Array.from(document.querySelectorAll<HTMLElement>(OPTION_SELECTOR)).find(
+                (el) => el.textContent?.trim() === 'x'
+            )!;
+            await firePointerLikeClick(option);
+
+            await waitFor(() => expect(api.getEditingCells()).toHaveLength(0));
+            expect(getAllRows(api)[0].data.a).toBe('x');
+        });
+    });
 });

--- a/testing/behavioural/src/formulas/formulas-interactive.test.ts
+++ b/testing/behavioural/src/formulas/formulas-interactive.test.ts
@@ -321,4 +321,51 @@ describe('ag-grid formulas interactive workflows', () => {
             └── LEAF id:r2 row-number:"2" a:3 b:300
         `);
     });
+
+    // A normalising parser is the discriminating input: without one the value round-trips unchanged
+    // and an untouched commit looks correct whether or not it is guarded.
+    test('opening and closing a formula cell without typing does not run the value parser', async () => {
+        const api = await createGrid('untouched-commit', {
+            columnDefs: [{ field: 'a', valueParser: (p) => String(p.newValue).toUpperCase() }],
+            rowData: [{ id: 'r0', a: 'abc' }],
+        });
+
+        const started = waitForEvent('cellEditingStarted', api);
+        api.startEditingCell({ rowIndex: 0, colKey: 'a' });
+        await started;
+
+        const stopped = waitForEvent('cellEditingStopped', api);
+        api.stopEditing();
+        await stopped;
+
+        await new GridRows(api, 'untouched formula cell keeps its value', gridRowsOpts).check(`
+            ROOT id:ROOT_NODE_ID
+            └── LEAF id:r0 row-number:"1" a:"abc"
+        `);
+    });
+
+    // `agSetEditValue` is the `setDataValue(..., 'edit')` path, so it is handed a model value that
+    // has already been parsed; running the column parser over it again would parse it twice.
+    test('a value pushed into an open formula editor commits without re-parsing', async () => {
+        const api = await createGrid('typed-commit', {
+            columnDefs: [{ field: 'a', valueParser: (p) => String(p.newValue).toUpperCase() }],
+            rowData: [{ id: 'r0', a: 'abc' }],
+        });
+
+        const started = waitForEvent('cellEditingStarted', api);
+        api.startEditingCell({ rowIndex: 0, colKey: 'a' });
+        await started;
+
+        const [editor] = api.getCellEditorInstances() as unknown as [{ agSetEditValue?: (v: unknown) => void }];
+        editor?.agSetEditValue?.('xyz');
+
+        const stopped = waitForEvent('cellEditingStopped', api);
+        api.stopEditing();
+        await stopped;
+
+        await new GridRows(api, 'pushed formula cell value is not re-parsed', gridRowsOpts).check(`
+            ROOT id:ROOT_NODE_ID
+            └── LEAF id:r0 row-number:"1" a:"xyz"
+        `);
+    });
 });


### PR DESCRIPTION
<!-- base: latest -->
FIX AG-17659

# Cell editing: an untouched editor no longer writes

Opening a cell editor, typing nothing and committing could change the underlying value. The editor is seeded with
one representation of the value and commits another, while the grid decides whether anything changed by comparing
the committed value against the original. That comparison is only a valid proxy while the two representations
agree.

| scope  | net lines |  lines changed | hunks | files changed |
| ------ | --------: | -------------: | ----: | ------------: |
| source |       +66 | 176 (+121 -55) |    54 |     12 edited |
| tests  |      +695 |  697 (+696 -1) |     7 |      4 edited |

## `refData` no longer formats the editor implicitly ([AG-17659](https://ag-grid.atlassian.net/browse/AG-17659))

`TextCellEditorInput.getStartValue` seeded the editor with the mapped label whenever a column carried `refData`,
whether or not the application asked for it. Nothing reverses that mapping on commit, so the label was written
back into the data as though it were a key: a double-click followed by a click elsewhere turned `bw` into
`Burlywood`, the cell then rendered blank, and a Set Filter listed one empty entry per corrupted key.

Only an explicit `useFormatter: true` now seeds the formatted value. That is the documented mechanism for it, and
the one an application pairs with a `valueParser`. The reference data documentation already describes this
behaviour: with a Text Cell Editor and `refData`, codes must be entered directly.

**Breaking:** a column combining `refData`, a text editor and a `valueParser` that maps labels back to keys, but
without `useFormatter: true`, was relying on the implicit formatting. Such a column must now set
`useFormatter: true` to keep the editor showing labels.

## An untouched editor commits its original value

`SimpleCellEditor` records the text the widget holds once seeded, and `getValue()` returns the original value
untouched while the input still holds it. The seed is read back off the widget rather than taken from
`getStartValue()`, because the widget normalises what it is given.

That normalisation is load-bearing. `agNumberCellEditor` with `cellEditorParams: { precision: 2 }` truncated
`5.6789` to `5.67` when an editor was opened and committed without being touched, and dispatched no
`cellValueChanged`, so nothing could observe it. `agDateCellEditor` reported a change on every untouched commit,
because it builds a fresh `Date` and the comparison is by identity.

A `valueParser` no longer runs when the input text still matches the seed, so a parser used to normalise a value
on every commit will not fire for an edit that changed nothing.

## The remaining provided editors carry the same guard

Five editors do not extend `SimpleCellEditor` and each wrote a different value when an editor was opened and
closed without being touched. None of them dispatched `cellValueChanged`, so nothing could observe the write.

- `agLargeTextCellEditor` and the enterprise formula cell editor ran the column `valueParser` over the stored
  value. The formula editor still commits formula text verbatim, which never went through that parser.
- `agCheckboxCellEditor` read the value back off a widget that cannot hold `null`, so a stored `null` was
  narrowed to `undefined`.
- `agSelectCellEditor` shows `values[0]` when the stored value is not one of the options, which is a display
  fallback; committing an untouched editor wrote that option over the stored value.
- `agRichSelectCellEditor` ran a supplied `cellEditorParams.parseValue` over the stored value.

`agSetEditValue` is the `setDataValue(..., 'edit')` path, so it receives a value that is already a model value.
Every provided editor now commits it verbatim; the formula cell editor previously put it through the column
`valueParser`, which parsed an already-parsed value. A value pushed into an open `agRichSelectCellEditor` also
keeps `undefined` rather than committing the `null` its widget stores.

## Custom validation grades the value that will be committed

A `cellEditorParams.getValidationErrors` callback is handed the value a commit would write. Each editor derived
that value from its own live reading of the widget, so on an untouched editor the callback graded something the
commit would not keep: with a `valueParser` that uppercases, `abc` was validated as `ABC`; a number column with
`precision: 2` validated `5.67` while `5.6789` was preserved; a date string column validated its reparsed result.

The number and date editors' own `min` and `max` checks continue to read the live widget, because those grade
what is being typed rather than what would be committed.

`agNumberCellEditor` reads its widget with `getValue(true)` when deriving the committed value. The widget
withholds a value while the input is invalid, and raising a validation error is itself what marks it invalid, so
without that flag the callback graded `undefined` from the first error onwards.

## `min` and `max` are enforced on a date editor using `includeTime`

`includeTime` switches the editor's input to `datetime-local`, where `valueAsDate` is defined to return `null`.
`agDateCellEditor` read that property and gated its whole `min`/`max` block on the result being a `Date`, so both
options were silently unenforced and a custom `getValidationErrors` callback received `null` for the value. The
editor now parses the input's value string, which is what `agDateStringCellEditor` already did.
