### PR TITLE
AG-3390 Add framework links to data-grid redirect pages and unblock them in robots.txt

### DIFF
--- a/documentation/ag-grid-docs/src/pages/data-grid/[pageName].astro
+++ b/documentation/ag-grid-docs/src/pages/data-grid/[pageName].astro
@@ -3,6 +3,9 @@ import { getCollection } from 'astro:content';
 import Layout from '@layouts/Layout.astro';
 import FrameworkRedirectPage from '@ag-website-shared/components/framework-redirect-page/FrameworkRedirectPage.astro';
 import { getDocsPages } from '@components/docs/utils/pageData';
+import { FRAMEWORKS } from '@constants';
+import { getFrameworkDisplayText } from '@utils/framework';
+import { urlWithPrefix } from '@utils/urlWithPrefix';
 
 export async function getStaticPaths() {
     const pages = await getCollection('docs');
@@ -12,6 +15,13 @@ export async function getStaticPaths() {
 const { page } = Astro.props;
 const { title } = page.data;
 const { pageName } = Astro.params;
+
+// Static links to every framework version of this page, so crawlers landing on the
+// framework-agnostic redirect page can discover and pass link equity to the real pages.
+const frameworkLinks = FRAMEWORKS.map((framework) => ({
+    href: urlWithPrefix({ framework, url: `./${pageName}` }),
+    text: `${getFrameworkDisplayText(framework)} Data Grid: ${title}`,
+}));
 ---
 
 <Layout
@@ -19,8 +29,18 @@ const { pageName } = Astro.params;
     description={'View the AG Grid Documentation - a feature-rich datagrid for major JavaScript frameworks, offering filtering, grouping, pivoting, and more.'}
     showSearchBar={false}
     showDocsNav={false}
+    hidePageFromSearchEngines={true}
 >
     <FrameworkRedirectPage redirectPageName={pageName}>
         <h1>Redirecting to "{title}" page</h1>
+        <ul>
+            {
+                frameworkLinks.map(({ href, text }) => (
+                    <li>
+                        <a href={href}>{text}</a>
+                    </li>
+                ))
+            }
+        </ul>
     </FrameworkRedirectPage>
 </Layout>

--- a/documentation/ag-grid-docs/src/pages/data-grid/[pageName].astro
+++ b/documentation/ag-grid-docs/src/pages/data-grid/[pageName].astro
@@ -13,12 +13,15 @@ export async function getStaticPaths() {
 }
 
 const { page } = Astro.props;
-const { title } = page.data;
+const { title, frameworks } = page.data;
 const { pageName } = Astro.params;
 
 // Static links to every framework version of this page, so crawlers landing on the
 // framework-agnostic redirect page can discover and pass link equity to the real pages.
-const frameworkLinks = FRAMEWORKS.map((framework) => ({
+// Restricted pages (`frameworks` frontmatter) only link to the framework pages that are
+// actually generated, matching `getDocsPages`.
+const supportedFrameworks = FRAMEWORKS.filter((framework) => !frameworks || frameworks.includes(framework));
+const frameworkLinks = supportedFrameworks.map((framework) => ({
     href: urlWithPrefix({ framework, url: `./${pageName}` }),
     text: `${getFrameworkDisplayText(framework)} Data Grid: ${title}`,
 }));

--- a/documentation/ag-grid-docs/src/utils/sitemapPages.test.ts
+++ b/documentation/ag-grid-docs/src/utils/sitemapPages.test.ts
@@ -7,4 +7,10 @@ describe('getSitemapIgnorePaths', () => {
         expect(ignorePaths).toContain('/*searchQuery=');
         expect(ignorePaths).not.toContain('/*searchQuery=/');
     });
+
+    test('does not block the /data-grid/ framework redirect pages, so crawlers can follow their framework links', async () => {
+        const ignorePaths = await getSitemapIgnorePaths();
+
+        expect(ignorePaths).not.toContain('/data-grid/');
+    });
 });

--- a/documentation/ag-grid-docs/src/utils/sitemapPages.ts
+++ b/documentation/ag-grid-docs/src/utils/sitemapPages.ts
@@ -1,5 +1,3 @@
-import { FRAMEWORK_REDIRECT_PATH } from '@constants';
-
 import { urlWithBaseUrl } from './urlWithBaseUrl';
 
 function addTrailingSlash(path: string) {
@@ -12,8 +10,10 @@ export async function getSitemapIgnorePaths() {
         urlWithBaseUrl('/examples'),
         urlWithBaseUrl('/archive'),
         urlWithBaseUrl('/campaigns'),
-        // Redirects
-        urlWithBaseUrl(`/${FRAMEWORK_REDIRECT_PATH}`),
+
+        // NOTE: /data-grid/ framework redirect pages are deliberately NOT disallowed: they are
+        // crawlable so their static links to the framework pages can be followed for SEO. They
+        // are still excluded from the sitemap (see sitemap.ts `isRedirectPage`).
 
         // Test pages
         urlWithBaseUrl('/*-data-grid/*-test'),


### PR DESCRIPTION
## Summary

- `/data-grid/[pageName]` redirect pages now render static links to all four framework versions of each page (React/Angular/Vue/JavaScript), so crawlers landing on the framework-agnostic URL can discover and pass link equity to the real framework pages.
- Removed the `/data-grid/` Disallow from the generated robots.txt (`getSitemapIgnorePaths` only feeds robots.txt — the sitemap filters redirect pages separately via `isRedirectPage`, so they stay out of the sitemap).
- The redirect pages are marked `noindex` (follow) via `hidePageFromSearchEngines`, so the thin "Redirecting to…" pages don't get indexed while their links remain followable.

## Testing

- Added a regression test asserting `/data-grid/` is no longer in the robots.txt ignore paths.
- `sitemapPages.test.ts` + `robotsTxt.test.ts` pass; `./checks.sh` green.