### PR TITLE
SE-191 Record the decision to accept Amazonbot's crawl load

### DIFF
--- a/documentation/ag-grid-docs/src/utils/robotsTxt.ts
+++ b/documentation/ag-grid-docs/src/utils/robotsTxt.ts
@@ -49,6 +49,14 @@ export const AI_CRAWLERS = [
     'Meta-ExternalAgent',
 ];
 
+// SE-191: Amazonbot is deliberately NOT in AI_CRAWLERS, and has no Disallow anywhere in this file —
+// it falls through to the wildcard `User-agent: *` group, the same treatment as Googlebot. It is
+// the single largest crawler on origin (~945k requests in the SE-191 window, ~10x verified Google
+// crawl, ~35% ending in a 499), but it is genuine traffic from Amazon's published ranges and it is
+// not one of the AI-training/answer bots the AI group exists to welcome onto example pages. Decision
+// (SE-191): accept the load as the cost of the open-crawl policy (SE-78) rather than disallow it —
+// Amazonbot honours robots.txt but not crawl-delay, so shedding it would mean a full Disallow.
+
 // Public example pages we actively want AI to crawl and train on. Internal `/debug/` example
 // fixtures (e.g. /charts/debug/docs-example-files) are dev/build artefacts, not real example
 // content, so they are NOT opened — they stay blocked for AI just as they are for search.


### PR DESCRIPTION
## Summary
Backport of #15124 to b36.1.0. SE-191 asked for a decision on Amazonbot's crawl load: accept it, or Disallow it in robots.txt. Decision: **accept**.

Amazonbot already falls through to the wildcard `User-agent: *` group (it's in neither `AI_CRAWLERS` nor any Disallow list), which already allows it — so no functional change to the generated robots.txt is needed. This PR adds a comment recording the decision and the reasoning (largest crawler on origin, ~945k requests, ~35% ending in 499, genuine traffic from Amazon's published ranges, accepted as the cost of the open-crawl policy from SE-78 rather than disallowed) and notes why Amazonbot is deliberately not added to `AI_CRAWLERS` either.

## Test plan
- [x] `./behave.sh robotsTxt --project ag-grid-docs` — 8/8 passing, unchanged
- [x] `yarn nx run-many -t build:types,lint -p ag-grid-docs` — passing
- [x] Diff is comment-only; `productionRobotsTxt()` output is unaffected