### PR TITLE
AG-18277 filter callback params

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/filter-advanced/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/filter-advanced/index.mdoc
@@ -148,6 +148,18 @@ The two values are validated against each other, as the column filters validate 
 
 For `text` and `object` Cell Data Types, `caseSensitive = true` can be set to enable case sensitivity.
 
+Text is compared the way the column's [Text Filter](./filter-text/) compares it, so the same condition matches the same rows in both:
+
+- `textFormatter` formats the cell value and the operand before they are compared, to substitute accented characters for example. It takes the place of the lower-casing the grid does by default, so `caseSensitive` no longer has any effect and a formatter that should ignore case has to lower-case the text itself.
+- `textMatcher` decides the comparison itself. It is called for `contains`, `does not contain`, `equals`, `does not equal`, `begins with` and `ends with`, but not for `is blank` or `is not blank`.
+- `trimInput` removes leading and trailing whitespace from the operand. An operand of only whitespace is left as it was entered.
+
+`textFormatter` and `textMatcher` are both told which filter is calling them: `params.source` is `'advancedFilter'` here and `'columnFilter'` when the column's own filter is comparing, so one callback can behave differently for each.
+
+All three are read from the column's Text Filter. On a [Multi Filter](./filter-multi/) column they come from its Text Filter child, as they do for the Multi Filter itself. On a [Set Filter](./filter-set/) column, `filterParams.textFormatter` formats the list of values shown in the filter instead, and is not used to compare text here.
+
+`trimInput` applies wherever the operand is set, including a model set through `setAdvancedFilterModel`, so `getAdvancedFilterModel` returns the trimmed value, and the Filter Builder shows the trimmed operand. The column filter trims the model it applies in the same way.
+
 For `number`, `date`, `dateString`, `dateTime` and `dateTimeString` Cell Data Types, the following properties can be set to include blank values for the relevant options:
 
 - `includeBlanksInEquals = true`
@@ -178,7 +190,7 @@ const gridOptions = {
 }
 ```
 
-It applies equally where the Date Filter is a child of a Multi Filter. A Set Filter column's `comparator` orders its values instead, and a custom filter component's `filterParams` are its own.
+It applies equally where the Date Filter is a child of a Multi Filter. A custom filter component's `filterParams` are its own. A Set Filter column's `comparator` orders its values instead, so it is not read as a date comparison there, but an `isValidDate` set on such a column still gates the comparisons above.
 
 These settings only apply when using the Client-Side Row Model. You need to implement support for these in your server-side filtering logic when using the Server-Side Row Model.
 
@@ -297,7 +309,7 @@ In the following example, **Country** uses a plain Set Filter, **Sport** formats
 
 ### Custom Filter Options
 
-`filterOptions` also accepts [Custom Filter Options](./filter-conditions/#custom-filter-options). The Advanced Filter evaluates the same `predicate` as the column filter, and supports options taking 0, 1 or 2 values. An option taking two values has them validated against each other in the same way as `is between`, as the column filter validates the two inputs it shows for one. As with the settings above, the `predicate` runs only under the Client-Side Row Model: with the Server-Side Row Model the option reaches the server as its `displayKey` in the filter model, where the server-side filtering logic decides what it means.
+`filterOptions` also accepts [Custom Filter Options](./filter-conditions/#custom-filter-options). The Advanced Filter evaluates the same `predicate` as the column filter, and supports options taking 0, 1 or 2 values. The `predicate` is told which of the two is asking through its third argument, whose `source` is `'advancedFilter'` here and `'columnFilter'` in the column filter. An option taking two values has them validated against each other in the same way as `is between`, as the column filter validates the two inputs it shows for one. As with the settings above, the `predicate` runs only under the Client-Side Row Model: with the Server-Side Row Model the option reaches the server as its `displayKey` in the filter model, where the server-side filtering logic decides what it means.
 
 ```{% frameworkTransform=true %}
 const gridOptions = {

--- a/documentation/ag-grid-docs/src/content/docs/filter-bigint/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/filter-bigint/index.mdoc
@@ -74,7 +74,7 @@ const gridOptions = {
 };
 ```
 
-The `bigintParser` and `bigintFormatter` are also passed the grid `api` and `context` as a second argument, along with the `column` and `colDef` they are working on. One callback set on `defaultColDef.filterParams` can therefore serve every column it applies to.
+The `bigintParser` and `bigintFormatter` are also passed the grid `api` and `context` as a second argument, along with the `column` and `colDef` they are working on. One callback set on `defaultColDef.filterParams` can therefore serve every column it applies to. The [Advanced Filter](./filter-advanced/) runs the same callbacks to read and write its operands; `params.source` is `'advancedFilter'` there and `'columnFilter'` here.
 
 ## BigInt Filter Model
 

--- a/documentation/ag-grid-docs/src/content/docs/filter-conditions/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/filter-conditions/index.mdoc
@@ -62,7 +62,7 @@ Custom filter options are supplied to the grid via `filterParams.filterOptions` 
 
 The `displayKey` should contain a unique key value that doesn't clash with the built-in filter keys. A default `displayName` should also be provided but can be replaced by a locale-specific value using a [getLocaleText](./localisation/#locale-callback).
 
-The custom filter logic is implemented through the `predicate` function, which receives the `filterValues` typed by the user along with the `cellValue` from the grid, and returns `true` or `false`.
+The custom filter logic is implemented through the `predicate` function, which receives the `filterValues` typed by the user along with the `cellValue` from the grid, and returns `true` or `false`. A third argument provides the grid `api` and `context` along with the `column` and `colDef` being filtered, so one predicate set on `defaultColDef.filterParams` can serve every column it applies to. Its `source` is `'columnFilter'` or `'advancedFilter'`, naming the filter that is asking.
 
 The number of `filterValues` and corresponding inputs is controlled by the optional property `numberOfInputs`:
 

--- a/documentation/ag-grid-docs/src/content/docs/filter-number/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/filter-number/index.mdoc
@@ -74,7 +74,7 @@ The `numberParser` should take the user-entered text and return either a number 
 
 The `numberFormatter` should take a number (e.g. from the Filter Model) and convert it into the formatted text to be displayed, or `null` if no value.
 
-`numberParser` and `numberFormatter` are also passed the grid `api` and `context` as a second argument, along with the `column` and `colDef` they are working on. One callback set on `defaultColDef.filterParams` can therefore serve every column it applies to.
+`numberParser` and `numberFormatter` are also passed the grid `api` and `context` as a second argument, along with the `column` and `colDef` they are working on. One callback set on `defaultColDef.filterParams` can therefore serve every column it applies to. The [Advanced Filter](./filter-advanced/) runs the same callbacks to read and write its operands; `params.source` is `'advancedFilter'` there and `'columnFilter'` here.
 
 An `allowedCharPattern` of `\\d\\-\\.` will give similar behaviour to the default `number` input.
 

--- a/documentation/ag-grid-docs/src/content/docs/filter-set-mini-filter/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/filter-set-mini-filter/index.mdoc
@@ -75,6 +75,8 @@ The following example demonstrates searching when there are accented characters.
 - The Athlete column's Set filter is supplied a text formatter via `filterParams.textFormatter` to ignore accents.
 - Searching using `'bjorn'` will return all values containing `'björn'`.
 
+The formatter is also passed the grid `api` and `context` as a second argument, along with the `column` and `colDef` it is working on. One callback set on `defaultColDef.filterParams` can therefore serve every column it applies to.
+
 {% gridExampleRunner title="Mini Filter Text Formatter" name="mini-filter-text-formatter"  exampleHeight=565 /%}
 
 ## Enabling Case-Sensitive Searches

--- a/documentation/ag-grid-docs/src/content/docs/filter-text/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/filter-text/index.mdoc
@@ -100,6 +100,8 @@ In most cases, you can customise the Text Filter matching logic by providing you
 
 For more advanced use cases, you can provide your own `textMatcher` to decide when to include a row in the filtered results. For example, you might want to apply different logic for the filter option `equals` than for `contains`.
 
+The [Advanced Filter](./filter-advanced/) compares text with the same `textFormatter`, `textMatcher` and `trimInput` the column is configured with, so a condition written there matches the rows this filter matches. `params.source` tells a `textFormatter` or `textMatcher` which of the two is asking.
+
 {% interfaceDocumentation interfaceName="ITextFilterParams" names=["textMatcher"] config={"description":"", "overrideBottomMargin":"1rem"} /%}
 
 The following is an example of a `textMatcher` that mimics the current implementation of AG Grid. This can be used as a template to create your own.

--- a/packages/ag-grid-community/src/filter/provided/bigInt/bigIntFilter.ts
+++ b/packages/ag-grid-community/src/filter/provided/bigInt/bigIntFilter.ts
@@ -47,7 +47,7 @@ export class BigIntFilter extends TextInputSimpleFilter<
     }
 
     protected override getValueFormatter(): ((value: bigint | null) => string | null) | undefined {
-        return _bindFilterCallback(this.params.bigintFormatter, this.gos, this.params.column);
+        return _bindFilterCallback(this.params.bigintFormatter, this.gos, this.params.column, 'columnFilter');
     }
 
     protected override createInputWidget(): GridInputTextField {

--- a/packages/ag-grid-community/src/filter/provided/bigInt/bigIntFilterModelFormatter.ts
+++ b/packages/ag-grid-community/src/filter/provided/bigInt/bigIntFilterModelFormatter.ts
@@ -12,7 +12,7 @@ export class BigIntFilterModelFormatter extends SimpleFilterModelFormatter<
     protected readonly filterTypeKeys = SCALAR_FILTER_TYPE_KEYS;
 
     protected override getValueFormatter(): ((value: bigint | null) => string | null) | undefined {
-        return _bindFilterCallback(this.filterParams.bigintFormatter, this.gos, this.column);
+        return _bindFilterCallback(this.filterParams.bigintFormatter, this.gos, this.column, 'columnFilter');
     }
 
     protected conditionToString(

--- a/packages/ag-grid-community/src/filter/provided/bigInt/bigIntFilterUtils.ts
+++ b/packages/ag-grid-community/src/filter/provided/bigInt/bigIntFilterUtils.ts
@@ -22,7 +22,9 @@ export function stringToBigInt(
         return null;
     }
     // Built here, not by the caller: the default configuration has no parser to hand them to.
-    return bigintParser ? bigintParser(value, filterCallbackParams(gos, column)) : _parseBigIntOrNull(value);
+    return bigintParser
+        ? bigintParser(value, filterCallbackParams(gos, column, 'columnFilter'))
+        : _parseBigIntOrNull(value);
 }
 
 export function mapValuesFromBigIntFilterModel(

--- a/packages/ag-grid-community/src/filter/provided/iSimpleFilter.ts
+++ b/packages/ag-grid-community/src/filter/provided/iSimpleFilter.ts
@@ -1,5 +1,5 @@
 import type { IAutoCompleteComponentParams } from '../../interfaces/iAutoComplete';
-import type { IFilterParams } from '../../interfaces/iFilter';
+import type { FilterInputCallbackParams, IFilterParams } from '../../interfaces/iFilter';
 import type { IFloatingFilterParent } from '../floating/floatingFilter';
 import type { IProvidedFilter, IProvidedFilterParams, ProvidedFilterModel } from './iProvidedFilter';
 import type { OptionsFactory } from './optionsFactory';
@@ -9,8 +9,8 @@ export interface IFilterOptionDef {
     displayKey: string;
     /** Display name for the filter. Can be replaced by a locale-specific value using a `localeTextFunc`. */
     displayName: string;
-    /** Custom filter logic that returns a boolean based on the `filterValues` and `cellValue`. */
-    predicate?: (filterValues: any[], cellValue: any) => boolean;
+    /** Custom filter logic returning a boolean from the `filterValues` and `cellValue`; `params` names the column and the calling filter. */
+    predicate?: (filterValues: any[], cellValue: any, params: FilterInputCallbackParams) => boolean;
     /** Number of inputs for this option, and the values an Advanced Filter writes. Defaults to `1`, clamped to 0-2. */
     numberOfInputs?: 0 | 1 | 2;
 }

--- a/packages/ag-grid-community/src/filter/provided/number/numberFilter.ts
+++ b/packages/ag-grid-community/src/filter/provided/number/numberFilter.ts
@@ -59,7 +59,7 @@ export class NumberFilter extends TextInputSimpleFilter<
     }
 
     protected override getValueFormatter(): ((value: number | null) => string | null) | undefined {
-        return _bindFilterCallback(this.params.numberFormatter, this.gos, this.params.column);
+        return _bindFilterCallback(this.params.numberFormatter, this.gos, this.params.column, 'columnFilter');
     }
 
     protected override createInputWidget(): NumberInput {

--- a/packages/ag-grid-community/src/filter/provided/number/numberFilterModelFormatter.ts
+++ b/packages/ag-grid-community/src/filter/provided/number/numberFilterModelFormatter.ts
@@ -10,7 +10,7 @@ export class NumberFilterModelFormatter extends SimpleFilterModelFormatter<
     protected readonly filterTypeKeys = SCALAR_FILTER_TYPE_KEYS;
 
     protected override getValueFormatter(): ((value: number | null) => string | null) | undefined {
-        return _bindFilterCallback(this.filterParams.numberFormatter, this.gos, this.column);
+        return _bindFilterCallback(this.filterParams.numberFormatter, this.gos, this.column, 'columnFilter');
     }
 
     protected conditionToString(

--- a/packages/ag-grid-community/src/filter/provided/number/numberFilterUtils.ts
+++ b/packages/ag-grid-community/src/filter/provided/number/numberFilterUtils.ts
@@ -35,7 +35,7 @@ export function stringToFloat(
 
     // Built here, not by the caller: this runs several times per keystroke and usually has no parser to pay for.
     if (numberParser) {
-        return numberParser(filterText, filterCallbackParams(gos, column));
+        return numberParser(filterText, filterCallbackParams(gos, column, 'columnFilter'));
     }
 
     return filterText == null || trimmed === '-' ? null : Number.parseFloat(filterText);

--- a/packages/ag-grid-community/src/filter/provided/simpleFilterHandler.ts
+++ b/packages/ag-grid-community/src/filter/provided/simpleFilterHandler.ts
@@ -215,7 +215,13 @@ export abstract class SimpleFilterHandler<
         const values = this.mapValuesFromModel(filterModel, optionsFactory);
         const customFilterOption = optionsFactory.getCustomOption(filterModel.type);
 
-        const customFilterResult = evaluateCustomFilter<TValue>(customFilterOption, values, cellValue);
+        const customFilterResult = evaluateCustomFilter<TValue>(
+            customFilterOption,
+            values,
+            cellValue,
+            this.beans.gos,
+            this.params.column
+        );
         if (customFilterResult != null) {
             return customFilterResult;
         }

--- a/packages/ag-grid-community/src/filter/provided/simpleFilterUtils.ts
+++ b/packages/ag-grid-community/src/filter/provided/simpleFilterUtils.ts
@@ -1,26 +1,34 @@
 import type { GridOptionsService } from '../../gridOptionsService';
 import { _addGridCommonParams } from '../../gridOptionsUtils';
 import type { Column } from '../../interfaces/iColumn';
-import type { FilterInputCallbackParams } from '../../interfaces/iFilter';
+import type { FilterCallbackSource, FilterInputCallbackParams } from '../../interfaces/iFilter';
 import type { LogService } from '../../validation/logService';
 import type { FilterLocaleTextKey } from '../filterLocaleText';
 import { PRESET_DATE_FILTER_TYPES } from './date/relativeDateRanges';
 import type { FilterOptionKey, IFilterOptionDef, ISimpleFilterModelType, JoinOperator, Tuple } from './iSimpleFilter';
 import type { OptionsFactory } from './optionsFactory';
 
-/** Built per call, not per binding: `context` is a grid option, so a captured one would go stale. */
-export function filterCallbackParams(gos: GridOptionsService, column: Column): FilterInputCallbackParams {
-    return _addGridCommonParams<FilterInputCallbackParams>(gos, { column, colDef: column.getColDef() });
+/**
+ * Built per call, not per binding: `context` is a grid option, so a captured one would go stale.
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
+ */
+export function filterCallbackParams(
+    gos: GridOptionsService,
+    column: Column,
+    source: FilterCallbackSource
+): FilterInputCallbackParams {
+    return _addGridCommonParams<FilterInputCallbackParams>(gos, { column, colDef: column.getColDef(), source });
 }
 
 /** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _bindFilterCallback<A, R>(
     callback: ((value: A, params: FilterInputCallbackParams) => R) | undefined,
     gos: GridOptionsService,
-    column: Column | null | undefined
+    column: Column | null | undefined,
+    source: FilterCallbackSource
 ): ((value: A) => R) | undefined {
     // A column is needed to name the callback's subject, so without one the default reading stands.
-    return callback && column ? (value) => callback(value, filterCallbackParams(gos, column)) : undefined;
+    return callback && column ? (value) => callback(value, filterCallbackParams(gos, column, source)) : undefined;
 }
 
 /** `NaN` is below it too: every comparison against it is false, so left through it would cap nothing. */
@@ -65,16 +73,14 @@ export function getDefaultJoinOperator(defaultJoinOperator?: JoinOperator): Join
 export function evaluateCustomFilter<V>(
     customFilterOption: IFilterOptionDef | undefined,
     values: Tuple<V>,
-    cellValue: V | null | undefined
+    cellValue: V | null | undefined,
+    gos: GridOptionsService,
+    column: Column
 ): boolean | undefined {
-    if (customFilterOption == null) {
-        return;
-    }
-
-    const { predicate } = customFilterOption;
     // only execute the custom filter if a value exists or a value isn't required, i.e. input is hidden
+    const predicate = customFilterOption?.predicate;
     if (predicate != null && !values.some((v) => v == null)) {
-        return predicate(values, cellValue);
+        return predicate(values, cellValue, filterCallbackParams(gos, column, 'columnFilter'));
     }
 
     // No custom filter invocation, indicate that to the caller.

--- a/packages/ag-grid-community/src/filter/provided/text/iTextFilter.ts
+++ b/packages/ag-grid-community/src/filter/provided/text/iTextFilter.ts
@@ -1,6 +1,6 @@
 import type { BaseColDefParams } from '../../../entities/colDef';
 import type { IAutoCompleteComponentParams } from '../../../interfaces/iAutoComplete';
-import type { IFilterParams } from '../../../interfaces/iFilter';
+import type { FilterCallbackSource, FilterInputCallbackParams, IFilterParams } from '../../../interfaces/iFilter';
 import type { IFloatingFilterParams } from '../../floating/floatingFilter';
 import type {
     CustomFilterOptionKey,
@@ -50,12 +50,15 @@ export interface TextMatcherParams extends BaseColDefParams {
      * the value will have been converted to lower case.
      */
     filterText: string | null;
+    /** The column's `textFormatter`, with its own params already supplied. */
     textFormatter?: TextFormatter;
+    /** Which filter is doing the matching. */
+    source: FilterCallbackSource;
 }
 
 export type TextMatcher = (params: TextMatcherParams) => boolean;
 
-export type TextFormatter = (from?: string | null) => string | null;
+export type TextFormatter = (from?: string | null, params?: FilterInputCallbackParams) => string | null;
 
 /**
  * Parameters provided by the grid to the `init` method of a `TextFilter`.
@@ -85,7 +88,7 @@ export interface ITextFilterParams extends ISimpleFilterParams {
      * Formats the text before applying the filter compare logic.
      * Useful if you want to substitute accented characters, for example.
      */
-    textFormatter?: (from: string) => string | null;
+    textFormatter?: (from: string, params: FilterInputCallbackParams) => string | null;
     /**
      * If `true`, the input that the user enters will be trimmed when the filter is applied, so any leading or trailing whitespace will be removed.
      * If only whitespace is entered, it will be left as-is.

--- a/packages/ag-grid-community/src/filter/provided/text/textFilterHandler.ts
+++ b/packages/ag-grid-community/src/filter/provided/text/textFilterHandler.ts
@@ -1,59 +1,39 @@
+import { _getOwn } from 'ag-stack';
+
 import type { Column } from '../../../interfaces/iColumn';
 import type { FilterHandlerParams, IDoesFilterPassParams } from '../../../interfaces/iFilter';
-import type { FilterOptionKey, ICombinedSimpleModel, TextFilterOptionKey, Tuple } from '../iSimpleFilter';
+import type { FilterOptionKey, ICombinedSimpleModel, Tuple } from '../iSimpleFilter';
 import { isCombinedFilterModel } from '../iSimpleFilter';
 import type { OptionsFactory } from '../optionsFactory';
 import { SimpleFilterHandler } from '../simpleFilterHandler';
-import { _hasValue, _isBlank } from '../simpleFilterUtils';
+import { _hasValue, _isBlank, filterCallbackParams } from '../simpleFilterUtils';
 import type { ITextFilterParams, TextFilterModel, TextFormatter, TextMatcher } from './iTextFilter';
 import { DEFAULT_TEXT_FILTER_OPTIONS } from './textFilterConstants';
 import { TextFilterModelFormatter } from './textFilterModelFormatter';
-import { mapValuesFromTextFilterModel, trimInputForFilter } from './textFilterUtils';
-
-/** Every key `defaultMatcher` answers; anything else needs a `textMatcher` to mean something. */
-const DEFAULT_MATCHER_KEYS: ReadonlySet<string> = new Set<TextFilterOptionKey>([
-    'contains',
-    'notContains',
-    'equals',
-    'notEqual',
-    'startsWith',
-    'endsWith',
-]);
+import {
+    TEXT_COMPARISONS,
+    defaultLowercaseFormatter,
+    mapValuesFromTextFilterModel,
+    trimInputForFilter,
+} from './textFilterUtils';
 
 const defaultMatcher: TextMatcher = ({ filterOption, value, filterText }) => {
-    if (filterText == null) {
+    // A `textFormatter` may return null for either side, and every comparison would throw on one.
+    if (filterText == null || value == null) {
         return false;
     }
-
-    switch (filterOption) {
-        case 'contains':
-            return value.includes(filterText);
-        case 'notContains':
-            return !value.includes(filterText);
-        case 'equals':
-            return value === filterText;
-        case 'notEqual':
-            return value != filterText;
-        case 'startsWith':
-            return value.indexOf(filterText) === 0;
-        case 'endsWith': {
-            const index = value.lastIndexOf(filterText);
-            return index >= 0 && index === value.length - filterText.length;
-        }
-        default:
-            return false;
-    }
+    const compare = filterOption == null ? undefined : _getOwn(TEXT_COMPARISONS, filterOption);
+    return compare ? compare(value, filterText) : false;
 };
 
 const defaultFormatter: TextFormatter = (from: string) => from;
-
-const defaultLowercaseFormatter: TextFormatter = (from: string) =>
-    from == null ? null : from.toString().toLowerCase();
 
 export class TextFilterHandler extends SimpleFilterHandler<TextFilterModel, string, ITextFilterParams> {
     public readonly filterType = 'text' as const;
     private matcher: TextMatcher;
     private formatter: TextFormatter;
+    /** The column's own formatter, bound to name this filter as the caller; absent where none is configured. */
+    private textFormatter: TextFormatter | undefined;
 
     constructor() {
         super(mapValuesFromTextFilterModel, DEFAULT_TEXT_FILTER_OPTIONS);
@@ -79,14 +59,22 @@ export class TextFilterHandler extends SimpleFilterHandler<TextFilterModel, stri
 
         const filterParams = params.filterParams;
 
+        const textFormatter = filterParams.textFormatter;
         this.matcher = filterParams.textMatcher ?? defaultMatcher;
+        // Absent input has nothing to format, which also keeps the column's own formatter off `null`.
+        this.textFormatter =
+            textFormatter &&
+            ((from) =>
+                from == null
+                    ? null
+                    : textFormatter(from, filterCallbackParams(this.beans.gos, params.column, 'columnFilter')));
         this.formatter =
-            filterParams.textFormatter ?? (filterParams.caseSensitive ? defaultFormatter : defaultLowercaseFormatter);
+            this.textFormatter ?? (filterParams.caseSensitive ? defaultFormatter : defaultLowercaseFormatter);
     }
 
     /** The key is checked rather than the matcher's answer, which cannot distinguish "no match" from "unknown". */
     private isUnmatchable(type?: FilterOptionKey | null): boolean {
-        return this.matcher === defaultMatcher && (type == null || !DEFAULT_MATCHER_KEYS.has(type));
+        return this.matcher === defaultMatcher && (type == null || !_getOwn(TEXT_COMPARISONS, type));
     }
 
     protected override evaluateNullValue(filterType: FilterOptionKey | null) {
@@ -106,13 +94,7 @@ export class TextFilterHandler extends SimpleFilterHandler<TextFilterModel, stri
     ): boolean {
         const formattedValues = values.map((v) => this.formatter(v)) || [];
         const cellValueFormatted = this.formatter(cellValue);
-        const {
-            api,
-            colDef,
-            column,
-            context,
-            filterParams: { textFormatter },
-        } = this.params;
+        const { api, colDef, column, context } = this.params;
 
         const type = filterModel.type;
         if (type === 'blank') {
@@ -136,7 +118,8 @@ export class TextFilterHandler extends SimpleFilterHandler<TextFilterModel, stri
             data: params.data,
             filterOption: type,
             value: cellValueFormatted,
-            textFormatter,
+            textFormatter: this.textFormatter,
+            source: 'columnFilter' as const,
         };
 
         return formattedValues.some((v) => matcher({ ...matcherParams, filterText: v }));

--- a/packages/ag-grid-community/src/filter/provided/text/textFilterUtils.ts
+++ b/packages/ag-grid-community/src/filter/provided/text/textFilterUtils.ts
@@ -23,11 +23,8 @@ export const TEXT_COMPARISONS: Record<
     notContains: (value, filterText) => !value.includes(filterText),
     equals: (value, filterText) => value === filterText,
     notEqual: (value, filterText) => value != filterText,
-    startsWith: (value, filterText) => value.indexOf(filterText) === 0,
-    endsWith: (value, filterText) => {
-        const index = value.lastIndexOf(filterText);
-        return index >= 0 && index === value.length - filterText.length;
-    },
+    startsWith: (value, filterText) => value.startsWith(filterText),
+    endsWith: (value, filterText) => value.endsWith(filterText),
 };
 
 /** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */

--- a/packages/ag-grid-community/src/filter/provided/text/textFilterUtils.ts
+++ b/packages/ag-grid-community/src/filter/provided/text/textFilterUtils.ts
@@ -1,8 +1,36 @@
-import type { Tuple } from '../iSimpleFilter';
+import type { CommonFilterOptionKey, TextFilterOptionKey, Tuple } from '../iSimpleFilter';
 import type { OptionsFactory } from '../optionsFactory';
 import { getNumberOfInputs } from '../simpleFilterUtils';
-import type { TextFilterModel } from './iTextFilter';
+import type { TextFilterModel, TextFormatter } from './iTextFilter';
 
+/**
+ * Locale-invariant, as the Quick Filter and Set Filter also fold: a locale-aware fold makes a letter fail to
+ * match its own other case in Lithuanian, and differs by the viewer's browser rather than the data.
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
+ */
+export const defaultLowercaseFormatter: TextFormatter = (from: string) =>
+    from == null ? null : from.toString().toLowerCase();
+
+/**
+ * The comparison each option makes, shared so the two filters cannot drift and neither carries a copy.
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
+ */
+export const TEXT_COMPARISONS: Record<
+    Exclude<TextFilterOptionKey, CommonFilterOptionKey>,
+    (value: string, filterText: string) => boolean
+> = {
+    contains: (value, filterText) => value.includes(filterText),
+    notContains: (value, filterText) => !value.includes(filterText),
+    equals: (value, filterText) => value === filterText,
+    notEqual: (value, filterText) => value != filterText,
+    startsWith: (value, filterText) => value.indexOf(filterText) === 0,
+    endsWith: (value, filterText) => {
+        const index = value.lastIndexOf(filterText);
+        return index >= 0 && index === value.length - filterText.length;
+    },
+};
+
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function trimInputForFilter(value?: string | null): string | null | undefined {
     const trimmedInput = value?.trim();
 

--- a/packages/ag-grid-community/src/interfaces/iFilter.ts
+++ b/packages/ag-grid-community/src/interfaces/iFilter.ts
@@ -304,6 +304,9 @@ export interface FilterWrapperParams {
     readOnly?: boolean;
 }
 
+/** Which filter is invoking a callback: both read the column's one `filterParams`. */
+export type FilterCallbackSource = 'columnFilter' | 'advancedFilter';
+
 /**
  * Passed to a filter callback that reads or judges a value rather than a row, such as a parser, a formatter
  * or an input rule. It names the column so that one callback can serve every column it is configured on.
@@ -313,6 +316,8 @@ export interface FilterInputCallbackParams<TData = any, TContext = any> extends 
     colDef: ColDef<TData>;
     /** The column this filter is on. */
     column: Column;
+    /** Which filter is invoking the callback. */
+    source: FilterCallbackSource;
 }
 
 export interface SharedFilterParams<TData = any, TContext = any> extends AgGridCommon<TData, TContext> {

--- a/packages/ag-grid-community/src/interfaces/iSetFilter.ts
+++ b/packages/ag-grid-community/src/interfaces/iSetFilter.ts
@@ -7,7 +7,7 @@ import type { Column } from '../interfaces/iColumn';
 import type { ITooltipParams } from '../tooltip/tooltipComponent';
 import type { IAutoCompleteComponentParams } from './iAutoComplete';
 import type { AgGridCommon } from './iCommon';
-import type { IFilterParams } from './iFilter';
+import type { FilterInputCallbackParams, IFilterParams } from './iFilter';
 
 export type SetFilterModelValue = (string | null)[];
 export interface SetFilterModel extends ProvidedFilterModel {
@@ -192,7 +192,7 @@ export interface ISetFilterParams<TData = any, V = string> extends IProvidedFilt
      * If specified, this formats the text before applying the Mini Filter compare logic, useful for
      * instance to substitute accented characters.
      */
-    textFormatter?: (from: string) => string;
+    textFormatter?: (from: string, params: FilterInputCallbackParams) => string;
     /**
      * If specified, this formats the value before it is displayed in the Filter List.
      * If a Key Creator is provided (see `keyCreator`), this must also be provided.

--- a/packages/ag-grid-community/src/main-internal.ts
+++ b/packages/ag-grid-community/src/main-internal.ts
@@ -158,12 +158,18 @@ export { _isUseApplyButton } from './filter/provided/providedFilterUtils';
 export {
     _bindFilterCallback,
     _classifyFilterOptions,
+    filterCallbackParams as _filterCallbackParams,
     _getCustomOptionDisplayName,
     _getCustomOptionNumberOfInputs,
     _hasValue,
     _isBlank,
     _isRangeOutOfOrder,
 } from './filter/provided/simpleFilterUtils';
+export {
+    defaultLowercaseFormatter as _defaultLowercaseFormatter,
+    TEXT_COMPARISONS as _TEXT_COMPARISONS,
+    trimInputForFilter as _trimInputForFilter,
+} from './filter/provided/text/textFilterUtils';
 export type { FocusService } from './focusService';
 export { _getGlobalGridOption } from './globalGridOptions';
 export { GridCoreCreator } from './grid';

--- a/packages/ag-grid-community/src/main.ts
+++ b/packages/ag-grid-community/src/main.ts
@@ -319,6 +319,7 @@ export type {
     DoesFilterPassParams,
     FilterAction,
     FilterActionParams,
+    FilterCallbackSource,
     FilterDisplay,
     FilterDisplayComp,
     FilterDisplayParams,

--- a/packages/ag-grid-enterprise/src/advancedFilter/advancedFilterExpressionService.ts
+++ b/packages/ag-grid-enterprise/src/advancedFilter/advancedFilterExpressionService.ts
@@ -12,11 +12,15 @@ import type {
     JoinAdvancedFilterModel,
     NamedBean,
     SetAdvancedFilterModel,
+    TextMatcherParams,
     ValueService,
 } from 'ag-grid-community';
 import {
     BeanStub,
+    _addGridCommonParams,
+    _bindFilterCallback,
     _classifyFilterOptions,
+    _filterCallbackParams,
     _getDefaultSimpleFilter,
     _isGridSuppliedFilterParam,
     _toFiniteNumber,
@@ -44,6 +48,7 @@ import {
     getBigIntParser,
     getNumberFormatter,
     getNumberParser,
+    getTextFilterParams,
     hasCustomNumberOperands,
 } from './filterExpressionUtils';
 import type { AdvancedFilterSetService } from './set/advancedFilterSetService';
@@ -542,7 +547,10 @@ export class AdvancedFilterExpressionService extends BeanStub implements NamedBe
             // Reported here too: a column filtered only through the Advanced Filter never builds an `OptionsFactory`.
             const { offered, customOptions } = _classifyFilterOptions(filterOptions, (keys) => this.warn(72, { keys }));
             if (customOptions.size) {
-                operators = createCustomOptionOperators(operators, customOptions, this.getLocaleTextFunc());
+                const gos = this.gos;
+                operators = createCustomOptionOperators(operators, customOptions, this.getLocaleTextFunc(), () =>
+                    _filterCallbackParams(gos, column, 'advancedFilter')
+                );
             }
             const operatorsByKey = operators.operators;
             const offeredOperators: string[] = [];
@@ -560,27 +568,25 @@ export class AdvancedFilterExpressionService extends BeanStub implements NamedBe
     }
 
     /**
-     * The params of the Date Filter a column filters through, if it filters through one at all: `comparator`
-     * is also a Set Filter's list sort and a custom filter component's own parameter, neither of them a date
-     * comparison. A Multi Filter carries the Date Filter as one of its children.
+     * The params a date column's comparisons read; a custom filter component's are its own. A Set Filter's are
+     * included so an author-written `isValidDate` still gates, the grid supplying none there.
      */
     private getDateFilterParams(
         column: AgColumn,
         baseCellDataType: BaseCellDataType | undefined
     ): IDateFilterParams | undefined {
         // The four date types are exactly those the Date Filter is the default for, so the table owns the list.
-        if (
-            _getDefaultSimpleFilter(baseCellDataType) !== DATE_FILTER ||
-            this.advFilterSetSvc.isSetFilterColumn(column)
-        ) {
+        if (_getDefaultSimpleFilter(baseCellDataType) !== DATE_FILTER) {
             return undefined;
         }
         const { filter, filterParams } = column.colDef;
         if (filter === 'agMultiColumnFilter') {
             return getMultiFilterChild(filterParams, DATE_FILTER)?.filterParams;
         }
-        // `filter: true` is the data type's default, which the guards above have established is the Date Filter.
-        return filter === true || filter === DATE_FILTER ? filterParams : undefined;
+        // `filter: true` is the data type's default, which under enterprise resolves to the Set Filter instead.
+        return filter === true || filter === DATE_FILTER || this.advFilterSetSvc.isSetFilterColumn(column)
+            ? filterParams
+            : undefined;
     }
 
     public getExpressionJoinOperators(): { AND: string; OR: string } {
@@ -672,12 +678,17 @@ export class AdvancedFilterExpressionService extends BeanStub implements NamedBe
                 }
             }
         }
+        this.addTextFilterParams(params, column, baseCellDataType);
         const dateFilterParams = this.getDateFilterParams(column, baseCellDataType);
         if (dateFilterParams) {
             // What the grid supplies restates the parse `valueConverter` does, and a comparator skips that
             // conversion, so only where none is in play is the grid's own gate already covered.
             const { comparator, isValidDate } = dateFilterParams;
-            const ownComparator = comparator && !_isGridSuppliedFilterParam(comparator) ? comparator : undefined;
+            // A Set Filter's `comparator` orders its list over two cell values, which is not a date comparison.
+            const ownComparator =
+                comparator && !_isGridSuppliedFilterParam(comparator) && !this.advFilterSetSvc.isSetFilterColumn(column)
+                    ? comparator
+                    : undefined;
             const coveredByConversion = converterParses && !ownComparator;
             params.comparator = ownComparator;
             params.isValid = coveredByConversion && _isGridSuppliedFilterParam(isValidDate) ? undefined : isValidDate;
@@ -685,6 +696,39 @@ export class AdvancedFilterExpressionService extends BeanStub implements NamedBe
         this.expressionEvaluatorParams[colId] = params;
 
         return params;
+    }
+
+    private addTextFilterParams(
+        params: FilterExpressionEvaluatorParams<any, any>,
+        column: AgColumn,
+        baseCellDataType: BaseCellDataType | undefined
+    ): void {
+        const textParams = getTextFilterParams(column, baseCellDataType, this.advFilterSetSvc);
+        if (!textParams) {
+            return;
+        }
+        const { textFormatter, textMatcher } = textParams;
+        const gos = this.gos;
+        const boundFormatter = _bindFilterCallback(textFormatter, gos, column, 'advancedFilter');
+        params.textFormatter = boundFormatter;
+        if (!textMatcher) {
+            return;
+        }
+        // Built per row rather than captured: `context` is a grid option, so a held copy would go stale.
+        params.textMatcher = (filterOption, value, filterText, node) =>
+            textMatcher(
+                _addGridCommonParams<TextMatcherParams>(gos, {
+                    colDef: column.colDef,
+                    column,
+                    node,
+                    data: node.data,
+                    filterOption,
+                    value,
+                    filterText,
+                    textFormatter: boundFormatter,
+                    source: 'advancedFilter',
+                })
+            );
     }
 
     public getColumnDetails(colId: string): { column?: AgColumn; baseCellDataType: BaseCellDataType } {

--- a/packages/ag-grid-enterprise/src/advancedFilter/colFilterExpressionParser.ts
+++ b/packages/ag-grid-enterprise/src/advancedFilter/colFilterExpressionParser.ts
@@ -1,4 +1,5 @@
 import type { AdvancedFilterModel, AgColumn, BaseCellDataType } from 'ag-grid-community';
+import { _trimInputForFilter } from 'ag-grid-community';
 
 import { quoteSetValue } from './advancedFilterExpressionService';
 import type { ADVANCED_FILTER_LOCALE_TEXT } from './advancedFilterLocaleText';
@@ -22,6 +23,7 @@ import {
     getNumberParser,
     getRangeOrderMessage,
     getSearchString,
+    getTextFilterParams,
     updateExpression,
 } from './filterExpressionUtils';
 import { SET_LIST_OPEN_CHAR, SET_TREE_SEPARATOR, SetOperandsParser } from './set/setOperandsParser';
@@ -372,8 +374,11 @@ class OperandParser implements Parser {
     }
 
     private parseOperand(fromComplete: boolean, position: number): void {
-        const { advFilterExpSvc } = this.params;
+        const { advFilterExpSvc, advFilterSetSvc } = this.params;
         this.endPosition = position;
+        if (getTextFilterParams(this.column, this.baseCellDataType, advFilterSetSvc)?.trimInput) {
+            this.operand = _trimInputForFilter(this.operand) ?? this.operand;
+        }
         this.modelValue = this.operand;
         if (fromComplete && this.quotes) {
             // missing end quote

--- a/packages/ag-grid-enterprise/src/advancedFilter/customFilterOptions.ts
+++ b/packages/ag-grid-enterprise/src/advancedFilter/customFilterOptions.ts
@@ -1,12 +1,13 @@
 import type { LocaleTextFunc } from 'ag-stack';
 
-import type { AgColumn, IFilterOptionDef, IMultiFilterDef } from 'ag-grid-community';
+import type { AgColumn, FilterInputCallbackParams, IFilterOptionDef, IMultiFilterDef } from 'ag-grid-community';
 import {
     _getCustomOptionDisplayName,
     _getCustomOptionNumberOfInputs,
     _isGridSuppliedFilterOptions,
 } from 'ag-grid-community';
 
+import { getChildFilter } from '../multiFilter/multiFilterUtil';
 import type {
     DataTypeFilterExpressionOperators,
     FilterExpressionOperator,
@@ -25,7 +26,7 @@ export function getMultiFilterChild(filterParams: any, filterName: string): IMul
     const filters: IMultiFilterDef[] | undefined = filterParams?.filters;
     for (let i = 0, len = filters?.length ?? 0; i < len; ++i) {
         const child = filters![i];
-        if (child?.filter === filterName) {
+        if (child && getChildFilter(child) === filterName) {
             return child;
         }
     }
@@ -50,21 +51,23 @@ export function getColumnFilterOptions(column: AgColumn): (string | IFilterOptio
 export function createCustomOptionOperators(
     dataTypeOperators: DataTypeFilterExpressionOperators<any>,
     customOptions: Map<string, IFilterOptionDef>,
-    localeTextFunc: LocaleTextFunc
+    localeTextFunc: LocaleTextFunc,
+    callbackParams: () => FilterInputCallbackParams
 ): DataTypeFilterExpressionOperators<any> {
     const operators: { [operator: string]: FilterExpressionOperator<any> } = Object.assign(
         Object.create(null),
         dataTypeOperators.operators
     );
     customOptions.forEach((option, key) => {
-        operators[key] = createCustomOptionOperator(option, localeTextFunc);
+        operators[key] = createCustomOptionOperator(option, localeTextFunc, callbackParams);
     });
     return { operators, getEntries: (activeOperators) => getEntries(operators, activeOperators) };
 }
 
 function createCustomOptionOperator(
     option: IFilterOptionDef,
-    localeTextFunc: LocaleTextFunc
+    localeTextFunc: LocaleTextFunc,
+    callbackParams: () => FilterInputCallbackParams
 ): FilterExpressionOperator<any> {
     const predicate = option.predicate!;
     // Arity bound here rather than branched on per row; the predicate gets the raw cell value.
@@ -72,16 +75,17 @@ function createCustomOptionOperator(
     let operands: OperandsKind;
     switch (_getCustomOptionNumberOfInputs(option)) {
         case 0:
-            evaluator = (value) => predicate([], value);
+            evaluator = (value) => predicate([], value, callbackParams());
             operands = 'none';
             break;
         case 1:
-            evaluator = (value, _node, _params, operand1) => predicate([freshOperand(operand1)], value);
+            evaluator = (value, _node, _params, operand1) =>
+                predicate([freshOperand(operand1)], value, callbackParams());
             operands = 'one';
             break;
         default:
             evaluator = (value, _node, _params, operand1, operand2) =>
-                predicate([freshOperand(operand1), freshOperand(operand2)], value);
+                predicate([freshOperand(operand1), freshOperand(operand2)], value, callbackParams());
             operands = 'range';
             break;
     }

--- a/packages/ag-grid-enterprise/src/advancedFilter/filterExpressionOperators.ts
+++ b/packages/ag-grid-enterprise/src/advancedFilter/filterExpressionOperators.ts
@@ -4,16 +4,22 @@ import {
     _PRESET_DATE_FILTER_RANGES,
     _PRESET_DATE_FILTER_TYPES,
     _RelativeDateRangeCache,
+    _TEXT_COMPARISONS,
+    _defaultLowercaseFormatter,
     _hasValue,
     _isBlank,
 } from 'ag-grid-community';
-import type { BaseCellDataType, IRowNode, ISimpleFilterModelPresetType } from 'ag-grid-community';
+import type { BaseCellDataType, IRowNode, ISimpleFilterModelPresetType, TextFormatter } from 'ag-grid-community';
 
 import type { ADVANCED_FILTER_LOCALE_TEXT } from './advancedFilterLocaleText';
 import type { AutocompleteEntry } from './autocomplete/autocompleteParams';
 
 export interface FilterExpressionEvaluatorParams<ConvertedTValue, TValue = ConvertedTValue> {
     caseSensitive?: boolean;
+    /** Normalises both sides before they are compared; replaces the case handling rather than adding to it. */
+    textFormatter?: TextFormatter;
+    /** Replaces the built-in text comparison. */
+    textMatcher?: (filterOption: string, value: string | null, filterText: string | null, node: IRowNode) => boolean;
     includeBlanksInEquals?: boolean;
     includeBlanksInNotEqual?: boolean;
     includeBlanksInLessThan?: boolean;
@@ -132,6 +138,8 @@ interface FilterExpressionOperatorsParams {
     translate: AdvancedFilterTranslate;
 }
 
+const identity: TextFormatter = (from) => from ?? null;
+
 export class TextFilterExpressionOperators<TValue = string> implements DataTypeFilterExpressionOperators<
     string,
     TValue
@@ -151,38 +159,32 @@ export class TextFilterExpressionOperators<TValue = string> implements DataTypeF
         this.operators = {
             contains: {
                 displayValue: translate('advancedFilterContains'),
-                evaluator: (value, node, params, operand1) =>
-                    this.evaluateExpression(value, node, params, operand1!, false, (v, o) => v.includes(o)),
+                evaluator: this.createEvaluator('contains', false),
                 operands: 'one',
             },
             notContains: {
                 displayValue: translate('advancedFilterNotContains'),
-                evaluator: (value, node, params, operand1) =>
-                    this.evaluateExpression(value, node, params, operand1!, true, (v, o) => !v.includes(o)),
+                evaluator: this.createEvaluator('notContains', true),
                 operands: 'one',
             },
             equals: {
                 displayValue: translate('advancedFilterTextEquals'),
-                evaluator: (value, node, params, operand1) =>
-                    this.evaluateExpression(value, node, params, operand1!, false, (v, o) => v === o),
+                evaluator: this.createEvaluator('equals', false),
                 operands: 'one',
             },
             notEqual: {
                 displayValue: translate('advancedFilterTextNotEqual'),
-                evaluator: (value, node, params, operand1) =>
-                    this.evaluateExpression(value, node, params, operand1!, true, (v, o) => v != o),
+                evaluator: this.createEvaluator('notEqual', true),
                 operands: 'one',
             },
             startsWith: {
                 displayValue: translate('advancedFilterStartsWith'),
-                evaluator: (value, node, params, operand1) =>
-                    this.evaluateExpression(value, node, params, operand1!, false, (v, o) => v.startsWith(o)),
+                evaluator: this.createEvaluator('startsWith', false),
                 operands: 'one',
             },
             endsWith: {
                 displayValue: translate('advancedFilterEndsWith'),
-                evaluator: (value, node, params, operand1) =>
-                    this.evaluateExpression(value, node, params, operand1!, false, (v, o) => v.endsWith(o)),
+                evaluator: this.createEvaluator('endsWith', false),
                 operands: 'one',
             },
             blank: {
@@ -198,20 +200,28 @@ export class TextFilterExpressionOperators<TValue = string> implements DataTypeF
         };
     }
 
-    private evaluateExpression(
-        value: TValue | null | undefined,
-        node: IRowNode,
-        params: FilterExpressionEvaluatorParams<string, TValue>,
-        operand: string,
-        nullsMatch: boolean,
-        expression: (value: string, operand: string) => boolean
-    ): boolean {
-        if (value == null) {
-            return nullsMatch;
-        }
-        return params.caseSensitive
-            ? expression(params.valueConverter(value, node), operand)
-            : expression(params.valueConverter(value, node).toLocaleLowerCase(), operand.toLocaleLowerCase());
+    private createEvaluator(
+        filterOption: keyof typeof _TEXT_COMPARISONS,
+        nullsMatch: boolean
+    ): FilterExpressionEvaluator<string, TValue> {
+        // Bound once per operator, and the key type is what makes the table's entry certain.
+        const compare = _TEXT_COMPARISONS[filterOption];
+        return (value, node, params, operand1) => {
+            if (value == null) {
+                return nullsMatch;
+            }
+            const formatter = params.textFormatter ?? (params.caseSensitive ? identity : _defaultLowercaseFormatter);
+            const formattedValue = formatter(params.valueConverter(value, node));
+            const formattedOperand = formatter(operand1!);
+            // Reached with either side null, as the Text Filter reaches its own matcher, which decides.
+            const matcher = params.textMatcher;
+            if (matcher) {
+                return matcher(filterOption, formattedValue, formattedOperand, node);
+            }
+            return formattedValue == null || formattedOperand == null
+                ? false
+                : compare(formattedValue, formattedOperand);
+        };
     }
 }
 

--- a/packages/ag-grid-enterprise/src/advancedFilter/filterExpressionUtils.ts
+++ b/packages/ag-grid-enterprise/src/advancedFilter/filterExpressionUtils.ts
@@ -10,6 +10,7 @@ import type {
     GridOptionsService,
     IBigIntFilterParams,
     IRowNode,
+    ITextFilterParams,
     NumberFilterParams,
     SetAdvancedFilterModel,
     SetFilterModelValue,
@@ -18,6 +19,7 @@ import type {
 
 import type { AdvancedFilterExpressionService } from './advancedFilterExpressionService';
 import type { ADVANCED_FILTER_LOCALE_TEXT } from './advancedFilterLocaleText';
+import { getMultiFilterChild } from './customFilterOptions';
 import type { FilterExpressionEvaluatorParams, FilterExpressionOperator } from './filterExpressionOperators';
 import { OPERAND_COUNT } from './filterExpressionOperators';
 import type { AdvancedFilterSetService } from './set/advancedFilterSetService';
@@ -248,10 +250,10 @@ export const getBigIntParser = (
     column: AgColumn | null | undefined,
     gos: GridOptionsService
 ): FilterOperandParser<bigint> =>
-    _bindFilterCallback(bigIntParams(column)?.bigintParser, gos, column) ?? _parseBigIntOrNull;
+    _bindFilterCallback(bigIntParams(column)?.bigintParser, gos, column, 'advancedFilter') ?? _parseBigIntOrNull;
 
 export const getBigIntFormatter = (column: AgColumn | null | undefined, gos: GridOptionsService) =>
-    _bindFilterCallback(bigIntParams(column)?.bigintFormatter, gos, column);
+    _bindFilterCallback(bigIntParams(column)?.bigintFormatter, gos, column, 'advancedFilter');
 
 /**
  * The `filterParams` of a number column whose operands are written in its own syntax rather than as plain
@@ -271,13 +273,37 @@ export const getNumberParser = (
     column: AgColumn | null | undefined,
     gos: GridOptionsService
 ): FilterOperandParser<number> =>
-    _bindFilterCallback(customNumberOperandParams(column)?.numberParser, gos, column) ?? parseNumberOrNull;
+    _bindFilterCallback(customNumberOperandParams(column)?.numberParser, gos, column, 'advancedFilter') ??
+    parseNumberOrNull;
 
 export const getNumberFormatter = (column: AgColumn | null | undefined, gos: GridOptionsService) =>
-    _bindFilterCallback(customNumberOperandParams(column)?.numberFormatter, gos, column);
+    _bindFilterCallback(customNumberOperandParams(column)?.numberFormatter, gos, column, 'advancedFilter');
 
 export function hasCustomNumberOperands(column: AgColumn | null | undefined): boolean {
     return customNumberOperandParams(column) != null;
+}
+
+/**
+ * The params the column's Text Filter compares with — for a Multi Filter, its Text Filter child's alone, as
+ * the child is created with (`MultiFilterHandler` merges the column's own params in only on a later refresh).
+ */
+export function getTextFilterParams(
+    column: AgColumn | null | undefined,
+    baseCellDataType: BaseCellDataType | undefined,
+    advFilterSetSvc: AdvancedFilterSetService
+): ITextFilterParams | undefined {
+    // An unresolved data type reads as text, as its converter does.
+    if (baseCellDataType != null && baseCellDataType !== 'text' && baseCellDataType !== 'object') {
+        return undefined;
+    }
+    const colDef = column?.colDef;
+    const filter = colDef?.filter;
+    if (filter === 'agMultiColumnFilter') {
+        return getMultiFilterChild(colDef?.filterParams, 'agTextColumnFilter')?.filterParams;
+    }
+    // A custom component's are its own, and a Set Filter's `textFormatter` formats its list, not a comparison.
+    const ownsItsParams = typeof filter === 'function' || (filter != null && typeof filter === 'object');
+    return ownsItsParams || advFilterSetSvc.isSetFilterColumn(column) ? undefined : colDef?.filterParams;
 }
 
 export function getSearchString(value: string, position: number, endPosition: number): string {

--- a/packages/ag-grid-enterprise/src/advancedFilter/filterExpressionUtils.ts
+++ b/packages/ag-grid-enterprise/src/advancedFilter/filterExpressionUtils.ts
@@ -301,9 +301,10 @@ export function getTextFilterParams(
     if (filter === 'agMultiColumnFilter') {
         return getMultiFilterChild(colDef?.filterParams, 'agTextColumnFilter')?.filterParams;
     }
-    // A custom component's are its own, and a Set Filter's `textFormatter` formats its list, not a comparison.
-    const ownsItsParams = typeof filter === 'function' || (filter != null && typeof filter === 'object');
-    return ownsItsParams || advFilterSetSvc.isSetFilterColumn(column) ? undefined : colDef?.filterParams;
+    // Named as readily as supplied, so any other component's params are its own; a Set Filter's `textFormatter`
+    // formats its list rather than a comparison, and `filter: true` resolves to one under enterprise.
+    const isTextFilter = filter == null || filter === true || filter === 'agTextColumnFilter';
+    return isTextFilter && !advFilterSetSvc.isSetFilterColumn(column) ? colDef?.filterParams : undefined;
 }
 
 export function getSearchString(value: string, position: number, endPosition: number): string {

--- a/packages/ag-grid-enterprise/src/multiFilter/multiFilterUtil.ts
+++ b/packages/ag-grid-enterprise/src/multiFilter/multiFilterUtil.ts
@@ -21,7 +21,7 @@ export function getMultiFilterDefs(params: IMultiFilterParams | undefined): IMul
 
 /** `true` means "use the default", which for a Multi Filter child is always the text filter. `undefined` is
  *  deliberately not folded in: the handler path gives it no filter at all rather than the default. */
-function getChildFilter(def: IMultiFilterDef): IMultiFilterDef['filter'] {
+export function getChildFilter(def: IMultiFilterDef): IMultiFilterDef['filter'] {
     const filter = def.filter;
     return filter === true ? 'agTextColumnFilter' : filter;
 }

--- a/packages/ag-grid-enterprise/src/setFilter/setFilter.ts
+++ b/packages/ag-grid-enterprise/src/setFilter/setFilter.ts
@@ -17,7 +17,13 @@ import type {
     SetFilterUi,
     TextFormatter,
 } from 'ag-grid-community';
-import { AgInputTextFieldSelector, KeyCode, ProvidedFilter, _createIconNoSpan } from 'ag-grid-community';
+import {
+    AgInputTextFieldSelector,
+    KeyCode,
+    ProvidedFilter,
+    _bindFilterCallback,
+    _createIconNoSpan,
+} from 'ag-grid-community';
 
 import type { VirtualListModel } from '../agStack/iVirtualList';
 import { VirtualList } from '../widgets/virtualList';
@@ -31,7 +37,7 @@ import type {
     SetFilterListItemSelectionChangedEvent,
 } from './setFilterListItem';
 import { SetFilterListItem } from './setFilterListItem';
-import { setFilterNullIfBlank, translateForSetFilter } from './setFilterUtils';
+import { setFilterNullIfBlank, translateForSetFilter, unformattedSetFilterText } from './setFilterUtils';
 import { TreeSetDisplayValueModel } from './treeSetDisplayValueModel';
 
 /** @param V type of value in the Set Filter */
@@ -78,7 +84,8 @@ export class SetFilter<V = string>
 
         const { column, textFormatter, treeList, treeListPathGetter, treeListFormatter } = params;
 
-        this.formatter = textFormatter ?? ((value) => value ?? null);
+        this.formatter =
+            _bindFilterCallback(textFormatter, this.beans.gos, column, 'columnFilter') ?? unformattedSetFilterText;
 
         this.displayValueModel = treeList
             ? new TreeSetDisplayValueModel(
@@ -136,9 +143,10 @@ export class SetFilter<V = string>
             this.createVirtualListModel(newParams);
         }
 
-        const { textFormatter, treeListPathGetter, treeListFormatter } = newParams;
+        const { column, textFormatter, treeListPathGetter, treeListFormatter } = newParams;
 
-        this.formatter = textFormatter ?? ((value) => value ?? null);
+        this.formatter =
+            _bindFilterCallback(textFormatter, this.beans.gos, column, 'columnFilter') ?? unformattedSetFilterText;
 
         if (this.displayValueModel instanceof TreeSetDisplayValueModel) {
             this.displayValueModel.updateParams(treeListPathGetter, treeListFormatter);

--- a/packages/ag-grid-enterprise/src/setFilter/setFilterHandler.ts
+++ b/packages/ag-grid-enterprise/src/setFilter/setFilterHandler.ts
@@ -15,7 +15,13 @@ import type {
     SetFilterModelValue,
     ValueFormatterParams,
 } from 'ag-grid-community';
-import { BeanStub, _addGridCommonParams, _isBlank, _isClientSideRowModel } from 'ag-grid-community';
+import {
+    BeanStub,
+    _addGridCommonParams,
+    _bindFilterCallback,
+    _isBlank,
+    _isClientSideRowModel,
+} from 'ag-grid-community';
 
 import { CsrmValuesExtractor } from './csrmValueExtractor';
 import type { SetFilterModelTreeItem } from './iSetDisplayValueModel';
@@ -25,6 +31,7 @@ import {
     setFilterFormattedValue,
     setFilterNullIfBlank,
     translateForSetFilter,
+    unformattedSetFilterText,
 } from './setFilterUtils';
 import SetFilterModelValuesType, { SetValueModel } from './setValueModel';
 import { TreeSetDisplayValueModel } from './treeSetDisplayValueModel';
@@ -194,7 +201,8 @@ export class SetFilterHandler<TValue = string>
         const filterParams = this.params.filterParams;
         const model = new TreeSetDisplayValueModel<any>(
             this.beans.log,
-            filterParams.textFormatter ?? ((value) => value ?? null),
+            _bindFilterCallback(filterParams.textFormatter, this.beans.gos, this.params.column, 'columnFilter') ??
+                unformattedSetFilterText,
             filterParams.treeListPathGetter,
             filterParams.treeListFormatter,
             this.isTreeDataOrGrouping()

--- a/packages/ag-grid-enterprise/src/setFilter/setFilterUtils.ts
+++ b/packages/ag-grid-enterprise/src/setFilter/setFilterUtils.ts
@@ -1,11 +1,20 @@
 import type { LocaleTextFunc } from 'ag-stack';
 import { _defaultComparator, _last, _toStringOrNull, _translate } from 'ag-stack';
 
-import type { AgColumn, BeanCollection, ISetFilterParams, ValueFormatterParams } from 'ag-grid-community';
+import type {
+    AgColumn,
+    BeanCollection,
+    ISetFilterParams,
+    TextFormatter,
+    ValueFormatterParams,
+} from 'ag-grid-community';
 import { _isBlank } from 'ag-grid-community';
 
 import type { SetFilterLocaleTextKey } from './localeText';
 import { DEFAULT_LOCALE_TEXT } from './localeText';
+
+/** What the Mini Filter searches when the column configures no `textFormatter`. */
+export const unformattedSetFilterText: TextFormatter = (value) => value ?? null;
 
 export function processDataPath(
     dataPath: string[] | null,

--- a/testing/behavioural/src/filters/advanced-filter/advanced-filter-column-filter-parity.test.ts
+++ b/testing/behavioural/src/filters/advanced-filter/advanced-filter-column-filter-parity.test.ts
@@ -7,7 +7,15 @@ import {
     uninstallFilterLayoutMock,
 } from 'ag-test-utils';
 
-import type { AdvancedFilterModel, ColDef, ColumnAdvancedFilterModel, GridApi, GridOptions } from 'ag-grid-community';
+import type {
+    AdvancedFilterModel,
+    ColDef,
+    ColumnAdvancedFilterModel,
+    FilterInputCallbackParams,
+    GridApi,
+    GridOptions,
+    TextMatcherParams,
+} from 'ag-grid-community';
 import {
     BigIntFilterModule,
     ClientSideRowModelModule,
@@ -62,7 +70,7 @@ const COLUMN_DEFS: GridOptions<TestRow>['columnDefs'] = [
     { field: 'qty', cellDataType: 'bigint', filter: 'agBigIntColumnFilter' },
 ];
 
-function getDisplayedIds(api: GridApi<TestRow>): number[] {
+function getDisplayedIds(api: GridApi<{ id: number }>): number[] {
     const result: number[] = [];
     for (let i = 0; i < api.getDisplayedRowCount(); i++) {
         result.push(api.getDisplayedRowAtIndex(i)!.data!.id);
@@ -229,6 +237,460 @@ describe('Advanced Filter matches the column filter', () => {
         ).toEqual(columnFilterIds);
     });
 
+    describe("the column's Text Filter configuration", () => {
+        const TEXT_ROWS = [
+            { id: 0, name: 'red car' },
+            { id: 1, name: 'carpet' },
+            { id: 2, name: 'scar' },
+            { id: 3, name: 'Café' },
+            { id: 4, name: 'cafe' },
+        ];
+
+        const textDefs = (filterParams: object): GridOptions['columnDefs'] => [
+            { field: 'id' },
+            { field: 'name', filter: 'agTextColumnFilter', filterParams },
+        ];
+
+        /** The rows the column filter shows for a model set through its API. */
+        async function withColumnModel(
+            filterParams: object,
+            model: object,
+            columnDefs = textDefs(filterParams)
+        ): Promise<number[]> {
+            const api = await gridsManager.createGridAndWait('columnFilterGrid', {
+                columnDefs,
+                rowData: TEXT_ROWS,
+            });
+            await api.setColumnFilterModel('name', model);
+            api.onFilterChanged();
+            await asyncSetTimeout(0);
+            const ids = getDisplayedIds(api);
+            api.destroy();
+            return ids;
+        }
+
+        /** The rows the Advanced Filter shows for the equivalent expression, applied as a user applies it. */
+        async function withExpression(
+            filterParams: object,
+            expression: string,
+            columnDefs = textDefs(filterParams)
+        ): Promise<number[]> {
+            const api = await gridsManager.createGridAndWait('advancedFilterGrid', {
+                columnDefs,
+                rowData: TEXT_ROWS,
+                enableAdvancedFilter: true,
+            });
+            await AdvancedFilterHarness.get(api).applyExpression(expression);
+            await asyncSetTimeout(0);
+            const ids = getDisplayedIds(api);
+            api.destroy();
+            return ids;
+        }
+
+        const contains = (filter: string) => ({ filterType: 'text', type: 'contains', filter });
+
+        const wholeWord = ({ value, filterText }: TextMatcherParams) =>
+            !!filterText && new RegExp(`\\b${filterText}\\b`).test(value);
+
+        test('a `textMatcher` decides `contains` in both, and is told which filter is asking', async () => {
+            const sources = new Set<string>();
+            const textMatcher = (params: TextMatcherParams) => {
+                sources.add(params.source);
+                return wholeWord(params);
+            };
+
+            // Without one, all three spellings contain the text; the matcher is what narrows them to the word.
+            expect(await withColumnModel({}, contains('car'))).toEqual([0, 1, 2]);
+            expect(await withColumnModel({ textMatcher }, contains('car'))).toEqual([0]);
+            expect([...sources]).toEqual(['columnFilter']);
+
+            sources.clear();
+            expect(await withExpression({ textMatcher }, '[Name] contains "car"')).toEqual([0]);
+            expect([...sources]).toEqual(['advancedFilter']);
+        });
+
+        // A matcher is keyed on `filterOption`, so it only means the same thing in both filters if both name
+        // the option the same way. Every option `defaultMatcher` answers is checked, not just the first.
+        test('a `textMatcher` is given the same `filterOption` by both filters, for every option', async () => {
+            const options = [
+                { type: 'contains', operator: 'contains' },
+                { type: 'notContains', operator: 'does not contain' },
+                { type: 'equals', operator: 'equals' },
+                { type: 'notEqual', operator: 'does not equal' },
+                { type: 'startsWith', operator: 'begins with' },
+                { type: 'endsWith', operator: 'ends with' },
+            ];
+            const seen: string[] = [];
+            const textMatcher = ({ filterOption }: TextMatcherParams) => {
+                if (filterOption != null && !seen.includes(filterOption)) {
+                    seen.push(filterOption);
+                }
+                return false;
+            };
+
+            for (const { type } of options) {
+                await withColumnModel({ textMatcher }, { filterType: 'text', type, filter: 'car' });
+            }
+            expect(seen).toEqual(options.map(({ type }) => type));
+
+            seen.length = 0;
+            for (const { operator } of options) {
+                await withExpression({ textMatcher }, `[Name] ${operator} "car"`);
+            }
+            expect(seen).toEqual(options.map(({ type }) => type));
+        });
+
+        /** A Multi Filter column whose params sit at the level `where` names. */
+        const multiDefs = (
+            where: 'child' | 'column',
+            params: object,
+            filter: ColDef['filter'] = 'agTextColumnFilter'
+        ) => {
+            const children = [
+                { filter, filterParams: where === 'child' ? params : undefined },
+                { filter: 'agSetColumnFilter' },
+            ];
+            return [
+                { field: 'id' },
+                {
+                    field: 'name',
+                    filter: 'agMultiColumnFilter',
+                    filterParams: { ...(where === 'column' ? params : {}), filters: children },
+                },
+            ] as GridOptions['columnDefs'];
+        };
+
+        /** A Multi Filter's model is positional over its children, the Text Filter being the first. */
+        const multiContains = (filter: string) => ({
+            filterType: 'multi',
+            filterModels: [contains(filter), null],
+        });
+
+        test('a Multi Filter column reads its Text Filter child', async () => {
+            const defs = multiDefs('child', { textMatcher: wholeWord });
+
+            expect(await withColumnModel({}, multiContains('car'), defs)).toEqual([0]);
+            expect(await withExpression({}, '[Name] contains "car"', defs)).toEqual([0]);
+        });
+
+        test('a Multi Filter child asking for the default gets the Text Filter, in both', async () => {
+            const defs = multiDefs('child', { textMatcher: wholeWord }, true);
+
+            expect(await withColumnModel({}, multiContains('car'), defs)).toEqual([0]);
+            expect(await withExpression({}, '[Name] contains "car"', defs)).toEqual([0]);
+        });
+
+        // A Multi Filter builds each child from the child's own params, so text params written at the column's
+        // level are not the Text Filter child's — in either filter. Pinned because it reads like an oversight.
+        test.each([
+            { children: 'named', defs: () => multiDefs('column', { textMatcher: wholeWord }) },
+            {
+                children: 'absent',
+                defs: (): GridOptions['columnDefs'] => [
+                    { field: 'id' },
+                    { field: 'name', filter: 'agMultiColumnFilter', filterParams: { textMatcher: wholeWord } },
+                ],
+            },
+        ])(
+            "a Multi Filter column with $children children ignores text params at the column's own level, in both",
+            async ({ defs }) => {
+                expect(await withColumnModel({}, multiContains('car'), defs())).toEqual([0, 1, 2]);
+                expect(await withExpression({}, '[Name] contains "car"', defs())).toEqual([0, 1, 2]);
+            }
+        );
+
+        test('a Multi Filter column reads `caseSensitive` from the same level as the formatter', async () => {
+            expect(await withExpression({}, '[Name] contains "CAR"', multiDefs('child', {}))).toEqual([0, 1, 2]);
+            expect(
+                await withExpression({}, '[Name] contains "CAR"', multiDefs('child', { caseSensitive: true }))
+            ).toEqual([]);
+
+            // A child asking for the default names no filter, so the text resolution is the only one that
+            // folds `true` to the Text Filter and reaches its params.
+            expect(await withExpression({}, '[Name] contains "CAR"', multiDefs('child', {}, true))).toEqual([0, 1, 2]);
+            expect(
+                await withExpression({}, '[Name] contains "CAR"', multiDefs('child', { caseSensitive: true }, true))
+            ).toEqual([]);
+        });
+
+        test('a `textFormatter` normalises the value and the operand alike in both, and is told which filter is asking', async () => {
+            const sources = new Set<string>();
+            const foldAccents = (from: string, params: FilterInputCallbackParams) => {
+                sources.add(params.source);
+                return from
+                    .normalize('NFD')
+                    .replace(/[\u0300-\u036f]/g, '')
+                    .toLowerCase();
+            };
+
+            expect(await withColumnModel({}, contains('cafe'))).toEqual([4]);
+            expect(await withColumnModel({ textFormatter: foldAccents }, contains('cafe'))).toEqual([3, 4]);
+            expect([...sources]).toEqual(['columnFilter']);
+
+            sources.clear();
+            expect(await withExpression({ textFormatter: foldAccents }, '[Name] contains "cafe"')).toEqual([3, 4]);
+            expect([...sources]).toEqual(['advancedFilter']);
+
+            // The formatter replaces the case handling rather than adding to it, so this changes nothing.
+            const withCase = { textFormatter: foldAccents, caseSensitive: true };
+            expect(await withColumnModel(withCase, contains('cafe'))).toEqual([3, 4]);
+            expect(await withExpression(withCase, '[Name] contains "cafe"')).toEqual([3, 4]);
+        });
+
+        test("a Custom Filter Option's `predicate` decides in both, and is told which filter is asking", async () => {
+            const sources = new Set<string>();
+            const filterOptions = [
+                {
+                    displayKey: 'wholeWord',
+                    displayName: 'whole word',
+                    numberOfInputs: 1,
+                    predicate: ([filterValue]: any[], cellValue: any, params: FilterInputCallbackParams) => {
+                        sources.add(params.source);
+                        return typeof cellValue === 'string' && new RegExp(`\\b${filterValue}\\b`).test(cellValue);
+                    },
+                },
+            ];
+            const model = { filterType: 'text', type: 'wholeWord', filter: 'car' };
+
+            expect(await withColumnModel({ filterOptions }, model)).toEqual([0]);
+            expect([...sources]).toEqual(['columnFilter']);
+
+            sources.clear();
+            expect(await withExpression({ filterOptions }, '[Name] whole word "car"')).toEqual([0]);
+            expect([...sources]).toEqual(['advancedFilter']);
+        });
+
+        // The column filter trims on its apply action rather than in the model, so this one is driven
+        // through its UI: a model set through the API keeps the whitespace it was given.
+        test('`trimInput` trims what was entered in both', async () => {
+            const filterParams = { trimInput: true, buttons: ['apply'] };
+            const api = await gridsManager.createGridAndWait('columnFilterGrid', {
+                columnDefs: textDefs(filterParams),
+                rowData: TEXT_ROWS,
+            });
+            const filter = await ColumnFilterHarness.open(api, 'name');
+            await filter.selectOperator('Begins with');
+            await filter.setText(' car ');
+            await filter.apply();
+
+            expect(filter.getModel()).toEqual({ filterType: 'text', type: 'startsWith', filter: 'car' });
+            expect(getDisplayedIds(api)).toEqual([1]);
+            expect(await withExpression(filterParams, '[Name] begins with " car "')).toEqual([1]);
+            // Without it the spaces are part of what is looked for, on both sides.
+            expect(await withExpression({}, '[Name] begins with " car "')).toEqual([]);
+        });
+
+        // Whatever is typed stays typed: the trim reaches the operand the filter matches on, never the text.
+        test('`trimInput` leaves the expression as it was written, and a whitespace-only operand alone', async () => {
+            const api = await gridsManager.createGridAndWait('advancedFilterGrid', {
+                columnDefs: textDefs({ trimInput: true }),
+                rowData: TEXT_ROWS,
+                enableAdvancedFilter: true,
+            });
+            const advanced = AdvancedFilterHarness.get(api);
+
+            await advanced.type('[Name] begins with " car ');
+            expect(advanced.value).toBe('[Name] begins with " car ');
+            await advanced.applyExpression('[Name] begins with " car "');
+            expect(advanced.value).toBe('[Name] begins with " car "');
+            api.destroy();
+
+            // Only whitespace is left as it was entered, so it matches nothing rather than everything.
+            expect(await withExpression({ trimInput: true }, '[Name] contains "   "')).toEqual([]);
+        });
+
+        // The Advanced Filter has one route in, so the trim reaches a model set through the API too.
+        // A `textFormatter` is declared as returning `string | null`, so the default comparison has to survive
+        // the null on either side rather than throwing out of `onFilterChanged`.
+        test('a `textFormatter` returning null excludes the row rather than throwing, in both', async () => {
+            const filterParams = { textFormatter: (from: string) => (from === 'carpet' ? null : from) };
+
+            expect(await withColumnModel(filterParams, contains('car'))).toEqual([0, 2]);
+            expect(await withExpression(filterParams, '[Name] contains "car"')).toEqual([0, 2]);
+        });
+
+        // Both filters fold case without consulting the locale, as the Quick and Set filters do: a locale-aware
+        // fold makes a letter fail to match its own other case in Turkish and Lithuanian.
+        test('the default comparison folds case without consulting the locale, in both', async () => {
+            // A Turkish fold maps `I` to a dotless `ı`, which would stop it matching the `i` in the operand.
+            const localeFold = vi.spyOn(String.prototype, 'toLocaleLowerCase').mockImplementation(function (
+                this: string
+            ) {
+                return this.replace(/I/g, 'ı').toLowerCase();
+            });
+            const columnDefs: GridOptions['columnDefs'] = [
+                { field: 'id' },
+                { field: 'name', filter: 'agTextColumnFilter' },
+            ];
+            const rowData = [
+                { id: 0, name: 'INDIGO' },
+                { id: 1, name: 'green' },
+            ];
+
+            try {
+                const columnApi = await gridsManager.createGridAndWait('columnFilterGrid', { columnDefs, rowData });
+                await columnApi.setColumnFilterModel('name', contains('indigo'));
+                columnApi.onFilterChanged();
+                await asyncSetTimeout(0);
+                expect(getDisplayedIds(columnApi)).toEqual([0]);
+                columnApi.destroy();
+
+                const advancedApi = await gridsManager.createGridAndWait('advancedFilterGrid', {
+                    columnDefs,
+                    rowData,
+                    enableAdvancedFilter: true,
+                });
+                advancedApi.setAdvancedFilterModel({
+                    filterType: 'text',
+                    colId: 'name',
+                    type: 'contains',
+                    filter: 'indigo',
+                });
+                advancedApi.onFilterChanged();
+                await asyncSetTimeout(0);
+                expect(getDisplayedIds(advancedApi)).toEqual([0]);
+                advancedApi.destroy();
+            } finally {
+                localeFold.mockRestore();
+            }
+        });
+
+        test('`trimInput` trims an operand set through `setAdvancedFilterModel`', async () => {
+            const api = await gridsManager.createGridAndWait('advancedFilterGrid', {
+                columnDefs: textDefs({ trimInput: true }),
+                rowData: TEXT_ROWS,
+                enableAdvancedFilter: true,
+            });
+
+            api.setAdvancedFilterModel({ filterType: 'text', colId: 'name', type: 'startsWith', filter: ' car ' });
+            api.onFilterChanged();
+            await asyncSetTimeout(0);
+
+            expect(getDisplayedIds(api)).toEqual([1]);
+            expect(api.getAdvancedFilterModel()).toEqual({
+                filterType: 'text',
+                colId: 'name',
+                type: 'startsWith',
+                filter: 'car',
+            });
+        });
+
+        // The column filter hands its matcher whatever the formatter returned, null included, and decides nothing
+        // for it; the Advanced Filter has to reach the matcher on the same values.
+        test('a `textMatcher` is reached with what the formatter returned, in both', async () => {
+            const seen: unknown[] = [];
+            const filterParams = {
+                textFormatter: (from: string) => (from === 'scar' ? null : from.toLowerCase()),
+                textMatcher: ({ value, filterText }: TextMatcherParams) => {
+                    seen.push(value);
+                    return value != null && !!filterText && value.includes(filterText);
+                },
+            };
+
+            expect(await withColumnModel(filterParams, contains('car'))).toEqual([0, 1]);
+            expect(seen).toContain(null);
+
+            seen.length = 0;
+            expect(await withExpression(filterParams, '[Name] contains "car"')).toEqual([0, 1]);
+            expect(seen).toContain(null);
+        });
+
+        // `notContains` returns the matcher's answer unnegated, which a re-implementation can get backwards.
+        test('a `textMatcher` decides `does not contain` unnegated, in both', async () => {
+            const params = { textMatcher: wholeWord };
+
+            expect(await withColumnModel(params, { filterType: 'text', type: 'notContains', filter: 'car' })).toEqual([
+                0,
+            ]);
+            expect(await withExpression(params, '[Name] does not contain "car"')).toEqual([0]);
+        });
+
+        // A Set Filter's `textFormatter` formats its list, so folding accents with it here would match rows
+        // the Set Filter itself never matches.
+        test('a Set Filter column does not read its `textFormatter` as a Text Filter one', async () => {
+            const columnDefs: GridOptions['columnDefs'] = [
+                { field: 'id' },
+                { field: 'name', filter: 'agSetColumnFilter', filterParams: { textFormatter: () => 'cafe' } },
+            ];
+
+            expect(await withExpression({}, '[Name] contains "cafe"', columnDefs)).toEqual([4]);
+        });
+    });
+
+    // The same `source` the `textMatcher` gets, on the callbacks that read a value rather than a row. Both
+    // filters run the column's own parser, so one parser can tell an expression operand from a typed input.
+    test("a number column's `numberParser` is told which filter is asking", async () => {
+        const sources = new Set<string>();
+        const filterParams = {
+            filterOptions: ['equals'],
+            numberParser: (text: string | null, params: FilterInputCallbackParams) => {
+                sources.add(params.source);
+                return text ? Number(text) : null;
+            },
+            numberFormatter: (value: number | null, params: FilterInputCallbackParams) => {
+                sources.add(params.source);
+                return value == null ? null : String(value);
+            },
+        };
+        const columnDefs: GridOptions<TestRow>['columnDefs'] = [
+            { field: 'id' },
+            { field: 'age', filter: 'agNumberColumnFilter', filterParams },
+        ];
+
+        const columnApi = await gridsManager.createGridAndWait('columnFilterGrid', { columnDefs, rowData: ROW_DATA });
+        const filter = await ColumnFilterHarness.open(columnApi, 'age');
+        await filter.setText('2');
+        expect([...sources]).toEqual(['columnFilter']);
+
+        sources.clear();
+        const advancedApi = await gridsManager.createGridAndWait('advancedFilterGrid', {
+            columnDefs,
+            rowData: ROW_DATA,
+            enableAdvancedFilter: true,
+        });
+        await AdvancedFilterHarness.get(advancedApi).applyExpression('[Age] = 2');
+        await asyncSetTimeout(0);
+
+        expect(getDisplayedIds(advancedApi)).toEqual([1]);
+        expect([...sources]).toEqual(['advancedFilter']);
+    });
+
+    // The bigint pair is the other half of the same threading, and reads through a different fallback.
+    test("a bigint column's parser and formatter are told which filter is asking", async () => {
+        const sources = new Set<string>();
+        const filterParams = {
+            bigintParser: (text: string | null, params: FilterInputCallbackParams) => {
+                sources.add(params.source);
+                return text ? BigInt(text) : null;
+            },
+            bigintFormatter: (value: bigint | null, params: FilterInputCallbackParams) => {
+                sources.add(params.source);
+                return value == null ? null : String(value);
+            },
+        };
+        const columnDefs: GridOptions<TestRow>['columnDefs'] = [
+            { field: 'id' },
+            { field: 'qty', cellDataType: 'bigint', filter: 'agBigIntColumnFilter', filterParams },
+        ];
+
+        const columnApi = await gridsManager.createGridAndWait('columnFilterGrid', { columnDefs, rowData: ROW_DATA });
+        const filter = await ColumnFilterHarness.open(columnApi, 'qty');
+        await filter.setText('10');
+        expect([...sources]).toEqual(['columnFilter']);
+
+        sources.clear();
+        const advancedApi = await gridsManager.createGridAndWait('advancedFilterGrid', {
+            columnDefs,
+            rowData: ROW_DATA,
+            enableAdvancedFilter: true,
+        });
+        await AdvancedFilterHarness.get(advancedApi).applyExpression('[Qty] = 10');
+        await asyncSetTimeout(0);
+
+        expect(getDisplayedIds(advancedApi)).toEqual([0, 1, 2]);
+        expect([...sources]).toEqual(['advancedFilter']);
+    });
+
     // Boolean has no column-filter counterpart to compare against — its options are `true`/`false`, not
     // `blank` — so this is the Advanced Filter alone, pinning that it answers blank the way every other type does.
     test('a boolean column answers blank for an empty or whitespace-only value', async () => {
@@ -249,12 +711,12 @@ describe('Advanced Filter matches the column filter', () => {
         api.setAdvancedFilterModel({ filterType: 'boolean', colId: 'active', type: 'blank' });
         api.onFilterChanged();
         await asyncSetTimeout(0);
-        expect(getDisplayedIds(api as GridApi<TestRow>)).toEqual([2, 3, 4]);
+        expect(getDisplayedIds(api)).toEqual([2, 3, 4]);
 
         api.setAdvancedFilterModel({ filterType: 'boolean', colId: 'active', type: 'notBlank' });
         api.onFilterChanged();
         await asyncSetTimeout(0);
-        expect(getDisplayedIds(api as GridApi<TestRow>)).toEqual([0, 1]);
+        expect(getDisplayedIds(api)).toEqual([0, 1]);
     });
 
     // Both sides refuse a date they cannot read, by different routes: the column filter through the grid's own
@@ -735,6 +1197,39 @@ describe('Advanced Filter matches the column filter', () => {
             }
         );
 
+        // A Set Filter has no `isValidDate` of its own, so unlike `comparator` there is nothing for it to mean
+        // instead, and it still gates the date comparisons the Advanced Filter offers such a column.
+        test.each(['agSetColumnFilter' as const, true as const])(
+            'a Set Filter column still gates on `isValidDate` (`filter: %s`)',
+            async (filter) => {
+                const columnDefs = timedDefs(
+                    { isValidDate: (value: any) => value instanceof Date && value.getFullYear() >= 1900 },
+                    filter
+                );
+                const rowData = [
+                    { id: 0, when: new Date(1899, 0, 1) },
+                    { id: 1, when: new Date(2012, 7, 5) },
+                ];
+
+                // The 1899 row is the only one below the bound, so an ungated comparison returns it.
+                expect(
+                    await timedAdvancedFilter(
+                        { filterType: 'date', colId: 'when', type: 'lessThan', filter: '2000-01-01' },
+                        columnDefs,
+                        rowData
+                    )
+                ).toEqual([]);
+                // Without a gate to apply, the same column still compares: the bound alone admits both rows.
+                expect(
+                    await timedAdvancedFilter(
+                        { filterType: 'date', colId: 'when', type: 'lessThan', filter: '2020-01-01' },
+                        timedDefs({}, filter),
+                        rowData
+                    )
+                ).toEqual([0, 1]);
+            }
+        );
+
         // `comparator` is the Date Filter's key; a custom component's `filterParams` are its own, and the
         // ordinary `(a, b)` sort shape is the inverse of `IDateComparatorFunc`, so reading it flips every option.
         test('a custom filter component column ignores its own `comparator`', async () => {
@@ -1058,5 +1553,116 @@ describe('Advanced Filter matches the column filter', () => {
             expect(seen.length).toBeGreaterThan(0);
             expect(seen.every((value) => typeof value === 'string')).toBe(true);
         });
+    });
+});
+
+/**
+ * `filter: true` names the Date Filter only where the Set Filter module is absent, so the reported repro's
+ * own shape — a column that names no filter and takes `true` from `defaultColDef` — needs a grid without it.
+ */
+describe('Advanced Filter on a date column defaulted to `filter: true`', () => {
+    const gridsManager = new TestGridsManager({
+        modules: [DateFilterModule, AdvancedFilterModule, ClientSideRowModelModule],
+    });
+
+    beforeAll(() => {
+        setupAgTestIds();
+        installFilterLayoutMock();
+    });
+    afterAll(() => uninstallFilterLayoutMock());
+    afterEach(() => gridsManager.reset());
+
+    interface TimedRow {
+        id: number;
+        when: Date | null;
+    }
+
+    const TIMED_ROWS: TimedRow[] = [
+        { id: 0, when: new Date(2008, 7, 24, 5, 33) },
+        { id: 1, when: new Date(2008, 7, 24) },
+        { id: 2, when: new Date(2012, 7, 5, 9, 30) },
+    ];
+
+    /** The ticket's own comparator: compare the day, ignore the time the cell carries. */
+    const midnightComparator = (filterDate: Date, cellValue: any) => {
+        const cellDate = new Date(cellValue);
+        cellDate.setHours(0, 0, 0, 0);
+        if (cellDate < filterDate) {
+            return -1;
+        }
+        return cellDate > filterDate ? 1 : 0;
+    };
+
+    /** The repro's custom `date` entry: it overrides the built-in the column would otherwise resolve to. */
+    const dataTypeDefinitions: GridOptions['dataTypeDefinitions'] = {
+        date: {
+            appendColumnTypes: true,
+            baseDataType: 'date',
+            extendsDataType: 'date',
+            valueParser: ({ newValue }) => {
+                const parts = newValue?.split('.') ?? [];
+                return parts.length === 3 ? new Date(+parts[2], +parts[1] - 1, +parts[0]) : null;
+            },
+            valueFormatter: ({ value }) =>
+                value == null ? '' : `${value.getDate()}.${value.getMonth() + 1}.${value.getFullYear()}`,
+        },
+    };
+
+    const columnDefs: GridOptions<TimedRow>['columnDefs'] = [
+        { field: 'id' },
+        { field: 'when', cellDataType: 'date', filterParams: { comparator: midnightComparator } },
+    ];
+
+    async function createGrid(gridOptions: GridOptions<TimedRow>): Promise<GridApi<TimedRow>> {
+        const api = gridsManager.createGrid('grid', {
+            defaultColDef: { filter: true },
+            columnDefs,
+            rowData: TIMED_ROWS,
+            ...gridOptions,
+        });
+        await asyncSetTimeout(0);
+        return api;
+    }
+
+    async function displayedIds(api: GridApi<TimedRow>): Promise<number[]> {
+        api.onFilterChanged();
+        await asyncSetTimeout(0);
+        return getDisplayedIds(api as GridApi<{ id: number }>);
+    }
+
+    // The reported case: rows 0 and 1 share a day and only row 1 sits at midnight, so a comparator that is
+    // never consulted matches row 1 alone. A custom `date` entry overrides the built-in the column resolves
+    // to, which is the shape the repro reaches `filterParams` through.
+    test.each([
+        ['a built-in data type', undefined],
+        ['a data type from `dataTypeDefinitions`', dataTypeDefinitions],
+    ])('`equals` matches every cell on the day with %s, in both', async (_name, definitions) => {
+        const columnApi = await createGrid({ dataTypeDefinitions: definitions });
+        await columnApi.setColumnFilterModel('when', { filterType: 'date', type: 'equals', dateFrom: '2008-08-24' });
+
+        expect(await displayedIds(columnApi)).toEqual([0, 1]);
+
+        gridsManager.reset();
+        const advancedApi = await createGrid({ dataTypeDefinitions: definitions, enableAdvancedFilter: true });
+        advancedApi.setAdvancedFilterModel({
+            filterType: 'date',
+            colId: 'when',
+            type: 'equals',
+            filter: '2008-08-24',
+        });
+
+        expect(await displayedIds(advancedApi)).toEqual([0, 1]);
+    });
+
+    // A written expression reaches the comparator through the column's own parser, which is the only path
+    // a custom `date` data type takes part in: the operand is read in the format that data type writes.
+    test.each([
+        ['a built-in data type', undefined, '2008-08-24'],
+        ['a data type from `dataTypeDefinitions`', dataTypeDefinitions, '24.08.2008'],
+    ])('an expression written against %s compares through the comparator', async (_name, definitions, operand) => {
+        const api = await createGrid({ dataTypeDefinitions: definitions, enableAdvancedFilter: true });
+        await AdvancedFilterHarness.get(api).applyExpression(`[When] = ${operand}`);
+
+        expect(await displayedIds(api)).toEqual([0, 1]);
     });
 });

--- a/testing/behavioural/src/filters/advanced-filter/advanced-filter-column-filter-parity.test.ts
+++ b/testing/behavioural/src/filters/advanced-filter/advanced-filter-column-filter-parity.test.ts
@@ -615,6 +615,30 @@ describe('Advanced Filter matches the column filter', () => {
 
             expect(await withExpression({}, '[Name] contains "cafe"', columnDefs)).toEqual([4]);
         });
+
+        // 'Café' and 'cafe' differ only in case, so the flag alone decides whether they are one match or two.
+        test('`caseSensitive` decides the comparison the same way in both', async () => {
+            expect(await withColumnModel({}, contains('Caf'))).toEqual([3, 4]);
+            expect(await withExpression({}, '[Name] contains "Caf"')).toEqual([3, 4]);
+
+            const params = { caseSensitive: true };
+            expect(await withColumnModel(params, contains('Caf'))).toEqual([3]);
+            expect(await withExpression(params, '[Name] contains "Caf"')).toEqual([3]);
+        });
+
+        // Unlike `textFormatter`, a Set Filter's `caseSensitive` folds the keys it matches rows by, so the
+        // Advanced Filter reading it on such a column is what keeps the two in step.
+        test('a Set Filter column reads `caseSensitive`, which its own matching folds by', async () => {
+            const setDefs = (filterParams: object): GridOptions['columnDefs'] => [
+                { field: 'id' },
+                { field: 'name', filter: 'agSetColumnFilter', filterParams },
+            ];
+
+            expect(await withExpression({}, '[Name] contains "Caf"', setDefs({}))).toEqual([3, 4]);
+
+            const params = { caseSensitive: true };
+            expect(await withExpression(params, '[Name] contains "Caf"', setDefs(params))).toEqual([3]);
+        });
     });
 
     // The same `source` the `textMatcher` gets, on the callbacks that read a value rather than a row. Both

--- a/testing/behavioural/src/filters/advanced-filter/advanced-filter-column-filter-parity.test.ts
+++ b/testing/behavioural/src/filters/advanced-filter/advanced-filter-column-filter-parity.test.ts
@@ -616,6 +616,26 @@ describe('Advanced Filter matches the column filter', () => {
             expect(await withExpression({}, '[Name] contains "cafe"', columnDefs)).toEqual([4]);
         });
 
+        // A component named through `components` owns its `filterParams` exactly as one supplied directly does.
+        test('a custom filter component registered by name keeps its own `filterParams`', async () => {
+            const api = await gridsManager.createGridAndWait('advancedFilterGrid', {
+                columnDefs: [
+                    { field: 'id' },
+                    { field: 'name', filter: 'myFilter', filterParams: { textFormatter: () => 'carpet' } },
+                ],
+                components: { myFilter: MinimalFilter },
+                rowData: TEXT_ROWS,
+                enableAdvancedFilter: true,
+            });
+            await AdvancedFilterHarness.get(api).applyExpression('[Name] contains "carpet"');
+            await asyncSetTimeout(0);
+            const ids = getDisplayedIds(api);
+            api.destroy();
+
+            // Read as a Text Filter's, the formatter would make every row read 'carpet' and so match them all.
+            expect(ids).toEqual([1]);
+        });
+
         // 'Café' and 'cafe' differ only in case, so the flag alone decides whether they are one match or two.
         test('`caseSensitive` decides the comparison the same way in both', async () => {
             expect(await withColumnModel({}, contains('Caf'))).toEqual([3, 4]);

--- a/testing/behavioural/src/filters/filter-behaviour/set-filter-values.test.ts
+++ b/testing/behavioural/src/filters/filter-behaviour/set-filter-values.test.ts
@@ -10,6 +10,7 @@ import {
 } from 'ag-test-utils';
 
 import type {
+    FilterInputCallbackParams,
     GridApi,
     GridOptions,
     ISetFilterCellRendererParams,
@@ -115,6 +116,35 @@ describe('Set Filter — value model & UI (coverage)', () => {
             ├── LEAF id:1 country:"Austria"
             └── LEAF id:2 country:"Italy"
         `);
+    });
+
+    // One `textFormatter` on `defaultColDef.filterParams` reaches Text and Set columns alike, so calling it
+    // with no params here would hand a shared function `undefined` on exactly the Set ones.
+    test('the mini-filter `textFormatter` is given the column params, not called bare', async () => {
+        const sources: (string | undefined)[] = [];
+        const api: GridApi = await gridsManager.createGridAndWait('grid1', {
+            columnDefs: [
+                {
+                    field: 'country',
+                    filter: 'agSetColumnFilter',
+                    filterParams: {
+                        textFormatter: (from: string, params: FilterInputCallbackParams) => {
+                            sources.push(params?.source);
+                            return from;
+                        },
+                    } as ISetFilterParams,
+                },
+            ],
+            rowData: [{ country: 'Australia' }, { country: 'Austria' }, { country: 'Italy' }],
+        });
+
+        const filter = await ColumnFilterHarness.open(api, 'country');
+        await filter.miniFilterSearch('aus');
+        await asyncSetTimeout(0);
+
+        expect(filter.setFilterItemLabels()).toEqual(['(Select All)', 'Australia', 'Austria']);
+        expect(sources.length).toBeGreaterThan(0);
+        expect([...new Set(sources)]).toEqual(['columnFilter']);
     });
 
     test('caseSensitive mini-filter only matches the exact case', async () => {


### PR DESCRIPTION
<!-- base: latest -->

# AG-18277: Honour the column's text filter params in the Advanced Filter

FIX AG-13360
FIX AG-18277

The Advanced Filter compared text and dates with its own logic, ignoring the `filterParams` the column filter
compares by. The same condition on the same data therefore matched different rows depending on which of the two
the user wrote it in.

| scope  | net lines |   lines changed | hunks | files changed |
| ------ | --------: | --------------: | ----: | ------------: |
| source |      +152 | 424 (+288 -136) |    99 |     25 edited |
| tests  |      +680 |   688 (+684 -4) |     9 |      2 edited |
| docs   |       +16 |     26 (+21 -5) |     8 |      6 edited |

## Additional fixes to complete ([AG-13360](https://ag-grid.atlassian.net/browse/AG-13360))

`getDateFilterParams` discarded `isValidDate` along with `comparator` on a Set Filter
column, though only `comparator` has a Set Filter meaning there (it sorts the filter list). An author-written
`isValidDate` now gates the Advanced Filter's date operators on such a column. Nothing else on the column reads
that param, so this is a judgement call rather than parity — flagging it for review.

**Tests added:** four cases for a date column taking `filter: true` from `defaultColDef` with the Set Filter
module absent — the path `filter: true` actually names the Date Filter on, which had no coverage at all, every
existing case naming `agDateColumnFilter` outright — plus two for the `isValidDate` gate.

## The three text params ([AG-18277](https://ag-grid.atlassian.net/browse/AG-18277))

**Changed:** the Advanced Filter now reads `textMatcher`, `textFormatter` and `trimInput` from the column instead
of comparing its own way. It resolves them from the filter that actually compares — a Multi Filter's Text Filter
child, not the parent; not a custom component's `filterParams`; and not a Set Filter's `textFormatter`, which
formats the filter list rather than deciding rows. `getMultiFilterChild` now folds a child written `filter: true`
to the Text Filter, so such a child's `caseSensitive` and blank-handling params reach the Advanced Filter too.

**Fixed:** the Text Filter's default comparison threw when a `textFormatter` returned `null`, which its own
declared `string | null` return type allows. It now excludes the row, as the Advanced Filter already did.

**Behaviour change:** a text column setting any of the three now returns different rows in the Advanced Filter.
That is the fix.

**Refactor:** the six default text comparisons were written twice, once per filter. They are now one shared table
the Text Filter looks up by its model's key and the Advanced Filter indexes once per operator, typed so an option
neither can compare fails to compile.

**Tests added:** a parity suite that drives both filters over the same rows and compares them — every built-in
option, the three params, `caseSensitive`, custom filter options, the number and bigint callbacks, and the date
`comparator`/`isValidDate` set.

## `source` tells a callback which filter is asking

**Changed:** `FilterInputCallbackParams` gains a required `source` of `'columnFilter' | 'advancedFilter'`, so one
callback set on `defaultColDef.filterParams` can behave differently for each filter. It reaches `textFormatter`,
`TextMatcherParams`, a Custom Filter Option's `predicate`, and the number and bigint parsers and formatters.

`predicate` gains a third argument and `textFormatter` a second, both of which an existing shorter function still
satisfies. `TextMatcherParams.source` is required, so hand-constructing that object stops compiling; the grid
builds it in every documented use.

**Fixed:** the Set Filter's own `textFormatter` — a separate param, which formats the Mini Filter's search rather
than deciding rows — was called with one argument. A formatter set on `defaultColDef.filterParams` therefore
received `params` on Text columns and `undefined` on Set ones. It is now passed the same second argument.
