### PR TITLE
SE-166 Fix the /archive/ redirect to land in one hop

### DIFF
--- a/documentation/ag-grid-docs/src/utils/htaccess/__snapshots__/htaccessRules.test.ts.snap
+++ b/documentation/ag-grid-docs/src/utils/htaccess/__snapshots__/htaccessRules.test.ts.snap
@@ -2594,7 +2594,7 @@ Header set Cache-Control "no-cache" "expr=%{REQUEST_URI} =~ m#^/studio/archive/#
     RedirectMatch 301 "^/documentation/angular/charts.*" "https://www.ag-grid.com/charts/angular/quick-start/"
     RedirectMatch 301 "^/documentation/react/charts.*" "https://www.ag-grid.com/charts/react/quick-start/"
     RedirectMatch 301 "^/documentation/vue/charts.*" "https://www.ag-grid.com/charts/vue/quick-start/"
-    RedirectMatch 301 "^/archive/$" "/documentation-archive"
+    RedirectMatch 301 "^/archive/$" "/documentation-archive/"
     Redirect 301 /javascript-data-grid/component-types/ /javascript-data-grid/components/
     Redirect 301 /angular-data-grid/component-types/ /angular-data-grid/components/
     Redirect 301 /react-data-grid/component-types/ /react-data-grid/components/

--- a/documentation/ag-grid-docs/src/utils/htaccess/redirects.ts
+++ b/documentation/ag-grid-docs/src/utils/htaccess/redirects.ts
@@ -2999,7 +2999,7 @@ export const SITE_301_REDIRECTS: Redirect[] = [
     // /charts sub-directory one, hijacks them to the grid's own documentation-archive. Keep it
     // scoped to the grid root only. No bare `^/archive$` rule is needed: the parent trailing-slash
     // rewrite ([L]) always turns `/archive` into `/archive/` first, which this rule then matches.
-    { fromPattern: '^/archive/$', to: '/documentation-archive' },
+    { fromPattern: '^/archive/$', to: '/documentation-archive/' },
 
     { from: '/javascript-data-grid/component-types/', to: '/javascript-data-grid/components/' },
     { from: '/angular-data-grid/component-types/', to: '/angular-data-grid/components/' },

--- a/documentation/ag-grid-docs/testing/htaccess-harness/expectations.generated.tsv
+++ b/documentation/ag-grid-docs/testing/htaccess-harness/expectations.generated.tsv
@@ -6705,7 +6705,7 @@ www	/documentation/react/chartssample/	301	/react-data-grid/chartssample/
 www	/documentation/react/chartssample	301	/documentation/react/chartssample/
 www	/documentation/vue/chartssample/	301	/vue-data-grid/chartssample/
 www	/documentation/vue/chartssample	301	/documentation/vue/chartssample/
-www	/archive/	301	/documentation-archive
+www	/archive/	301	/documentation-archive/
 www	/javascript-grid-virtual-paging/sample/	301	/javascript-data-grid/infinite-scrolling/
 www	/javascript-grid-virtual-paging/sample	301	/javascript-grid-virtual-paging/sample/
 www	/javascript-grid-enterprise-model/sample/	301	/javascript-data-grid/server-side-model/

--- a/documentation/ag-grid-docs/testing/htaccess-harness/expectations.tsv
+++ b/documentation/ag-grid-docs/testing/htaccess-harness/expectations.tsv
@@ -88,6 +88,9 @@ www	/vue-data-grid/whats-new/	301	/whats-new/
 www	/angular-data-grid/whats-new/	301	/whats-new/
 www	/javascript-data-grid/whats-new/	301	/whats-new/
 
+# --- SE-166: /archive/ must reach /documentation-archive/ in ONE hop, not two ---
+www	/archive/	301	/documentation-archive/
+
 # --- No-shadow negatives: real live pages must NOT be redirected (expect 200) ---
 www	/angular-data-grid/getting-started/	200
 www	/react-data-grid/cell-editing/	200


### PR DESCRIPTION
## Summary
- Adds the missing trailing slash to the `/archive/` -> `/documentation-archive` redirect target, so it resolves to `/documentation-archive/` directly instead of taking a second hop through the site's trailing-slash normalization.
- Updates the `htaccessRules` snapshot to match.
- Adds a single-hop assertion for `/archive/` to `expectations.tsv` and corrects the frozen row in `expectations.generated.tsv`.

Fixes a defect found in QA for SE-166 (footer link fixes): the "Documentation Archive" blog footer link still took two hops.

SE-166: https://ag-grid.atlassian.net/browse/SE-166

## Test plan
- [x] `./behave.sh --project ag-grid-docs` — snapshot updated, all htaccess tests pass
- [x] `./checks.sh` — passes
- [x] `documentation/ag-grid-docs/testing/htaccess-harness/run.sh` — 7245 passed, 0 failed; `/archive/` now resolves to `/documentation-archive/` in a single hop