### PR TITLE
AG-3390 Hydrate docs example runners when they scroll into view

### DIFF
--- a/documentation/ag-grid-docs/src/components/docs/components/DocsExampleRunner.astro
+++ b/documentation/ag-grid-docs/src/components/docs/components/DocsExampleRunner.astro
@@ -54,7 +54,7 @@ try {
             hasExampleConsoleLog={hasExampleConsoleLog}
         >
             <DocsExampleRunner
-                client:only="react"
+                client:visible={{ rootMargin: '200px' }}
                 title={title}
                 name={name}
                 exampleHeight={exampleHeight}

--- a/documentation/ag-grid-docs/src/components/docs/components/DocsExampleRunner.tsx
+++ b/documentation/ag-grid-docs/src/components/docs/components/DocsExampleRunner.tsx
@@ -1,12 +1,13 @@
 import type { InternalFramework } from '@ag-grid-types';
 import { getLoadingIFrameId } from '@ag-website-shared/components/loading-logo/getElementId';
 import type { GeneratedContents } from '@components/example-generator/types';
-import { ExampleRunner } from '@components/example-runner/components/ExampleRunner';
+import { DEFAULT_HEIGHT, ExampleRunner } from '@components/example-runner/components/ExampleRunner';
 import { ExternalLinks } from '@components/example-runner/components/ExternalLinks';
 import { useStore } from '@nanostores/react';
 import { $internalFramework, $internalFrameworkState } from '@stores/frameworkStore';
 import { $queryClient, defaultQueryOptions } from '@stores/queryClientStore';
 import { QueryClientProvider, useQuery } from '@tanstack/react-query';
+import { useHasMounted } from '@utils/hooks/useHasMounted';
 import { useEffect, useMemo, useState } from 'react';
 
 import {
@@ -196,6 +197,16 @@ const DocsExampleRunnerInner = ({
 
 export const DocsExampleRunner = (props: Props) => {
     const queryClient = useStore($queryClient);
+    // The island hydrates when scrolled into view, so it is also rendered on the server. The
+    // runner's framework and dark mode live in localStorage and its contents come from a client
+    // query, so until mounted render a placeholder rather than a default that hydration would
+    // replace. It has the example's height because Astro's visibility observer watches the
+    // island's children: an empty island would never hydrate.
+    const hasMounted = useHasMounted();
+
+    if (!hasMounted) {
+        return <div style={{ height: props.exampleHeight || DEFAULT_HEIGHT }} />;
+    }
 
     return (
         <QueryClientProvider client={queryClient}>

--- a/documentation/ag-grid-docs/src/components/example-runner/components/ExampleRunner.tsx
+++ b/documentation/ag-grid-docs/src/components/example-runner/components/ExampleRunner.tsx
@@ -34,7 +34,7 @@ interface Props {
     consoleBufferSize?: number;
 }
 
-const DEFAULT_HEIGHT = 500;
+export const DEFAULT_HEIGHT = 500;
 
 export const ExampleRunner: FunctionComponent<Props> = ({
     id,

--- a/documentation/ag-grid-docs/src/components/landing-pages/sections/example-runner/ExampleRunner.astro
+++ b/documentation/ag-grid-docs/src/components/landing-pages/sections/example-runner/ExampleRunner.astro
@@ -48,7 +48,7 @@ try {
             hasExampleConsoleLog={hasExampleConsoleLog}
         >
             <DocsExampleRunner
-                client:only="react"
+                client:visible={{ rootMargin: '200px' }}
                 title={title}
                 name={name}
                 exampleHeight={exampleHeight}

--- a/documentation/ag-grid-docs/src/content/docs/example-runner-lazy-hydration.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/example-runner-lazy-hydration.spec.ts
@@ -1,0 +1,56 @@
+import { expect, test } from '@playwright/test';
+import { blockConsentAndAnalytics } from '@utils/grid/test-utils';
+
+// Example runners hydrate when they scroll into view (`client:visible`), so a page with many
+// examples only mounts, and only fetches source for, the runners near the viewport. Off-screen
+// runners keep their reserved height and mount when the reader reaches them.
+
+// Fourteen runners, the most rendered on any docs page
+const PAGE_PATH = 'react-data-grid/server-side-model-grouping/';
+
+test.describe('Example runner lazy hydration', () => {
+    test('mounts and fetches source only for runners the reader reaches', async ({ page }) => {
+        await blockConsentAndAnalytics(page);
+        await page.setViewportSize({ width: 1280, height: 800 });
+
+        const contentsRequests = new Set<string>();
+        page.on('request', (request) => {
+            if (/\/examples\/.*\/contents\.json/.test(request.url())) {
+                contentsRequests.add(request.url());
+            }
+        });
+
+        await page.goto(PAGE_PATH);
+        const runners = page.locator('.example-runner-outer');
+        const codeButtons = page.getByRole('button', { name: 'Code', exact: true });
+        await expect(runners.first()).toBeAttached();
+        const runnerCount = await runners.count();
+        expect(runnerCount).toBeGreaterThan(5);
+
+        // Give any eager hydration time to happen before counting
+        await page.waitForTimeout(2000);
+        expect(await codeButtons.count(), 'runners mounted on load').toBeLessThan(runnerCount);
+        expect(contentsRequests.size, 'contents.json requests on load').toBeLessThan(runnerCount);
+
+        // Reaching a runner mounts it and loads its source
+        const firstRunner = runners.first();
+        await firstRunner.scrollIntoViewIfNeeded();
+        await expect(firstRunner.getByRole('button', { name: 'Code', exact: true })).toBeVisible();
+        await expect.poll(() => contentsRequests.size).toBeGreaterThan(0);
+        const mountedAtFirst = await codeButtons.count();
+        expect(mountedAtFirst, 'runners mounted with the first in view').toBeLessThan(runnerCount);
+
+        const lastRunner = runners.last();
+        await lastRunner.scrollIntoViewIfNeeded();
+        await expect(lastRunner.getByRole('button', { name: 'Code', exact: true })).toBeVisible();
+        expect(await codeButtons.count()).toBeGreaterThan(mountedAtFirst);
+
+        // The reserved height keeps the layout stable while runners hydrate and switch views.
+        // Document-relative, since the click may scroll the page.
+        const documentTop = (element: HTMLElement) => element.getBoundingClientRect().top + window.scrollY;
+        const topBefore = await lastRunner.evaluate(documentTop);
+        await lastRunner.getByRole('button', { name: 'Code', exact: true }).click();
+        await expect(lastRunner.getByRole('button', { name: 'Preview', exact: true })).toBeVisible();
+        expect(await lastRunner.evaluate(documentTop)).toBe(topBefore);
+    });
+});

--- a/documentation/ag-grid-docs/src/utils/hooks/useHasMounted.ts
+++ b/documentation/ag-grid-docs/src/utils/hooks/useHasMounted.ts
@@ -1,0 +1,18 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * `false` on the server and for the first client render, `true` once the component has mounted.
+ *
+ * For islands whose UI depends on browser-only state (localStorage stores, client queries): the
+ * server render and the hydrating render agree on an empty tree, and the real UI follows at once.
+ */
+export const useHasMounted = () => {
+    const [hasMounted, setHasMounted] = useState(false);
+
+    useEffect(() => {
+        // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional hydration pattern
+        setHasMounted(true);
+    }, []);
+
+    return hasMounted;
+};


### PR DESCRIPTION
## Summary

The docs example runner island switches from `client:only="react"` to `client:visible={{ rootMargin: '200px' }}`, on docs pages and on the landing-page wrapper. Runners below the fold no longer hydrate, fetch their `contents.json`, register scroll listeners or load the shiki highlighter until the reader is within 200px of them.

Independent of #15126 (build-time source embed); the two can land in either order.

### Why it was `client:only`

The runner has been `client:only` since the first Astro docs commit. `client:visible` renders the component on the server, and the runner's state lives in localStorage (framework, dark mode) and a client-side TanStack query, so a server render would have emitted a default variant that hydration then replaced. The layout shift that made `client:only` feel necessary was solved separately by `ExampleRunnerContainer.astro` reserving the runner's height, which has been in place since the runner was added.

### How the server render is made safe

- `useHasMounted` (new hook, `src/utils/hooks/useHasMounted.ts`): `false` on the server and for the hydrating render, `true` after mount. `DocsExampleRunner` renders a placeholder until then, so server and client agree and the real UI mounts right after hydration with the visitor's stored framework.
- The placeholder is a `<div>` with the example's height, not `null`: Astro's `client:visible` directive observes the island's **children** with an IntersectionObserver, so an empty island never hydrates. (Found the hard way: the first attempt rendered `null` and nothing ever mounted.) `DEFAULT_HEIGHT` is exported from `ExampleRunner.tsx` for this.

### Measured on `react-data-grid/server-side-model-grouping/` (14 runners, 1280×800 viewport, dev server)

| | `client:only` (latest) | `client:visible` (this PR) |
| --- | --- | --- |
| Runners mounted on load | 14 | 0 (first runner sits below the fold) |
| `contents.json` requests on load | 14 | 0 |
| After scrolling the first runner into view | – | 1 mounted, 1 request |
| After scrolling the full page | 14 | 11 mounted, 11 requests |

The CSP hash for the `client:visible` bootstrap script is already in `cspRules.ts`.

### Behaviour notes

- Deep links (`#example-name`) scroll the runner into view, which triggers hydration.
- The `LoadingLogo` (already `client:load`) keeps showing in the reserved box until the runner mounts and its iframe initialises, as before.
- With view transitions, islands are recreated on navigation either way; now only the visible ones hydrate after the swap.
- If #15126 lands too, the hidden source panel of an off-screen runner stays in the DOM until that runner hydrates (the island removes it on mount). Harmless, since it is hidden.

## Testing

- New Playwright spec `example-runner-lazy-hydration.spec.ts`: on the 14-runner page, asserts fewer runners are mounted and fewer `contents.json` requests made than runners on load; scrolling the first runner into view mounts it and fetches its source while the rest stay unmounted; scrolling to the last runner mounts it; and clicking **Code** on it does not move the runner (document-relative position). 1/1 passing against a local dev server.
- `./checks.sh --projects ag-grid-docs` passes.