### PR TITLE
[AG-18473] Perf(cell-selection): refresh only the cells a range change can affect

### DIFF
--- a/packages/ag-grid-community/src/interfaces/IRangeService.ts
+++ b/packages/ag-grid-community/src/interfaces/IRangeService.ts
@@ -18,6 +18,12 @@ export interface IRangeService {
     removeAllCellRanges(silent?: boolean): void;
     getCellRangeCount(cell: CellPosition): number;
     getRangeRowCount(cellRange: CellRange): number;
+    /**
+     * Returns a predicate matching the rendered cells whose selection state can have changed since
+     * the last refresh, or `null` when every cell has to be refreshed. Calling this records the
+     * current ranges as painted, so the caller must then refresh every matching cell.
+     */
+    takeSelectionRefreshFilter(): ((cell: CellPosition) => boolean) | null;
     isCellInAnyRange(cell: CellPosition): boolean;
     isCellInSpecificRange(cell: CellPosition, range: CellRange): boolean;
     isColumnInAnyRange(column: AgColumn | AgColumnGroup): boolean;

--- a/packages/ag-grid-community/src/interfaces/IRangeService.ts
+++ b/packages/ag-grid-community/src/interfaces/IRangeService.ts
@@ -24,6 +24,7 @@ export interface IRangeService {
      * current ranges as painted, so the caller must then refresh every matching cell.
      */
     takeSelectionRefreshFilter(): ((cell: CellPosition) => boolean) | null;
+    getSelectionState(): CellSelectionSnapshot;
     isCellInAnyRange(cell: CellPosition): boolean;
     isCellInSpecificRange(cell: CellPosition, range: CellRange): boolean;
     isColumnInAnyRange(column: AgColumn | AgColumnGroup): boolean;
@@ -67,6 +68,41 @@ export interface IRangeService {
     createHeaderGroupCellMouseListenerFeature(column: AgColumnGroup, eGui: HTMLElement): BeanStub;
     forEachRowInRange(cellRange: CellRange, callback: (row: RowPosition) => void): void;
     handleColumnSelection(column: AgColumn | AgColumnGroup, event: MouseEvent | KeyboardEvent): void;
+}
+
+/**
+ * One range with everything a cell's selection styling needs precomputed, so that refreshing a
+ * viewport of cells does not repeat per cell what is common to all of them.
+ *
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
+ */
+export interface CellSelectionRange {
+    range: CellRange;
+    /** Normalised (topmost) row of the range. */
+    firstRow: RowPosition;
+    /** Normalised (bottommost) row of the range. */
+    lastRow: RowPosition;
+    /** `true` when both rows sit in the same pinned section, so row indexes alone order them. */
+    withinOneSection: boolean;
+    columns: Set<Column>;
+    /** The rightmost column, which with `lastRow` owns the selection handle. */
+    lastColumn: Column | undefined;
+    contiguous: boolean;
+    type: CellRangeType | undefined;
+    colorClass: string | null | undefined;
+}
+
+/**
+ * The selection as of one refresh of the rendered cells.
+ *
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
+ */
+export interface CellSelectionSnapshot {
+    ranges: CellSelectionRange[];
+    /** Mirrors `isMoreThanOneCell()`, which every cell reads for the single-cell class. */
+    moreThanOneCell: boolean;
+    /** `true` when every range is a chart range, the all-ranges test behind the chart class. */
+    allChartRanges: boolean;
 }
 
 export enum CellRangeType {

--- a/packages/ag-grid-community/src/interfaces/IRangeService.ts
+++ b/packages/ag-grid-community/src/interfaces/IRangeService.ts
@@ -18,11 +18,6 @@ export interface IRangeService {
     removeAllCellRanges(silent?: boolean): void;
     getCellRangeCount(cell: CellPosition): number;
     getRangeRowCount(cellRange: CellRange): number;
-    /**
-     * Returns a predicate matching the rendered cells whose selection state can have changed since
-     * the last refresh, or `null` when every cell has to be refreshed. Calling this records the
-     * current ranges as painted, so the caller must then refresh every matching cell.
-     */
     takeSelectionRefreshFilter(): ((cell: CellPosition) => boolean) | null;
     getSelectionState(): CellSelectionSnapshot;
     isCellInAnyRange(cell: CellPosition): boolean;
@@ -70,38 +65,23 @@ export interface IRangeService {
     handleColumnSelection(column: AgColumn | AgColumnGroup, event: MouseEvent | KeyboardEvent): void;
 }
 
-/**
- * One range with everything a cell's selection styling needs precomputed, so that refreshing a
- * viewport of cells does not repeat per cell what is common to all of them.
- *
- * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
- */
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface CellSelectionRange {
     range: CellRange;
-    /** Normalised (topmost) row of the range. */
     firstRow: RowPosition;
-    /** Normalised (bottommost) row of the range. */
     lastRow: RowPosition;
-    /** `true` when both rows sit in the same pinned section, so row indexes alone order them. */
     withinOneSection: boolean;
     columns: Set<Column>;
-    /** The rightmost column, which with `lastRow` owns the selection handle. */
     lastColumn: Column | undefined;
     contiguous: boolean;
     type: CellRangeType | undefined;
     colorClass: string | null | undefined;
 }
 
-/**
- * The selection as of one refresh of the rendered cells.
- *
- * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
- */
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface CellSelectionSnapshot {
     ranges: CellSelectionRange[];
-    /** Mirrors `isMoreThanOneCell()`, which every cell reads for the single-cell class. */
     moreThanOneCell: boolean;
-    /** `true` when every range is a chart range, the all-ranges test behind the chart class. */
     allChartRanges: boolean;
 }
 

--- a/packages/ag-grid-community/src/interfaces/iCellRangeFeature.ts
+++ b/packages/ag-grid-community/src/interfaces/iCellRangeFeature.ts
@@ -1,11 +1,12 @@
 import type { ICellComp } from '../rendering/cell/cellCtrl';
+import type { CellSelectionSnapshot } from './IRangeService';
 
 /** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface ICellRangeFeature {
     setComp(cellComp: ICellComp): void;
     unsetComp(): void;
     scheduleRefreshRangeStyleAndHandle(): void;
-    updateRangeBordersIfRangeCount(): void;
-    onCellSelectionChanged(): void;
+    updateRangeBordersIfRangeCount(state?: CellSelectionSnapshot): void;
+    onCellSelectionChanged(state?: CellSelectionSnapshot): void;
     destroy(): void;
 }

--- a/packages/ag-grid-community/src/main-internal.ts
+++ b/packages/ag-grid-community/src/main-internal.ts
@@ -322,7 +322,7 @@ export type { IPinnedSectionCompHost } from './interfaces/iPinnedSectionCompHost
 export type { IPinnedRowModel } from './interfaces/iPinnedRowModel';
 export type { IPivotColDefService } from './interfaces/iPivotColDefService';
 export type { IPivotResultColsService } from './interfaces/iPivotResultColsService';
-export type { IRangeService } from './interfaces/IRangeService';
+export type { CellSelectionRange, CellSelectionSnapshot, IRangeService } from './interfaces/IRangeService';
 export type { IRowChildrenService } from './interfaces/iRowChildrenService';
 
 export type {

--- a/packages/ag-grid-community/src/rendering/cell/cellCtrl.ts
+++ b/packages/ag-grid-community/src/rendering/cell/cellCtrl.ts
@@ -29,6 +29,7 @@ import {
     _setDomData,
 } from '../../gridOptionsUtils';
 import { refreshFirstAndLastStyles } from '../../headerRendering/cells/cssClassApplier';
+import type { CellSelectionSnapshot } from '../../interfaces/IRangeService';
 import type { BrandedType } from '../../interfaces/brandedType';
 import type { ICellEditor } from '../../interfaces/iCellEditor';
 import type { CellPosition } from '../../interfaces/iCellPosition';
@@ -824,18 +825,18 @@ export class CellCtrl extends BeanStub {
         };
     }
 
-    public updateRangeBordersIfRangeCount(): void {
+    public updateRangeBordersIfRangeCount(state?: CellSelectionSnapshot): void {
         if (!this.comp) {
             return;
         }
-        this.rangeFeature?.updateRangeBordersIfRangeCount();
+        this.rangeFeature?.updateRangeBordersIfRangeCount(state);
     }
 
-    public onCellSelectionChanged(): void {
+    public onCellSelectionChanged(state?: CellSelectionSnapshot): void {
         if (!this.comp) {
             return;
         }
-        this.rangeFeature?.onCellSelectionChanged();
+        this.rangeFeature?.onCellSelectionChanged(state);
     }
 
     public isRangeSelectionEnabled(): boolean {

--- a/packages/ag-grid-community/src/rendering/rowRenderer.ts
+++ b/packages/ag-grid-community/src/rendering/rowRenderer.ts
@@ -355,11 +355,8 @@ export class RowRenderer extends BeanStub implements NamedBean {
 
     private readonly setupRangeSelectionListeners = () => {
         const onCellSelectionChanged = () => {
-            // one drag frame typically moves a single edge of the selection, so refreshing every
-            // rendered cell would cost the whole viewport instead of just the cells that changed
             const rangeSvc = this.beans.rangeSvc;
             const isCellStale = rangeSvc?.takeSelectionRefreshFilter();
-            // built once here rather than per cell: every cell reads the same selection
             const state = rangeSvc?.getSelectionState();
             for (const cellCtrl of this.getAllCellCtrls()) {
                 if (isCellStale && !isCellStale(cellCtrl.cellPosition)) {

--- a/packages/ag-grid-community/src/rendering/rowRenderer.ts
+++ b/packages/ag-grid-community/src/rendering/rowRenderer.ts
@@ -355,7 +355,13 @@ export class RowRenderer extends BeanStub implements NamedBean {
 
     private readonly setupRangeSelectionListeners = () => {
         const onCellSelectionChanged = () => {
+            // one drag frame typically moves a single edge of the selection, so refreshing every
+            // rendered cell would cost the whole viewport instead of just the cells that changed
+            const isCellStale = this.beans.rangeSvc?.takeSelectionRefreshFilter();
             for (const cellCtrl of this.getAllCellCtrls()) {
+                if (isCellStale && !isCellStale(cellCtrl.cellPosition)) {
+                    continue;
+                }
                 cellCtrl.onCellSelectionChanged();
             }
         };

--- a/packages/ag-grid-community/src/rendering/rowRenderer.ts
+++ b/packages/ag-grid-community/src/rendering/rowRenderer.ts
@@ -357,18 +357,22 @@ export class RowRenderer extends BeanStub implements NamedBean {
         const onCellSelectionChanged = () => {
             // one drag frame typically moves a single edge of the selection, so refreshing every
             // rendered cell would cost the whole viewport instead of just the cells that changed
-            const isCellStale = this.beans.rangeSvc?.takeSelectionRefreshFilter();
+            const rangeSvc = this.beans.rangeSvc;
+            const isCellStale = rangeSvc?.takeSelectionRefreshFilter();
+            // built once here rather than per cell: every cell reads the same selection
+            const state = rangeSvc?.getSelectionState();
             for (const cellCtrl of this.getAllCellCtrls()) {
                 if (isCellStale && !isCellStale(cellCtrl.cellPosition)) {
                     continue;
                 }
-                cellCtrl.onCellSelectionChanged();
+                cellCtrl.onCellSelectionChanged(state);
             }
         };
 
         const onColumnMovedPinnedVisible = () => {
+            const state = this.beans.rangeSvc?.getSelectionState();
             for (const cellCtrl of this.getAllCellCtrls()) {
-                cellCtrl.updateRangeBordersIfRangeCount();
+                cellCtrl.updateRangeBordersIfRangeCount(state);
             }
         };
 

--- a/packages/ag-grid-enterprise/src/rangeSelection/cellRangeFeature.ts
+++ b/packages/ag-grid-enterprise/src/rangeSelection/cellRangeFeature.ts
@@ -28,7 +28,6 @@ const CSS_CELL_RANGE_TOP = 'ag-cell-range-top';
 const CSS_CELL_RANGE_RIGHT = 'ag-cell-range-right';
 const CSS_CELL_RANGE_BOTTOM = 'ag-cell-range-bottom';
 const CSS_CELL_RANGE_LEFT = 'ag-cell-range-left';
-// OPTIMIZATION: every rendered cell toggles all four, so the names are built once, not per cell
 const CSS_CELL_RANGE_SELECTED_COUNT = [
     `${CSS_CELL_RANGE_SELECTED}-1`,
     `${CSS_CELL_RANGE_SELECTED}-2`,

--- a/packages/ag-grid-enterprise/src/rangeSelection/cellRangeFeature.ts
+++ b/packages/ag-grid-enterprise/src/rangeSelection/cellRangeFeature.ts
@@ -4,7 +4,9 @@ import type {
     AgColumn,
     BeanCollection,
     CellCtrl,
-    CellRange,
+    CellPosition,
+    CellSelectionRange,
+    CellSelectionSnapshot,
     GridOptionsService,
     ICellComp,
     ICellRangeFeature,
@@ -15,6 +17,7 @@ import { CellRangeType, _isSameRow } from 'ag-grid-community';
 import { SelectionHandleType } from './abstractSelectionHandle';
 import type { AgFillHandle } from './agFillHandle';
 import type { AgRangeHandle } from './agRangeHandle';
+import { isCellInSelectionRange } from './cellSelectionState';
 
 const CSS_CELL_RANGE_SELECTED = 'ag-cell-range-selected';
 const CSS_CELL_RANGE_CHART = 'ag-cell-range-chart';
@@ -25,6 +28,13 @@ const CSS_CELL_RANGE_TOP = 'ag-cell-range-top';
 const CSS_CELL_RANGE_RIGHT = 'ag-cell-range-right';
 const CSS_CELL_RANGE_BOTTOM = 'ag-cell-range-bottom';
 const CSS_CELL_RANGE_LEFT = 'ag-cell-range-left';
+// OPTIMIZATION: every rendered cell toggles all four, so the names are built once, not per cell
+const CSS_CELL_RANGE_SELECTED_COUNT = [
+    `${CSS_CELL_RANGE_SELECTED}-1`,
+    `${CSS_CELL_RANGE_SELECTED}-2`,
+    `${CSS_CELL_RANGE_SELECTED}-3`,
+    `${CSS_CELL_RANGE_SELECTED}-4`,
+];
 
 function _isRangeHandleEnabled(gos: GridOptionsService): boolean {
     const selection = gos.get('cellSelection');
@@ -78,38 +88,53 @@ export class CellRangeFeature implements ICellRangeFeature {
         this.beans.context.destroyBean(this.selectionHandle);
     }
 
-    public onCellSelectionChanged(): void {
+    public onCellSelectionChanged(state?: CellSelectionSnapshot): void {
         const cellComp = this.cellComp;
         // when using reactUi, given UI is async, it's possible this method is called before the comp is registered
         if (!cellComp) {
             return;
         }
 
-        const { rangeSvc, cellCtrl, eGui } = this;
+        const selection = state ?? this.rangeSvc.getSelectionState();
+        const eGui = this.eGui;
 
-        const rangeCount = rangeSvc.getCellRangeCount(cellCtrl.cellPosition);
+        const rangeCount = this.countRangesAtCell(selection);
         this.rangeCount = rangeCount;
-        const hasChartRange = this.getHasChartRange();
+        const hasChartRange = rangeCount > 0 && selection.allChartRanges;
         this.hasChartRange = hasChartRange;
 
         cellComp.toggleCss(CSS_CELL_RANGE_SELECTED, rangeCount !== 0);
-        cellComp.toggleCss(`${CSS_CELL_RANGE_SELECTED}-1`, rangeCount === 1);
-        cellComp.toggleCss(`${CSS_CELL_RANGE_SELECTED}-2`, rangeCount === 2);
-        cellComp.toggleCss(`${CSS_CELL_RANGE_SELECTED}-3`, rangeCount === 3);
-        cellComp.toggleCss(`${CSS_CELL_RANGE_SELECTED}-4`, rangeCount >= 4);
+        cellComp.toggleCss(CSS_CELL_RANGE_SELECTED_COUNT[0], rangeCount === 1);
+        cellComp.toggleCss(CSS_CELL_RANGE_SELECTED_COUNT[1], rangeCount === 2);
+        cellComp.toggleCss(CSS_CELL_RANGE_SELECTED_COUNT[2], rangeCount === 3);
+        cellComp.toggleCss(CSS_CELL_RANGE_SELECTED_COUNT[3], rangeCount >= 4);
         cellComp.toggleCss(CSS_CELL_RANGE_CHART, hasChartRange);
 
         _setAriaSelected(eGui, rangeCount > 0 ? true : undefined);
-        cellComp.toggleCss(CSS_CELL_RANGE_SINGLE_CELL, this.isSingleCell());
+        cellComp.toggleCss(CSS_CELL_RANGE_SINGLE_CELL, this.isSingleCell(selection));
 
-        this.updateRangeBorders();
+        this.updateRangeBorders(selection);
 
-        this.refreshRangeStyleAndHandle();
+        this.refreshRangeStyleAndHandle(selection);
     }
 
-    private updateRangeBorders(): void {
-        const rangeBorders = this.getRangeBorders();
-        const isSingleCell = this.isSingleCell();
+    private countRangesAtCell(selection: CellSelectionSnapshot): number {
+        const { cellPosition } = this.cellCtrl;
+        const ranges = selection.ranges;
+        let count = 0;
+
+        for (let i = 0, len = ranges.length; i < len; i++) {
+            if (isCellInSelectionRange(ranges[i], cellPosition)) {
+                count++;
+            }
+        }
+
+        return count;
+    }
+
+    private updateRangeBorders(selection: CellSelectionSnapshot): void {
+        const rangeBorders = this.getRangeBorders(selection);
+        const isSingleCell = this.isSingleCell(selection);
         const isTop = !isSingleCell && rangeBorders.top;
         const isRight = !isSingleCell && rangeBorders.right;
         const isBottom = !isSingleCell && rangeBorders.bottom;
@@ -122,35 +147,20 @@ export class CellRangeFeature implements ICellRangeFeature {
         cellComp.toggleCss(CSS_CELL_RANGE_LEFT, isLeft);
     }
 
-    private isSingleCell(): boolean {
-        const { rangeSvc } = this;
-        return this.rangeCount === 1 && !!rangeSvc && !rangeSvc.isMoreThanOneCell();
+    private isSingleCell(selection: CellSelectionSnapshot): boolean {
+        return this.rangeCount === 1 && !selection.moreThanOneCell;
     }
 
-    private getHasChartRange(): boolean {
-        const { rangeSvc } = this;
-
-        if (!this.rangeCount || !rangeSvc) {
-            return false;
-        }
-
-        const cellRanges = rangeSvc.getCellRanges();
-
-        return (
-            cellRanges.length > 0 &&
-            cellRanges.every((range) => [CellRangeType.DIMENSION, CellRangeType.VALUE].includes(range.type!))
-        );
-    }
-
-    public updateRangeBordersIfRangeCount(): void {
+    public updateRangeBordersIfRangeCount(state?: CellSelectionSnapshot): void {
         // we only need to update range borders if we are in a range
         if (this.rangeCount > 0) {
-            this.updateRangeBorders();
-            this.refreshRangeStyleAndHandle();
+            const selection = state ?? this.rangeSvc.getSelectionState();
+            this.updateRangeBorders(selection);
+            this.refreshRangeStyleAndHandle(selection);
         }
     }
 
-    private getRangeBorders(): {
+    private getRangeBorders(selection: CellSelectionSnapshot): {
         top: boolean;
         right: boolean;
         bottom: boolean;
@@ -164,14 +174,12 @@ export class CellRangeFeature implements ICellRangeFeature {
         let left = false;
 
         const {
-            rangeSvc,
             beans: { visibleCols },
             cellCtrl: { cellPosition },
         } = this;
         const thisCol = cellPosition.column as AgColumn;
 
-        const ranges = rangeSvc.getCellRanges().filter((range) => rangeSvc.isCellInSpecificRange(cellPosition, range));
-        if (!ranges.length) {
+        if (!this.rangeCount) {
             return { top, right, bottom, left };
         }
 
@@ -196,28 +204,32 @@ export class CellRangeFeature implements ICellRangeFeature {
             right = true;
         }
 
-        for (let i = 0; i < ranges.length; i++) {
+        const ranges = selection.ranges;
+        for (let i = 0, len = ranges.length; i < len; i++) {
             if (top && right && bottom && left) {
                 break;
             }
 
             const range = ranges[i];
-            const startRow = rangeSvc.getRangeStartRow(range);
-            const endRow = rangeSvc.getRangeEndRow(range);
+            if (!isCellInSelectionRange(range, cellPosition)) {
+                continue;
+            }
 
-            if (!top && _isSameRow(startRow, cellPosition)) {
+            const { firstRow, lastRow, columns } = range;
+
+            if (!top && _isSameRow(firstRow, cellPosition)) {
                 top = true;
             }
 
-            if (!bottom && _isSameRow(endRow, cellPosition)) {
+            if (!bottom && _isSameRow(lastRow, cellPosition)) {
                 bottom = true;
             }
 
-            if (!left && leftCol && range.columns.indexOf(leftCol) < 0) {
+            if (!left && leftCol && !columns.has(leftCol)) {
                 left = true;
             }
 
-            if (!right && rightCol && range.columns.indexOf(rightCol) < 0) {
+            if (!right && rightCol && !columns.has(rightCol)) {
                 right = true;
             }
         }
@@ -225,15 +237,15 @@ export class CellRangeFeature implements ICellRangeFeature {
         return { top, right, bottom, left };
     }
 
-    private refreshRangeStyleAndHandle(): void {
+    private refreshRangeStyleAndHandle(selection: CellSelectionSnapshot): void {
         const { context } = this.beans;
         if (context.isDestroyed()) {
             return;
         }
 
-        this.styleCellForRangeType();
+        this.styleCellForRangeType(selection);
 
-        const rangeForHandle = this.getRangeForHandle();
+        const rangeForHandle = this.getRangeForHandle(selection);
 
         if (this.selectionHandle && !rangeForHandle) {
             this.selectionHandle = context.destroyBean(this.selectionHandle);
@@ -254,22 +266,21 @@ export class CellRangeFeature implements ICellRangeFeature {
         this.refreshScheduled = true;
         _requestAnimationFrame(this.beans, () => {
             this.refreshScheduled = false;
-            this.refreshRangeStyleAndHandle();
+            this.refreshRangeStyleAndHandle(this.rangeSvc.getSelectionState());
         });
     }
 
-    private styleCellForRangeType(): void {
+    private styleCellForRangeType(selection: CellSelectionSnapshot): void {
         if (this.hasChartRange) {
-            const { rangeSvc } = this;
-            const dimensionRange = rangeSvc.getCellRanges()[0];
+            const dimensionRange = selection.ranges[0];
             const hasCategoryRange = dimensionRange.type === CellRangeType.DIMENSION;
             const isCategoryCell =
-                hasCategoryRange && rangeSvc.isCellInSpecificRange(this.cellCtrl.cellPosition, dimensionRange);
+                hasCategoryRange && isCellInSelectionRange(dimensionRange, this.cellCtrl.cellPosition);
 
             this.cellComp.toggleCss(CSS_CELL_RANGE_CHART_CATEGORY, isCategoryCell);
         } else {
             this.cellComp.toggleCss(CSS_CELL_RANGE_CHART_CATEGORY, false);
-            this.applyRangeColor(this.getRangeColorClass());
+            this.applyRangeColor(this.getRangeColorClass(selection));
         }
     }
 
@@ -287,13 +298,13 @@ export class CellRangeFeature implements ICellRangeFeature {
         this.rangeColorClass = nextClass ?? null;
     }
 
-    private getRangeColorClass(): string | null {
-        const { rangeSvc, rangeCount } = this;
-        if (!rangeSvc || !rangeCount) {
+    private getRangeColorClass(selection: CellSelectionSnapshot): string | null {
+        if (!this.rangeCount) {
             return null;
         }
 
-        const ranges = rangeSvc.getCellRanges();
+        const { cellPosition } = this.cellCtrl;
+        const ranges = selection.ranges;
 
         for (let i = ranges.length - 1; i >= 0; i--) {
             const range = ranges[i];
@@ -303,7 +314,7 @@ export class CellRangeFeature implements ICellRangeFeature {
                 continue;
             }
 
-            if (rangeSvc.isCellInSpecificRange(this.cellCtrl.cellPosition, range)) {
+            if (isCellInSelectionRange(range, cellPosition)) {
                 return colorClass;
             }
         }
@@ -311,7 +322,7 @@ export class CellRangeFeature implements ICellRangeFeature {
         return null;
     }
 
-    private refreshHandleColor(rangeForHandle: CellRange | null): void {
+    private refreshHandleColor(rangeForHandle: CellSelectionRange | null): void {
         const handleGui = this.selectionHandle?.getGui?.();
         const nextClass = rangeForHandle?.colorClass ?? null;
 
@@ -333,10 +344,9 @@ export class CellRangeFeature implements ICellRangeFeature {
         this.handleColorClass = nextClass ?? null;
     }
 
-    private getRangeForHandle(): CellRange | null {
+    private getRangeForHandle(selection: CellSelectionSnapshot): CellSelectionRange | null {
         const { gos, editSvc } = this.beans;
-        const rangeSvc = this.rangeSvc;
-        const allRanges = rangeSvc.getCellRanges();
+        const allRanges = selection.ranges;
         const rangesLen = allRanges.length;
 
         if (this.rangeCount < 1 || rangesLen < 1) {
@@ -346,7 +356,7 @@ export class CellRangeFeature implements ICellRangeFeature {
         const isRangeSelectionEnabledWhileEditing = editSvc?.isRangeSelectionEnabledWhileEditing();
         const rangesToRefreshHandle = isRangeSelectionEnabledWhileEditing ? allRanges : [_last(allRanges)];
 
-        for (const cellRange of rangesToRefreshHandle) {
+        for (const selectionRange of rangesToRefreshHandle) {
             const { cellPosition, column } = this.cellCtrl;
             const isFillHandleAvailable = _isFillHandleEnabled(gos) && !column.isSuppressFillHandle();
             const isRangeHandleAvailable = _isRangeHandleEnabled(gos);
@@ -358,26 +368,36 @@ export class CellRangeFeature implements ICellRangeFeature {
                     (rangesLen === 1 && (isFillHandleAvailable || isRangeHandleAvailable)));
 
             if (this.hasChartRange) {
-                handleIsAvailable = cellRange.type === CellRangeType.VALUE;
+                handleIsAvailable = selectionRange.type === CellRangeType.VALUE;
             }
 
             if (
                 handleIsAvailable &&
-                cellRange.endRow != null &&
-                rangeSvc.isContiguousRange(cellRange) &&
-                rangeSvc.isBottomRightCell(cellRange, cellPosition)
+                selectionRange.range.endRow != null &&
+                selectionRange.contiguous &&
+                this.isBottomRightCell(selectionRange, cellPosition)
             ) {
-                return cellRange;
+                return selectionRange;
             }
         }
 
         return null;
     }
 
-    private addSelectionHandle(cellRange: CellRange) {
+    private isBottomRightCell({ lastRow, lastColumn }: CellSelectionRange, cell: CellPosition): boolean {
+        if (!lastColumn) {
+            return false;
+        }
+
+        const isRightColumn = (cell.column as AgColumn).allColsIndex === (lastColumn as AgColumn).allColsIndex;
+
+        return isRightColumn && _isSameRow(lastRow, cell);
+    }
+
+    private addSelectionHandle(selectionRange: CellSelectionRange) {
         const { editSvc, gos, context, registry } = this.beans;
         const isRangeSelectionEnabledWhileEditing = editSvc?.isRangeSelectionEnabledWhileEditing();
-        const cellRangeType = cellRange.type;
+        const cellRangeType = selectionRange.type;
         const selectionHandleFill =
             !isRangeSelectionEnabledWhileEditing && _isFillHandleEnabled(gos) && _missing(cellRangeType);
         const type = selectionHandleFill ? SelectionHandleType.FILL : SelectionHandleType.RANGE;
@@ -396,7 +416,7 @@ export class CellRangeFeature implements ICellRangeFeature {
             }
         }
 
-        this.selectionHandle?.refresh(this.cellCtrl, cellRange);
+        this.selectionHandle?.refresh(this.cellCtrl, selectionRange.range);
     }
 
     public destroy(): void {

--- a/packages/ag-grid-enterprise/src/rangeSelection/cellSelectionRefreshFilter.test.ts
+++ b/packages/ag-grid-enterprise/src/rangeSelection/cellSelectionRefreshFilter.test.ts
@@ -40,7 +40,6 @@ function range(
     };
 }
 
-/** Wraps the ranges the way `RangeService.getSelectionState()` does, so the globals match. */
 function state(...ranges: CellSelectionRange[]): CellSelectionSnapshot {
     return {
         ranges,
@@ -62,11 +61,8 @@ describe('createCellSelectionRefreshFilter', () => {
     });
 
     test('no cell is stale when the ranges are unchanged', () => {
-        const filter = createCellSelectionRefreshFilter(
-            [range(0, 5, ALL_COLUMNS)],
-            state(range(0, 5, ALL_COLUMNS)),
-            columnNeighbours
-        )!;
+        const unchanged = range(0, 5, ALL_COLUMNS);
+        const filter = createCellSelectionRefreshFilter([unchanged], state(unchanged), columnNeighbours)!;
 
         expect(filter(cell(0, 'a'))).toBe(false);
         expect(filter(cell(3, 'c'))).toBe(false);
@@ -132,6 +128,19 @@ describe('createCellSelectionRefreshFilter', () => {
 
         expect(filter(cell(10, 'e'))).toBe(true);
         expect(filter(cell(5, 'e'))).toBe(false);
+    });
+
+    test('replacing a range with an equivalent object stales only the handle owner', () => {
+        const filter = createCellSelectionRefreshFilter(
+            [range(0, 10, ALL_COLUMNS)],
+            state(range(0, 10, ALL_COLUMNS)),
+            columnNeighbours
+        )!;
+
+        expect(filter(cell(10, 'e'))).toBe(true);
+        expect(filter(cell(10, 'a'))).toBe(false);
+        expect(filter(cell(0, 'a'))).toBe(false);
+        expect(filter(cell(5, 'c'))).toBe(false);
     });
 
     test('a colour change stales every cell of the range', () => {

--- a/packages/ag-grid-enterprise/src/rangeSelection/cellSelectionRefreshFilter.test.ts
+++ b/packages/ag-grid-enterprise/src/rangeSelection/cellSelectionRefreshFilter.test.ts
@@ -1,13 +1,13 @@
 import { describe, expect, test } from 'vitest';
 
-import type { AgColumn, CellPosition } from 'ag-grid-community';
+import type { AgColumn, CellPosition, CellSelectionRange, CellSelectionSnapshot } from 'ag-grid-community';
 import { CellRangeType } from 'ag-grid-community';
 
-import type { RangeSnapshot } from './cellSelectionRefreshFilter';
 import { createCellSelectionRefreshFilter } from './cellSelectionRefreshFilter';
+import { areAllChartRanges, isMoreThanOneCell } from './cellSelectionState';
 
 const COLUMN_IDS = ['a', 'b', 'c', 'd', 'e'];
-const COLUMNS = COLUMN_IDS.map((colId) => ({ colId }) as unknown as AgColumn);
+const COLUMNS = COLUMN_IDS.map((colId, i) => ({ colId, allColsIndex: i }) as unknown as AgColumn);
 
 const columnNeighbours = {
     getColBefore: (col: AgColumn) => COLUMNS[COLUMNS.indexOf(col) - 1] ?? null,
@@ -18,22 +18,34 @@ function columnById(colId: string): AgColumn {
     return COLUMNS[COLUMN_IDS.indexOf(colId)];
 }
 
-function snapshot(
+function range(
     firstRow: number,
     lastRow: number,
     colIds: string[],
-    extra: Partial<RangeSnapshot> = {}
-): RangeSnapshot {
+    extra: Partial<CellSelectionRange> = {}
+): CellSelectionRange {
+    const columns = colIds.map(columnById);
+
     return {
-        firstRow,
-        lastRow,
-        firstRowPinned: null,
-        lastRowPinned: null,
-        columns: new Set(colIds.map(columnById)),
-        lastColumn: columnById(colIds[colIds.length - 1]),
+        range: { columns, startColumn: columns[0], startRow: { rowIndex: firstRow, rowPinned: null } },
+        firstRow: { rowIndex: firstRow, rowPinned: null },
+        lastRow: { rowIndex: lastRow, rowPinned: null },
+        withinOneSection: true,
+        columns: new Set(columns),
+        lastColumn: columns[columns.length - 1],
+        contiguous: true,
         type: undefined,
         colorClass: undefined,
         ...extra,
+    };
+}
+
+/** Wraps the ranges the way `RangeService.getSelectionState()` does, so the globals match. */
+function state(...ranges: CellSelectionRange[]): CellSelectionSnapshot {
+    return {
+        ranges,
+        moreThanOneCell: isMoreThanOneCell(ranges),
+        allChartRanges: areAllChartRanges(ranges),
     };
 }
 
@@ -45,14 +57,14 @@ const ALL_COLUMNS = COLUMN_IDS;
 
 describe('createCellSelectionRefreshFilter', () => {
     test('every cell is stale when a range is added or removed', () => {
-        expect(createCellSelectionRefreshFilter([], [snapshot(0, 5, ALL_COLUMNS)], columnNeighbours)).toBeNull();
-        expect(createCellSelectionRefreshFilter([snapshot(0, 5, ALL_COLUMNS)], [], columnNeighbours)).toBeNull();
+        expect(createCellSelectionRefreshFilter([], state(range(0, 5, ALL_COLUMNS)), columnNeighbours)).toBeNull();
+        expect(createCellSelectionRefreshFilter([range(0, 5, ALL_COLUMNS)], state(), columnNeighbours)).toBeNull();
     });
 
     test('no cell is stale when the ranges are unchanged', () => {
         const filter = createCellSelectionRefreshFilter(
-            [snapshot(0, 5, ALL_COLUMNS)],
-            [snapshot(0, 5, ALL_COLUMNS)],
+            [range(0, 5, ALL_COLUMNS)],
+            state(range(0, 5, ALL_COLUMNS)),
             columnNeighbours
         )!;
 
@@ -63,8 +75,8 @@ describe('createCellSelectionRefreshFilter', () => {
 
     test('extending the bottom edge stales only the rows around it', () => {
         const filter = createCellSelectionRefreshFilter(
-            [snapshot(0, 5, ALL_COLUMNS)],
-            [snapshot(0, 6, ALL_COLUMNS)],
+            [range(0, 5, ALL_COLUMNS)],
+            state(range(0, 6, ALL_COLUMNS)),
             columnNeighbours
         )!;
 
@@ -76,8 +88,8 @@ describe('createCellSelectionRefreshFilter', () => {
 
     test('extending the right edge stales only the columns around it', () => {
         const filter = createCellSelectionRefreshFilter(
-            [snapshot(0, 20, ['a', 'b', 'c'])],
-            [snapshot(0, 20, ['a', 'b', 'c', 'd'])],
+            [range(0, 20, ['a', 'b', 'c'])],
+            state(range(0, 20, ['a', 'b', 'c', 'd'])),
             columnNeighbours
         )!;
 
@@ -89,8 +101,8 @@ describe('createCellSelectionRefreshFilter', () => {
 
     test('a diagonal edge move stales the moved row and column, not the interior', () => {
         const filter = createCellSelectionRefreshFilter(
-            [snapshot(0, 5, ['a', 'b', 'c'])],
-            [snapshot(0, 6, ['a', 'b', 'c', 'd'])],
+            [range(0, 5, ['a', 'b', 'c'])],
+            state(range(0, 6, ['a', 'b', 'c', 'd'])),
             columnNeighbours
         )!;
 
@@ -101,8 +113,8 @@ describe('createCellSelectionRefreshFilter', () => {
 
     test('the handle owner is stale when the opposite row edge moves', () => {
         const filter = createCellSelectionRefreshFilter(
-            [snapshot(3, 10, ALL_COLUMNS)],
-            [snapshot(2, 10, ALL_COLUMNS)],
+            [range(3, 10, ALL_COLUMNS)],
+            state(range(2, 10, ALL_COLUMNS)),
             columnNeighbours
         )!;
 
@@ -113,8 +125,8 @@ describe('createCellSelectionRefreshFilter', () => {
 
     test('the handle owner is stale when an interior column changes the contiguity', () => {
         const filter = createCellSelectionRefreshFilter(
-            [snapshot(0, 10, ['a', 'b', 'c', 'd', 'e'])],
-            [snapshot(0, 10, ['a', 'c', 'd', 'e'])],
+            [range(0, 10, ['a', 'b', 'c', 'd', 'e'])],
+            state(range(0, 10, ['a', 'c', 'd', 'e'])),
             columnNeighbours
         )!;
 
@@ -124,8 +136,8 @@ describe('createCellSelectionRefreshFilter', () => {
 
     test('a colour change stales every cell of the range', () => {
         const filter = createCellSelectionRefreshFilter(
-            [snapshot(0, 5, ['a', 'b'])],
-            [snapshot(0, 5, ['a', 'b'], { colorClass: 'ag-formula-range-1' })],
+            [range(0, 5, ['a', 'b'])],
+            state(range(0, 5, ['a', 'b'], { colorClass: 'ag-formula-range-1' })),
             columnNeighbours
         )!;
 
@@ -137,8 +149,13 @@ describe('createCellSelectionRefreshFilter', () => {
     test('every cell is stale when a range edge crosses a pinned section', () => {
         expect(
             createCellSelectionRefreshFilter(
-                [snapshot(0, 5, ALL_COLUMNS)],
-                [snapshot(0, 5, ALL_COLUMNS, { lastRowPinned: 'bottom' })],
+                [range(0, 5, ALL_COLUMNS)],
+                state(
+                    range(0, 5, ALL_COLUMNS, {
+                        lastRow: { rowIndex: 5, rowPinned: 'bottom' },
+                        withinOneSection: false,
+                    })
+                ),
                 columnNeighbours
             )
         ).toBeNull();
@@ -146,15 +163,15 @@ describe('createCellSelectionRefreshFilter', () => {
 
     test('every cell is stale when the selection stops being a single cell', () => {
         expect(
-            createCellSelectionRefreshFilter([snapshot(3, 3, ['a'])], [snapshot(3, 3, ['a', 'b'])], columnNeighbours)
+            createCellSelectionRefreshFilter([range(3, 3, ['a'])], state(range(3, 3, ['a', 'b'])), columnNeighbours)
         ).toBeNull();
     });
 
     test('every cell is stale when the ranges start or stop being chart ranges', () => {
         expect(
             createCellSelectionRefreshFilter(
-                [snapshot(0, 5, ['a', 'b'])],
-                [snapshot(0, 5, ['a', 'b'], { type: CellRangeType.VALUE })],
+                [range(0, 5, ['a', 'b'])],
+                state(range(0, 5, ['a', 'b'], { type: CellRangeType.VALUE })),
                 columnNeighbours
             )
         ).toBeNull();

--- a/packages/ag-grid-enterprise/src/rangeSelection/cellSelectionRefreshFilter.test.ts
+++ b/packages/ag-grid-enterprise/src/rangeSelection/cellSelectionRefreshFilter.test.ts
@@ -30,6 +30,7 @@ function snapshot(
         firstRowPinned: null,
         lastRowPinned: null,
         columns: new Set(colIds.map(columnById)),
+        lastColumn: columnById(colIds[colIds.length - 1]),
         type: undefined,
         colorClass: undefined,
         ...extra,
@@ -96,6 +97,29 @@ describe('createCellSelectionRefreshFilter', () => {
         expect(filter(cell(6, 'a'))).toBe(true);
         expect(filter(cell(2, 'd'))).toBe(true);
         expect(filter(cell(2, 'a'))).toBe(false);
+    });
+
+    test('the handle owner is stale when the opposite row edge moves', () => {
+        const filter = createCellSelectionRefreshFilter(
+            [snapshot(3, 10, ALL_COLUMNS)],
+            [snapshot(2, 10, ALL_COLUMNS)],
+            columnNeighbours
+        )!;
+
+        expect(filter(cell(10, 'e'))).toBe(true);
+        expect(filter(cell(10, 'c'))).toBe(false);
+        expect(filter(cell(7, 'c'))).toBe(false);
+    });
+
+    test('the handle owner is stale when an interior column changes the contiguity', () => {
+        const filter = createCellSelectionRefreshFilter(
+            [snapshot(0, 10, ['a', 'b', 'c', 'd', 'e'])],
+            [snapshot(0, 10, ['a', 'c', 'd', 'e'])],
+            columnNeighbours
+        )!;
+
+        expect(filter(cell(10, 'e'))).toBe(true);
+        expect(filter(cell(5, 'e'))).toBe(false);
     });
 
     test('a colour change stales every cell of the range', () => {

--- a/packages/ag-grid-enterprise/src/rangeSelection/cellSelectionRefreshFilter.test.ts
+++ b/packages/ag-grid-enterprise/src/rangeSelection/cellSelectionRefreshFilter.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, test } from 'vitest';
+
+import type { AgColumn, CellPosition } from 'ag-grid-community';
+import { CellRangeType } from 'ag-grid-community';
+
+import type { RangeSnapshot } from './cellSelectionRefreshFilter';
+import { createCellSelectionRefreshFilter } from './cellSelectionRefreshFilter';
+
+const COLUMN_IDS = ['a', 'b', 'c', 'd', 'e'];
+const COLUMNS = COLUMN_IDS.map((colId) => ({ colId }) as unknown as AgColumn);
+
+const columnNeighbours = {
+    getColBefore: (col: AgColumn) => COLUMNS[COLUMNS.indexOf(col) - 1] ?? null,
+    getColAfter: (col: AgColumn) => COLUMNS[COLUMNS.indexOf(col) + 1] ?? null,
+};
+
+function columnById(colId: string): AgColumn {
+    return COLUMNS[COLUMN_IDS.indexOf(colId)];
+}
+
+function snapshot(
+    firstRow: number,
+    lastRow: number,
+    colIds: string[],
+    extra: Partial<RangeSnapshot> = {}
+): RangeSnapshot {
+    return {
+        firstRow,
+        lastRow,
+        firstRowPinned: null,
+        lastRowPinned: null,
+        columns: new Set(colIds.map(columnById)),
+        type: undefined,
+        colorClass: undefined,
+        ...extra,
+    };
+}
+
+function cell(rowIndex: number, colId: string): CellPosition {
+    return { rowIndex, rowPinned: null, column: columnById(colId) };
+}
+
+const ALL_COLUMNS = COLUMN_IDS;
+
+describe('createCellSelectionRefreshFilter', () => {
+    test('every cell is stale when a range is added or removed', () => {
+        expect(createCellSelectionRefreshFilter([], [snapshot(0, 5, ALL_COLUMNS)], columnNeighbours)).toBeNull();
+        expect(createCellSelectionRefreshFilter([snapshot(0, 5, ALL_COLUMNS)], [], columnNeighbours)).toBeNull();
+    });
+
+    test('no cell is stale when the ranges are unchanged', () => {
+        const filter = createCellSelectionRefreshFilter(
+            [snapshot(0, 5, ALL_COLUMNS)],
+            [snapshot(0, 5, ALL_COLUMNS)],
+            columnNeighbours
+        )!;
+
+        expect(filter(cell(0, 'a'))).toBe(false);
+        expect(filter(cell(3, 'c'))).toBe(false);
+        expect(filter(cell(9, 'e'))).toBe(false);
+    });
+
+    test('extending the bottom edge stales only the rows around it', () => {
+        const filter = createCellSelectionRefreshFilter(
+            [snapshot(0, 5, ALL_COLUMNS)],
+            [snapshot(0, 6, ALL_COLUMNS)],
+            columnNeighbours
+        )!;
+
+        expect(filter(cell(6, 'c'))).toBe(true);
+        expect(filter(cell(5, 'c'))).toBe(true);
+        expect(filter(cell(4, 'c'))).toBe(false);
+        expect(filter(cell(0, 'c'))).toBe(false);
+    });
+
+    test('extending the right edge stales only the columns around it', () => {
+        const filter = createCellSelectionRefreshFilter(
+            [snapshot(0, 20, ['a', 'b', 'c'])],
+            [snapshot(0, 20, ['a', 'b', 'c', 'd'])],
+            columnNeighbours
+        )!;
+
+        expect(filter(cell(10, 'd'))).toBe(true);
+        expect(filter(cell(10, 'c'))).toBe(true);
+        expect(filter(cell(10, 'b'))).toBe(false);
+        expect(filter(cell(10, 'a'))).toBe(false);
+    });
+
+    test('a diagonal edge move stales the moved row and column, not the interior', () => {
+        const filter = createCellSelectionRefreshFilter(
+            [snapshot(0, 5, ['a', 'b', 'c'])],
+            [snapshot(0, 6, ['a', 'b', 'c', 'd'])],
+            columnNeighbours
+        )!;
+
+        expect(filter(cell(6, 'a'))).toBe(true);
+        expect(filter(cell(2, 'd'))).toBe(true);
+        expect(filter(cell(2, 'a'))).toBe(false);
+    });
+
+    test('a colour change stales every cell of the range', () => {
+        const filter = createCellSelectionRefreshFilter(
+            [snapshot(0, 5, ['a', 'b'])],
+            [snapshot(0, 5, ['a', 'b'], { colorClass: 'ag-formula-range-1' })],
+            columnNeighbours
+        )!;
+
+        expect(filter(cell(3, 'a'))).toBe(true);
+        expect(filter(cell(3, 'b'))).toBe(true);
+        expect(filter(cell(3, 'c'))).toBe(false);
+    });
+
+    test('every cell is stale when a range edge crosses a pinned section', () => {
+        expect(
+            createCellSelectionRefreshFilter(
+                [snapshot(0, 5, ALL_COLUMNS)],
+                [snapshot(0, 5, ALL_COLUMNS, { lastRowPinned: 'bottom' })],
+                columnNeighbours
+            )
+        ).toBeNull();
+    });
+
+    test('every cell is stale when the selection stops being a single cell', () => {
+        expect(
+            createCellSelectionRefreshFilter([snapshot(3, 3, ['a'])], [snapshot(3, 3, ['a', 'b'])], columnNeighbours)
+        ).toBeNull();
+    });
+
+    test('every cell is stale when the ranges start or stop being chart ranges', () => {
+        expect(
+            createCellSelectionRefreshFilter(
+                [snapshot(0, 5, ['a', 'b'])],
+                [snapshot(0, 5, ['a', 'b'], { type: CellRangeType.VALUE })],
+                columnNeighbours
+            )
+        ).toBeNull();
+    });
+});

--- a/packages/ag-grid-enterprise/src/rangeSelection/cellSelectionRefreshFilter.ts
+++ b/packages/ag-grid-enterprise/src/rangeSelection/cellSelectionRefreshFilter.ts
@@ -16,6 +16,8 @@ export interface RangeSnapshot {
     firstRowPinned: RowPinnedType;
     lastRowPinned: RowPinnedType;
     columns: Set<Column>;
+    /** The rightmost column, which with `lastRow` owns the selection handle. */
+    lastColumn: Column | undefined;
     type: CellRangeType | undefined;
     colorClass: string | null | undefined;
 }
@@ -37,9 +39,22 @@ export function snapshotCellRange(range: CellRange, firstRow: RowPosition, lastR
         lastRowPinned: _makeNull(lastRow.rowPinned),
         // ranges are mutated in place while dragging, so the columns are copied rather than shared
         columns: new Set(range.columns),
+        lastColumn: findLastColumn(range.columns),
         type: range.type,
         colorClass: range.colorClass,
     };
+}
+
+/** Mirrors the rightmost column that `IRangeService.isBottomRightCell()` compares against. */
+function findLastColumn(columns: Column[]): Column | undefined {
+    let last: AgColumn | undefined;
+    for (let i = 0, len = columns.length; i < len; i++) {
+        const column = columns[i] as AgColumn;
+        if (!last || column.allColsIndex > last.allColsIndex) {
+            last = column;
+        }
+    }
+    return last;
 }
 
 /**
@@ -107,7 +122,18 @@ interface RangeChange {
     wholeRange: boolean;
     rowPinned: RowPinnedType;
     regions: CandidateRegion[];
+    /**
+     * The cells owning the selection handle before and after the change. The handle caches the range
+     * row boundaries and its availability depends on contiguity across every selected column, so it
+     * goes stale on changes that leave its own cell's membership and borders untouched.
+     */
+    handleCells: CandidateCell[];
     columns: ColumnNeighbours;
+}
+
+interface CandidateCell {
+    rowIndex: number;
+    column: Column;
 }
 
 function createRangeChange(before: RangeSnapshot, after: RangeSnapshot, columns: ColumnNeighbours): RangeChange | null {
@@ -117,7 +143,15 @@ function createRangeChange(before: RangeSnapshot, after: RangeSnapshot, columns:
     }
 
     const wholeRange = before.type !== after.type || before.colorClass !== after.colorClass;
-    const change: RangeChange = { before, after, wholeRange, rowPinned, regions: [], columns };
+    const change: RangeChange = {
+        before,
+        after,
+        wholeRange,
+        rowPinned,
+        regions: [],
+        handleCells: collectHandleCells(before, after),
+        columns,
+    };
 
     const spannedFirstRow = Math.min(before.firstRow, after.firstRow);
     const spannedLastRow = Math.max(before.lastRow, after.lastRow);
@@ -161,12 +195,29 @@ function createRangeChange(before: RangeSnapshot, after: RangeSnapshot, columns:
     return change;
 }
 
+function collectHandleCells(before: RangeSnapshot, after: RangeSnapshot): CandidateCell[] {
+    const cells: CandidateCell[] = [];
+    for (const { lastRow, lastColumn } of [before, after]) {
+        if (lastColumn && !cells.some((cell) => cell.rowIndex === lastRow && cell.column === lastColumn)) {
+            cells.push({ rowIndex: lastRow, column: lastColumn });
+        }
+    }
+    return cells;
+}
+
 function isCellAffected(change: RangeChange, cell: CellPosition): boolean {
-    const { regions, rowPinned } = change;
+    const { regions, rowPinned, handleCells } = change;
     const { column, rowIndex } = cell;
 
     if (_makeNull(cell.rowPinned) !== rowPinned) {
         return false;
+    }
+
+    for (let i = 0, len = handleCells.length; i < len; i++) {
+        const handleCell = handleCells[i];
+        if (handleCell.rowIndex === rowIndex && handleCell.column === column) {
+            return true;
+        }
     }
 
     let isCandidate = false;

--- a/packages/ag-grid-enterprise/src/rangeSelection/cellSelectionRefreshFilter.ts
+++ b/packages/ag-grid-enterprise/src/rangeSelection/cellSelectionRefreshFilter.ts
@@ -1,0 +1,299 @@
+import { _makeNull } from 'ag-stack';
+
+import type { AgColumn, CellPosition, CellRange, Column, RowPinnedType, RowPosition } from 'ag-grid-community';
+import { CellRangeType } from 'ag-grid-community';
+
+/**
+ * Everything about a single cell range that the selection styling of a cell depends on, captured as
+ * of the last time the rendered cells were refreshed. Rows are held as plain indexes so that the
+ * per-cell filter can compare them without going through the row position helpers.
+ */
+export interface RangeSnapshot {
+    /** Normalised (topmost) row of the range. */
+    firstRow: number;
+    /** Normalised (bottommost) row of the range. */
+    lastRow: number;
+    firstRowPinned: RowPinnedType;
+    lastRowPinned: RowPinnedType;
+    columns: Set<Column>;
+    type: CellRangeType | undefined;
+    colorClass: string | null | undefined;
+}
+
+/** Matches the rendered cells whose selection state can have changed. */
+export type CellSelectionRefreshFilter = (cell: CellPosition) => boolean;
+
+/** The columns adjacent to a column, in visible order. Modelled on `VisibleColsService`. */
+interface ColumnNeighbours {
+    getColBefore(col: AgColumn): AgColumn | null;
+    getColAfter(col: AgColumn): AgColumn | null;
+}
+
+export function snapshotCellRange(range: CellRange, firstRow: RowPosition, lastRow: RowPosition): RangeSnapshot {
+    return {
+        firstRow: firstRow.rowIndex,
+        lastRow: lastRow.rowIndex,
+        firstRowPinned: _makeNull(firstRow.rowPinned),
+        lastRowPinned: _makeNull(lastRow.rowPinned),
+        // ranges are mutated in place while dragging, so the columns are copied rather than shared
+        columns: new Set(range.columns),
+        type: range.type,
+        colorClass: range.colorClass,
+    };
+}
+
+/**
+ * Works out which rendered cells need their selection state refreshed, given the ranges as they were
+ * last painted and as they are now. Returns `null` when every cell has to be refreshed.
+ */
+export function createCellSelectionRefreshFilter(
+    painted: RangeSnapshot[],
+    current: RangeSnapshot[],
+    columns: ColumnNeighbours
+): CellSelectionRefreshFilter | null {
+    // adding or removing a range changes the range count and which range owns the selection handle,
+    // neither of which is a per-cell property, so there is nothing to narrow down
+    if (painted.length !== current.length) {
+        return null;
+    }
+    // both are read globally by every cell, so a flip invalidates the whole viewport
+    if (isMoreThanOneCell(painted) !== isMoreThanOneCell(current)) {
+        return null;
+    }
+    if (isChartRangeSet(painted) !== isChartRangeSet(current)) {
+        return null;
+    }
+
+    const changes: RangeChange[] = [];
+
+    for (let i = 0; i < current.length; i++) {
+        const before = painted[i];
+        const after = current[i];
+
+        if (isUnchanged(before, after)) {
+            continue;
+        }
+
+        const change = createRangeChange(before, after, columns);
+        // a range spanning more than one pinned section cannot be compared by row index alone
+        if (!change) {
+            return null;
+        }
+
+        changes.push(change);
+    }
+
+    return function isCellStale(cell: CellPosition): boolean {
+        for (let i = 0, len = changes.length; i < len; i++) {
+            if (isCellAffected(changes[i], cell)) {
+                return true;
+            }
+        }
+        return false;
+    };
+}
+
+/** A band of rows crossed with a set of columns, holding every cell a change could have staled. */
+interface CandidateRegion {
+    firstRow: number;
+    lastRow: number;
+    columns: Set<Column>;
+}
+
+interface RangeChange {
+    before: RangeSnapshot;
+    after: RangeSnapshot;
+    /** The colour and chart category classes apply to every cell of the range, not just its edge. */
+    wholeRange: boolean;
+    rowPinned: RowPinnedType;
+    regions: CandidateRegion[];
+    columns: ColumnNeighbours;
+}
+
+function createRangeChange(before: RangeSnapshot, after: RangeSnapshot, columns: ColumnNeighbours): RangeChange | null {
+    const rowPinned = before.firstRowPinned;
+    if (before.lastRowPinned !== rowPinned || after.firstRowPinned !== rowPinned || after.lastRowPinned !== rowPinned) {
+        return null;
+    }
+
+    const wholeRange = before.type !== after.type || before.colorClass !== after.colorClass;
+    const change: RangeChange = { before, after, wholeRange, rowPinned, regions: [], columns };
+
+    const spannedFirstRow = Math.min(before.firstRow, after.firstRow);
+    const spannedLastRow = Math.max(before.lastRow, after.lastRow);
+
+    if (wholeRange) {
+        change.regions.push({
+            firstRow: spannedFirstRow,
+            lastRow: spannedLastRow,
+            columns: unionColumns(before.columns, after.columns),
+        });
+
+        return change;
+    }
+
+    // borders, the single-cell class and the selection handle all depend on whether the neighbouring
+    // cells share the range, so each region is widened by one cell in every direction
+    const changedColumns = widenColumns(symmetricDifferenceOfColumns(before.columns, after.columns), columns);
+    if (changedColumns.size) {
+        change.regions.push({ firstRow: spannedFirstRow - 1, lastRow: spannedLastRow + 1, columns: changedColumns });
+    }
+
+    if (before.firstRow !== after.firstRow || before.lastRow !== after.lastRow) {
+        const spannedColumns = widenColumns(unionColumns(before.columns, after.columns), columns);
+
+        if (before.firstRow !== after.firstRow) {
+            change.regions.push({
+                firstRow: Math.min(before.firstRow, after.firstRow) - 1,
+                lastRow: Math.max(before.firstRow, after.firstRow) + 1,
+                columns: spannedColumns,
+            });
+        }
+        if (before.lastRow !== after.lastRow) {
+            change.regions.push({
+                firstRow: Math.min(before.lastRow, after.lastRow) - 1,
+                lastRow: Math.max(before.lastRow, after.lastRow) + 1,
+                columns: spannedColumns,
+            });
+        }
+    }
+
+    return change;
+}
+
+function isCellAffected(change: RangeChange, cell: CellPosition): boolean {
+    const { regions, rowPinned } = change;
+    const { column, rowIndex } = cell;
+
+    if (_makeNull(cell.rowPinned) !== rowPinned) {
+        return false;
+    }
+
+    let isCandidate = false;
+    for (let i = 0, len = regions.length; i < len && !isCandidate; i++) {
+        const region = regions[i];
+        isCandidate = rowIndex >= region.firstRow && rowIndex <= region.lastRow && region.columns.has(column);
+    }
+    if (!isCandidate) {
+        return false;
+    }
+
+    const { before, after } = change;
+    if (change.wholeRange) {
+        return isCellIn(before, column, rowIndex) || isCellIn(after, column, rowIndex);
+    }
+
+    if (
+        hasMembershipChanged(change, column, rowIndex) ||
+        (rowIndex > 0 && hasMembershipChanged(change, column, rowIndex - 1)) ||
+        hasMembershipChanged(change, column, rowIndex + 1)
+    ) {
+        return true;
+    }
+
+    const agColumn = column as AgColumn;
+    const colBefore = change.columns.getColBefore(agColumn);
+    const colAfter = change.columns.getColAfter(agColumn);
+
+    return (
+        (!!colBefore && hasMembershipChanged(change, colBefore, rowIndex)) ||
+        (!!colAfter && hasMembershipChanged(change, colAfter, rowIndex))
+    );
+}
+
+function hasMembershipChanged({ before, after }: RangeChange, column: Column, rowIndex: number): boolean {
+    return isCellIn(before, column, rowIndex) !== isCellIn(after, column, rowIndex);
+}
+
+function isCellIn({ columns, firstRow, lastRow }: RangeSnapshot, column: Column, rowIndex: number): boolean {
+    return rowIndex >= firstRow && rowIndex <= lastRow && columns.has(column);
+}
+
+function unionColumns(before: Set<Column>, after: Set<Column>): Set<Column> {
+    const union = new Set(before);
+    for (const column of after) {
+        union.add(column);
+    }
+    return union;
+}
+
+function symmetricDifferenceOfColumns(before: Set<Column>, after: Set<Column>): Set<Column> {
+    const difference = new Set<Column>();
+    for (const column of before) {
+        if (!after.has(column)) {
+            difference.add(column);
+        }
+    }
+    for (const column of after) {
+        if (!before.has(column)) {
+            difference.add(column);
+        }
+    }
+    return difference;
+}
+
+function widenColumns(selected: Set<Column>, columns: ColumnNeighbours): Set<Column> {
+    if (!selected.size) {
+        return selected;
+    }
+
+    const widened = new Set(selected);
+    for (const column of selected) {
+        const agColumn = column as AgColumn;
+        const colBefore = columns.getColBefore(agColumn);
+        const colAfter = columns.getColAfter(agColumn);
+        if (colBefore) {
+            widened.add(colBefore);
+        }
+        if (colAfter) {
+            widened.add(colAfter);
+        }
+    }
+    return widened;
+}
+
+function isUnchanged(before: RangeSnapshot, after: RangeSnapshot): boolean {
+    return (
+        before.type === after.type &&
+        before.colorClass === after.colorClass &&
+        before.firstRow === after.firstRow &&
+        before.lastRow === after.lastRow &&
+        before.firstRowPinned === after.firstRowPinned &&
+        before.lastRowPinned === after.lastRowPinned &&
+        haveSameColumns(before.columns, after.columns)
+    );
+}
+
+function haveSameColumns(before: Set<Column>, after: Set<Column>): boolean {
+    if (before.size !== after.size) {
+        return false;
+    }
+    for (const column of before) {
+        if (!after.has(column)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+/** Mirrors `IRangeService.isMoreThanOneCell()`, which every cell reads for the single-cell class. */
+function isMoreThanOneCell(snapshots: RangeSnapshot[]): boolean {
+    if (snapshots.length === 0) {
+        return false;
+    }
+    if (snapshots.length > 1) {
+        return true;
+    }
+
+    const { firstRow, lastRow, firstRowPinned, lastRowPinned, columns } = snapshots[0];
+
+    return firstRow !== lastRow || firstRowPinned !== lastRowPinned || columns.size !== 1;
+}
+
+/** Mirrors the all-ranges test behind the `ag-cell-range-chart` class. */
+function isChartRangeSet(snapshots: RangeSnapshot[]): boolean {
+    return (
+        snapshots.length > 0 &&
+        snapshots.every(({ type }) => type === CellRangeType.DIMENSION || type === CellRangeType.VALUE)
+    );
+}

--- a/packages/ag-grid-enterprise/src/rangeSelection/cellSelectionRefreshFilter.ts
+++ b/packages/ag-grid-enterprise/src/rangeSelection/cellSelectionRefreshFilter.ts
@@ -1,26 +1,8 @@
 import { _makeNull } from 'ag-stack';
 
-import type { AgColumn, CellPosition, CellRange, Column, RowPinnedType, RowPosition } from 'ag-grid-community';
-import { CellRangeType } from 'ag-grid-community';
+import type { AgColumn, CellPosition, CellSelectionRange, CellSelectionSnapshot, Column } from 'ag-grid-community';
 
-/**
- * Everything about a single cell range that the selection styling of a cell depends on, captured as
- * of the last time the rendered cells were refreshed. Rows are held as plain indexes so that the
- * per-cell filter can compare them without going through the row position helpers.
- */
-export interface RangeSnapshot {
-    /** Normalised (topmost) row of the range. */
-    firstRow: number;
-    /** Normalised (bottommost) row of the range. */
-    lastRow: number;
-    firstRowPinned: RowPinnedType;
-    lastRowPinned: RowPinnedType;
-    columns: Set<Column>;
-    /** The rightmost column, which with `lastRow` owns the selection handle. */
-    lastColumn: Column | undefined;
-    type: CellRangeType | undefined;
-    colorClass: string | null | undefined;
-}
+import { areAllChartRanges, isCellInSelectionRange, isMoreThanOneCell } from './cellSelectionState';
 
 /** Matches the rendered cells whose selection state can have changed. */
 export type CellSelectionRefreshFilter = (cell: CellPosition) => boolean;
@@ -31,59 +13,35 @@ interface ColumnNeighbours {
     getColAfter(col: AgColumn): AgColumn | null;
 }
 
-export function snapshotCellRange(range: CellRange, firstRow: RowPosition, lastRow: RowPosition): RangeSnapshot {
-    return {
-        firstRow: firstRow.rowIndex,
-        lastRow: lastRow.rowIndex,
-        firstRowPinned: _makeNull(firstRow.rowPinned),
-        lastRowPinned: _makeNull(lastRow.rowPinned),
-        // ranges are mutated in place while dragging, so the columns are copied rather than shared
-        columns: new Set(range.columns),
-        lastColumn: findLastColumn(range.columns),
-        type: range.type,
-        colorClass: range.colorClass,
-    };
-}
-
-/** Mirrors the rightmost column that `IRangeService.isBottomRightCell()` compares against. */
-function findLastColumn(columns: Column[]): Column | undefined {
-    let last: AgColumn | undefined;
-    for (let i = 0, len = columns.length; i < len; i++) {
-        const column = columns[i] as AgColumn;
-        if (!last || column.allColsIndex > last.allColsIndex) {
-            last = column;
-        }
-    }
-    return last;
-}
-
 /**
  * Works out which rendered cells need their selection state refreshed, given the ranges as they were
  * last painted and as they are now. Returns `null` when every cell has to be refreshed.
  */
 export function createCellSelectionRefreshFilter(
-    painted: RangeSnapshot[],
-    current: RangeSnapshot[],
+    painted: CellSelectionRange[],
+    current: CellSelectionSnapshot,
     columns: ColumnNeighbours
 ): CellSelectionRefreshFilter | null {
+    const currentRanges = current.ranges;
+
     // adding or removing a range changes the range count and which range owns the selection handle,
     // neither of which is a per-cell property, so there is nothing to narrow down
-    if (painted.length !== current.length) {
+    if (painted.length !== currentRanges.length) {
         return null;
     }
     // both are read globally by every cell, so a flip invalidates the whole viewport
-    if (isMoreThanOneCell(painted) !== isMoreThanOneCell(current)) {
+    if (isMoreThanOneCell(painted) !== current.moreThanOneCell) {
         return null;
     }
-    if (isChartRangeSet(painted) !== isChartRangeSet(current)) {
+    if (areAllChartRanges(painted) !== current.allChartRanges) {
         return null;
     }
 
     const changes: RangeChange[] = [];
 
-    for (let i = 0; i < current.length; i++) {
+    for (let i = 0; i < currentRanges.length; i++) {
         const before = painted[i];
-        const after = current[i];
+        const after = currentRanges[i];
 
         if (isUnchanged(before, after)) {
             continue;
@@ -115,12 +73,17 @@ interface CandidateRegion {
     columns: Set<Column>;
 }
 
+interface CandidateCell {
+    rowIndex: number;
+    column: Column;
+}
+
 interface RangeChange {
-    before: RangeSnapshot;
-    after: RangeSnapshot;
+    before: CellSelectionRange;
+    after: CellSelectionRange;
     /** The colour and chart category classes apply to every cell of the range, not just its edge. */
     wholeRange: boolean;
-    rowPinned: RowPinnedType;
+    rowPinned: string | null;
     regions: CandidateRegion[];
     /**
      * The cells owning the selection handle before and after the change. The handle caches the range
@@ -131,16 +94,20 @@ interface RangeChange {
     columns: ColumnNeighbours;
 }
 
-interface CandidateCell {
-    rowIndex: number;
-    column: Column;
-}
-
-function createRangeChange(before: RangeSnapshot, after: RangeSnapshot, columns: ColumnNeighbours): RangeChange | null {
-    const rowPinned = before.firstRowPinned;
-    if (before.lastRowPinned !== rowPinned || after.firstRowPinned !== rowPinned || after.lastRowPinned !== rowPinned) {
+function createRangeChange(
+    before: CellSelectionRange,
+    after: CellSelectionRange,
+    columns: ColumnNeighbours
+): RangeChange | null {
+    const rowPinned = before.firstRow.rowPinned ?? null;
+    if (!before.withinOneSection || !after.withinOneSection || (after.firstRow.rowPinned ?? null) !== rowPinned) {
         return null;
     }
+
+    const beforeFirst = before.firstRow.rowIndex;
+    const beforeLast = before.lastRow.rowIndex;
+    const afterFirst = after.firstRow.rowIndex;
+    const afterLast = after.lastRow.rowIndex;
 
     const wholeRange = before.type !== after.type || before.colorClass !== after.colorClass;
     const change: RangeChange = {
@@ -153,8 +120,8 @@ function createRangeChange(before: RangeSnapshot, after: RangeSnapshot, columns:
         columns,
     };
 
-    const spannedFirstRow = Math.min(before.firstRow, after.firstRow);
-    const spannedLastRow = Math.max(before.lastRow, after.lastRow);
+    const spannedFirstRow = Math.min(beforeFirst, afterFirst);
+    const spannedLastRow = Math.max(beforeLast, afterLast);
 
     if (wholeRange) {
         change.regions.push({
@@ -166,27 +133,27 @@ function createRangeChange(before: RangeSnapshot, after: RangeSnapshot, columns:
         return change;
     }
 
-    // borders, the single-cell class and the selection handle all depend on whether the neighbouring
-    // cells share the range, so each region is widened by one cell in every direction
+    // borders and the single-cell class depend on whether the neighbouring cells share the range, so
+    // each region is widened by one cell in every direction
     const changedColumns = widenColumns(symmetricDifferenceOfColumns(before.columns, after.columns), columns);
     if (changedColumns.size) {
         change.regions.push({ firstRow: spannedFirstRow - 1, lastRow: spannedLastRow + 1, columns: changedColumns });
     }
 
-    if (before.firstRow !== after.firstRow || before.lastRow !== after.lastRow) {
+    if (beforeFirst !== afterFirst || beforeLast !== afterLast) {
         const spannedColumns = widenColumns(unionColumns(before.columns, after.columns), columns);
 
-        if (before.firstRow !== after.firstRow) {
+        if (beforeFirst !== afterFirst) {
             change.regions.push({
-                firstRow: Math.min(before.firstRow, after.firstRow) - 1,
-                lastRow: Math.max(before.firstRow, after.firstRow) + 1,
+                firstRow: Math.min(beforeFirst, afterFirst) - 1,
+                lastRow: Math.max(beforeFirst, afterFirst) + 1,
                 columns: spannedColumns,
             });
         }
-        if (before.lastRow !== after.lastRow) {
+        if (beforeLast !== afterLast) {
             change.regions.push({
-                firstRow: Math.min(before.lastRow, after.lastRow) - 1,
-                lastRow: Math.max(before.lastRow, after.lastRow) + 1,
+                firstRow: Math.min(beforeLast, afterLast) - 1,
+                lastRow: Math.max(beforeLast, afterLast) + 1,
                 columns: spannedColumns,
             });
         }
@@ -195,11 +162,12 @@ function createRangeChange(before: RangeSnapshot, after: RangeSnapshot, columns:
     return change;
 }
 
-function collectHandleCells(before: RangeSnapshot, after: RangeSnapshot): CandidateCell[] {
+function collectHandleCells(before: CellSelectionRange, after: CellSelectionRange): CandidateCell[] {
     const cells: CandidateCell[] = [];
     for (const { lastRow, lastColumn } of [before, after]) {
-        if (lastColumn && !cells.some((cell) => cell.rowIndex === lastRow && cell.column === lastColumn)) {
-            cells.push({ rowIndex: lastRow, column: lastColumn });
+        const rowIndex = lastRow.rowIndex;
+        if (lastColumn && !cells.some((cell) => cell.rowIndex === rowIndex && cell.column === lastColumn)) {
+            cells.push({ rowIndex, column: lastColumn });
         }
     }
     return cells;
@@ -256,8 +224,12 @@ function hasMembershipChanged({ before, after }: RangeChange, column: Column, ro
     return isCellIn(before, column, rowIndex) !== isCellIn(after, column, rowIndex);
 }
 
-function isCellIn({ columns, firstRow, lastRow }: RangeSnapshot, column: Column, rowIndex: number): boolean {
-    return rowIndex >= firstRow && rowIndex <= lastRow && columns.has(column);
+function isCellIn(selectionRange: CellSelectionRange, column: Column, rowIndex: number): boolean {
+    return isCellInSelectionRange(selectionRange, {
+        rowIndex,
+        rowPinned: selectionRange.firstRow.rowPinned,
+        column,
+    });
 }
 
 function unionColumns(before: Set<Column>, after: Set<Column>): Set<Column> {
@@ -303,14 +275,14 @@ function widenColumns(selected: Set<Column>, columns: ColumnNeighbours): Set<Col
     return widened;
 }
 
-function isUnchanged(before: RangeSnapshot, after: RangeSnapshot): boolean {
+function isUnchanged(before: CellSelectionRange, after: CellSelectionRange): boolean {
     return (
         before.type === after.type &&
         before.colorClass === after.colorClass &&
-        before.firstRow === after.firstRow &&
-        before.lastRow === after.lastRow &&
-        before.firstRowPinned === after.firstRowPinned &&
-        before.lastRowPinned === after.lastRowPinned &&
+        before.firstRow.rowIndex === after.firstRow.rowIndex &&
+        before.lastRow.rowIndex === after.lastRow.rowIndex &&
+        before.firstRow.rowPinned === after.firstRow.rowPinned &&
+        before.lastRow.rowPinned === after.lastRow.rowPinned &&
         haveSameColumns(before.columns, after.columns)
     );
 }
@@ -325,26 +297,4 @@ function haveSameColumns(before: Set<Column>, after: Set<Column>): boolean {
         }
     }
     return true;
-}
-
-/** Mirrors `IRangeService.isMoreThanOneCell()`, which every cell reads for the single-cell class. */
-function isMoreThanOneCell(snapshots: RangeSnapshot[]): boolean {
-    if (snapshots.length === 0) {
-        return false;
-    }
-    if (snapshots.length > 1) {
-        return true;
-    }
-
-    const { firstRow, lastRow, firstRowPinned, lastRowPinned, columns } = snapshots[0];
-
-    return firstRow !== lastRow || firstRowPinned !== lastRowPinned || columns.size !== 1;
-}
-
-/** Mirrors the all-ranges test behind the `ag-cell-range-chart` class. */
-function isChartRangeSet(snapshots: RangeSnapshot[]): boolean {
-    return (
-        snapshots.length > 0 &&
-        snapshots.every(({ type }) => type === CellRangeType.DIMENSION || type === CellRangeType.VALUE)
-    );
 }

--- a/packages/ag-grid-enterprise/src/rangeSelection/cellSelectionRefreshFilter.ts
+++ b/packages/ag-grid-enterprise/src/rangeSelection/cellSelectionRefreshFilter.ts
@@ -1,22 +1,23 @@
 import { _makeNull } from 'ag-stack';
 
-import type { AgColumn, CellPosition, CellSelectionRange, CellSelectionSnapshot, Column } from 'ag-grid-community';
+import type {
+    AgColumn,
+    CellPosition,
+    CellSelectionRange,
+    CellSelectionSnapshot,
+    Column,
+    RowPinnedType,
+} from 'ag-grid-community';
 
 import { areAllChartRanges, isCellInSelectionRange, isMoreThanOneCell } from './cellSelectionState';
 
-/** Matches the rendered cells whose selection state can have changed. */
 export type CellSelectionRefreshFilter = (cell: CellPosition) => boolean;
 
-/** The columns adjacent to a column, in visible order. Modelled on `VisibleColsService`. */
 interface ColumnNeighbours {
     getColBefore(col: AgColumn): AgColumn | null;
     getColAfter(col: AgColumn): AgColumn | null;
 }
 
-/**
- * Works out which rendered cells need their selection state refreshed, given the ranges as they were
- * last painted and as they are now. Returns `null` when every cell has to be refreshed.
- */
 export function createCellSelectionRefreshFilter(
     painted: CellSelectionRange[],
     current: CellSelectionSnapshot,
@@ -24,12 +25,9 @@ export function createCellSelectionRefreshFilter(
 ): CellSelectionRefreshFilter | null {
     const currentRanges = current.ranges;
 
-    // adding or removing a range changes the range count and which range owns the selection handle,
-    // neither of which is a per-cell property, so there is nothing to narrow down
     if (painted.length !== currentRanges.length) {
         return null;
     }
-    // both are read globally by every cell, so a flip invalidates the whole viewport
     if (isMoreThanOneCell(painted) !== current.moreThanOneCell) {
         return null;
     }
@@ -44,11 +42,13 @@ export function createCellSelectionRefreshFilter(
         const after = currentRanges[i];
 
         if (isUnchanged(before, after)) {
+            if (before.range !== after.range) {
+                changes.push(createHandleOnlyChange(before, after, columns));
+            }
             continue;
         }
 
         const change = createRangeChange(before, after, columns);
-        // a range spanning more than one pinned section cannot be compared by row index alone
         if (!change) {
             return null;
         }
@@ -66,7 +66,6 @@ export function createCellSelectionRefreshFilter(
     };
 }
 
-/** A band of rows crossed with a set of columns, holding every cell a change could have staled. */
 interface CandidateRegion {
     firstRow: number;
     lastRow: number;
@@ -75,21 +74,16 @@ interface CandidateRegion {
 
 interface CandidateCell {
     rowIndex: number;
+    rowPinned: RowPinnedType;
     column: Column;
 }
 
 interface RangeChange {
     before: CellSelectionRange;
     after: CellSelectionRange;
-    /** The colour and chart category classes apply to every cell of the range, not just its edge. */
     wholeRange: boolean;
-    rowPinned: string | null;
+    rowPinned: RowPinnedType;
     regions: CandidateRegion[];
-    /**
-     * The cells owning the selection handle before and after the change. The handle caches the range
-     * row boundaries and its availability depends on contiguity across every selected column, so it
-     * goes stale on changes that leave its own cell's membership and borders untouched.
-     */
     handleCells: CandidateCell[];
     columns: ColumnNeighbours;
 }
@@ -133,8 +127,6 @@ function createRangeChange(
         return change;
     }
 
-    // borders and the single-cell class depend on whether the neighbouring cells share the range, so
-    // each region is widened by one cell in every direction
     const changedColumns = widenColumns(symmetricDifferenceOfColumns(before.columns, after.columns), columns);
     if (changedColumns.size) {
         change.regions.push({ firstRow: spannedFirstRow - 1, lastRow: spannedLastRow + 1, columns: changedColumns });
@@ -165,27 +157,47 @@ function createRangeChange(
 function collectHandleCells(before: CellSelectionRange, after: CellSelectionRange): CandidateCell[] {
     const cells: CandidateCell[] = [];
     for (const { lastRow, lastColumn } of [before, after]) {
-        const rowIndex = lastRow.rowIndex;
-        if (lastColumn && !cells.some((cell) => cell.rowIndex === rowIndex && cell.column === lastColumn)) {
-            cells.push({ rowIndex, column: lastColumn });
+        const { rowIndex, rowPinned } = lastRow;
+        const seen = cells.some(
+            (cell) => cell.rowIndex === rowIndex && cell.rowPinned === rowPinned && cell.column === lastColumn
+        );
+        if (lastColumn && !seen) {
+            cells.push({ rowIndex, rowPinned, column: lastColumn });
         }
     }
     return cells;
 }
 
+function createHandleOnlyChange(
+    before: CellSelectionRange,
+    after: CellSelectionRange,
+    columns: ColumnNeighbours
+): RangeChange {
+    return {
+        before,
+        after,
+        wholeRange: false,
+        rowPinned: before.firstRow.rowPinned ?? null,
+        regions: [],
+        handleCells: collectHandleCells(before, after),
+        columns,
+    };
+}
+
 function isCellAffected(change: RangeChange, cell: CellPosition): boolean {
     const { regions, rowPinned, handleCells } = change;
     const { column, rowIndex } = cell;
-
-    if (_makeNull(cell.rowPinned) !== rowPinned) {
-        return false;
-    }
+    const cellPinned = _makeNull(cell.rowPinned);
 
     for (let i = 0, len = handleCells.length; i < len; i++) {
         const handleCell = handleCells[i];
-        if (handleCell.rowIndex === rowIndex && handleCell.column === column) {
+        if (handleCell.rowIndex === rowIndex && handleCell.rowPinned === cellPinned && handleCell.column === column) {
             return true;
         }
+    }
+
+    if (cellPinned !== rowPinned) {
+        return false;
     }
 
     let isCandidate = false;

--- a/packages/ag-grid-enterprise/src/rangeSelection/cellSelectionState.ts
+++ b/packages/ag-grid-enterprise/src/rangeSelection/cellSelectionState.ts
@@ -3,7 +3,6 @@ import { _makeNull } from 'ag-stack';
 import type { AgColumn, CellPosition, CellRange, CellSelectionRange, Column, RowPosition } from 'ag-grid-community';
 import { CellRangeType, _isRowBefore, _isSameRow } from 'ag-grid-community';
 
-/** The per-range facts a cell needs, gathered once so a viewport of cells does not each recompute them. */
 export function buildCellSelectionRange(
     range: CellRange,
     firstRow: RowPosition,
@@ -15,7 +14,6 @@ export function buildCellSelectionRange(
 
     return {
         range,
-        // ranges are mutated in place while dragging, so the rows are copied rather than shared
         firstRow: { rowIndex: firstRow.rowIndex, rowPinned: firstRowPinned },
         lastRow: { rowIndex: lastRow.rowIndex, rowPinned: lastRowPinned },
         withinOneSection: firstRowPinned === lastRowPinned,
@@ -27,7 +25,6 @@ export function buildCellSelectionRange(
     };
 }
 
-/** Mirrors the rightmost column that `IRangeService.isBottomRightCell()` compares against. */
 function findLastColumn(columns: Column[]): Column | undefined {
     let last: AgColumn | undefined;
     for (let i = 0, len = columns.length; i < len; i++) {
@@ -41,7 +38,6 @@ function findLastColumn(columns: Column[]): Column | undefined {
 
 function isRowInSelectionRange({ firstRow, lastRow, withinOneSection }: CellSelectionRange, row: RowPosition) {
     if (withinOneSection) {
-        // the common case: one pinned section, so the row indexes alone order the rows
         return (
             _makeNull(row.rowPinned) === firstRow.rowPinned &&
             row.rowIndex >= firstRow.rowIndex &&
@@ -60,7 +56,6 @@ export function isCellInSelectionRange(selectionRange: CellSelectionRange, cell:
     return selectionRange.columns.has(cell.column) && isRowInSelectionRange(selectionRange, cell);
 }
 
-/** Mirrors `IRangeService.isMoreThanOneCell()`. */
 export function isMoreThanOneCell(ranges: CellSelectionRange[]): boolean {
     if (ranges.length === 0) {
         return false;
@@ -74,7 +69,6 @@ export function isMoreThanOneCell(ranges: CellSelectionRange[]): boolean {
     return firstRow.rowIndex !== lastRow.rowIndex || firstRow.rowPinned !== lastRow.rowPinned || columns.size !== 1;
 }
 
-/** Mirrors the all-ranges test behind the `ag-cell-range-chart` class. */
 export function areAllChartRanges(ranges: CellSelectionRange[]): boolean {
     return (
         ranges.length > 0 &&

--- a/packages/ag-grid-enterprise/src/rangeSelection/cellSelectionState.ts
+++ b/packages/ag-grid-enterprise/src/rangeSelection/cellSelectionState.ts
@@ -1,0 +1,83 @@
+import { _makeNull } from 'ag-stack';
+
+import type { AgColumn, CellPosition, CellRange, CellSelectionRange, Column, RowPosition } from 'ag-grid-community';
+import { CellRangeType, _isRowBefore, _isSameRow } from 'ag-grid-community';
+
+/** The per-range facts a cell needs, gathered once so a viewport of cells does not each recompute them. */
+export function buildCellSelectionRange(
+    range: CellRange,
+    firstRow: RowPosition,
+    lastRow: RowPosition,
+    contiguous: boolean
+): CellSelectionRange {
+    const firstRowPinned = _makeNull(firstRow.rowPinned);
+    const lastRowPinned = _makeNull(lastRow.rowPinned);
+
+    return {
+        range,
+        // ranges are mutated in place while dragging, so the rows are copied rather than shared
+        firstRow: { rowIndex: firstRow.rowIndex, rowPinned: firstRowPinned },
+        lastRow: { rowIndex: lastRow.rowIndex, rowPinned: lastRowPinned },
+        withinOneSection: firstRowPinned === lastRowPinned,
+        columns: new Set(range.columns),
+        lastColumn: findLastColumn(range.columns),
+        contiguous,
+        type: range.type,
+        colorClass: range.colorClass,
+    };
+}
+
+/** Mirrors the rightmost column that `IRangeService.isBottomRightCell()` compares against. */
+function findLastColumn(columns: Column[]): Column | undefined {
+    let last: AgColumn | undefined;
+    for (let i = 0, len = columns.length; i < len; i++) {
+        const column = columns[i] as AgColumn;
+        if (!last || column.allColsIndex > last.allColsIndex) {
+            last = column;
+        }
+    }
+    return last;
+}
+
+function isRowInSelectionRange({ firstRow, lastRow, withinOneSection }: CellSelectionRange, row: RowPosition) {
+    if (withinOneSection) {
+        // the common case: one pinned section, so the row indexes alone order the rows
+        return (
+            _makeNull(row.rowPinned) === firstRow.rowPinned &&
+            row.rowIndex >= firstRow.rowIndex &&
+            row.rowIndex <= lastRow.rowIndex
+        );
+    }
+
+    if (_isSameRow(row, firstRow) || _isSameRow(row, lastRow)) {
+        return true;
+    }
+
+    return !_isRowBefore(row, firstRow) && _isRowBefore(row, lastRow);
+}
+
+export function isCellInSelectionRange(selectionRange: CellSelectionRange, cell: CellPosition): boolean {
+    return selectionRange.columns.has(cell.column) && isRowInSelectionRange(selectionRange, cell);
+}
+
+/** Mirrors `IRangeService.isMoreThanOneCell()`. */
+export function isMoreThanOneCell(ranges: CellSelectionRange[]): boolean {
+    if (ranges.length === 0) {
+        return false;
+    }
+    if (ranges.length > 1) {
+        return true;
+    }
+
+    const { firstRow, lastRow, columns } = ranges[0];
+
+    return firstRow.rowIndex !== lastRow.rowIndex || firstRow.rowPinned !== lastRow.rowPinned || columns.size !== 1;
+}
+
+/** Mirrors the all-ranges test behind the `ag-cell-range-chart` class. */
+export function areAllChartRanges(ranges: CellSelectionRange[]): boolean {
+    return (
+        ranges.length > 0 &&
+        ranges.every(({ type }) => type === CellRangeType.DIMENSION || type === CellRangeType.VALUE)
+    );
+}

--- a/packages/ag-grid-enterprise/src/rangeSelection/rangeService.ts
+++ b/packages/ag-grid-enterprise/src/rangeSelection/rangeService.ts
@@ -122,23 +122,17 @@ export class RangeService extends BeanStub implements NamedBean, IRangeService, 
 
     private readonly columnRangeSelectionCtx: ColumnRangeSelectionContext = {};
 
-    /** The ranges as of the last time the rendered cells had their selection state refreshed. */
     private paintedRanges: CellSelectionRange[] = [];
-    // OPTIMIZATION: cells rendered while scrolling each ask for the state, so it is built once per
-    // change rather than once per cell. Every mutation of `cellRanges` clears it.
     private selectionState: CellSelectionSnapshot | null = null;
 
     public postConstruct(): void {
         const onColumnsChanged = this.onColumnsChanged.bind(this);
         const removeAllCellRanges = () => this.removeAllCellRanges();
-        // a column order change moves `allColsIndex`, which the cached state's contiguity and
-        // rightmost column are derived from
         const refreshLastRangeStart = () => {
             this.selectionState = null;
             this.refreshLastRangeStart();
         };
         this.addManagedEventListeners({
-            // an open-ended range takes its last row from the row count
             modelUpdated: () => {
                 this.selectionState = null;
             },
@@ -1155,7 +1149,6 @@ export class RangeService extends BeanStub implements NamedBean, IRangeService, 
         const current = this.getSelectionState();
 
         const filter = createCellSelectionRefreshFilter(this.paintedRanges, current, this.visibleCols);
-        // the caller refreshes every matching cell, so the ranges are painted as of now
         this.paintedRanges = current.ranges;
 
         return filter;

--- a/packages/ag-grid-enterprise/src/rangeSelection/rangeService.ts
+++ b/packages/ag-grid-enterprise/src/rangeSelection/rangeService.ts
@@ -19,6 +19,8 @@ import type {
     CellRange,
     CellRangeBoundaryParams,
     CellRangeParams,
+    CellSelectionRange,
+    CellSelectionSnapshot,
     ClearCellRangeParams,
     ColumnModel,
     CtrlsService,
@@ -58,8 +60,9 @@ import {
 } from 'ag-grid-community';
 
 import { CellRangeFeature } from './cellRangeFeature';
-import type { CellSelectionRefreshFilter, RangeSnapshot } from './cellSelectionRefreshFilter';
-import { createCellSelectionRefreshFilter, snapshotCellRange } from './cellSelectionRefreshFilter';
+import type { CellSelectionRefreshFilter } from './cellSelectionRefreshFilter';
+import { createCellSelectionRefreshFilter } from './cellSelectionRefreshFilter';
+import { areAllChartRanges, buildCellSelectionRange, isMoreThanOneCell } from './cellSelectionState';
 import { DragListenerFeature } from './dragListenerFeature';
 import { HeaderGroupCellMouseListenerFeature } from './headerGroupCellMouseListenerFeature';
 import { RangeHeaderHighlightFeature } from './rangeHeaderHighlightFeature';
@@ -120,13 +123,25 @@ export class RangeService extends BeanStub implements NamedBean, IRangeService, 
     private readonly columnRangeSelectionCtx: ColumnRangeSelectionContext = {};
 
     /** The ranges as of the last time the rendered cells had their selection state refreshed. */
-    private paintedRanges: RangeSnapshot[] = [];
+    private paintedRanges: CellSelectionRange[] = [];
+    // OPTIMIZATION: cells rendered while scrolling each ask for the state, so it is built once per
+    // change rather than once per cell. Every mutation of `cellRanges` clears it.
+    private selectionState: CellSelectionSnapshot | null = null;
 
     public postConstruct(): void {
         const onColumnsChanged = this.onColumnsChanged.bind(this);
         const removeAllCellRanges = () => this.removeAllCellRanges();
-        const refreshLastRangeStart = this.refreshLastRangeStart.bind(this);
+        // a column order change moves `allColsIndex`, which the cached state's contiguity and
+        // rightmost column are derived from
+        const refreshLastRangeStart = () => {
+            this.selectionState = null;
+            this.refreshLastRangeStart();
+        };
         this.addManagedEventListeners({
+            // an open-ended range takes its last row from the row count
+            modelUpdated: () => {
+                this.selectionState = null;
+            },
             newColumnsLoaded: onColumnsChanged,
             columnVisible: onColumnsChanged,
             columnValueChanged: onColumnsChanged,
@@ -327,6 +342,8 @@ export class RangeService extends BeanStub implements NamedBean, IRangeService, 
 
     // Called for both columns loaded and column visibility events
     public onColumnsChanged(): void {
+        this.selectionState = null;
+
         // first move start column in last cell range (i.e. series chart range)
         this.refreshLastRangeStart();
 
@@ -1102,19 +1119,44 @@ export class RangeService extends BeanStub implements NamedBean, IRangeService, 
 
         this.onDragStop();
         this.cellRanges.length = 0;
+        this.selectionState = null;
 
         if (!silent) {
             this.dispatchChangedEvent(false, true);
         }
     }
 
-    public takeSelectionRefreshFilter(): CellSelectionRefreshFilter | null {
-        const current = this.cellRanges.map((range) =>
-            snapshotCellRange(range, this.getRangeStartRow(range), this.getRangeEndRow(range))
+    public getSelectionState(): CellSelectionSnapshot {
+        const cached = this.selectionState;
+        if (cached) {
+            return cached;
+        }
+
+        const ranges = this.cellRanges.map((range) =>
+            buildCellSelectionRange(
+                range,
+                this.getRangeStartRow(range),
+                this.getRangeEndRow(range),
+                this.isContiguousRange(range)
+            )
         );
+
+        const state: CellSelectionSnapshot = {
+            ranges,
+            moreThanOneCell: isMoreThanOneCell(ranges),
+            allChartRanges: areAllChartRanges(ranges),
+        };
+        this.selectionState = state;
+
+        return state;
+    }
+
+    public takeSelectionRefreshFilter(): CellSelectionRefreshFilter | null {
+        const current = this.getSelectionState();
+
         const filter = createCellSelectionRefreshFilter(this.paintedRanges, current, this.visibleCols);
         // the caller refreshes every matching cell, so the ranges are painted as of now
-        this.paintedRanges = current;
+        this.paintedRanges = current.ranges;
 
         return filter;
     }
@@ -1447,6 +1489,7 @@ export class RangeService extends BeanStub implements NamedBean, IRangeService, 
     }
 
     private dispatchChangedEvent(started: boolean, finished: boolean, id?: string): void {
+        this.selectionState = null;
         this.eventSvc.dispatchEvent({
             type: 'cellSelectionChanged',
             started,

--- a/packages/ag-grid-enterprise/src/rangeSelection/rangeService.ts
+++ b/packages/ag-grid-enterprise/src/rangeSelection/rangeService.ts
@@ -58,6 +58,8 @@ import {
 } from 'ag-grid-community';
 
 import { CellRangeFeature } from './cellRangeFeature';
+import type { CellSelectionRefreshFilter, RangeSnapshot } from './cellSelectionRefreshFilter';
+import { createCellSelectionRefreshFilter, snapshotCellRange } from './cellSelectionRefreshFilter';
 import { DragListenerFeature } from './dragListenerFeature';
 import { HeaderGroupCellMouseListenerFeature } from './headerGroupCellMouseListenerFeature';
 import { RangeHeaderHighlightFeature } from './rangeHeaderHighlightFeature';
@@ -116,6 +118,9 @@ export class RangeService extends BeanStub implements NamedBean, IRangeService, 
     public autoScrollService: AutoScrollService;
 
     private readonly columnRangeSelectionCtx: ColumnRangeSelectionContext = {};
+
+    /** The ranges as of the last time the rendered cells had their selection state refreshed. */
+    private paintedRanges: RangeSnapshot[] = [];
 
     public postConstruct(): void {
         const onColumnsChanged = this.onColumnsChanged.bind(this);
@@ -1101,6 +1106,17 @@ export class RangeService extends BeanStub implements NamedBean, IRangeService, 
         if (!silent) {
             this.dispatchChangedEvent(false, true);
         }
+    }
+
+    public takeSelectionRefreshFilter(): CellSelectionRefreshFilter | null {
+        const current = this.cellRanges.map((range) =>
+            snapshotCellRange(range, this.getRangeStartRow(range), this.getRangeEndRow(range))
+        );
+        const filter = createCellSelectionRefreshFilter(this.paintedRanges, current, this.visibleCols);
+        // the caller refreshes every matching cell, so the ranges are painted as of now
+        this.paintedRanges = current;
+
+        return filter;
     }
 
     public isCellInAnyRange(cell: CellPosition): boolean {

--- a/testing/behavioural/src/benchmarks/cell-range-drag.bench.ts
+++ b/testing/behavioural/src/benchmarks/cell-range-drag.bench.ts
@@ -1,14 +1,3 @@
-// Cell-range drag benchmark: the cost of ONE frame of a mouse drag that extends a cell range.
-//
-// This drives the real drag path — a `mousemove` over a neighbouring cell, which mutates the live
-// range and dispatches `cellSelectionChanged` once. That matters for what is measured: only the
-// cells at the moving edge change CSS classes, and the rest of the viewport hits the class-state
-// dedupe in `CssClassManager`. Rebuilding a selection through `clearCellSelection()` +
-// `addCellRange()` instead makes every rendered cell write classes twice, which is a different and
-// much more expensive scenario — see `cell-range-selection.bench.ts`.
-//
-// Column virtualisation is suppressed and rowHeight is small, so the fixed 100vh viewport holds as
-// many cells as possible.
 import { bench, suite } from 'vitest';
 
 import type { ColDef, GridApi, GridOptions } from 'ag-grid-community';
@@ -77,17 +66,10 @@ const dispatchMouse = (cell: HTMLElement, type: string): void => {
     );
 };
 
-/**
- * Press on `c0` of the first row and drag far enough to open a range, leaving the mouse down so
- * every later `mousemove` is measured as a drag frame.
- */
 const startDrag = (api: GridApi, gridId: string, edgeRow: number): void => {
     const edgeCell = findCell(gridId, edgeRow, `c${COL_COUNT - 1}`);
-    // Release any drag a previous suite left open: the range service stays in its dragging state
-    // until it sees a mouseup, and would ignore the mousedown below.
     dispatchMouse(edgeCell, 'mouseup');
     dispatchMouse(findCell(gridId, 0, 'c0'), 'mousedown');
-    // The first move past the drag threshold only opens the drag; the second one extends the range.
     dispatchMouse(edgeCell, 'mousemove');
     dispatchMouse(edgeCell, 'mousemove');
     api.flushAllAnimationFrames();
@@ -100,10 +82,6 @@ const startDrag = (api: GridApi, gridId: string, edgeRow: number): void => {
 
 let benchGridSeq = 0;
 
-/**
- * Alternate the drag's pointer between two adjacent cells, so each measured iteration is one frame
- * of a drag whose selection edge moves by `edgeRow` - `edgeRowAlt` (a row) or by one column.
- */
 const benchDragFrame = (name: string, edgeRow: number, altCol: string, noiseFactor: number): void => {
     suite(`cell range drag: ${name}`, () => {
         const gridsManager = new BenchGridsManager({ modules });
@@ -136,8 +114,6 @@ const benchDragFrame = (name: string, edgeRow: number, altCol: string, noiseFact
     });
 };
 
-// Edge moves by one row: the selection grows/shrinks by a single row of cells.
 benchDragFrame('extend by one row', 20, `c${COL_COUNT - 1}`, 2);
 
-// Edge moves by one row and one column: a diagonal drag frame, the common gesture.
 benchDragFrame('extend by one row and column', 20, `c${COL_COUNT - 2}`, 2);

--- a/testing/behavioural/src/benchmarks/cell-range-drag.bench.ts
+++ b/testing/behavioural/src/benchmarks/cell-range-drag.bench.ts
@@ -1,0 +1,143 @@
+// Cell-range drag benchmark: the cost of ONE frame of a mouse drag that extends a cell range.
+//
+// This drives the real drag path — a `mousemove` over a neighbouring cell, which mutates the live
+// range and dispatches `cellSelectionChanged` once. That matters for what is measured: only the
+// cells at the moving edge change CSS classes, and the rest of the viewport hits the class-state
+// dedupe in `CssClassManager`. Rebuilding a selection through `clearCellSelection()` +
+// `addCellRange()` instead makes every rendered cell write classes twice, which is a different and
+// much more expensive scenario — see `cell-range-selection.bench.ts`.
+//
+// Column virtualisation is suppressed and rowHeight is small, so the fixed 100vh viewport holds as
+// many cells as possible.
+import { bench, suite } from 'vitest';
+
+import type { ColDef, GridApi, GridOptions } from 'ag-grid-community';
+import { ClientSideRowModelModule } from 'ag-grid-community';
+import { CellSelectionModule } from 'ag-grid-enterprise';
+
+import { BenchGridsManager, benchDefaults } from './bench-utils';
+
+const modules = [ClientSideRowModelModule, CellSelectionModule];
+
+const COL_COUNT = 40;
+const ROW_COUNT = 500;
+
+interface Row {
+    [key: string]: string;
+}
+
+const buildCols = (): ColDef[] => {
+    const cols: ColDef[] = [];
+    for (let i = 0; i < COL_COUNT; ++i) {
+        cols.push({ colId: `c${i}`, field: `c${i}`, width: 100 });
+    }
+    return cols;
+};
+
+const buildData = (): Row[] => {
+    const rows: Row[] = [];
+    for (let r = 0; r < ROW_COUNT; ++r) {
+        const row: Row = {};
+        for (let c = 0; c < COL_COUNT; ++c) {
+            row[`c${c}`] = `r${r}c${c}`;
+        }
+        rows.push(row);
+    }
+    return rows;
+};
+
+const gridOptions: GridOptions = {
+    columnDefs: buildCols(),
+    rowHeight: 20,
+    suppressColumnVirtualisation: true,
+    cellSelection: { handle: { mode: 'range' } },
+};
+
+const data = buildData();
+
+const findCell = (gridId: string, rowIndex: number, colId: string): HTMLElement => {
+    const cell = document.querySelector<HTMLElement>(`#${gridId} [row-index="${rowIndex}"] [col-id="${colId}"]`);
+    if (!cell) {
+        throw new Error(`bench setup: no rendered cell at row ${rowIndex}, col ${colId}`);
+    }
+    return cell;
+};
+
+const dispatchMouse = (cell: HTMLElement, type: string): void => {
+    const rect = cell.getBoundingClientRect();
+    cell.dispatchEvent(
+        new MouseEvent(type, {
+            bubbles: true,
+            cancelable: true,
+            button: 0,
+            buttons: type === 'mouseup' ? 0 : 1,
+            clientX: rect.left + rect.width / 2,
+            clientY: rect.top + rect.height / 2,
+        })
+    );
+};
+
+/**
+ * Press on `c0` of the first row and drag far enough to open a range, leaving the mouse down so
+ * every later `mousemove` is measured as a drag frame.
+ */
+const startDrag = (api: GridApi, gridId: string, edgeRow: number): void => {
+    const edgeCell = findCell(gridId, edgeRow, `c${COL_COUNT - 1}`);
+    // Release any drag a previous suite left open: the range service stays in its dragging state
+    // until it sees a mouseup, and would ignore the mousedown below.
+    dispatchMouse(edgeCell, 'mouseup');
+    dispatchMouse(findCell(gridId, 0, 'c0'), 'mousedown');
+    // The first move past the drag threshold only opens the drag; the second one extends the range.
+    dispatchMouse(edgeCell, 'mousemove');
+    dispatchMouse(edgeCell, 'mousemove');
+    api.flushAllAnimationFrames();
+
+    const ranges = api.getCellRanges();
+    if (!ranges?.length || ranges[0].columns.length < 2) {
+        throw new Error('bench setup: drag did not open a multi-column range');
+    }
+};
+
+let benchGridSeq = 0;
+
+/**
+ * Alternate the drag's pointer between two adjacent cells, so each measured iteration is one frame
+ * of a drag whose selection edge moves by `edgeRow` - `edgeRowAlt` (a row) or by one column.
+ */
+const benchDragFrame = (name: string, edgeRow: number, altCol: string, noiseFactor: number): void => {
+    suite(`cell range drag: ${name}`, () => {
+        const gridsManager = new BenchGridsManager({ modules });
+        const gridId = `bench-drag-grid-${++benchGridSeq}`;
+        let api!: GridApi;
+        let forward = true;
+        let cellA!: HTMLElement;
+        let cellB!: HTMLElement;
+
+        bench(
+            name,
+            () => {
+                dispatchMouse(forward ? cellA : cellB, 'mousemove');
+                api.flushAllAnimationFrames();
+                forward = !forward;
+            },
+            {
+                ...benchDefaults({ noiseFactor }),
+                setup: async () => {
+                    await gridsManager.reset();
+                    api = gridsManager.createGrid(gridId, { ...gridOptions, rowData: data });
+                    api.flushAllAnimationFrames();
+                    startDrag(api, gridId, edgeRow);
+                    cellA = findCell(gridId, edgeRow, `c${COL_COUNT - 1}`);
+                    cellB = findCell(gridId, edgeRow - 1, altCol);
+                    forward = true;
+                },
+            }
+        );
+    });
+};
+
+// Edge moves by one row: the selection grows/shrinks by a single row of cells.
+benchDragFrame('extend by one row', 20, `c${COL_COUNT - 1}`, 2);
+
+// Edge moves by one row and one column: a diagonal drag frame, the common gesture.
+benchDragFrame('extend by one row and column', 20, `c${COL_COUNT - 2}`, 2);

--- a/testing/behavioural/src/benchmarks/cell-range-selection.bench.ts
+++ b/testing/behavioural/src/benchmarks/cell-range-selection.bench.ts
@@ -1,11 +1,3 @@
-// Cell-range-selection benchmark: the cost of one range change over a full viewport of cells.
-//
-// A range change dispatches `cellSelectionChanged` and every rendered cell refreshes its own range
-// classes and borders, so one measured iteration is the work behind one frame of a mouse drag — the
-// number to read against the ~16ms frame budget.
-//
-// Column virtualisation is suppressed and rowHeight is small, so the fixed 100vh viewport holds as
-// many cells as possible: the wide drag users notice.
 import { suite } from 'vitest';
 
 import type { ColDef, GridApi, GridOptions } from 'ag-grid-community';
@@ -52,7 +44,6 @@ const gridOptions: GridOptions = {
 
 const data = buildData();
 
-/** Replace the selection with a single range spanning `colSpan` columns down to `rowEnd`. */
 const selectRange = (api: GridApi, colSpan: number, rowEnd: number): void => {
     api.clearCellSelection();
     api.addCellRange({
@@ -63,7 +54,6 @@ const selectRange = (api: GridApi, colSpan: number, rowEnd: number): void => {
     });
 };
 
-/** Replace the selection with `count` adjacent single-column ranges, each `rowEnd` rows tall. */
 const selectManyRanges = (api: GridApi, count: number, rowEnd: number): void => {
     api.clearCellSelection();
     for (let i = 0; i < count; ++i) {
@@ -76,9 +66,6 @@ const selectManyRanges = (api: GridApi, count: number, rowEnd: number): void => 
     }
 };
 
-// One range, wide: the common drag. Alternating between a 40-column and a 39-column span is the
-// shape of a drag frame that crosses a column boundary — the selection changes by one column and
-// every rendered cell is re-tested.
 suite('cell range selection: extend wide range', () => {
     const gridsManager = new BenchGridsManager({ modules });
     benchAlternating(
@@ -92,8 +79,6 @@ suite('cell range selection: extend wide range', () => {
     );
 });
 
-// One range, narrow: isolates the fixed per-cell overhead (border/chart-range/CSS work) from the
-// column-list scan, so a membership-cost change shows up as a gap between this and the wide suite.
 suite('cell range selection: extend narrow range', () => {
     const gridsManager = new BenchGridsManager({ modules });
     benchAlternating(
@@ -107,8 +92,6 @@ suite('cell range selection: extend narrow range', () => {
     );
 });
 
-// Rebuilding a multi-range selection: clearing and re-adding 20 ranges is 21 dispatches, so this
-// case measures the cost of restoring a saved multi-range selection, NOT a single drag frame.
 suite('cell range selection: rebuild many ranges', () => {
     const gridsManager = new BenchGridsManager({ modules });
     benchAlternating(

--- a/testing/behavioural/src/benchmarks/cell-range-selection.bench.ts
+++ b/testing/behavioural/src/benchmarks/cell-range-selection.bench.ts
@@ -1,0 +1,123 @@
+// Cell-range-selection benchmark: the cost of one range change over a full viewport of cells.
+//
+// A range change dispatches `cellSelectionChanged` and every rendered cell refreshes its own range
+// classes and borders, so one measured iteration is the work behind one frame of a mouse drag — the
+// number to read against the ~16ms frame budget.
+//
+// Column virtualisation is suppressed and rowHeight is small, so the fixed 100vh viewport holds as
+// many cells as possible: the wide drag users notice.
+import { suite } from 'vitest';
+
+import type { ColDef, GridApi, GridOptions } from 'ag-grid-community';
+import { ClientSideRowModelModule } from 'ag-grid-community';
+import { CellSelectionModule } from 'ag-grid-enterprise';
+
+import { BenchGridsManager, benchAlternating } from './bench-utils';
+
+const modules = [ClientSideRowModelModule, CellSelectionModule];
+
+const COL_COUNT = 40;
+const ROW_COUNT = 500;
+
+interface Row {
+    [key: string]: string;
+}
+
+const buildCols = (): ColDef[] => {
+    const cols: ColDef[] = [];
+    for (let i = 0; i < COL_COUNT; ++i) {
+        cols.push({ colId: `c${i}`, field: `c${i}`, width: 100 });
+    }
+    return cols;
+};
+
+const buildData = (): Row[] => {
+    const rows: Row[] = [];
+    for (let r = 0; r < ROW_COUNT; ++r) {
+        const row: Row = {};
+        for (let c = 0; c < COL_COUNT; ++c) {
+            row[`c${c}`] = `r${r}c${c}`;
+        }
+        rows.push(row);
+    }
+    return rows;
+};
+
+const gridOptions: GridOptions = {
+    columnDefs: buildCols(),
+    rowHeight: 20,
+    suppressColumnVirtualisation: true,
+    cellSelection: { handle: { mode: 'range' } },
+};
+
+const data = buildData();
+
+/** Replace the selection with a single range spanning `colSpan` columns down to `rowEnd`. */
+const selectRange = (api: GridApi, colSpan: number, rowEnd: number): void => {
+    api.clearCellSelection();
+    api.addCellRange({
+        rowStartIndex: 0,
+        rowEndIndex: rowEnd,
+        columnStart: 'c0',
+        columnEnd: `c${colSpan - 1}`,
+    });
+};
+
+/** Replace the selection with `count` adjacent single-column ranges, each `rowEnd` rows tall. */
+const selectManyRanges = (api: GridApi, count: number, rowEnd: number): void => {
+    api.clearCellSelection();
+    for (let i = 0; i < count; ++i) {
+        api.addCellRange({
+            rowStartIndex: 0,
+            rowEndIndex: rowEnd,
+            columnStart: `c${i}`,
+            columnEnd: `c${i}`,
+        });
+    }
+};
+
+// One range, wide: the common drag. Alternating between a 40-column and a 39-column span is the
+// shape of a drag frame that crosses a column boundary — the selection changes by one column and
+// every rendered cell is re-tested.
+suite('cell range selection: extend wide range', () => {
+    const gridsManager = new BenchGridsManager({ modules });
+    benchAlternating(
+        gridsManager,
+        `${COL_COUNT} cols x ${ROW_COUNT} rows`,
+        gridOptions,
+        data,
+        (api) => selectRange(api, COL_COUNT, ROW_COUNT - 1),
+        (api) => selectRange(api, COL_COUNT - 1, ROW_COUNT - 1),
+        2
+    );
+});
+
+// One range, narrow: isolates the fixed per-cell overhead (border/chart-range/CSS work) from the
+// column-list scan, so a membership-cost change shows up as a gap between this and the wide suite.
+suite('cell range selection: extend narrow range', () => {
+    const gridsManager = new BenchGridsManager({ modules });
+    benchAlternating(
+        gridsManager,
+        `2 cols x ${ROW_COUNT} rows`,
+        gridOptions,
+        data,
+        (api) => selectRange(api, 2, ROW_COUNT - 1),
+        (api) => selectRange(api, 2, ROW_COUNT - 2),
+        2
+    );
+});
+
+// Rebuilding a multi-range selection: clearing and re-adding 20 ranges is 21 dispatches, so this
+// case measures the cost of restoring a saved multi-range selection, NOT a single drag frame.
+suite('cell range selection: rebuild many ranges', () => {
+    const gridsManager = new BenchGridsManager({ modules });
+    benchAlternating(
+        gridsManager,
+        `20 ranges x ${ROW_COUNT} rows (21 dispatches)`,
+        gridOptions,
+        data,
+        (api) => selectManyRanges(api, 20, ROW_COUNT - 1),
+        (api) => selectManyRanges(api, 20, ROW_COUNT - 2),
+        2
+    );
+});


### PR DESCRIPTION
Closes [AG-18473](https://ag-grid.atlassian.net/browse/AG-18473).

A range change refreshed every rendered cell, and each cell recomputed what the whole refresh shares. Two changes:

- **Refresh only the cells a change can affect.** The range service snapshots the ranges as last painted and gives the row renderer a predicate for the cells whose membership, borders, single-cell class or selection handle can have changed. Falls back to a full refresh when narrowing is not sound (a range added or removed, an `isMoreThanOneCell()` or chart-range flip, an edge crossing a pinned section).
- **Gather the selection once per refresh.** Normalised rows, a column `Set`, contiguity, the rightmost column and the two global flags are built once and passed to each cell, instead of every cell rescanning each range's column list and re-deriving the range rows through the row models. Cached, and cleared when the ranges, the column order or the row model change.

Per-cell CSS classes and `aria-selected` are unchanged.

Interleaved against `latest`, headless Chromium, with each revert assertion-checked:

| bench | latest | this PR | |
| --- | --- | --- | --- |
| drag frame, extend by one row | 1.233ms | 0.301ms | 4.1x |
| drag frame, diagonal edge move | 1.330ms | 0.423ms | 3.1x |
| range change, 40 cols x 500 rows | 6.12ms | 5.11ms | 1.20x |
| range change, 2 cols x 500 rows | 1.87ms | 1.64ms | 1.14x |
| rebuild 20 ranges (21 dispatches) | 38.1ms | 23.2ms | 1.64x |

The drag frame is what the delta refresh buys; the rebuild cases are what gathering the selection once buys. A full refresh is still dominated by the per-cell DOM writes — removing essentially all the per-cell computation moved the 40-column case only 6.12ms to 5.11ms — so select-all is not addressed here. Painting an overlay rectangle instead is tracked separately.

`./checks.sh` and `./behave.sh` (11,563 tests) pass, plus 11 new unit tests for the diff logic.