### PR TITLE
SE-189 Give /robots.txt and /favicon.ico a sensible cache lifetime

### DIFF
--- a/documentation/ag-grid-docs/src/utils/htaccess/__snapshots__/htaccessRules.test.ts.snap
+++ b/documentation/ag-grid-docs/src/utils/htaccess/__snapshots__/htaccessRules.test.ts.snap
@@ -29,6 +29,12 @@ Header set Cache-Control "public, max-age=604800, s-maxage=31536000" "expr=%{REQ
 Header set Cache-Control "no-cache" "expr=%{REQUEST_URI} =~ m#^/studio/archive/#"
 
 
+# Root static files (robots.txt, favicon.ico): unhashed but low-churn, so a moderate
+# max-age is enough to cut repeat crawler fetches (SE-189 measured /robots.txt refetched
+# ~25x/day with no header at all) without risking a stale copy for long after a real change.
+Header set Cache-Control "public, max-age=86400" "expr=%{REQUEST_URI} =~ m#^/(robots\\.txt|favicon\\.ico)$#"
+
+
 # BEGIN in-flight release archives - patched in place, do not edit by hand
 # END in-flight release archives
 
@@ -2994,6 +3000,12 @@ Header set Cache-Control "no-cache" "expr=%{CONTENT_TYPE} =~ m#^text/html# && !(
 
 # Archived Studio versions: never cached. Does not apply to /studio/ itself.
 Header set Cache-Control "no-cache" "expr=%{REQUEST_URI} =~ m#^/studio/archive/#"
+
+
+# Root static files (robots.txt, favicon.ico): unhashed but low-churn, so a moderate
+# max-age is enough to cut repeat crawler fetches (SE-189 measured /robots.txt refetched
+# ~25x/day with no header at all) without risking a stale copy for long after a real change.
+Header set Cache-Control "public, max-age=86400" "expr=%{REQUEST_URI} =~ m#^/(robots\\.txt|favicon\\.ico)$#"
 
 
 # BEGIN in-flight release archives - patched in place, do not edit by hand

--- a/documentation/ag-grid-docs/src/utils/htaccess/htaccessRules.test.ts
+++ b/documentation/ag-grid-docs/src/utils/htaccess/htaccessRules.test.ts
@@ -120,8 +120,11 @@ describe('htaccessRules', () => {
         });
 
         it('should NOT long-cache on staging, so testers never see a stale asset', () => {
-            // Staging carries the no-cache document rule but no max-age of any kind.
-            expect(stagingContent).not.toContain('max-age');
+            // Staging carries the no-cache document rule and no year-long asset cache. The
+            // SE-189 root-static rule (max-age=86400 for /robots.txt and /favicon.ico only) is
+            // a deliberate, bounded exception - see that describe block - so this checks for
+            // the hashed-asset value specifically rather than any max-age.
+            expect(stagingContent).not.toContain('max-age=604800');
         });
 
         it('should NOT use immutable, which would make a mistake unfixable for a year', () => {
@@ -400,6 +403,46 @@ describe('htaccessRules', () => {
         });
     });
 
+    describe('SE-189: /robots.txt and /favicon.ico get a sensible cache lifetime', () => {
+        // Pulls the expr= regex out of the GENERATED output rather than re-declaring it: a
+        // copy would let the rule and its test drift apart.
+        const getRootStaticCacheRule = (content: string) => {
+            const line = content.split('\n').find((l) => l.includes('robots\\.txt|favicon\\.ico'));
+            expect(line).toBeDefined();
+            return line!;
+        };
+
+        it('should set a moderate Cache-Control on /robots.txt and /favicon.ico, in both envs', () => {
+            [productionContent, stagingContent].forEach((content) => {
+                const rule = getRootStaticCacheRule(content);
+                expect(rule).toContain('Cache-Control "public, max-age=86400"');
+            });
+        });
+
+        it('should NOT use the year-long immutable lifetime given to hashed assets', () => {
+            // Neither /robots.txt nor /favicon.ico is content-addressed, so a real change
+            // must be able to land same-day rather than waiting out a year-long cache.
+            const rule = getRootStaticCacheRule(productionContent);
+            expect(rule).not.toContain('604800');
+            expect(rule).not.toContain('31536000');
+            expect(rule).not.toContain('immutable');
+        });
+
+        it('should NOT use no-cache, which would defeat the point of caching them at all', () => {
+            expect(getRootStaticCacheRule(productionContent)).not.toContain('no-cache');
+        });
+
+        it('should match /robots.txt and /favicon.ico only, not any other root file', () => {
+            const rule = getRootStaticCacheRule(productionContent);
+            const pattern = new RegExp(rule.match(/m#([^#]+)#/)![1]);
+            expect(pattern.test('/robots.txt')).toBe(true);
+            expect(pattern.test('/favicon.ico')).toBe(true);
+            expect(pattern.test('/sitemap-index.xml')).toBe(false);
+            expect(pattern.test('/llms.txt')).toBe(false);
+            expect(pattern.test('/some/robots.txt')).toBe(false);
+        });
+    });
+
     describe('SE-81: agent-useful Link header', () => {
         it('should include a Link header pointing at llms.txt, the sitemap index and the MCP server', () => {
             expect(productionContent).toContain('Header set Link');
@@ -536,9 +579,10 @@ describe('htaccessRules', () => {
 
         it('should include the asset cache header in production only', () => {
             // Replaces an assertion that the (inert, now removed) mod_expires block was
-            // present. Staging gets no max-age so testers never hit a stale asset.
+            // present. Staging gets no long-lived asset cache so testers never hit a stale
+            // asset (the SE-189 root-static exception aside - see that describe block).
             expect(productionContent).toContain('max-age=604800');
-            expect(stagingContent).not.toContain('max-age');
+            expect(stagingContent).not.toContain('max-age=604800');
         });
 
         it('should include CORS headers in production only', () => {

--- a/documentation/ag-grid-docs/src/utils/htaccess/htaccessRules.ts
+++ b/documentation/ag-grid-docs/src/utils/htaccess/htaccessRules.ts
@@ -59,6 +59,13 @@ const studioArchiveNoCacheRules = `
 Header set Cache-Control "no-cache" "expr=%{REQUEST_URI} =~ m#^/studio/archive/#"
 `;
 
+const rootStaticFileCacheRules = `
+# Root static files (robots.txt, favicon.ico): unhashed but low-churn, so a moderate
+# max-age is enough to cut repeat crawler fetches (SE-189 measured /robots.txt refetched
+# ~25x/day with no header at all) without risking a stale copy for long after a real change.
+Header set Cache-Control "public, max-age=86400" "expr=%{REQUEST_URI} =~ m#^/(robots\\.txt|favicon\\.ico)$#"
+`;
+
 // Delimiters for the in-place patchable block. Exported so the patch script and the tests
 // use the same literals rather than duplicating them.
 export const IN_FLIGHT_BEGIN = '# BEGIN in-flight release archives - patched in place, do not edit by hand';
@@ -484,6 +491,7 @@ function getStagingHtaccessContent(inFlightArchiveRules: string): string {
     return `${baseRules}
 ${documentNoCacheRules}
 ${studioArchiveNoCacheRules}
+${rootStaticFileCacheRules}
 ${inFlightArchiveRules}
 
 ${markdownNegotiationBlock}
@@ -507,6 +515,7 @@ function getProductionHtaccessContent(inFlightArchiveRules: string): string {
 ${documentNoCacheRules}
 ${hashedAssetCacheRules}
 ${studioArchiveNoCacheRules}
+${rootStaticFileCacheRules}
 ${inFlightArchiveRules}
 ${modDeflateRules}
 ${getModRewriteRules()}


### PR DESCRIPTION
## Summary
- `/robots.txt` and `/favicon.ico` currently get no `Cache-Control` header at all, so browsers fall back to the heuristic ~10%-of-age freshness window. SE-189 measured `/robots.txt` being refetched ~25x/day as a result.
- Adds a new `rootStaticFileCacheRules` rule (`Cache-Control: public, max-age=86400`) scoped to exactly `/robots.txt` and `/favicon.ico`, wired into both the staging and production `.htaccess` generation.
- 86400s (1 day) is deliberately well short of the year-long immutable value used for content-hashed `/_astro/` assets, since neither file is content-addressed and a real change should still land same-day.

## Ticket
[SE-189](https://ag-grid.atlassian.net/browse/SE-189): confirm cache lifetimes on `/robots.txt` and root static files.

## Test plan
- [x] Added a `SE-189` describe block to `htaccessRules.test.ts` asserting the rule is present on both envs, is not the hashed-asset immutable value, is not `no-cache`, and matches only `/robots.txt` and `/favicon.ico`.
- [x] Updated two pre-existing staging assertions (`should NOT long-cache on staging...`, `should include the asset cache header in production only`) to check specifically for the hashed-asset `max-age=604800` value rather than any `max-age`, since this new rule is a deliberate, bounded exception on staging too.
- [x] `./behave.sh --project ag-grid-docs -t htaccessRules -u` — all 131 tests pass.
- [x] `./checks.sh` — passes.