### PR TITLE
SE-71 Add the Wikidata link, founder and company facts to the Organization structured data

### DIFF
--- a/documentation/ag-grid-docs/src/content/footer/footer.json
+++ b/documentation/ag-grid-docs/src/content/footer/footer.json
@@ -102,7 +102,7 @@
             },
             {
                 "name": "X",
-                "url": "https://twitter.com/ag_grid",
+                "url": "https://x.com/ag_grid",
                 "iconName": "xLogo"
             },
             {

--- a/documentation/ag-grid-docs/src/layouts/Layout.astro
+++ b/documentation/ag-grid-docs/src/layouts/Layout.astro
@@ -104,25 +104,38 @@ const sameAsUrls = includeStructuredData
     : [];
 const organizationLogoUrl = `${siteRoot}images/ag-logos/png-logos/AG-Grid-Logo_Light-Theme_476_140.png`;
 const licensePricingUrl = `${siteRoot}license-pricing/`;
-// AG Grid's Wikidata item, appended to the footer-derived social profiles so Google can tie
-// the site, the Wikidata entry and the Knowledge Graph panel to the same entity.
-const organizationSameAs = [...sameAsUrls, 'https://www.wikidata.org/wiki/Q128283374'];
+// Authoritative entries for the company, appended to the footer-derived social profiles so
+// Google can tie the site, the Wikidata entry and the Knowledge Graph panel to the same entity.
+// Only pages identifying the company itself belong here — the npm package identifies the
+// software, so it goes on the SoftwareApplication node instead.
+const organizationSameAs = [
+    ...sameAsUrls,
+    'https://www.crunchbase.com/organization/ag-grid',
+    'https://www.wikidata.org/wiki/Q128283374',
+];
+const softwareApplicationSameAs = ['https://www.npmjs.com/package/ag-grid-community'];
 const organizationDescription =
-    'AG Grid is the maker of the industry-leading JavaScript Data Grid, offering high-performance, feature-rich data grid components for React, Angular, Vue and JavaScript, available as a free open-source Community edition and a commercial Enterprise edition.';
+    'AG Grid is a JavaScript data grid and charting library for building enterprise web applications, developed by AG Grid Ltd. Its product family is AG Grid, AG Charts and AG Studio.';
 const organizationFounder = {
     name: 'Niall Crosby',
     sameAs: ['https://www.wikidata.org/wiki/Q114758691'],
 };
-const organizationLegalName = 'AG Grid Ltd.';
+const organizationLegalName = 'AG Grid Ltd';
 // ISO 8601 (YYYY-MM-DD) for schema.org — the company was founded on 19 July 2010.
 const organizationFoundingDate = '2010-07-19';
 const organizationAddress = {
-    streetAddress: '70 Wilson St',
+    streetAddress: '70 Wilson Street',
     addressLocality: 'London',
     postalCode: 'EC2A 2DB',
     // ISO 3166-1 alpha-2 country code, the form Google expects for addressCountry.
     addressCountry: 'GB',
 };
+// Registry numbers as shown in the footer, verified against Companies House. Naming the
+// issuing register in propertyID is what lets a consumer resolve each value to its source.
+const organizationIdentifiers = [
+    { propertyID: 'Companies House', value: '07318192' },
+    { propertyID: 'VAT', value: 'GB998360167' },
+];
 const structuredData: JsonLdObject[] = includeStructuredData
     ? [
           buildOrganization({
@@ -134,14 +147,21 @@ const structuredData: JsonLdObject[] = includeStructuredData
               legalName: organizationLegalName,
               foundingDate: organizationFoundingDate,
               address: organizationAddress,
+              identifiers: organizationIdentifiers,
               founder: organizationFounder,
               // Line up with the enquiry-type options on the contact page. Sales enquiries go
               // through the contact form; technical support is handled via the Zendesk portal.
               contactPoints: [
-                  { contactType: 'sales', url: `${siteRoot}contact/`, availableLanguage: 'English' },
+                  {
+                      contactType: 'sales',
+                      url: `${siteRoot}contact/`,
+                      areaServed: 'Worldwide',
+                      availableLanguage: 'English',
+                  },
                   {
                       contactType: 'technical support',
                       url: 'https://ag-grid.zendesk.com/',
+                      areaServed: 'Worldwide',
                       availableLanguage: 'English',
                   },
               ],
@@ -155,6 +175,7 @@ const structuredData: JsonLdObject[] = includeStructuredData
               canonicalUrlBase: metadata.canonicalUrlBase,
               name: 'AG Grid',
               version: agGridVersion.split('-')[0],
+              sameAs: softwareApplicationSameAs,
               offers: [
                   {
                       '@type': 'Offer',

--- a/external/ag-website-shared/src/utils/structuredData.test.ts
+++ b/external/ag-website-shared/src/utils/structuredData.test.ts
@@ -19,7 +19,7 @@ describe('buildOrganization', () => {
             canonicalUrlBase: CANONICAL_URL_BASE,
             name: 'AG Grid',
             logoUrl: `${CANONICAL_URL_BASE}/images/logo.png`,
-            sameAs: ['https://github.com/ag-grid/ag-grid', 'https://twitter.com/ag_grid'],
+            sameAs: ['https://github.com/ag-grid/ag-grid', 'https://x.com/ag_grid'],
         });
 
         expect(result).toEqual({
@@ -28,7 +28,7 @@ describe('buildOrganization', () => {
             name: 'AG Grid',
             url: `${CANONICAL_URL_BASE}/`,
             logo: `${CANONICAL_URL_BASE}/images/logo.png`,
-            sameAs: ['https://github.com/ag-grid/ag-grid', 'https://twitter.com/ag_grid'],
+            sameAs: ['https://github.com/ag-grid/ag-grid', 'https://x.com/ag_grid'],
         });
         expect(result['@context']).toBeUndefined();
         expect(result.contactPoint).toBeUndefined();
@@ -41,10 +41,16 @@ describe('buildOrganization', () => {
             logoUrl: `${CANONICAL_URL_BASE}/images/logo.png`,
             sameAs: [],
             contactPoints: [
-                { contactType: 'sales', url: `${CANONICAL_URL_BASE}/contact/`, availableLanguage: 'English' },
+                {
+                    contactType: 'sales',
+                    url: `${CANONICAL_URL_BASE}/contact/`,
+                    areaServed: 'Worldwide',
+                    availableLanguage: 'English',
+                },
                 {
                     contactType: 'technical support',
                     url: 'https://ag-grid.zendesk.com/',
+                    areaServed: 'Worldwide',
                     availableLanguage: 'English',
                 },
             ],
@@ -55,12 +61,14 @@ describe('buildOrganization', () => {
                 '@type': 'ContactPoint',
                 contactType: 'sales',
                 url: `${CANONICAL_URL_BASE}/contact/`,
+                areaServed: 'Worldwide',
                 availableLanguage: 'English',
             },
             {
                 '@type': 'ContactPoint',
                 contactType: 'technical support',
                 url: 'https://ag-grid.zendesk.com/',
+                areaServed: 'Worldwide',
                 availableLanguage: 'English',
             },
         ]);
@@ -93,25 +101,43 @@ describe('buildOrganization', () => {
             name: 'AG Grid',
             logoUrl: `${CANONICAL_URL_BASE}/images/logo.png`,
             sameAs: [],
-            legalName: 'AG Grid Ltd.',
+            legalName: 'AG Grid Ltd',
             foundingDate: '2010-07-19',
             address: {
-                streetAddress: '70 Wilson St',
+                streetAddress: '70 Wilson Street',
                 addressLocality: 'London',
                 postalCode: 'EC2A 2DB',
                 addressCountry: 'GB',
             },
         });
 
-        expect(result.legalName).toBe('AG Grid Ltd.');
+        expect(result.legalName).toBe('AG Grid Ltd');
         expect(result.foundingDate).toBe('2010-07-19');
         expect(result.address).toEqual({
             '@type': 'PostalAddress',
-            streetAddress: '70 Wilson St',
+            streetAddress: '70 Wilson Street',
             addressLocality: 'London',
             postalCode: 'EC2A 2DB',
             addressCountry: 'GB',
         });
+    });
+
+    test('emits a typed identifier array of PropertyValue nodes when identifiers are provided', () => {
+        const result = buildOrganization({
+            canonicalUrlBase: CANONICAL_URL_BASE,
+            name: 'AG Grid',
+            logoUrl: `${CANONICAL_URL_BASE}/images/logo.png`,
+            sameAs: [],
+            identifiers: [
+                { propertyID: 'Companies House', value: '07318192' },
+                { propertyID: 'VAT', value: 'GB998360167' },
+            ],
+        });
+
+        expect(result.identifier).toEqual([
+            { '@type': 'PropertyValue', propertyID: 'Companies House', value: '07318192' },
+            { '@type': 'PropertyValue', propertyID: 'VAT', value: 'GB998360167' },
+        ]);
     });
 
     test('omits description and founder when not provided, and a founder without sameAs has no sameAs key', () => {
@@ -126,6 +152,16 @@ describe('buildOrganization', () => {
         expect(withoutOptionals.legalName).toBeUndefined();
         expect(withoutOptionals.foundingDate).toBeUndefined();
         expect(withoutOptionals.address).toBeUndefined();
+        expect(withoutOptionals.identifier).toBeUndefined();
+
+        const emptyIdentifiers = buildOrganization({
+            canonicalUrlBase: CANONICAL_URL_BASE,
+            name: 'AG Grid',
+            logoUrl: `${CANONICAL_URL_BASE}/images/logo.png`,
+            sameAs: [],
+            identifiers: [],
+        });
+        expect(emptyIdentifiers.identifier).toBeUndefined();
 
         const bareFounder = buildOrganization({
             canonicalUrlBase: CANONICAL_URL_BASE,
@@ -202,6 +238,7 @@ describe('buildSoftwareApplication', () => {
         expect(result.softwareVersion).toBe('34.0.0');
         expect(result.publisher).toEqual({ '@id': `https://www.ag-grid.com/#organization` });
         expect(result.offers).toBeUndefined();
+        expect(result.sameAs).toBeUndefined();
     });
 
     test('honours caller-supplied applicationCategory, operatingSystem and offers', () => {
@@ -217,6 +254,25 @@ describe('buildSoftwareApplication', () => {
         expect(result.applicationCategory).toBe('BusinessApplication');
         expect(result.operatingSystem).toBe('iOS');
         expect(result.offers).toEqual([{ '@type': 'Offer', price: '0', priceCurrency: 'USD' }]);
+    });
+
+    test('emits sameAs entries identifying the application, e.g. its npm package', () => {
+        const result = buildSoftwareApplication({
+            canonicalUrlBase: CANONICAL_URL_BASE,
+            name: 'AG Grid',
+            version: '34.0.0',
+            sameAs: ['https://www.npmjs.com/package/ag-grid-community'],
+        });
+
+        expect(result.sameAs).toEqual(['https://www.npmjs.com/package/ag-grid-community']);
+
+        const emptySameAs = buildSoftwareApplication({
+            canonicalUrlBase: CANONICAL_URL_BASE,
+            name: 'AG Grid',
+            version: '34.0.0',
+            sameAs: [],
+        });
+        expect(emptySameAs.sameAs).toBeUndefined();
     });
 });
 

--- a/external/ag-website-shared/src/utils/structuredData.ts
+++ b/external/ag-website-shared/src/utils/structuredData.ts
@@ -24,6 +24,8 @@ export interface ContactPoint {
     telephone?: string;
     email?: string;
     availableLanguage?: string | string[];
+    /** Geographic area the contact point serves, e.g. `Worldwide`. */
+    areaServed?: string | string[];
 }
 
 export interface OrganizationFounder {
@@ -45,6 +47,16 @@ export interface OrganizationAddress {
     addressRegion?: string;
 }
 
+/**
+ * A registry identifier for the organisation, emitted as a schema.org
+ * `PropertyValue`. `propertyID` names the register (e.g. `Companies House`,
+ * `VAT`) so each value is attributable to the source that issued it.
+ */
+export interface OrganizationIdentifier {
+    propertyID: string;
+    value: string;
+}
+
 interface OrgInput {
     canonicalUrlBase: string;
     name: string;
@@ -58,6 +70,11 @@ interface OrgInput {
     foundingDate?: string;
     /** Optional registered address, emitted as a nested schema.org `PostalAddress`. */
     address?: OrganizationAddress;
+    /**
+     * Optional registry identifiers (company number, VAT number, etc.), emitted
+     * as an `identifier` array of schema.org `PropertyValue` nodes.
+     */
+    identifiers?: OrganizationIdentifier[];
     /** Optional founder, emitted as a nested schema.org `Person`. */
     founder?: OrganizationFounder;
     /**
@@ -81,6 +98,12 @@ interface SoftwareApplicationInput {
     applicationCategory?: string;
     operatingSystem?: string;
     offers?: JsonLdObject[];
+    /**
+     * Authoritative entries for the application itself, e.g. its npm package
+     * page. These identify the software, not the company that publishes it —
+     * company-level profiles belong on the Organization's `sameAs`.
+     */
+    sameAs?: string[];
 }
 
 interface TechArticleInput {
@@ -167,6 +190,7 @@ export function buildOrganization({
     legalName,
     foundingDate,
     address,
+    identifiers,
     founder,
     contactPoints,
 }: OrgInput): JsonLdObject {
@@ -189,6 +213,9 @@ export function buildOrganization({
     }
     if (address) {
         result.address = { '@type': 'PostalAddress', ...address };
+    }
+    if (identifiers && identifiers.length > 0) {
+        result.identifier = identifiers.map((identifier) => ({ '@type': 'PropertyValue', ...identifier }));
     }
     if (founder) {
         const founderNode: JsonLdObject = { '@type': 'Person', name: founder.name };
@@ -225,6 +252,7 @@ export function buildSoftwareApplication({
     applicationCategory = 'DeveloperApplication',
     operatingSystem = 'Web Browser',
     offers,
+    sameAs,
 }: SoftwareApplicationInput): JsonLdObject {
     const result: JsonLdObject = {
         '@type': 'SoftwareApplication',
@@ -238,6 +266,9 @@ export function buildSoftwareApplication({
     };
     if (offers && offers.length > 0) {
         result.offers = offers;
+    }
+    if (sameAs && sameAs.length > 0) {
+        result.sameAs = sameAs;
     }
     return result;
 }


### PR DESCRIPTION
## What

Cherry-pick of #14949 (`79220c06dd2bd7e0f67ee6b8b5cd1fabd8d545fc`) onto `b36.1.0`.

## Why

[SE-71](https://ag-grid.atlassian.net/browse/SE-71) shipped as two PRs: #14580 (Wikidata/founder/description) was backported to `b36.1.0` at the time and is live on production today. #14949 (legalName, registered address, Companies House/VAT `identifier`, Crunchbase, `x.com` instead of `twitter.com`, `areaServed`) merged to `latest` on 2026-08-25, passed QA on staging the same week, but was never backported — confirmed by searching `b36.1.0`'s own history for content unique to that PR (zero hits) and by pulling production's live JSON-LD, which still shows the pre-#14949 state (`"AG Grid Ltd."` with a trailing full stop, `"70 Wilson St"`, `twitter.com/ag_grid`, no `identifier`). Not a regression — it simply never got the backport step #14580 got.

Cherry-picked cleanly, no conflicts, despite `b36.1.0` having since picked up #15106 (SE-154, `getOrganizationId()` signature change) which touches the same file — verified the merged `structuredData.ts` keeps SE-154's signature and all of #14949's new fields.

## Testing

Already QA'd on staging against this exact commit (see SE-71 comments, 2026-08-25/28, "Test Passed"). No new test changes needed beyond what #14949 already added.