### PR TITLE
[AG-13042] Test(theming): cover the compact-direction row-height shrink in SSRM

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/theming-compactness/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/theming-compactness/index.mdoc
@@ -15,6 +15,11 @@ The following example changes compactness dynamically by updating the `--ag-spac
 
 By default, row height is determined by the content height plus padding. Content height is `max(iconSize, cellFontSize)`. Padding is a multiple of `spacing`. This means that your rows can change size if you change any of the icon size, font size, or spacing.
 
+Because content height is a `max()`, reducing `cellFontSize` on its own only shortens rows while the font size is
+larger than `iconSize`. Below that, the icon size sets the floor and the row height stops responding to the font
+size. To make rows more compact, reduce `spacing`, reduce `iconSize` alongside the font size, or set a fixed
+`rowHeight`.
+
 To customise the height of grid data rows:
 
 1. **Padding scale** - `rowVerticalPaddingScale` and `headerVerticalPaddingScale` are plain numbers without units. The padding is multiplied by this number, so `0.75` would mean 3/4 of the usual padding. Using these scale parameters preserves the behaviour that row size adjusts when font size changes, which is useful if font size is not known in advance.

--- a/testing/behavioural/src/theming/theme-row-height-virtualised.test.ts
+++ b/testing/behavioural/src/theming/theme-row-height-virtualised.test.ts
@@ -21,6 +21,13 @@ import { ServerSideRowModelModule, ViewportRowModelModule } from 'ag-grid-enterp
 const NEW_ROW_HEIGHT = 64;
 const SECOND_ROW_HEIGHT = 48;
 const ROOT_ONLY_ROW_HEIGHT = 100;
+/**
+ * Below the 42px Quartz default, unlike every other height here. A compact theme shrinks rows, and
+ * `onRowHeightStyleChanged`'s `lastDefaultRowHeight` guard plus `resetRowHeights` are the only
+ * things standing between that and a row height that never comes back down (AG-13042 QA).
+ * 26px is what `spacing: 3px` actually resolves to: `max(iconSize, cellFontSize) + spacing * 3.25`.
+ */
+const COMPACT_ROW_HEIGHT = 26;
 
 /**
  * Simulates a theme size parameter change: the environment now measures `height` for the row-height
@@ -103,6 +110,30 @@ describe('theme row height in virtualised row models', () => {
             await asyncSetTimeout(0);
 
             expectUniformRowLayout(api, NEW_ROW_HEIGHT);
+        });
+
+        test('row heights shrink below the default on a compact theme change', async () => {
+            const api = await createLoadedSsrmGrid();
+
+            const before = api.getDisplayedRowAtIndex(0)!.rowHeight!;
+            expect(before).toBeGreaterThan(COMPACT_ROW_HEIGHT);
+
+            applyThemeRowHeight(api.getDisplayedRowAtIndex(0), COMPACT_ROW_HEIGHT);
+            await asyncSetTimeout(0);
+
+            expectUniformRowLayout(api, COMPACT_ROW_HEIGHT);
+        });
+
+        test('a grow followed by a shrink both land, so the no-op guard is not a one-way latch', async () => {
+            const api = await createLoadedSsrmGrid();
+
+            applyThemeRowHeight(api.getDisplayedRowAtIndex(0), NEW_ROW_HEIGHT);
+            await asyncSetTimeout(0);
+            expectUniformRowLayout(api, NEW_ROW_HEIGHT);
+
+            applyThemeRowHeight(api.getDisplayedRowAtIndex(0), COMPACT_ROW_HEIGHT);
+            await asyncSetTimeout(0);
+            expectUniformRowLayout(api, COMPACT_ROW_HEIGHT);
         });
 
         test('a repeated theme change at the same height does not update the model', async () => {


### PR DESCRIPTION
The QA failure on AG-13042 ("row height changes for LARGE but not for COMPACT") is not an SSRM defect — verified, SSRM already shrinks correctly. Two gaps are closed here instead.

**Test coverage.** The existing 9 cases in `theme-row-height-virtualised.test.ts` all assert 64px or 48px — both *above* the 42px Quartz default, so the compact direction was untested. Adds an SSRM shrink to 26px (below the default) and a grow-then-shrink leg, confirming `onRowHeightStyleChanged`'s `lastDefaultRowHeight` guard is not a one-way latch. Both pass on unmodified source: regression guards, not a fix.

**Docs.** `theming-compactness` said rows "can change size if you change any of the icon size, font size, or spacing" without noting that `max(iconSize, cellFontSize)` floors a font-only shrink — which is what made the compact preset look broken.

The reporter's `compact` preset is inert on v36 for two reasons, both unchanged here: `--ag-grid-size` has no Theming API meaning, and `--ag-font-size: 10px` is swallowed by the 16px icon floor. The repro still needs rebuilding on `--ag-spacing` before QA re-runs it.