### PR TITLE
AG-8950 set-filter-fixes

### DIFF
--- a/packages/ag-grid-enterprise/src/advancedFilter/advancedFilterComp.ts
+++ b/packages/ag-grid-enterprise/src/advancedFilter/advancedFilterComp.ts
@@ -215,20 +215,16 @@ export class AdvancedFilterComp extends Component {
 
     private onValueChanged(value: string | null): void {
         value = _makeNull(value);
-        let parser = this.advancedFilter.createExpressionParser(value);
-        let updatedExpression = parser?.parseExpression() ?? null;
+        this.expressionParser = this.advancedFilter.createExpressionParser(value);
+        let updatedExpression = this.expressionParser?.parseExpression() ?? null;
         const caretPosition = this.eAutocomplete.getCaretPosition();
-        const stripped = parser?.stripRedundantSeparators(caretPosition) ?? null;
+        const stripped = this.stripRedundantSeparators(caretPosition);
         let position: number | undefined;
         if (stripped != null) {
             // Every span removed sits before the caret, so what it loses is what the caret moves back by.
             position = caretPosition - (updatedExpression!.length - stripped.length);
             updatedExpression = stripped;
-            // Parsed again: the positions the first parse recorded belong to the text it read, not this one.
-            parser = this.advancedFilter.createExpressionParser(stripped);
-            parser!.parseExpression();
         }
-        this.expressionParser = parser;
         if (updatedExpression != null && updatedExpression !== value) {
             value = updatedExpression;
             this.eAutocomplete.setValue({ value, position, silent: true, restoreFocus: true });
@@ -236,11 +232,37 @@ export class AdvancedFilterComp extends Component {
         this.advancedFilter.setExpressionDisplayValue(value);
     }
 
+    /**
+     * Removes the separators the parse found redundant, reporting the text left or null where none was.
+     * Parsed again, since the positions the first parse recorded belong to the text it read.
+     */
+    private stripRedundantSeparators(caretPosition: number): string | null {
+        const stripped = this.expressionParser?.stripRedundantSeparators(caretPosition) ?? null;
+        if (stripped != null) {
+            this.expressionParser = this.advancedFilter.createExpressionParser(stripped);
+            this.expressionParser!.parseExpression();
+        }
+        return stripped;
+    }
+
     private onValueConfirmed(isValid: boolean): void {
         if (!isValid || this.isApplyDisabled) {
             return;
         }
         this.eButtons?.updateValidity(false);
+        // Applying finishes every list the expression holds, so a separator naming no value in one is
+        // redundant wherever the caret sits: it never has to have left the list, or moved at all.
+        const stripped = this.stripRedundantSeparators(this.eAutocomplete.getValue()?.length ?? 0);
+        if (stripped != null) {
+            // The list is only updated if one is open, so tidying the text cannot open one.
+            this.eAutocomplete.setValue({
+                value: stripped,
+                position: stripped.length,
+                silent: true,
+                updateListOnlyIfOpen: true,
+            });
+            this.advancedFilter.setExpressionDisplayValue(stripped);
+        }
         this.advancedFilter.applyExpression();
         this.filterManager?.onFilterChanged({ source: 'advancedFilter' });
     }

--- a/packages/ag-grid-enterprise/src/advancedFilter/advancedFilterComp.ts
+++ b/packages/ag-grid-enterprise/src/advancedFilter/advancedFilterComp.ts
@@ -215,12 +215,25 @@ export class AdvancedFilterComp extends Component {
 
     private onValueChanged(value: string | null): void {
         value = _makeNull(value);
-        this.advancedFilter.setExpressionDisplayValue(value);
-        this.expressionParser = this.advancedFilter.createExpressionParser(value);
-        const updatedExpression = this.expressionParser?.parseExpression();
-        if (updatedExpression && updatedExpression !== value) {
-            this.eAutocomplete.setValue({ value: updatedExpression, silent: true, restoreFocus: true });
+        let parser = this.advancedFilter.createExpressionParser(value);
+        let updatedExpression = parser?.parseExpression() ?? null;
+        const caretPosition = this.eAutocomplete.getCaretPosition();
+        const stripped = parser?.stripRedundantSeparators(caretPosition) ?? null;
+        let position: number | undefined;
+        if (stripped != null) {
+            // Every span removed sits before the caret, so what it loses is what the caret moves back by.
+            position = caretPosition - (updatedExpression!.length - stripped.length);
+            updatedExpression = stripped;
+            // Parsed again: the positions the first parse recorded belong to the text it read, not this one.
+            parser = this.advancedFilter.createExpressionParser(stripped);
+            parser!.parseExpression();
         }
+        this.expressionParser = parser;
+        if (updatedExpression != null && updatedExpression !== value) {
+            value = updatedExpression;
+            this.eAutocomplete.setValue({ value, position, silent: true, restoreFocus: true });
+        }
+        this.advancedFilter.setExpressionDisplayValue(value);
     }
 
     private onValueConfirmed(isValid: boolean): void {

--- a/packages/ag-grid-enterprise/src/advancedFilter/autocomplete/agAutocomplete.ts
+++ b/packages/ag-grid-enterprise/src/advancedFilter/autocomplete/agAutocomplete.ts
@@ -229,6 +229,8 @@ export class AgAutocomplete extends Component<AgAutocompleteEvent> {
         }
         const eInput = this.eAutocompleteInput.getInputElement();
         eInput.setSelectionRange(position, position);
+        // Read back rather than taken as given: the caret has moved, and the input clamps where to.
+        this.updateLastPosition();
         if (position === eInput.value.length) {
             // ensure the caret is visible
             eInput.scrollLeft = eInput.scrollWidth;
@@ -310,6 +312,11 @@ export class AgAutocomplete extends Component<AgAutocompleteEvent> {
 
     public getValue(): string | null {
         return _makeNull(this.eAutocompleteInput.getValue());
+    }
+
+    /** Where the caret was when the value last changed, which is what says where the author is working. */
+    public getCaretPosition(): number {
+        return this.lastPosition;
     }
 
     public setInputPlaceholder(placeholder: string): this {

--- a/packages/ag-grid-enterprise/src/advancedFilter/colFilterExpressionParser.ts
+++ b/packages/ag-grid-enterprise/src/advancedFilter/colFilterExpressionParser.ts
@@ -802,10 +802,16 @@ export class ColFilterExpressionParser {
             startPosition = findStartPosition(expression, columnParser!.endPosition! + 1, endPosition);
         }
         let openBracket: string | undefined;
-        if (isList) {
-            openBracket = SET_LIST_OPEN_CHAR;
-        } else if (operands === 'range') {
-            openBracket = '(';
+        let appendQuote = false;
+        // An operand already written after the option is left as it stands: opening a second list or
+        // quote there would leave the text holding both.
+        if (hasOperand && !opensOperand(expression, endPosition + (empty ? 0 : 1))) {
+            if (isList) {
+                openBracket = SET_LIST_OPEN_CHAR;
+            } else if (operands === 'range') {
+                openBracket = '(';
+            }
+            appendQuote = isList || this.doesOperandNeedQuotes(baseCellDataType);
         }
         const update = updateExpression(
             expression,
@@ -813,7 +819,7 @@ export class ColFilterExpressionParser {
             endPosition,
             updateEntry.displayValue ?? updateEntry.key,
             hasOperand,
-            hasOperand && (isList || this.doesOperandNeedQuotes(baseCellDataType)),
+            appendQuote,
             empty,
             openBracket
         );
@@ -1010,4 +1016,10 @@ export class ColFilterExpressionParser {
 
 function addToListAndGetIndex<T>(list: T[], value: T): number {
     return list.push(value) - 1;
+}
+
+/** Whether the text from `position` already opens an operand region: a list, a range, or a quoted value. */
+function opensOperand(expression: string, position: number): boolean {
+    const char = expression[findStartPosition(expression, position, expression.length)];
+    return char === SET_LIST_OPEN_CHAR || char === '(' || char === '"' || char === `'`;
 }

--- a/packages/ag-grid-enterprise/src/advancedFilter/filterExpressionParser.ts
+++ b/packages/ag-grid-enterprise/src/advancedFilter/filterExpressionParser.ts
@@ -54,6 +54,29 @@ export class FilterExpressionParser {
         };
     }
 
+    /**
+     * The expression without the separators the parse found redundant, or null where it keeps them all.
+     * Only a list the caret has left is tidied: before its end bracket another value may still follow.
+     */
+    public stripRedundantSeparators(caretPosition: number): string | null {
+        const separators = this.params.redundantSeparators;
+        if (!separators) {
+            return null;
+        }
+        let expression = this.params.expression;
+        let stripped = false;
+        // Backwards, so removing one span cannot move the next one still to be removed.
+        for (let i = separators.length - 1; i >= 0; --i) {
+            const { startPosition, endPosition } = separators[i];
+            // The end bracket is the character after the span, so a caret past it has left the list.
+            if (caretPosition > endPosition + 1) {
+                expression = expression.slice(0, startPosition) + expression.slice(endPosition + 1);
+                stripped = true;
+            }
+        }
+        return stripped ? expression : null;
+    }
+
     public getAutocompleteListParams(position: number): AutocompleteListParams {
         return this.joinExpressionParser.getAutocompleteListParams(position) ?? { enabled: false };
     }

--- a/packages/ag-grid-enterprise/src/advancedFilter/filterExpressionUtils.ts
+++ b/packages/ag-grid-enterprise/src/advancedFilter/filterExpressionUtils.ts
@@ -156,6 +156,11 @@ export interface FilterExpressionParserParams {
     valueSvc: ValueService;
     advFilterExpSvc: AdvancedFilterExpressionService;
     advFilterSetSvc: AdvancedFilterSetService;
+    /**
+     * Where a written list ends with a separator that names no value. Collected as the list is read and
+     * removed once it is, since deleting characters mid-parse would shift every position read after them.
+     */
+    redundantSeparators?: { startPosition: number; endPosition: number }[];
 }
 
 export interface AutocompleteUpdate {

--- a/packages/ag-grid-enterprise/src/advancedFilter/set/setOperandsParser.ts
+++ b/packages/ag-grid-enterprise/src/advancedFilter/set/setOperandsParser.ts
@@ -60,6 +60,8 @@ export class SetOperandsParser {
     private pendingQuoteClose = false;
     /** Set once a value is read and the next character must be a separator or the end bracket. */
     private expectSeparator = false;
+    /** Where a separator with no value yet after it was read, so closing the list makes it redundant. */
+    private separatorPosition = -1;
     private readonly validation: RegionValidation;
 
     constructor(
@@ -250,6 +252,11 @@ export class SetOperandsParser {
             this.finishValue(position - 1, true);
             if (!this.values.length) {
                 this.validation.reject('advancedFilterValidationMissingValue', position);
+            } else if (this.separatorPosition >= 0) {
+                (this.params.redundantSeparators ??= []).push({
+                    startPosition: this.separatorPosition,
+                    endPosition: position - 1,
+                });
             }
             return false;
         }
@@ -268,6 +275,7 @@ export class SetOperandsParser {
                 return this.validation.reject('advancedFilterValidationMissingValue', position);
             }
             this.finishValue(position - 1, true);
+            this.separatorPosition = position;
             return undefined;
         }
 
@@ -292,6 +300,7 @@ export class SetOperandsParser {
     }
 
     private startSegment(char: string, position: number): void {
+        this.separatorPosition = -1;
         if (!this.value) {
             this.value = {
                 segments: [],

--- a/testing/behavioural/src/filters/advanced-filter/advanced-filter-autocomplete.test.ts
+++ b/testing/behavioural/src/filters/advanced-filter/advanced-filter-autocomplete.test.ts
@@ -474,6 +474,40 @@ describe('Advanced Filter - Autocomplete Interaction', () => {
                 `
             );
         });
+
+        test('retargeting the operator leaves the operand already written alone', async () => {
+            const api = gridsManager.createGrid('grid1', DEFAULT_OPTIONS);
+            await asyncSetTimeout(0);
+            const input = getInput(getGridElement(api)! as HTMLElement);
+
+            const partial = '[Athlete] eq "Bolt"';
+            typeInto(input, partial, partial.indexOf(' "Bolt"'));
+            await asyncSetTimeout(0);
+            selectAutocomplete(input);
+            await asyncSetTimeout(0);
+
+            expect(input.value).toBe('[Athlete] equals "Bolt"');
+            applyFilter(input);
+            await asyncSetTimeout(0);
+            expect(getDisplayedAthletes(api)).toEqual([]);
+        });
+
+        test('a range operator does not reopen a bracket the expression already has', async () => {
+            const api = gridsManager.createGrid('grid1', DEFAULT_OPTIONS);
+            await asyncSetTimeout(0);
+            const input = getInput(getGridElement(api)! as HTMLElement);
+
+            const partial = '[Age] betw (20, 26)';
+            typeInto(input, partial, partial.indexOf(' (20'));
+            await asyncSetTimeout(0);
+            selectAutocomplete(input);
+            await asyncSetTimeout(0);
+
+            expect(input.value).toBe('[Age] is between (20, 26)');
+            applyFilter(input);
+            await asyncSetTimeout(0);
+            expect(getDisplayedAthletes(api)).toEqual(['Michael Phelps', 'Usain Bolt']);
+        });
     });
 
     describe('Full autocomplete flow → filter applied', () => {

--- a/testing/behavioural/src/filters/advanced-filter/advanced-filter-set-autocomplete.test.ts
+++ b/testing/behavioural/src/filters/advanced-filter/advanced-filter-set-autocomplete.test.ts
@@ -393,5 +393,10 @@ describe('Advanced Filter - Set Filter value list', () => {
         // Readied for the next value, as selecting anywhere else in the list is.
         await af.selectAutocomplete();
         expect(af.value).toBe('[Country] is any of ["Jamaica", "(Blanks)", ]');
+
+        // Applying finishes the list, so the separator the caret was still sitting behind goes too.
+        await af.apply();
+        expect(af.value).toBe('[Country] is any of ["Jamaica", "(Blanks)"]');
+        expect(af.getModel().values).toEqual(['Jamaica', null]);
     });
 });

--- a/testing/behavioural/src/filters/advanced-filter/advanced-filter-set-autocomplete.test.ts
+++ b/testing/behavioural/src/filters/advanced-filter/advanced-filter-set-autocomplete.test.ts
@@ -356,6 +356,32 @@ describe('Advanced Filter - Set Filter value list', () => {
         expect(af.autocompleteEntries()).toEqual(['(Blanks)', 'United Kingdom', 'United States']);
     });
 
+    test('closing the list drops the separator left behind by the value before it', async () => {
+        const api = await gridsManager.createGridAndWait('grid1', DEFAULT_OPTIONS);
+        const af = AdvancedFilterHarness.get(api);
+
+        await af.type('[Country] is any of ["Jamaica", ');
+        await af.append(']');
+        expect(af.value).toBe('[Country] is any of ["Jamaica"]');
+
+        // The same list arriving whole, as a paste of it does.
+        await af.applyExpression('[Country] is any of ["Jamaica", "Poland", ]');
+        expect(af.value).toBe('[Country] is any of ["Jamaica", "Poland"]');
+        expect(af.input.validationMessage).toBe('');
+        expect(af.getModel().values).toEqual(['Jamaica', 'Poland']);
+    });
+
+    test('retargeting the option leaves the list already written alone', async () => {
+        const api = await gridsManager.createGridAndWait('grid1', DEFAULT_OPTIONS);
+        const af = AdvancedFilterHarness.get(api);
+
+        const partial = '[Country] is none ["Jamaica"]';
+        await af.type(partial, partial.indexOf(' ["'));
+        await af.selectAutocomplete();
+
+        expect(af.value).toBe('[Country] is none of ["Jamaica"]');
+    });
+
     test('a caret before the end bracket of a closed list can still start another value', async () => {
         const api = await gridsManager.createGridAndWait('grid1', DEFAULT_OPTIONS);
         const af = AdvancedFilterHarness.get(api);


### PR DESCRIPTION
<!-- base: latest -->

# AG-8950: Advanced Filter Set Filter list and option editing fixes

FIX AG-8950

Two defects in the Advanced Filter's text editor, both found on a Set Filter value list but one of them
shared with every other option: a value list kept the separator left behind by the value before it, and
retargeting an option wrote a second operand region over the one already there.

| scope  | net lines | lines changed | hunks | files changed |
| ------ | --------: | ------------: | ----: | ------------: |
| source |       +69 |  89 (+79 -10) |    13 |      6 edited |
| tests  |       +60 |      60 added |     2 |      2 edited |

## A closed value list drops the separator that names no value ([AG-8950](https://ag-grid.atlassian.net/browse/AG-8950))

Choosing a value writes it followed by `, `, ready for the next one, so closing the list there left
`[Country] is any of ["Afghanistan", ]`, and that is the text the filter applied and displayed.

The separator is now removed once the list is closed and the caret has left it, which is both the moment it
becomes redundant and what tells a finished list from one still being added to: a caret before the end
bracket keeps offering values, so the separator it sits behind stays.

`SetOperandsParser` records the span rather than cutting it as it reads, since deleting characters mid-parse
would shift every position read after them; `AdvancedFilterComp` cuts the recorded spans and parses the
shorter text again, and moves the caret back by what it lost. The expression the filter applies is now the
corrected text in every case, the option and column names a parse already rewrites included.

## Retargeting an option leaves the operand already written alone ([AG-8950](https://ag-grid.atlassian.net/browse/AG-8950))

Choosing an option from the autocomplete opens the operand region it takes, writing ` ["` for a value list,
` (` for a range and ` "` for a single value. Choosing one over a condition that already had its operand
wrote that opening a second time, so retargeting `is any of` to `is none of` gave
`[Country] is none of ["["Afghanistan"]`, `contains "Bolt"` to `equals` gave `[Athlete] equals ""Bolt"`, and
a range gave `[Age] is between ((20, 26)`. Only the first was reported; all three are the same line.

An option now opens its operand region only where the text after it does not already open one.
