### PR TITLE
AG-8950 qa-fixes2 TC9 TC22 TC23

### DIFF
--- a/packages/ag-grid-enterprise/src/advancedFilter/autocomplete/agAutocomplete.ts
+++ b/packages/ag-grid-enterprise/src/advancedFilter/autocomplete/agAutocomplete.ts
@@ -140,6 +140,8 @@ export class AgAutocomplete extends Component<AgAutocompleteEvent> {
                 break;
             case KeyCode.DOWN:
             case KeyCode.UP:
+            case KeyCode.PAGE_DOWN:
+            case KeyCode.PAGE_UP:
                 this.onUpDownKeyDown(event, key);
                 break;
             case KeyCode.LEFT:
@@ -268,6 +270,7 @@ export class AgAutocomplete extends Component<AgAutocompleteEvent> {
                 onConfirmed: () => this.confirmSelection(),
                 forceLastSelection: this.forceLastSelection,
                 rowComponentCreator: this.autocompleteListParams.rowComponentCreator,
+                suggestFirstMatch: this.autocompleteListParams.suggestFirstMatch,
             })
         );
         const ePopupGui = this.autocompleteList.getGui();

--- a/packages/ag-grid-enterprise/src/advancedFilter/autocomplete/agAutocompleteList.ts
+++ b/packages/ag-grid-enterprise/src/advancedFilter/autocomplete/agAutocompleteList.ts
@@ -65,6 +65,7 @@ export class AgAutocompleteList extends AgPopupComponent<
             autocompleteEntries: AutocompleteEntry[];
             onConfirmed: () => void;
             useStartsWithSearch?: boolean;
+            suggestFirstMatch?: boolean;
             autoSizeList?: boolean;
             maxVisibleItems?: number;
             onListHeightChanged?: () => void;
@@ -123,11 +124,20 @@ export class AgAutocompleteList extends AgPopupComponent<
         const oldIndex = this.autocompleteEntries[cachedIndex] === this.selectedValue ? cachedIndex : -1;
         let nextIndex = 0;
         if (oldIndex >= 0) {
-            nextIndex = key === KeyCode.UP ? oldIndex - 1 : oldIndex + 1;
+            const isPage = key === KeyCode.PAGE_UP || key === KeyCode.PAGE_DOWN;
+            const step = isPage ? this.getPageSize() : 1;
+            nextIndex = key === KeyCode.UP || key === KeyCode.PAGE_UP ? oldIndex - step : oldIndex + step;
         }
         const lastIndex = this.autocompleteEntries.length - 1;
 
         this.setSelectedValue(_clamp(nextIndex, 0, lastIndex));
+    }
+
+    private getPageSize(): number {
+        const virtualList = this.virtualList;
+        const rowHeight = virtualList.getRowHeight();
+        const height = virtualList.getGui().getBoundingClientRect().height;
+        return rowHeight > 0 ? Math.max(1, Math.floor(height / rowHeight)) : 1;
     }
 
     public setSearch(searchString: string): void {
@@ -141,7 +151,6 @@ export class AgAutocompleteList extends AgPopupComponent<
             this.checkSetSelectedValue(0);
             this.updateListHeight();
         }
-        this.updateSearchInList();
     }
 
     /**
@@ -194,7 +203,7 @@ export class AgAutocompleteList extends AgPopupComponent<
 
     /** One pass, producing the list to show and the row to suggest together, per keystroke. */
     private runSearch(): void {
-        const { autocompleteEntries, useStartsWithSearch, forceLastSelection } = this.params;
+        const { autocompleteEntries, useStartsWithSearch, suggestFirstMatch, forceLastSelection } = this.params;
         const searchString = this.searchString;
 
         let matches: AutocompleteEntry[];
@@ -203,6 +212,9 @@ export class AgAutocompleteList extends AgPopupComponent<
             matches = this.runStartsWithSearch(searchString, autocompleteEntries);
         } else {
             ({ matches, topIndex } = this.runContainsSearch(searchString, autocompleteEntries));
+            if (suggestFirstMatch) {
+                topIndex = 0;
+            }
         }
 
         const selectedValue = this.selectedValue;
@@ -215,10 +227,6 @@ export class AgAutocompleteList extends AgPopupComponent<
         this.refreshVirtualList();
         this.updateListHeight();
         this.checkSetSelectedValue(topIndex);
-    }
-
-    private updateSearchInList(): void {
-        this.virtualList.forEachRenderedRow((row) => row.setSearchString(this.searchString));
     }
 
     private updateListHeight(): void {
@@ -318,17 +326,18 @@ export class AgAutocompleteList extends AgPopupComponent<
         listItemElement: HTMLElement,
         rowIndex: number
     ): AutocompleteRowComponent {
-        const customRow = this.params.rowComponentCreator?.(value, value === this.selectedValue);
-        if (customRow) {
-            this.createBean(customRow);
-            this.updateRowAriaProperties(customRow, listItemElement, rowIndex);
-            return customRow;
+        const selected = value === this.selectedValue;
+        let row = this.params.rowComponentCreator?.(value, selected);
+        if (row) {
+            this.createBean(row);
+        } else {
+            const defaultRow = new AgAutocompleteRow();
+            this.createBean(defaultRow);
+            defaultRow.setState(value.displayValue ?? value.key, selected);
+            row = defaultRow;
         }
-
-        const row = new AgAutocompleteRow();
-
-        this.createBean(row);
-        row.setState(value.displayValue ?? value.key, value === this.selectedValue);
+        // A row drawn after the search ran, scrolling to it say, has to mark up its own match.
+        row.setSearchString(this.searchString);
         this.updateRowAriaProperties(row, listItemElement, rowIndex);
 
         return row;

--- a/packages/ag-grid-enterprise/src/advancedFilter/autocomplete/autocompleteParams.ts
+++ b/packages/ag-grid-enterprise/src/advancedFilter/autocomplete/autocompleteParams.ts
@@ -12,6 +12,8 @@ export interface AutocompleteListParams {
     searchString?: string;
     entries?: AutocompleteEntry[];
     rowComponentCreator?: AutocompleteRowComponentCreator;
+    /** Suggest the first match rather than the closest one, the list being in an order of its own. */
+    suggestFirstMatch?: boolean;
 }
 
 export interface AutocompleteEntry {

--- a/packages/ag-grid-enterprise/src/advancedFilter/builder/conditionPillWrapperComp.ts
+++ b/packages/ag-grid-enterprise/src/advancedFilter/builder/conditionPillWrapperComp.ts
@@ -261,7 +261,9 @@ export class ConditionPillWrapperComp extends Component<AdvancedFilterBuilderEve
         if (!keepOperator) {
             delete (this.filterModel as PartialColumnFilterModel).type;
         }
+        // A pill reads its option list once, so a change of column rebuilds it even where the text stands.
         if (
+            previousColumn !== column ||
             this.filterModel.type !== previousOperatorKey ||
             this.advFilterExpSvc.getOperatorDisplayValue(this.filterModel) !== previousOperatorDisplayValue
         ) {

--- a/packages/ag-grid-enterprise/src/advancedFilter/colFilterExpressionParser.ts
+++ b/packages/ag-grid-enterprise/src/advancedFilter/colFilterExpressionParser.ts
@@ -990,6 +990,8 @@ export class ColFilterExpressionParser {
         }
         const params = advFilterExpSvc.generateAutocompleteListParams(list.entries, list.type, searchString);
         params.rowComponentCreator = list.rowComponentCreator;
+        // The values are in the column's own Set Filter order, which is what the reader is scanning.
+        params.suggestFirstMatch = true;
         return params;
     }
 

--- a/testing/ag-test-utils/src/filters/advancedFilterBuilderHarness.ts
+++ b/testing/ag-test-utils/src/filters/advancedFilterBuilderHarness.ts
@@ -20,6 +20,7 @@ const OPTION_PILL = '.ag-advanced-filter-builder-option-pill';
 const VALUE_PILL = '.ag-advanced-filter-builder-value-pill';
 const PILL_DISPLAY = '.ag-advanced-filter-builder-pill-display';
 const JOIN_PILL = '.ag-advanced-filter-builder-join-pill';
+const ADD_DROPDOWN = '.ag-advanced-filter-builder-item-button';
 
 /** Column-pill captions in rendered order — the observable signature of the builder's item list. */
 function columnPillOrder(): string {
@@ -148,16 +149,18 @@ export class AdvancedFilterBuilderHarness {
         });
     }
 
-    /** Adds a new condition via the builder add-item button. */
+    /** Adds an empty condition through the add row's dropdown, which is the only row offering one. */
     public async addCondition(): Promise<this> {
-        const addButton = document.querySelector<HTMLElement>(
-            '.ag-advanced-filter-builder-item-button.ag-advanced-filter-builder-add-item-button, .ag-advanced-filter-builder-item-add .ag-advanced-filter-builder-item-button'
+        const addRow = (await this.items()).find(
+            (item) => !item.querySelector(COLUMN_PILL) && !item.querySelector(JOIN_PILL)
         );
-        if (!addButton) {
-            throw new Error('Advanced filter builder add-condition button not found');
+        const eDropdown = addRow?.querySelector<HTMLElement>(ADD_DROPDOWN);
+        if (!eDropdown) {
+            throw new Error('Advanced filter builder add dropdown not found');
         }
-        await firePointerLikeClick(addButton);
-        await asyncSetTimeout(0);
+        await openPicker(eDropdown);
+        await selectRichSelectRow('Add Filter');
+        await this.ensureItemsRendered();
         return this;
     }
 

--- a/testing/ag-test-utils/src/filters/advancedFilterHarness.ts
+++ b/testing/ag-test-utils/src/filters/advancedFilterHarness.ts
@@ -72,6 +72,19 @@ export class AdvancedFilterHarness {
         );
     }
 
+    /** The entry the list is suggesting, which is what Enter would confirm. */
+    public selectedAutocompleteEntry(): string | null {
+        const row = document.querySelector('.ag-autocomplete-list .ag-autocomplete-row-selected');
+        return row?.textContent?.trim() ?? null;
+    }
+
+    /** What each rendered entry marks up as matching the search, `''` where a row marks nothing. */
+    public autocompleteMatches(): string[] {
+        return Array.from(document.querySelectorAll('.ag-autocomplete-list .ag-autocomplete-row')).map(
+            (row) => row.querySelector('b')?.textContent ?? ''
+        );
+    }
+
     /** Selects the highlighted autocomplete entry (Enter). */
     public async selectAutocomplete(): Promise<this> {
         return this.pressKey('Enter');

--- a/testing/behavioural/src/filters/advanced-filter/advanced-filter-autocomplete.test.ts
+++ b/testing/behavioural/src/filters/advanced-filter/advanced-filter-autocomplete.test.ts
@@ -1,5 +1,12 @@
 import { waitFor } from '@testing-library/dom';
-import { GridColumns, GridRows, TestGridsManager, asyncSetTimeout } from 'ag-test-utils';
+import {
+    GridColumns,
+    GridRows,
+    TestGridsManager,
+    asyncSetTimeout,
+    installFilterLayoutMock,
+    uninstallFilterLayoutMock,
+} from 'ag-test-utils';
 
 import type { GridApi, GridOptions } from 'ag-grid-community';
 import {
@@ -887,6 +894,39 @@ describe('Advanced Filter - Autocomplete Interaction', () => {
             selectAutocomplete(input);
             await asyncSetTimeout(0);
             expect(input.value).toContain('[Athlete]');
+        });
+    });
+
+    describe('Page navigation', () => {
+        // A page is however many rows fit, so the list needs a height for one to mean anything.
+        beforeAll(() => installFilterLayoutMock());
+        afterAll(() => uninstallFilterLayoutMock());
+
+        test('the page keys move through the list rather than scrolling the grid behind it', async () => {
+            const api = gridsManager.createGrid('grid1', DEFAULT_OPTIONS);
+            await asyncSetTimeout(0);
+            const input = getInput(getGridElement(api)! as HTMLElement);
+
+            typeInto(input, '[');
+            await asyncSetTimeout(0);
+            expectActiveOption(0);
+
+            pressKey(input, 'ArrowDown');
+            await asyncSetTimeout(0);
+            expectActiveOption(1);
+
+            // A page is taller than these five columns, so it lands on the last of them.
+            pressKey(input, 'PageDown');
+            await asyncSetTimeout(0);
+            expectActiveOption(4);
+
+            pressKey(input, 'PageUp');
+            await asyncSetTimeout(0);
+            expectActiveOption(0);
+
+            selectAutocomplete(input);
+            await asyncSetTimeout(0);
+            expect(input.value).toContain('[Age]');
         });
     });
 

--- a/testing/behavioural/src/filters/advanced-filter/advanced-filter-builder.test.ts
+++ b/testing/behavioural/src/filters/advanced-filter/advanced-filter-builder.test.ts
@@ -563,37 +563,36 @@ describe('Advanced Filter - Builder UI', () => {
 
     describe('Changing a condition column', () => {
         test('the operator pill offers the new column options, not the ones it was opened with', async () => {
-            const api = gridsManager.createGrid('grid1', DEFAULT_OPTIONS);
-            await asyncSetTimeout(0);
+            const api = await gridsManager.createGridAndWait('grid1', DEFAULT_OPTIONS);
 
             const builder = await AdvancedFilterBuilderHarness.open(api);
+            await builder.addCondition();
             const [item] = await builder.conditionItems();
 
             await builder.selectColumn(item, 'Age');
             expect(await builder.operatorOptions(item)).toEqual([
-                'Equals',
-                'Does not equal',
-                'Greater than',
-                'Greater than or equal to',
-                'Less than',
-                'Less than or equal to',
-                'Between',
-                'Not between',
-                'Is blank',
-                'Is not blank',
+                '=',
+                '!=',
+                '>',
+                '>=',
+                '<',
+                '<=',
+                'is between',
+                'is blank',
+                'is not blank',
             ]);
 
             // No operator has been chosen, so nothing the pill displays changes with the column.
             await builder.selectColumn(item, 'Athlete');
             expect(await builder.operatorOptions(item)).toEqual([
-                'Contains',
-                'Does not contain',
-                'Equals',
-                'Does not equal',
-                'Begins with',
-                'Ends with',
-                'Is blank',
-                'Is not blank',
+                'contains',
+                'does not contain',
+                'equals',
+                'does not equal',
+                'begins with',
+                'ends with',
+                'is blank',
+                'is not blank',
             ]);
         });
     });

--- a/testing/behavioural/src/filters/advanced-filter/advanced-filter-builder.test.ts
+++ b/testing/behavioural/src/filters/advanced-filter/advanced-filter-builder.test.ts
@@ -1,4 +1,4 @@
-import { GridColumns, GridRows, TestGridsManager, asyncSetTimeout } from 'ag-test-utils';
+import { AdvancedFilterBuilderHarness, GridColumns, GridRows, TestGridsManager, asyncSetTimeout } from 'ag-test-utils';
 
 import type { GridApi, GridOptions } from 'ag-grid-community';
 import { ClientSideRowModelModule, DateFilterModule, NumberFilterModule, TextFilterModule } from 'ag-grid-community';
@@ -558,6 +558,43 @@ describe('Advanced Filter - Builder UI', () => {
                 ├── LEAF id:2 athlete:"Usain Bolt" age:25 hasGold:true
                 └── LEAF id:3 athlete:"Anna Kowalski" age:19 hasGold:false
             `);
+        });
+    });
+
+    describe('Changing a condition column', () => {
+        test('the operator pill offers the new column options, not the ones it was opened with', async () => {
+            const api = gridsManager.createGrid('grid1', DEFAULT_OPTIONS);
+            await asyncSetTimeout(0);
+
+            const builder = await AdvancedFilterBuilderHarness.open(api);
+            const [item] = await builder.conditionItems();
+
+            await builder.selectColumn(item, 'Age');
+            expect(await builder.operatorOptions(item)).toEqual([
+                'Equals',
+                'Does not equal',
+                'Greater than',
+                'Greater than or equal to',
+                'Less than',
+                'Less than or equal to',
+                'Between',
+                'Not between',
+                'Is blank',
+                'Is not blank',
+            ]);
+
+            // No operator has been chosen, so nothing the pill displays changes with the column.
+            await builder.selectColumn(item, 'Athlete');
+            expect(await builder.operatorOptions(item)).toEqual([
+                'Contains',
+                'Does not contain',
+                'Equals',
+                'Does not equal',
+                'Begins with',
+                'Ends with',
+                'Is blank',
+                'Is not blank',
+            ]);
         });
     });
 });

--- a/testing/behavioural/src/filters/advanced-filter/advanced-filter-set-autocomplete.test.ts
+++ b/testing/behavioural/src/filters/advanced-filter/advanced-filter-set-autocomplete.test.ts
@@ -120,6 +120,19 @@ describe('Advanced Filter - Set Filter autocomplete rendering', () => {
         expect(highlighted).toEqual(['nit', 'nit']);
     });
 
+    test('the first value matching is the one suggested, and every match is marked up', async () => {
+        const api = await gridsManager.createGridAndWait('grid1', DEFAULT_OPTIONS);
+        const af = AdvancedFilterHarness.get(api);
+
+        // Both values begin with it, and the later one is the shorter: the order the column offers
+        // them in is what decides, not their length.
+        await af.type('[Country] is any of ["United');
+
+        expect(af.autocompleteEntries()).toEqual(['United Kingdom', 'United States']);
+        expect(af.selectedAutocompleteEntry()).toBe('United Kingdom');
+        expect(af.autocompleteMatches()).toEqual(['United', 'United']);
+    });
+
     test('a cell renderer owns the row, so the match is not marked up inside it', async () => {
         const api = await gridsManager.createGridAndWait('grid1', {
             ...DEFAULT_OPTIONS,


### PR DESCRIPTION
<!-- base: latest -->

# AG-8950: Advanced Filter QA fixes

FIX AG-8950

Three defects in the Advanced Filter's autocomplete and Builder.

| scope  | net lines | lines changed | hunks | files changed |
| ------ | --------: | ------------: | ----: | ------------: |
| source |       +18 |  52 (+35 -17) |    15 |      5 edited |
| tests  |      +103 | 107 (+105 -2) |     6 |      4 edited |

## The first matching value is the one suggested ([AG-8950](https://ag-grid.atlassian.net/browse/AG-8950)) TC9

The autocomplete suggests the shortest entry holding what was typed, which is a reasonable guess at a column or
an option: those lists are short and their order says nothing. A Set Filter value list is neither. It is in the
column's own order, which is the order the reader is scanning, and its entries are all of a kind, so typing
`2018` into a tree list of dates suggested whichever path happened to be spelled shortest and moved the
selection into the middle of the list.

A value list now asks for the first match instead, `suggestFirstMatch` on its `AutocompleteListParams`. The
column and option lists keep the shortest-match suggestion.

## A row marks up its own match ([AG-8950](https://ag-grid.atlassian.net/browse/AG-8950)) TC9

The match was marked up by one pass over the rows rendered at the moment the search ran, so a row drawn any
later carried none: scrolling the list, which the suggestion above does whenever it lands off screen, left the
rows it revealed unmarked. A row now marks up its own match as it is created, and the sweep is gone.

## A condition's options follow its column ([AG-8950](https://ag-grid.atlassian.net/browse/AG-8950)) TC22

A Builder pill reads its option list once, when its picker is first opened, so it stands for one column and has
to be rebuilt when the condition names another. The operator pill was rebuilt only when the text it displays
changed, which a column change need not do: with no operator chosen yet the pill reads "Select an option"
either way, and moving a condition from a number column to a text one went on offering the number options.

## The page keys move through the autocomplete ([AG-8950](https://ag-grid.atlassian.net/browse/AG-8950)) TC23

`PageUp` and `PageDown` were not handled while the expression autocomplete was open, so they reached the
browser and scrolled the grid behind the popup. They now move the selection by as many rows as the list shows,
and open the list when it is closed, as the arrow keys do. The two other lists built on `AgAutocompleteList`,
the Calculated Columns suggestions and the formula input, route only the arrow keys into it and are unaffected.
