### PR TITLE
SE-115 Reduce grid-options and grid-api page size

### DIFF
--- a/documentation/ag-grid-docs/src/components/reference-documentation/components/ApiDocumentation.astro
+++ b/documentation/ag-grid-docs/src/components/reference-documentation/components/ApiDocumentation.astro
@@ -4,7 +4,9 @@ import { getPropertiesFromSource } from '../utils/getPropertiesFromSource';
 import { getApiDocumentationModel } from '../utils/getApiDocumentationModel';
 import { flattenModules } from '../utils/flattenModules';
 import { ApiDocumentation } from './ApiDocumentation';
+import { getReferenceDetailsPath } from '../utils/referenceDetails';
 import { getJsonFile } from '@utils/pages';
+import { getExtraFileUrl } from '@utils/extraFileUrl';
 import { getEntry, type CollectionEntry } from 'astro:content';
 
 const { names, config, source, sources: sourcesProp, section } = Astro.props;
@@ -20,12 +22,19 @@ const { sources, propertiesFromFiles, propertyConfigs, codeConfigs } = await get
     sources: sourcesProp,
 });
 
+// The fetched file is keyed by source and framework only. `isApi` changes the signatures the same
+// source produces, so those few pages keep theirs inline rather than earning a second variant.
+const detailsUrl =
+    source && !config?.isApi
+        ? getExtraFileUrl({ filePath: getReferenceDetailsPath({ framework, source }) })
+        : undefined;
+
 const model = getApiDocumentationModel({
     framework,
     sources,
     section,
     names,
-    config,
+    config: { ...config, detailsUrl },
     propertiesFromFiles,
     propertyConfigs,
     interfaceLookup,

--- a/documentation/ag-grid-docs/src/components/reference-documentation/components/Property.tsx
+++ b/documentation/ag-grid-docs/src/components/reference-documentation/components/Property.tsx
@@ -225,7 +225,11 @@ export const Property: FunctionComponent<{
 
                     {hasDetails && isExpanded && (
                         <div id={getDetailsId(idName)} className={styles.expandedContent}>
-                            {expandedCode && <Code code={expandedCode} keepMarkup={true} />}
+                            {expandedCode ? (
+                                <Code code={expandedCode} keepMarkup={true} />
+                            ) : (
+                                <p className="text-secondary">Loading type details&hellip;</p>
+                            )}
                         </div>
                     )}
                 </div>

--- a/documentation/ag-grid-docs/src/components/reference-documentation/components/Property.tsx
+++ b/documentation/ag-grid-docs/src/components/reference-documentation/components/Property.tsx
@@ -1,192 +1,16 @@
 import type { Framework } from '@ag-grid-types';
 import Code from '@ag-website-shared/components/code/Code';
-import { Icon } from '@ag-website-shared/components/icon/Icon';
 import { LinkIcon } from '@ag-website-shared/components/link-icon/LinkIcon';
 import styles from '@ag-website-shared/components/reference-documentation/ApiReference.module.scss';
 import { urlWithPrefix } from '@utils/urlWithPrefix';
 import classnames from 'classnames';
 import { Fragment, type FunctionComponent, useCallback, useEffect, useRef, useState } from 'react';
 
-import { AG_MODULE_TAG_NAME } from '../constants';
-import type { ChildDocEntry, Config, ICallSignature, InterfaceEntry } from '../types';
-import {
-    convertMarkdown,
-    extractJSDocTags,
-    formatJsDocString,
-    getTypeUrl,
-    inferType,
-    removeDefaultValue,
-} from '../utils/documentation-helpers';
-import { formatJson, getInterfaceName } from '../utils/interface-helpers';
+import type { Config, PropertyViewModel } from '../types';
+import { useReferenceDetails } from '../utils/useReferenceDetails';
 import legacyStyles from './LegacyApiReference.module.scss';
 import { PropertyModules } from './PropertyModules';
-
-function getDisplayNameSplit({ name, definition }: { name: string; definition: ChildDocEntry }) {
-    let displayName = name;
-    if (definition.isRequired) {
-        displayName += `&nbsp;<span class="${styles.required}">required</span>`;
-    }
-
-    if (definition.strikeThrough) {
-        displayName = `<span style='text-decoration: line-through'>${displayName}</span>`;
-    }
-
-    // Split display name on capital letter, add <wbr> to improve text splitting across lines
-    let displayNameSplit: string;
-
-    const { isRequired, strikeThrough } = definition;
-    // displayName is hardCoded for isRequired and strikeThrough
-    if (isRequired || strikeThrough) {
-        displayNameSplit = displayName;
-    } else {
-        displayNameSplit = displayName
-            .split(/(?=[A-Z])/)
-            .reverse()
-            .reduce((acc, cv) => {
-                return `${cv}<wbr />` + acc;
-            });
-    }
-
-    return displayNameSplit;
-}
-
-function getDescription({
-    definition,
-    gridOpProp,
-    framework,
-}: {
-    definition: ChildDocEntry;
-    gridOpProp: InterfaceEntry;
-    framework: Framework;
-}) {
-    let description: string | undefined = '';
-    let isObject: boolean = false;
-    let propDescription: string | undefined =
-        definition.description || (gridOpProp && (gridOpProp.meta as ICallSignature['meta'])?.comment) || undefined;
-
-    if (propDescription) {
-        propDescription = formatJsDocString(propDescription);
-        if (!definition.description && gridOpProp && (gridOpProp.meta as ICallSignature['meta'])?.all) {
-            const { params, returns } = extractJSDocTags(
-                definition.description || (gridOpProp && (gridOpProp.meta as ICallSignature['meta'])?.all)
-            );
-            const paramsStr = params?.map((p) => `<span class="param">\`${p.name}\`: ${p.value}</span>`).join('');
-            const returnsStr = returns ? `<strong>Returns:</strong> ${returns}` : '';
-
-            propDescription = [propDescription, paramsStr, returnsStr].filter(Boolean).join('\n');
-        }
-
-        // process property object
-        description = convertMarkdown(propDescription, framework);
-    } else {
-        // this must be the parent of a child object
-        if (definition.meta != null && definition.meta.description != null) {
-            description = convertMarkdown(definition.meta.description, framework);
-        }
-
-        isObject = true;
-    }
-
-    return {
-        isObject,
-        description,
-    };
-}
-
-// Use the type definition if manually specified in config
-function getDefinitionTypeUrl({
-    id,
-    name,
-    framework,
-    definition,
-    propertyType,
-    gridOpProp,
-    isObject,
-    config,
-}: {
-    id: string;
-    name: string;
-    framework: Framework;
-    definition: ChildDocEntry;
-    propertyType: string;
-    gridOpProp: InterfaceEntry;
-    isObject: boolean;
-    config: Config;
-}) {
-    let type: any = definition.type;
-    if (!type) {
-        // No type specified in the doc config file so check the GridOptions property
-        if (gridOpProp && gridOpProp.type) {
-            type = gridOpProp.type;
-
-            const isDeprecated = gridOpProp.meta?.tags?.some((t) => t.name === 'deprecated');
-            if (isDeprecated) {
-                // eslint-disable-next-line no-console
-                console.warn(
-                    `<api-documentation>: Docs include a property: ${name} that has been marked as deprecated.`
-                );
-                // eslint-disable-next-line no-console
-                console.warn('<api-documentation>: ' + gridOpProp.meta?.all);
-            }
-        } else {
-            if (type == null && config.codeSrcProvided?.length > 0) {
-                throw new Error(
-                    `We could not find a type for "${name}" from the code sources ${config.codeSrcProvided.join()}. Has this property been removed from the source code / or is there a typo?`
-                );
-            }
-
-            // If a codeSrc is not provided as a last resort try and infer the type
-            type = inferType(definition.default);
-        }
-    }
-
-    const typeUrl = isObject
-        ? `#reference-${id}.${name}`
-        : propertyType !== 'Function'
-          ? getTypeUrl(type, framework)
-          : null;
-
-    return typeUrl;
-}
-
-function getTagsData({
-    definition,
-    gridOpProp,
-    config,
-}: {
-    definition: ChildDocEntry;
-    gridOpProp: InterfaceEntry;
-    config: Config;
-}) {
-    // Default may or may not be on a new line in JsDoc but in both cases we want the default to be on the next line
-    const tags = gridOpProp?.meta?.tags ?? definition?.tags ?? [];
-    const jsdocDefault = tags.find((t) => t.name === 'default');
-    const defaultValue = definition?.default ?? jsdocDefault?.comment;
-    const formattedDefaultValue = Array.isArray(defaultValue)
-        ? '[' +
-          defaultValue.map((v, i) => {
-              return i === 0 ? `"${v}"` : ` "${v}"`;
-          }) +
-          ']'
-        : defaultValue;
-    const isInitial = tags.some((t) => t.name === 'initial') ?? false;
-    let modules = tags.find((t) => t.name === AG_MODULE_TAG_NAME)?.modules ?? [];
-
-    const restrictedModule: string | undefined = definition?.restrictModule ?? config.restrictModule;
-    if (modules.length > 1 && restrictedModule) {
-        // If the property contains the restricted module and others then only show the restricted module
-        const restrictedModuleTag = modules.find((mod) => restrictedModule == mod.name);
-        if (restrictedModuleTag) {
-            modules = [restrictedModuleTag];
-        }
-    }
-
-    return {
-        formattedDefaultValue,
-        isInitial,
-        modules,
-    };
-}
+import { ReferenceIcon } from './ReferenceIcon';
 
 function getDetailsId(id: string) {
     return `${id}-details`;
@@ -217,7 +41,7 @@ function CollapsibleButton({
             aria-controls={isExpanded ? detailsId : undefined}
             aria-label={`${isExpanded ? 'Hide' : 'See more'} details about ${name}`}
         >
-            <Icon className={`${styles.chevron} ${isExpanded ? 'expandedIcon' : ''}`} name="chevronDown" />
+            <ReferenceIcon name="chevronDown" />
         </button>
     );
 }
@@ -226,35 +50,37 @@ export const Property: FunctionComponent<{
     id: string;
     name: string;
     framework: Framework;
-    definition: ChildDocEntry;
-    gridOpProp: InterfaceEntry;
-    detailsCode: string;
-    propertyType: string;
+    property: PropertyViewModel;
     config: Config;
-}> = ({ id, name, framework, definition, gridOpProp, detailsCode, propertyType, config }) => {
+}> = ({ id, name, framework, property, config }) => {
     const idName = `reference-${id}-${name}`;
-    const displayNameSplit = getDisplayNameSplit({ name, definition });
-    const { isObject, description } = getDescription({ definition, gridOpProp, framework });
-    const typeUrl = getDefinitionTypeUrl({
-        id,
-        name,
-        framework,
-        definition,
-        propertyType,
-        gridOpProp,
+    const {
+        displayNameSplit,
+        description,
         isObject,
-        config,
-    });
-    const { formattedDefaultValue, isInitial, modules } = getTagsData({
-        definition,
-        gridOpProp,
-        config,
-    });
-
-    const { more } = definition;
+        propertyType,
+        interfaceName,
+        defaultValue,
+        isInitial,
+        modules,
+        more,
+        options,
+        detailsCode,
+        detailsKey,
+    } = property;
 
     const propertyRef = useRef<HTMLTableRowElement>(null);
     const [isExpanded, setExpanded] = useState(config.defaultExpand);
+
+    const hasDetails = Boolean(detailsCode ?? detailsKey);
+    const fetchedDetails = useReferenceDetails({
+        url: config.detailsUrl,
+        enabled: Boolean(isExpanded && detailsKey),
+    });
+    const expandedCode = detailsCode ?? (detailsKey ? fetchedDetails?.[detailsKey] : undefined);
+
+    // An object property links to its own section, whose id only the rendering table knows.
+    const typeUrl = isObject ? `#reference-${id}.${name}` : property.typeUrl;
 
     useEffect(() => {
         const hashId = location.hash.slice(1); // Remove the '#' symbol
@@ -292,7 +118,7 @@ export const Property: FunctionComponent<{
 
                         <div className={styles.metaItem}>
                             <div className={styles.metaRow}>
-                                {detailsCode && (
+                                {hasDetails && (
                                     <CollapsibleButton
                                         name={more?.name ?? name}
                                         isExpanded={isExpanded}
@@ -308,13 +134,13 @@ export const Property: FunctionComponent<{
                                         target={typeUrl.startsWith('http') ? '_blank' : '_self'}
                                         rel="noreferrer"
                                     >
-                                        {isObject ? getInterfaceName(name) : propertyType}
+                                        {isObject ? interfaceName : propertyType}
                                     </a>
                                 ) : (
                                     <span
                                         onClick={onCollapseClick}
                                         className={classnames(styles.metaValue, {
-                                            [styles.isClickable]: detailsCode,
+                                            [styles.isClickable]: hasDetails,
                                         })}
                                     >
                                         {propertyType}
@@ -322,11 +148,11 @@ export const Property: FunctionComponent<{
                                 )}
                             </div>
 
-                            {formattedDefaultValue != null && (
+                            {defaultValue != null && (
                                 <div className={styles.metaItem}>
                                     <span className={classnames(styles.metaValue, styles.defaultValue)}>
                                         <span className={styles.defaultLabel}>default: </span>
-                                        {formattedDefaultValue}
+                                        {defaultValue}
                                     </span>
                                 </div>
                             )}
@@ -353,7 +179,7 @@ export const Property: FunctionComponent<{
                             role="presentation"
                             className={styles.description}
                             data-api-property-description
-                            dangerouslySetInnerHTML={{ __html: removeDefaultValue(description) }}
+                            dangerouslySetInnerHTML={{ __html: description ?? '' }}
                         ></div>
 
                         <div className={styles.actions}>
@@ -367,13 +193,13 @@ export const Property: FunctionComponent<{
                                 </div>
                             )}
 
-                            {definition.options != null && (
+                            {options != null && (
                                 <div>
                                     Options:{' '}
-                                    {definition.options.map((o, i) => (
-                                        <Fragment key={o}>
+                                    {options.map((option, i) => (
+                                        <Fragment key={option}>
                                             {i > 0 ? ', ' : ''}
-                                            <code>{formatJson(o)}</code>
+                                            <code>{option}</code>
                                         </Fragment>
                                     ))}
                                 </div>
@@ -389,7 +215,7 @@ export const Property: FunctionComponent<{
                                     })}
                                 >
                                     {more.name}
-                                    <Icon name="newTab" />
+                                    <ReferenceIcon name="newTab" />
                                 </a>
                             )}
 
@@ -397,9 +223,9 @@ export const Property: FunctionComponent<{
                         </div>
                     </div>
 
-                    {detailsCode && isExpanded && (
+                    {hasDetails && isExpanded && (
                         <div id={getDetailsId(idName)} className={styles.expandedContent}>
-                            {detailsCode && <Code code={detailsCode} keepMarkup={true} />}
+                            {expandedCode && <Code code={expandedCode} keepMarkup={true} />}
                         </div>
                     )}
                 </div>

--- a/documentation/ag-grid-docs/src/components/reference-documentation/components/PropertyModules.tsx
+++ b/documentation/ag-grid-docs/src/components/reference-documentation/components/PropertyModules.tsx
@@ -1,10 +1,10 @@
 import type { Framework } from '@ag-grid-types';
-import { Icon } from '@ag-website-shared/components/icon/Icon';
 import { urlWithPrefix } from '@utils/urlWithPrefix';
 import classnames from 'classnames';
 import { type FunctionComponent, useCallback, useEffect, useId, useRef, useState } from 'react';
 
 import styles from './PropertyModules.module.scss';
+import { ReferenceIcon } from './ReferenceIcon';
 
 const Module: FunctionComponent<{
     module: object;
@@ -18,9 +18,9 @@ const Module: FunctionComponent<{
                 framework,
             })}
         >
-            <Icon name="module" />
+            <ReferenceIcon name="module" />
             <span>{module.name}</span>
-            {module.isEnterprise && <Icon name="enterprise" svgClasses={styles.enterpriseIcon} />}
+            {module.isEnterprise && <ReferenceIcon name="enterprise" svgClasses={styles.enterpriseIcon} />}
         </a>
     );
 };
@@ -92,7 +92,7 @@ export const PropertyModules: FunctionComponent<{
                                 toggleModuleTooltip();
                             }}
                         >
-                            +{labelCount} <Icon name="chevronDown" />
+                            +{labelCount} <ReferenceIcon name="chevronDown" />
                         </button>
 
                         <div

--- a/documentation/ag-grid-docs/src/components/reference-documentation/components/ReferenceIcon.tsx
+++ b/documentation/ag-grid-docs/src/components/reference-documentation/components/ReferenceIcon.tsx
@@ -1,0 +1,25 @@
+import iconStyles from '@ag-website-shared/components/icon/Icon.module.scss';
+import classnames from 'classnames';
+import type { FunctionComponent } from 'react';
+
+export const REFERENCE_ICON_SPRITE_ID_PREFIX = 'ag-reference-icon-';
+
+export const REFERENCE_ICON_NAMES = ['chevronDown', 'enterprise', 'module', 'newTab'] as const;
+
+export type ReferenceIconName = (typeof REFERENCE_ICON_NAMES)[number];
+
+/**
+ * A reference table repeats these icons once per property row, so they point at the page's
+ * <ReferenceIconSprite> rather than inlining the SVG at every call site. Emits the same
+ * element and classes as <Icon>, so the shared reference styles apply unchanged.
+ */
+export const ReferenceIcon: FunctionComponent<{ name: ReferenceIconName; svgClasses?: string }> = ({
+    name,
+    svgClasses,
+}) => {
+    return (
+        <svg aria-hidden="true" className={classnames(iconStyles.icon, 'icon', svgClasses)}>
+            <use href={`#${REFERENCE_ICON_SPRITE_ID_PREFIX}${name}`}></use>
+        </svg>
+    );
+};

--- a/documentation/ag-grid-docs/src/components/reference-documentation/components/ReferenceIconSprite.astro
+++ b/documentation/ag-grid-docs/src/components/reference-documentation/components/ReferenceIconSprite.astro
@@ -1,0 +1,34 @@
+---
+import chevronDown from '@ag-website-shared/images/inline-svgs/bold-chevron-down.svg?raw';
+import enterprise from '@ag-website-shared/images/inline-svgs/enterprise.svg?raw';
+import moduleIcon from '@ag-website-shared/images/inline-svgs/module.svg?raw';
+import newTab from '@ag-website-shared/images/inline-svgs/new-tab.svg?raw';
+
+import { REFERENCE_ICON_SPRITE_ID_PREFIX, REFERENCE_ICON_NAMES, type ReferenceIconName } from './ReferenceIcon';
+
+const SOURCES: Record<ReferenceIconName, string> = {
+    chevronDown,
+    enterprise,
+    module: moduleIcon,
+    newTab,
+};
+
+function toSymbol(name: ReferenceIconName) {
+    const svg = SOURCES[name];
+    const openTag = svg.match(/<svg\b[^>]*>/)?.[0] ?? '';
+    const contents = svg.replace(/^[\s\S]*?<svg\b[^>]*>/, '').replace(/<\/svg>\s*$/, '');
+    const viewBox = openTag.match(/viewBox="([^"]*)"/)?.[1];
+    // fill-rule and friends are declared on the source root and inherit into its paths,
+    // so they have to travel with the symbol.
+    const style = openTag.match(/style="([^"]*)"/)?.[1];
+
+    return `<symbol id="${REFERENCE_ICON_SPRITE_ID_PREFIX}${name}"${viewBox ? ` viewBox="${viewBox}"` : ''}${
+        style ? ` style="${style}"` : ''
+    }>${contents}</symbol>`;
+}
+
+const symbols = REFERENCE_ICON_NAMES.map(toSymbol).join('');
+---
+
+{/* Emit once per page: <ReferenceIcon> resolves against these ids. */}
+<svg aria-hidden="true" style="display: none" set:html={symbols} />

--- a/documentation/ag-grid-docs/src/components/reference-documentation/components/Section.tsx
+++ b/documentation/ag-grid-docs/src/components/reference-documentation/components/Section.tsx
@@ -7,7 +7,7 @@ import classnames from 'classnames';
 import type { FunctionComponent, ReactElement } from 'react';
 import React, { Fragment } from 'react';
 
-import type { Config, ObjectCode, Properties, SectionProps } from '../types';
+import type { Config, ObjectCode, PropertyViewModelMap, SectionProps } from '../types';
 import { convertMarkdown, escapeGenericCode, getLinkedType } from '../utils/documentation-helpers';
 import { formatJson, getInterfaceName } from '../utils/interface-helpers';
 import legacyStyles from './LegacyApiReference.module.scss';
@@ -64,7 +64,7 @@ const ObjectCodeSample: React.FC<ObjectCode> = ({ framework, id, breadcrumbs = {
         indentationLevel++;
     });
 
-    Object.entries(properties).forEach(([key, definition]) => {
+    Object.entries(properties).forEach(([key, { definition = {} }]) => {
         let line = getIndent(indentationLevel) + key;
 
         // process property object
@@ -126,7 +126,7 @@ const SectionHeader = ({
     headerLevel?: number;
     hideHeader?: boolean;
     showSnippets?: boolean;
-    properties: Properties;
+    properties: PropertyViewModelMap;
 }) => {
     const breadcrumbKeys = Object.keys(breadcrumbs);
     const id = breadcrumbKeys.join('.');
@@ -211,17 +211,14 @@ export const Section: FunctionComponent<SectionProps> = ({
                     <col></col>
                 </colgroup>
                 <tbody>
-                    {Object.entries(properties).map(([name, { definition, gridOpProp, detailsCode, propertyType }]) => {
+                    {Object.entries(properties).map(([name, property]) => {
                         return (
                             <Property
                                 key={name}
                                 id={id}
                                 name={name}
                                 framework={framework}
-                                definition={definition}
-                                gridOpProp={gridOpProp}
-                                detailsCode={detailsCode}
-                                propertyType={propertyType}
+                                property={property}
                                 config={config}
                             />
                         );

--- a/documentation/ag-grid-docs/src/components/reference-documentation/types.d.ts
+++ b/documentation/ag-grid-docs/src/components/reference-documentation/types.d.ts
@@ -206,9 +206,9 @@ export interface PropertyViewModel {
     /** Key into the reference-details file named by `Config.detailsUrl`. */
     detailsKey?: string;
     /** Sent with the page instead, where the detail cannot be keyed by source alone. */
-    detailsCode?: string[];
+    detailsCode?: string;
     /** Only populated for `Config.showSnippets`, which ObjectCodeSample needs the raw entry for. */
-    definition?: ChildDocEntry;
+    definition?: Properties;
 }
 
 export type PropertyViewModelMap = Record<string, PropertyViewModel>;

--- a/documentation/ag-grid-docs/src/components/reference-documentation/types.d.ts
+++ b/documentation/ag-grid-docs/src/components/reference-documentation/types.d.ts
@@ -63,7 +63,7 @@ export interface ObjectCode {
     framework: Framework;
     id: string;
     breadcrumbs?: Record<string, string>;
-    properties: Properties;
+    properties: PropertyViewModelMap;
 }
 interface CodeEntry {
     description?: string;
@@ -182,14 +182,43 @@ export interface Config {
 
     /** Only show this module if it is one of a number of options for the given property. */
     restrictModule?: string;
+
+    /** Where <Property> fetches expandable type detail from, when it is not inlined. */
+    detailsUrl?: string;
 }
+
+/**
+ * Everything a property row renders, resolved at build time so the island is not handed the
+ * generated TypeScript metadata it was derived from (SE-115).
+ */
+export interface PropertyViewModel {
+    displayNameSplit: string;
+    description?: string;
+    isObject: boolean;
+    typeUrl?: string;
+    propertyType: string;
+    interfaceName?: string;
+    defaultValue?: string;
+    isInitial: boolean;
+    modules: { name: string; isEnterprise?: boolean }[];
+    more?: { name: string; url: string };
+    options?: string[];
+    /** Key into the reference-details file named by `Config.detailsUrl`. */
+    detailsKey?: string;
+    /** Sent with the page instead, where the detail cannot be keyed by source alone. */
+    detailsCode?: string[];
+    /** Only populated for `Config.showSnippets`, which ObjectCodeSample needs the raw entry for. */
+    definition?: ChildDocEntry;
+}
+
+export type PropertyViewModelMap = Record<string, PropertyViewModel>;
 
 export type Properties = DocEntryMap | DocEntry | ChildDocEntry;
 export type SectionProps = {
     title: string;
     framework: Framework;
     names?: string[];
-    properties: Properties;
+    properties: PropertyViewModelMap;
     config: Config;
     breadcrumbs?: Record<string, string>;
     meta?: MetaTag;
@@ -211,7 +240,7 @@ export type FunctionCode = {
 
 export interface DocProperties {
     type: 'properties';
-    properties: Properties;
+    properties: Record<string, PropertyViewModelMap>;
     meta: MetaTag;
 }
 export interface DocCode {
@@ -224,7 +253,7 @@ export type InterfaceDocumentationModel = DocProperties | DocCode;
 export interface SingleApiModel {
     type: 'single';
     title: string;
-    properties: Properties;
+    properties: PropertyViewModelMap;
     config: Config;
     meta: MetaTag;
 }
@@ -234,7 +263,7 @@ export interface MultipleApiModel {
     entries: [
         string,
         {
-            properties: ChildDocEntry | DocEntry;
+            properties: PropertyViewModelMap;
             meta: MetaTag;
         },
     ][];

--- a/documentation/ag-grid-docs/src/components/reference-documentation/utils/getApiDocumentationModel.ts
+++ b/documentation/ag-grid-docs/src/components/reference-documentation/utils/getApiDocumentationModel.ts
@@ -1,20 +1,21 @@
 import type { Framework } from '@ag-grid-types';
 import { throwDevWarning } from '@ag-website-shared/utils/throwDevWarning';
 
-import { AG_MODULE_TAG_NAME } from '../constants';
 import type {
     ApiDocumentationModel,
     ChildDocEntry,
     Config,
     GridModule,
-    ICallSignature,
     InterfaceEntry,
     MetaTag,
+    PropertyViewModelMap,
 } from '../types';
 import { getDefinitionType } from './getDefinitionType';
 import { getDetailsCode } from './getDetailsCode';
+import { getPropertyViewModel } from './getPropertyViewModel';
 import { getShowAdditionalDetails } from './getShowAdditionalDetails';
 import { getAllSectionPropertyEntries, mergeObjects } from './interface-helpers';
+import { getDetailsKey } from './referenceDetails';
 
 interface Params {
     framework: Framework;
@@ -27,55 +28,6 @@ interface Params {
     interfaceLookup: Record<string, InterfaceEntry>;
     codeConfigs: Record<string, any>;
     allModules: GridModule[];
-}
-
-function addEnterprisePropertyToTags({
-    callSignature,
-    allModules,
-}: {
-    callSignature: ICallSignature;
-    allModules: GridModule[];
-}) {
-    if (!callSignature?.meta?.tags) {
-        return callSignature;
-    }
-
-    const newTags = callSignature.meta?.tags.map((tag) => {
-        if (tag.name === AG_MODULE_TAG_NAME) {
-            const tagModule = tag.comment.replace(/`/g, '');
-
-            const modules = tagModule
-                .split(/\s*\/\s*/)
-                .map((m) => {
-                    const name = m.trim();
-                    if (!name) {
-                        return false;
-                    }
-
-                    const module = allModules.find((mod) => mod.moduleName === name);
-                    return {
-                        name,
-                        isEnterprise: module?.isEnterprise,
-                    };
-                })
-                .filter(Boolean);
-
-            return {
-                ...tag,
-                modules,
-            };
-        }
-
-        return tag;
-    });
-
-    return {
-        ...callSignature,
-        meta: {
-            ...callSignature.meta,
-            tags: newTags,
-        },
-    };
 }
 
 function getCodeLookup({ propertyConfigs, codeConfigs }: { propertyConfigs: any[]; codeConfigs: Record<string, any> }) {
@@ -92,6 +44,7 @@ function getCodeLookup({ propertyConfigs, codeConfigs }: { propertyConfigs: any[
 
 function getResolvedProperties({
     framework,
+    sectionKey,
     names,
     properties,
     codeLookup,
@@ -100,6 +53,7 @@ function getResolvedProperties({
     allModules,
 }: {
     framework: Framework;
+    sectionKey: string;
     names?: string[];
     properties: Record<string, any>;
     codeLookup: Record<string, any>;
@@ -120,11 +74,7 @@ function getResolvedProperties({
             return config.sortAlphabetically ? (a[0] < b[0] ? -1 : 1) : 0;
         })
         .map(([name, definition]) => {
-            const codeLookUpGridOpProp = codeLookup[name];
-            const gridOpProp = addEnterprisePropertyToTags({
-                callSignature: codeLookUpGridOpProp,
-                allModules,
-            });
+            const gridOpProp = codeLookup[name];
             const showAdditionalDetails = getShowAdditionalDetails({ name, definition, gridOpProp, interfaceLookup });
             const { type, propertyType } = getDefinitionType({
                 name,
@@ -149,15 +99,23 @@ function getResolvedProperties({
 
             return [
                 name,
-                {
+                getPropertyViewModel({
+                    name,
+                    framework,
                     definition,
                     gridOpProp,
-                    detailsCode,
+                    type,
                     propertyType,
-                },
+                    config,
+                    allModules,
+                    // A detailsUrl means the page fetches these on expand; without one they travel with it.
+                    detailsKey:
+                        detailsCode && config.detailsUrl ? getDetailsKey({ section: sectionKey, name }) : undefined,
+                    detailsCode: config.detailsUrl ? undefined : detailsCode,
+                }),
             ];
         });
-    const resolvedProperties = Object.fromEntries(resolvedPropertyEntries);
+    const resolvedProperties = Object.fromEntries(resolvedPropertyEntries) as PropertyViewModelMap;
 
     return { meta, resolvedProperties };
 }
@@ -200,6 +158,7 @@ function getSectionProperties({
     const properties = mergeObjects(processed);
     const { meta, resolvedProperties } = getResolvedProperties({
         framework,
+        sectionKey: title,
         names,
         properties,
         codeLookup,
@@ -263,6 +222,7 @@ export function getApiDocumentationModel({
         ([name, properties]) => {
             const { meta, resolvedProperties } = getResolvedProperties({
                 framework,
+                sectionKey: name,
                 names,
                 properties,
                 codeLookup,
@@ -271,7 +231,7 @@ export function getApiDocumentationModel({
                 allModules,
             });
 
-            return [name, { meta: meta as MetaTag, properties: resolvedProperties as ChildDocEntry }];
+            return [name, { meta: meta as MetaTag, properties: resolvedProperties }];
         }
     );
 

--- a/documentation/ag-grid-docs/src/components/reference-documentation/utils/getInterfaceDocumentationModel.ts
+++ b/documentation/ag-grid-docs/src/components/reference-documentation/utils/getInterfaceDocumentationModel.ts
@@ -6,11 +6,11 @@ import type {
     CodeEntry,
     Config,
     DocCode,
-    DocEntryMap,
     DocProperties,
     InterfaceDocumentationModel,
     InterfaceEntry,
     Overrides,
+    PropertyViewModelMap,
 } from '../types';
 import {
     escapeGenericCode,
@@ -21,6 +21,7 @@ import {
 } from './documentation-helpers';
 import { getDefinitionType } from './getDefinitionType';
 import { getDetailsCode } from './getDetailsCode';
+import { getPropertyViewModel } from './getPropertyViewModel';
 import { getShowAdditionalDetails } from './getShowAdditionalDetails';
 import { getInterfacesToWrite } from './interface-helpers';
 
@@ -154,15 +155,19 @@ export function getProperties({
               })
             : undefined;
 
-        orderedProps[name] = {
+        orderedProps[name] = getPropertyViewModel({
+            name,
+            framework,
             definition,
-            detailsCode,
             gridOpProp,
+            type,
             propertyType,
-        };
+            config,
+            detailsCode,
+        });
     });
 
-    const properties: DocEntryMap = {
+    const properties: Record<string, PropertyViewModelMap> = {
         [interfaceName]: {
             ...orderedProps,
         },

--- a/documentation/ag-grid-docs/src/components/reference-documentation/utils/getPropertyViewModel.ts
+++ b/documentation/ag-grid-docs/src/components/reference-documentation/utils/getPropertyViewModel.ts
@@ -1,0 +1,188 @@
+import type { Framework } from '@ag-grid-types';
+import styles from '@ag-website-shared/components/reference-documentation/ApiReference.module.scss';
+
+import { AG_MODULE_TAG_NAME } from '../constants';
+import type {
+    ChildDocEntry,
+    Config,
+    GridModule,
+    ICallSignature,
+    InterfaceEntry,
+    PropertyType,
+    PropertyViewModel,
+} from '../types';
+import {
+    convertMarkdown,
+    extractJSDocTags,
+    formatJsDocString,
+    getTypeUrl,
+    removeDefaultValue,
+} from './documentation-helpers';
+import { formatJson, getInterfaceName } from './interface-helpers';
+
+function getDisplayNameSplit({ name, definition }: { name: string; definition: ChildDocEntry }) {
+    let displayName = name;
+    if (definition.isRequired) {
+        displayName += `&nbsp;<span class="${styles.required}">required</span>`;
+    }
+
+    if (definition.strikeThrough) {
+        displayName = `<span style='text-decoration: line-through'>${displayName}</span>`;
+    }
+
+    const { isRequired, strikeThrough } = definition;
+    // displayName is hardCoded for isRequired and strikeThrough
+    if (isRequired || strikeThrough) {
+        return displayName;
+    }
+
+    // Split display name on capital letter, add <wbr> to improve text splitting across lines
+    return displayName
+        .split(/(?=[A-Z])/)
+        .reverse()
+        .reduce((acc, cv) => {
+            return `${cv}<wbr />` + acc;
+        });
+}
+
+function getDescription({
+    definition,
+    gridOpProp,
+    framework,
+}: {
+    definition: ChildDocEntry;
+    gridOpProp: InterfaceEntry;
+    framework: Framework;
+}) {
+    let description: string | undefined = '';
+    let isObject = false;
+    let propDescription: string | undefined =
+        definition.description || (gridOpProp && (gridOpProp.meta as ICallSignature['meta'])?.comment) || undefined;
+
+    if (propDescription) {
+        propDescription = formatJsDocString(propDescription);
+        if (!definition.description && gridOpProp && (gridOpProp.meta as ICallSignature['meta'])?.all) {
+            const { params, returns } = extractJSDocTags(
+                definition.description || (gridOpProp && (gridOpProp.meta as ICallSignature['meta'])?.all)
+            );
+            const paramsStr = params?.map((p) => `<span class="param">\`${p.name}\`: ${p.value}</span>`).join('');
+            const returnsStr = returns ? `<strong>Returns:</strong> ${returns}` : '';
+
+            propDescription = [propDescription, paramsStr, returnsStr].filter(Boolean).join('\n');
+        }
+
+        description = convertMarkdown(propDescription, framework);
+    } else {
+        // this must be the parent of a child object
+        if (definition.meta != null && definition.meta.description != null) {
+            description = convertMarkdown(definition.meta.description, framework);
+        }
+
+        isObject = true;
+    }
+
+    return { isObject, description: removeDefaultValue(description) };
+}
+
+function getTagsData({
+    definition,
+    gridOpProp,
+    config,
+    allModules,
+}: {
+    definition: ChildDocEntry;
+    gridOpProp: InterfaceEntry;
+    config: Config;
+    allModules?: GridModule[];
+}) {
+    // Default may or may not be on a new line in JsDoc but in both cases we want the default to be on the next line
+    const tags = gridOpProp?.meta?.tags ?? definition?.tags ?? [];
+    const jsdocDefault = tags.find((t) => t.name === 'default');
+    const defaultValue = definition?.default ?? jsdocDefault?.comment;
+    const formattedDefaultValue = Array.isArray(defaultValue)
+        ? '[' +
+          defaultValue.map((v, i) => {
+              return i === 0 ? `"${v}"` : ` "${v}"`;
+          }) +
+          ']'
+        : defaultValue;
+    const isInitial = tags.some((t) => t.name === 'initial') ?? false;
+
+    // Module badges are an apiDocumentation concern: interfaceDocumentation passes no module
+    // data and has never shown them.
+    const moduleTag = allModules && tags.find((t) => t.name === AG_MODULE_TAG_NAME);
+    let modules = moduleTag
+        ? moduleTag.comment
+              .replace(/`/g, '')
+              .split(/\s*\/\s*/)
+              .map((m) => m.trim())
+              .filter(Boolean)
+              .map((name) => ({ name, isEnterprise: allModules?.find((mod) => mod.moduleName === name)?.isEnterprise }))
+        : [];
+
+    const restrictedModule: string | undefined = definition?.restrictModule ?? config.restrictModule;
+    if (modules.length > 1 && restrictedModule) {
+        // If the property contains the restricted module and others then only show the restricted module
+        const restrictedModuleTag = modules.find((mod) => restrictedModule == mod.name);
+        if (restrictedModuleTag) {
+            modules = [restrictedModuleTag];
+        }
+    }
+
+    return { formattedDefaultValue, isInitial, modules };
+}
+
+/**
+ * Resolve everything a property row renders, so the island receives display strings rather than
+ * the generated TypeScript metadata they are derived from (SE-115).
+ */
+export function getPropertyViewModel({
+    name,
+    framework,
+    definition,
+    gridOpProp,
+    type,
+    propertyType,
+    config,
+    allModules,
+    detailsKey,
+    detailsCode,
+}: {
+    name: string;
+    framework: Framework;
+    definition: ChildDocEntry;
+    gridOpProp: InterfaceEntry;
+    type: PropertyType | string;
+    propertyType: string;
+    config: Config;
+    allModules?: GridModule[];
+    detailsKey?: string;
+    detailsCode?: string[];
+}): PropertyViewModel {
+    const { isObject, description } = getDescription({ definition, gridOpProp, framework });
+    const { formattedDefaultValue, isInitial, modules } = getTagsData({
+        definition,
+        gridOpProp,
+        config,
+        allModules,
+    });
+
+    return {
+        displayNameSplit: getDisplayNameSplit({ name, definition }),
+        description,
+        isObject,
+        // The object case links to its own section, which only the rendering <Section> knows the id of.
+        typeUrl: isObject || propertyType === 'Function' ? undefined : (getTypeUrl(type, framework) ?? undefined),
+        propertyType,
+        interfaceName: isObject ? getInterfaceName(name) : undefined,
+        defaultValue: formattedDefaultValue ?? undefined,
+        isInitial,
+        modules,
+        more: definition.more,
+        options: definition.options?.map((option) => formatJson(option)),
+        detailsKey,
+        detailsCode,
+        // ObjectCodeSample still reads the raw entry, and nothing sets showSnippets today.
+        definition: config.showSnippets ? definition : undefined,
+    };
+}

--- a/documentation/ag-grid-docs/src/components/reference-documentation/utils/getPropertyViewModel.ts
+++ b/documentation/ag-grid-docs/src/components/reference-documentation/utils/getPropertyViewModel.ts
@@ -157,7 +157,7 @@ export function getPropertyViewModel({
     config: Config;
     allModules?: GridModule[];
     detailsKey?: string;
-    detailsCode?: string[];
+    detailsCode?: string;
 }): PropertyViewModel {
     const { isObject, description } = getDescription({ definition, gridOpProp, framework });
     const { formattedDefaultValue, isInitial, modules } = getTagsData({

--- a/documentation/ag-grid-docs/src/components/reference-documentation/utils/referenceDetails.ts
+++ b/documentation/ag-grid-docs/src/components/reference-documentation/utils/referenceDetails.ts
@@ -1,0 +1,14 @@
+/**
+ * Expandable type signatures are large and only read when a row is expanded, so they are built
+ * into one file per source per framework and fetched on demand rather than shipped with the page.
+ */
+export const REFERENCE_DETAILS_BASE_PATH = '/reference-details';
+
+export function getReferenceDetailsPath({ framework, source }: { framework: string; source: string }) {
+    return `${REFERENCE_DETAILS_BASE_PATH}/${framework}/${source.replace(/\.json$/, '')}.json`;
+}
+
+/** Section-scoped, because a source can document the same property name under more than one section. */
+export function getDetailsKey({ section, name }: { section: string; name: string }) {
+    return `${section}.${name}`;
+}

--- a/documentation/ag-grid-docs/src/components/reference-documentation/utils/referenceDetails.ts
+++ b/documentation/ag-grid-docs/src/components/reference-documentation/utils/referenceDetails.ts
@@ -1,10 +1,12 @@
+import type { Framework } from '@ag-grid-types';
+
 /**
  * Expandable type signatures are large and only read when a row is expanded, so they are built
  * into one file per source per framework and fetched on demand rather than shipped with the page.
  */
-export const REFERENCE_DETAILS_BASE_PATH = '/reference-details';
+const REFERENCE_DETAILS_BASE_PATH = '/reference-details';
 
-export function getReferenceDetailsPath({ framework, source }: { framework: string; source: string }) {
+export function getReferenceDetailsPath({ framework, source }: { framework: Framework; source: string }) {
     return `${REFERENCE_DETAILS_BASE_PATH}/${framework}/${source.replace(/\.json$/, '')}.json`;
 }
 

--- a/documentation/ag-grid-docs/src/components/reference-documentation/utils/useReferenceDetails.ts
+++ b/documentation/ag-grid-docs/src/components/reference-documentation/utils/useReferenceDetails.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 
-type ReferenceDetails = Record<string, string[]>;
+type ReferenceDetails = Record<string, string>;
 
 const requests = new Map<string, Promise<ReferenceDetails>>();
 

--- a/documentation/ag-grid-docs/src/components/reference-documentation/utils/useReferenceDetails.ts
+++ b/documentation/ag-grid-docs/src/components/reference-documentation/utils/useReferenceDetails.ts
@@ -7,7 +7,18 @@ const requests = new Map<string, Promise<ReferenceDetails>>();
 function loadReferenceDetails(url: string) {
     let request = requests.get(url);
     if (!request) {
-        request = fetch(url).then((response) => response.json());
+        request = fetch(url)
+            .then((response) => {
+                if (!response.ok) {
+                    throw new Error(`${response.status} fetching ${url}`);
+                }
+                return response.json();
+            })
+            .catch((error) => {
+                // Drop the failure so the next expand retries rather than reusing a rejected promise.
+                requests.delete(url);
+                throw error;
+            });
         requests.set(url, request);
     }
 
@@ -24,11 +35,16 @@ export function useReferenceDetails({ url, enabled }: { url?: string; enabled: b
         }
 
         let active = true;
-        loadReferenceDetails(url).then((loaded) => {
-            if (active) {
-                setDetails(loaded);
-            }
-        });
+        loadReferenceDetails(url)
+            .then((loaded) => {
+                if (active) {
+                    setDetails(loaded);
+                }
+            })
+            .catch((error) => {
+                // eslint-disable-next-line no-console
+                console.error('<api-documentation>: could not load type details.', error);
+            });
 
         return () => {
             active = false;

--- a/documentation/ag-grid-docs/src/components/reference-documentation/utils/useReferenceDetails.ts
+++ b/documentation/ag-grid-docs/src/components/reference-documentation/utils/useReferenceDetails.ts
@@ -1,0 +1,39 @@
+import { useEffect, useState } from 'react';
+
+type ReferenceDetails = Record<string, string[]>;
+
+const requests = new Map<string, Promise<ReferenceDetails>>();
+
+function loadReferenceDetails(url: string) {
+    let request = requests.get(url);
+    if (!request) {
+        request = fetch(url).then((response) => response.json());
+        requests.set(url, request);
+    }
+
+    return request;
+}
+
+/** Shared across every row on the page, so expanding a second row costs no further request. */
+export function useReferenceDetails({ url, enabled }: { url?: string; enabled: boolean }) {
+    const [details, setDetails] = useState<ReferenceDetails>();
+
+    useEffect(() => {
+        if (!enabled || !url || details) {
+            return;
+        }
+
+        let active = true;
+        loadReferenceDetails(url).then((loaded) => {
+            if (active) {
+                setDetails(loaded);
+            }
+        });
+
+        return () => {
+            active = false;
+        };
+    }, [url, enabled, details]);
+
+    return details;
+}

--- a/documentation/ag-grid-docs/src/pages/[framework]-data-grid/[pageName].astro
+++ b/documentation/ag-grid-docs/src/pages/[framework]-data-grid/[pageName].astro
@@ -11,6 +11,7 @@ import { DOCS_TAB_ITEM_ID_PREFIX, MIGRATION_DOCUMENTATION_NAV_DATA } from '@ag-w
 import { getHeadings } from '@utils/markdoc/getHeadings';
 import { isApiMenuPath } from '@utils/apiMenuPath';
 import { DocsNav } from '@ag-website-shared/components/docs-navigation/DocsNav';
+import ReferenceIconSprite from '@components/reference-documentation/components/ReferenceIconSprite.astro';
 
 import styles from '@ag-website-shared/components/page-styles/docs.module.scss';
 import { parseVersion } from '@ag-website-shared/utils/parseVersion';
@@ -118,6 +119,14 @@ const headings = await getHeadings({
                 version={version}
                 markdownHref={markdownUrl}
             />
+
+            {
+                /*
+              Unconditional: a reference table can arrive through a markdoc partial, so the page
+              body alone does not say whether one is coming.
+            */
+            }
+            <ReferenceIconSprite />
 
             {/* Wrapping div is a hack to target "intro" section of docs page */}
             <div class={styles.pageSections}>

--- a/documentation/ag-grid-docs/src/pages/files/reference-details/[framework]/[...source].json.ts
+++ b/documentation/ag-grid-docs/src/pages/files/reference-details/[framework]/[...source].json.ts
@@ -1,0 +1,66 @@
+import type { Framework } from '@ag-grid-types';
+import type { Config } from '@components/reference-documentation/types';
+import { flattenModules } from '@components/reference-documentation/utils/flattenModules';
+import { getApiDocumentationModel } from '@components/reference-documentation/utils/getApiDocumentationModel';
+import { getPropertiesFromSource } from '@components/reference-documentation/utils/getPropertiesFromSource';
+import { getDetailsKey } from '@components/reference-documentation/utils/referenceDetails';
+import { FRAMEWORKS } from '@constants';
+import { getJsonFile } from '@utils/pages';
+import { type CollectionEntry, getCollection, getEntry } from 'astro:content';
+
+// The expandable type signatures for one apiDocumentation source, keyed by section and property
+// name. <Property> fetches this on first expand so the signatures — which dwarf the rest of a
+// reference page — no longer ship with every page that documents the source (SE-115).
+export async function getStaticPaths() {
+    const sources = await getCollection('apiDocumentation');
+
+    return sources.flatMap((entry) =>
+        FRAMEWORKS.map((framework) => ({
+            params: { framework, source: entry.id },
+        }))
+    );
+}
+
+export async function GET({ params }: { params: Record<string, string> }) {
+    const framework = params.framework as Framework;
+    const source = `${params.source}.json`;
+
+    const interfaceLookup = getJsonFile('reference/interfaces.AUTO.json');
+    const { data: modules } = (await getEntry('moduleMappings', 'modules')) as CollectionEntry<'moduleMappings'>;
+    const { sources, propertiesFromFiles, propertyConfigs, codeConfigs } = await getPropertiesFromSource({
+        source,
+        sources: [],
+    });
+
+    // Built without a `detailsUrl`, so the model resolves the signatures inline for collection here.
+    const model = getApiDocumentationModel({
+        framework,
+        sources,
+        section: '',
+        names: [],
+        config: {} as Config,
+        propertiesFromFiles,
+        propertyConfigs,
+        interfaceLookup,
+        codeConfigs,
+        allModules: flattenModules(modules),
+    });
+
+    const details: Record<string, string[]> = {};
+    if (model?.type === 'multiple') {
+        for (const [section, { properties }] of model.entries) {
+            for (const [name, property] of Object.entries(properties)) {
+                if (property.detailsCode) {
+                    details[getDetailsKey({ section, name })] = property.detailsCode;
+                }
+            }
+        }
+    }
+
+    return new Response(JSON.stringify(details), {
+        status: 200,
+        headers: {
+            'Content-Type': 'application/json; charset=utf-8',
+        },
+    });
+}

--- a/documentation/ag-grid-docs/src/pages/files/reference-details/[framework]/[...source].json.ts
+++ b/documentation/ag-grid-docs/src/pages/files/reference-details/[framework]/[...source].json.ts
@@ -46,7 +46,7 @@ export async function GET({ params }: { params: Record<string, string> }) {
         allModules: flattenModules(modules),
     });
 
-    const details: Record<string, string[]> = {};
+    const details: Record<string, string> = {};
     if (model?.type === 'multiple') {
         for (const [section, { properties }] of model.entries) {
             for (const [name, property] of Object.entries(properties)) {


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/SE-115

Sprites the repeated reference-table icons and resolves property rows at build time, moving expandable type signatures to fetch-on-expand. grid-options 2.79 -> 1.32 MiB, grid-api 2.08 -> 1.07 MiB, both now under Google's 2 MiB crawl budget.

Fix #SE-115