### PR TITLE
AG-3390 - Move the footer legal links into their own strip under the columns

### DIFF
--- a/documentation/ag-grid-docs/src/content.config.ts
+++ b/documentation/ag-grid-docs/src/content.config.ts
@@ -189,6 +189,8 @@ const footer = defineCollection({
     schema: z.array(
         z.object({
             title: z.string(),
+            /** Where the group renders: the legal strip, the social icons, or (default) a navigation column. */
+            placement: z.enum(['legal', 'social']).optional(),
             links: z.array(
                 z.object({
                     name: z.string(),

--- a/documentation/ag-grid-docs/src/content.config.ts
+++ b/documentation/ag-grid-docs/src/content.config.ts
@@ -189,8 +189,8 @@ const footer = defineCollection({
     schema: z.array(
         z.object({
             title: z.string(),
-            /** Where the group renders: the legal strip, the social icons, or (default) a navigation column. */
-            placement: z.enum(['legal', 'social']).optional(),
+            /** Where the group renders: the legal strip under the columns, or (default) a menu column. */
+            placement: z.enum(['legal']).optional(),
             links: z.array(
                 z.object({
                     name: z.string(),

--- a/documentation/ag-grid-docs/src/content/footer/footer.json
+++ b/documentation/ag-grid-docs/src/content/footer/footer.json
@@ -1,22 +1,5 @@
 [
     {
-        "title": "Products",
-        "links": [
-            {
-                "name": "AG Charts",
-                "url": "https://www.ag-grid.com/charts/"
-            },
-            {
-                "name": "AG Studio",
-                "url": "https://www.ag-grid.com/studio/"
-            },
-            {
-                "name": "License & Pricing",
-                "url": "/license-pricing/"
-            }
-        ]
-    },
-    {
         "title": "Documentation",
         "links": [
             {
@@ -45,13 +28,17 @@
         "title": "Support & Community",
         "links": [
             {
-                "name": "Support via Zendesk",
-                "url": "https://ag-grid.zendesk.com/",
+                "name": "Stack Overflow",
+                "url": "https://stackoverflow.com/questions/tagged/ag-grid",
                 "newTab": true
             },
             {
-                "name": "Stack Overflow",
-                "url": "https://stackoverflow.com/questions/tagged/ag-grid",
+                "name": "License & Pricing",
+                "url": "/license-pricing/"
+            },
+            {
+                "name": "Support via Zendesk",
+                "url": "https://ag-grid.zendesk.com/",
                 "newTab": true
             },
             {
@@ -64,53 +51,29 @@
         "title": "The Company",
         "links": [
             {
+                "name": "AG Charts",
+                "url": "https://www.ag-grid.com/charts/"
+            },
+            {
+                "name": "AG Studio",
+                "url": "https://www.ag-grid.com/studio/"
+            },
+            {
                 "name": "About",
                 "url": "/about/"
             },
             {
-                "name": "Blog",
-                "url": "https://www.ag-grid.com/blog/"
-            },
-            {
                 "name": "Contact Us",
                 "url": "/contact/"
-            }
-        ]
-    },
-    {
-        "title": "Legal",
-        "placement": "legal",
-        "links": [
-            {
-                "name": "Privacy Policy",
-                "url": "/privacy/"
             },
             {
-                "name": "Cookies Policy",
-                "url": "/cookies/"
-            },
-            {
-                "name": "Manage Cookies",
-                "url": "#manage_cookies",
-                "showCookiesPrefs": true
-            },
-            {
-                "name": "Terms of Use",
-                "url": "/terms-of-use/"
-            },
-            {
-                "name": "Modern Slavery",
-                "url": "/modern-slavery/"
-            },
-            {
-                "name": "Sitemap",
-                "url": "https://www.ag-grid.com/sitemap/"
+                "name": "Blog",
+                "url": "https://www.ag-grid.com/blog/"
             }
         ]
     },
     {
         "title": "Follow",
-        "placement": "social",
         "links": [
             {
                 "name": "GitHub",
@@ -131,6 +94,37 @@
                 "name": "LinkedIn",
                 "url": "https://www.linkedin.com/company/ag-grid",
                 "iconName": "linkedin"
+            }
+        ]
+    },
+    {
+        "title": "Legal",
+        "placement": "legal",
+        "links": [
+            {
+                "name": "Terms of Use",
+                "url": "/terms-of-use/"
+            },
+            {
+                "name": "Privacy Policy",
+                "url": "/privacy/"
+            },
+            {
+                "name": "Cookies Policy",
+                "url": "/cookies/"
+            },
+            {
+                "name": "Manage Cookies",
+                "url": "#manage_cookies",
+                "showCookiesPrefs": true
+            },
+            {
+                "name": "Modern Slavery",
+                "url": "/modern-slavery/"
+            },
+            {
+                "name": "Sitemap",
+                "url": "https://www.ag-grid.com/sitemap/"
             }
         ]
     }

--- a/documentation/ag-grid-docs/src/content/footer/footer.json
+++ b/documentation/ag-grid-docs/src/content/footer/footer.json
@@ -1,5 +1,22 @@
 [
     {
+        "title": "Products",
+        "links": [
+            {
+                "name": "AG Charts",
+                "url": "https://www.ag-grid.com/charts/"
+            },
+            {
+                "name": "AG Studio",
+                "url": "https://www.ag-grid.com/studio/"
+            },
+            {
+                "name": "License & Pricing",
+                "url": "/license-pricing/"
+            }
+        ]
+    },
+    {
         "title": "Documentation",
         "links": [
             {
@@ -28,17 +45,13 @@
         "title": "Support & Community",
         "links": [
             {
-                "name": "Stack Overflow",
-                "url": "https://stackoverflow.com/questions/tagged/ag-grid",
+                "name": "Support via Zendesk",
+                "url": "https://ag-grid.zendesk.com/",
                 "newTab": true
             },
             {
-                "name": "License & Pricing",
-                "url": "/license-pricing/"
-            },
-            {
-                "name": "Support via Zendesk",
-                "url": "https://ag-grid.zendesk.com/",
+                "name": "Stack Overflow",
+                "url": "https://stackoverflow.com/questions/tagged/ag-grid",
                 "newTab": true
             },
             {
@@ -51,29 +64,23 @@
         "title": "The Company",
         "links": [
             {
-                "name": "AG Charts",
-                "url": "https://www.ag-grid.com/charts/"
-            },
-            {
-                "name": "AG Studio",
-                "url": "https://www.ag-grid.com/studio/"
-            },
-            {
                 "name": "About",
                 "url": "/about/"
-            },
-            {
-                "name": "Contact Us",
-                "url": "/contact/"
             },
             {
                 "name": "Blog",
                 "url": "https://www.ag-grid.com/blog/"
             },
             {
-                "name": "Terms of Use",
-                "url": "/terms-of-use/"
-            },
+                "name": "Contact Us",
+                "url": "/contact/"
+            }
+        ]
+    },
+    {
+        "title": "Legal",
+        "placement": "legal",
+        "links": [
             {
                 "name": "Privacy Policy",
                 "url": "/privacy/"
@@ -88,6 +95,10 @@
                 "showCookiesPrefs": true
             },
             {
+                "name": "Terms of Use",
+                "url": "/terms-of-use/"
+            },
+            {
                 "name": "Modern Slavery",
                 "url": "/modern-slavery/"
             },
@@ -99,6 +110,7 @@
     },
     {
         "title": "Follow",
+        "placement": "social",
         "links": [
             {
                 "name": "GitHub",

--- a/documentation/ag-grid-docs/src/layouts/Layout.astro
+++ b/documentation/ag-grid-docs/src/layouts/Layout.astro
@@ -353,7 +353,6 @@ const announcementBannerProps = {
                     client:load
                     showMicrosoftMessage={showMicrosoftMessage || path === SITE_BASE_URL || path === undefined}
                     footerItems={footerItems}
-                    tagline="The best JavaScript Data Grid in the world. Trusted by 90% of the Fortune 500."
                 />
             )
         }

--- a/documentation/ag-grid-docs/src/layouts/Layout.astro
+++ b/documentation/ag-grid-docs/src/layouts/Layout.astro
@@ -353,6 +353,7 @@ const announcementBannerProps = {
                     client:load
                     showMicrosoftMessage={showMicrosoftMessage || path === SITE_BASE_URL || path === undefined}
                     footerItems={footerItems}
+                    tagline="The best JavaScript Data Grid in the world. Trusted by 90% of the Fortune 500."
                 />
             )
         }

--- a/documentation/ag-grid-docs/src/types/ag-grid.d.ts
+++ b/documentation/ag-grid-docs/src/types/ag-grid.d.ts
@@ -30,8 +30,8 @@ export interface MenuItem {
 
 export interface FooterItem {
     title: string;
-    /** Where the group renders: the legal strip, the social icons, or (default) a navigation column. */
-    placement?: 'legal' | 'social';
+    /** Where the group renders: the legal strip under the columns, or (default) a menu column. */
+    placement?: 'legal';
     links: {
         name: string;
         url: string;

--- a/documentation/ag-grid-docs/src/types/ag-grid.d.ts
+++ b/documentation/ag-grid-docs/src/types/ag-grid.d.ts
@@ -30,12 +30,14 @@ export interface MenuItem {
 
 export interface FooterItem {
     title: string;
+    /** Where the group renders: the legal strip, the social icons, or (default) a navigation column. */
+    placement?: 'legal' | 'social';
     links: {
         name: string;
         url: string;
         newTab?: boolean;
         showCookiesPrefs?: boolean;
-        iconName: string;
+        iconName?: string;
     }[];
 }
 

--- a/documentation/ag-grid-docs/src/utils/markdown-pages/gridFrontmatter.test.ts
+++ b/documentation/ag-grid-docs/src/utils/markdown-pages/gridFrontmatter.test.ts
@@ -12,7 +12,11 @@ describe('getFooterRelatedLinks', () => {
         expect(titlesFor('/roadmap/')).toContain('Changelog');
         expect(titlesFor('/roadmap/')).toContain('Documentation Archive');
         expect(titlesFor('/about/')).toContain('Contact Us');
-        expect(titlesFor('/about/')).toContain('Privacy Policy');
+        expect(titlesFor('/privacy/')).toContain('Terms of Use');
+    });
+
+    test('keeps legal pages out of the company group now that the footer lists them separately', () => {
+        expect(titlesFor('/about/')).not.toContain('Privacy Policy');
     });
 
     test('excludes the page itself', () => {
@@ -21,20 +25,24 @@ describe('getFooterRelatedLinks', () => {
     });
 
     test('excludes the cookie-preferences control, which opens a dialog rather than a page', () => {
-        expect(titlesFor('/about/')).not.toContain('Manage Cookies');
+        expect(titlesFor('/privacy/')).not.toContain('Manage Cookies');
     });
 
     test('makes internal links absolute and leaves external ones whole', () => {
-        const links = getFooterRelatedLinks({ pageUrl: '/license-pricing/', siteRoot: SITE_ROOT });
+        const links = getFooterRelatedLinks({ pageUrl: '/data-grid/security/', siteRoot: SITE_ROOT });
         const bySource = Object.fromEntries(links.map(({ title, url }) => [title, url]));
 
-        expect(bySource['Security']).toBe('https://www.ag-grid.com/data-grid/security/');
         expect(bySource['Stack Overflow']).toBe('https://stackoverflow.com/questions/tagged/ag-grid');
+
+        const roadmapLinks = getFooterRelatedLinks({ pageUrl: '/roadmap/', siteRoot: SITE_ROOT });
+        const roadmapBySource = Object.fromEntries(roadmapLinks.map(({ title, url }) => [title, url]));
+
+        expect(roadmapBySource['Changelog']).toBe('https://www.ag-grid.com/changelog/');
     });
 
     test('matches a footer entry written as a full production URL', () => {
         // The footer lists /sitemap/ with its origin, so the comparison has to ignore origins.
-        expect(titlesFor('/sitemap/')).toContain('About');
+        expect(titlesFor('/sitemap/')).toContain('Privacy Policy');
     });
 
     test('returns nothing for a page the footer does not list, or when no page is given', () => {

--- a/documentation/ag-grid-docs/src/utils/markdown-pages/gridFrontmatter.test.ts
+++ b/documentation/ag-grid-docs/src/utils/markdown-pages/gridFrontmatter.test.ts
@@ -29,15 +29,11 @@ describe('getFooterRelatedLinks', () => {
     });
 
     test('makes internal links absolute and leaves external ones whole', () => {
-        const links = getFooterRelatedLinks({ pageUrl: '/data-grid/security/', siteRoot: SITE_ROOT });
+        const links = getFooterRelatedLinks({ pageUrl: '/license-pricing/', siteRoot: SITE_ROOT });
         const bySource = Object.fromEntries(links.map(({ title, url }) => [title, url]));
 
+        expect(bySource['Security']).toBe('https://www.ag-grid.com/data-grid/security/');
         expect(bySource['Stack Overflow']).toBe('https://stackoverflow.com/questions/tagged/ag-grid');
-
-        const roadmapLinks = getFooterRelatedLinks({ pageUrl: '/roadmap/', siteRoot: SITE_ROOT });
-        const roadmapBySource = Object.fromEntries(roadmapLinks.map(({ title, url }) => [title, url]));
-
-        expect(roadmapBySource['Changelog']).toBe('https://www.ag-grid.com/changelog/');
     });
 
     test('matches a footer entry written as a full production URL', () => {

--- a/external/ag-website-shared/src/components/footer/Footer.module.scss
+++ b/external/ag-website-shared/src/components/footer/Footer.module.scss
@@ -4,126 +4,27 @@
     width: 100%;
     border-top: 1px solid var(--color-border-secondary);
     padding-top: $spacing-size-10;
-    padding-bottom: calc($spacing-size-10 * 2);
+    padding-bottom: $spacing-size-10;
     background-color: var(--color-bg-primary);
-    color: var(--color-white);
+    color: var(--color-text-secondary);
 
     #{$selector-darkmode} & {
         color: var(--color-fg-primary);
-        background-color: var(--color-bg-primary);
         border-top: 1px solid var(--color-border-primary);
     }
 
     p {
+        margin-bottom: 0;
         color: var(--color-text-secondary);
         opacity: 0.666;
     }
 
-    h4 {
-        color: var(--color-fg-primary);
-        font-weight: var(--text-semibold);
-        opacity: 1;
-        #{$selector-darkmode} & {
-            color: var(--color-fg-white);
-        }
-    }
-
-    svg {
-        fill: var(--color-white);
-    }
-}
-
-.footerColumns {
-    max-width: calc(var(--layout-max-width-small) + var(--layout-horizontal-margins) * 2);
-    margin-right: auto;
-    margin-left: auto;
-    padding: $spacing-size-2;
-
-    @media screen and (min-width: $breakpoint-site-footer-five-column) {
-        justify-content: space-between;
-    }
-}
-
-.footerColumns .menuColumn:last-child a::after {
-    content: ' ↗';
-    opacity: 0.85;
-}
-
-.footerInfo {
-    margin-top: -4%;
-    display: flex;
-    flex-direction: column;
-    gap: $spacing-size-4;
-}
-
-.menuColumn {
-    margin-bottom: $spacing-size-10;
-    width: var(--layout-width-4-4);
-    display: flex;
-    gap: $spacing-size-3;
-    flex-direction: column;
-
-    p {
-        margin-bottom: 0;
-    }
-
-    .menuColumnTitle {
-        display: block;
-        font-size: var(--text-fs-base);
-        line-height: var(--text-lh-base);
-        font-weight: var(--text-semibold);
-        color: var(--color-text-primary);
-    }
-
-    &:first-child {
-        width: 100%;
-        text-align: center;
-    }
-
-    @media screen and (min-width: $breakpoint-site-footer-two-column) and (max-width: $breakpoint-site-footer-five-column) {
-        width: var(--layout-width-2-4);
-
-        &:nth-child(even) {
-            text-align: right;
-        }
-    }
-
-    @media screen and (min-width: $breakpoint-site-footer-five-column) {
-        width: auto;
-
-        &:first-child {
-            max-width: 18%;
-            min-width: 230px;
-            margin-right: -4%;
-            text-align: left;
-        }
-
-        &:last-child {
-            text-align: right;
-        }
-    }
-
-    ul {
-        display: block;
-    }
-
-    li {
-        overflow: hidden;
-    }
-
-    li a {
+    a {
         text-decoration: underline;
-        display: inline-block;
-        min-width: $spacing-size-12;
-        margin-top: -12px;
-        margin-bottom: -12px;
-        padding-top: 12px;
-        padding-bottom: 20px;
         text-decoration-color: color-mix(in srgb, var(--color-text-secondary), var(--color-bg-primary) 80%);
         text-underline-offset: 4px;
         color: var(--color-text-secondary);
         transition: color $transition-default-timing;
-        opacity: 1;
         font-weight: var(--text-regular);
 
         &:hover {
@@ -137,12 +38,6 @@
     }
 
     :global(.icon) {
-        display: inline;
-        position: relative;
-        width: 22px;
-        height: 22px;
-        top: -1px;
-        margin-right: $spacing-size-1;
         opacity: 0.6666;
         transition: opacity $transition-default-timing;
         fill: var(--color-text-tertiary);
@@ -153,13 +48,46 @@
     }
 }
 
-.logoContainer a {
-    display: inline-block;
+.footerInner {
+    max-width: var(--layout-max-width-small);
+    margin-right: auto;
+    margin-left: auto;
+    padding-right: var(--layout-horizontal-margins);
+    padding-left: var(--layout-horizontal-margins);
+}
+
+// Brand column plus one column per navigation group. Columns wrap: one per row on phones, two per
+// row on small screens, and everything on a single row from the five-column breakpoint up.
+.footerColumns {
+    display: flex;
+    flex-wrap: wrap;
+    gap: $spacing-size-8 $spacing-size-10;
+    padding-bottom: $spacing-size-10;
+}
+
+.brandColumn {
+    display: flex;
+    flex-direction: column;
+    gap: $spacing-size-4;
+    flex: 1 1 100%;
 
     @media screen and (min-width: $breakpoint-site-footer-five-column) {
-        margin-top: -18px;
-        margin-left: -12px;
+        flex: 1.15 1 0;
+        min-width: 230px;
+        max-width: 320px;
     }
+}
+
+.tagline {
+    max-width: 260px;
+    text-wrap: pretty;
+}
+
+.logoContainer a {
+    display: inline-flex;
+    min-height: unset;
+    margin-top: -$spacing-size-2;
+    margin-left: -10px;
 
     :global(.logotype) * {
         fill: var(--color-logo-text);
@@ -170,19 +98,137 @@
     }
 }
 
-.listStyleNone {
+.socialLinks {
     display: flex;
-    flex-direction: row;
-    list-style: none;
-    padding-left: 0;
-    opacity: 0.7;
+    flex-wrap: wrap;
+    gap: $spacing-size-2;
 
-    #{$selector-darkmode} & {
-        opacity: 1;
+    a {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 36px;
+        height: 36px;
+        border: 1px solid var(--color-border-primary);
+        border-radius: var(--radius-xs);
+        text-decoration: none;
+        transition:
+            color $transition-default-timing,
+            border-color $transition-default-timing;
+
+        &:hover {
+            border-color: var(--color-text-primary);
+        }
+    }
+
+    :global(.icon) {
+        width: 20px;
+        height: 20px;
     }
 }
 
-.headerTitle {
-    padding-top: $spacing-size-4;
-    color: var(--color-text-secondary);
+.menuColumn {
+    display: flex;
+    flex-direction: column;
+    gap: $spacing-size-3;
+    flex: 1 1 100%;
+
+    @media screen and (min-width: $breakpoint-site-footer-two-column) {
+        flex: 1 1 calc(50% - #{$spacing-size-10});
+    }
+
+    @media screen and (min-width: $breakpoint-site-footer-five-column) {
+        flex: 1 1 0;
+        min-width: 140px;
+    }
+
+    ul {
+        display: block;
+        margin: 0;
+    }
+
+    li {
+        overflow: hidden;
+    }
+
+    li a {
+        display: inline-block;
+        min-width: $spacing-size-12;
+        margin-top: -12px;
+        margin-bottom: -12px;
+        padding-top: 12px;
+        padding-bottom: 20px;
+    }
+
+    :global(.icon) {
+        display: inline;
+        position: relative;
+        width: 22px;
+        height: 22px;
+        top: -1px;
+        margin-right: $spacing-size-1;
+    }
+}
+
+.menuColumnTitle {
+    display: block;
+    font-size: var(--text-fs-base);
+    line-height: var(--text-lh-base);
+    font-weight: var(--text-semibold);
+    color: var(--color-text-primary);
+}
+
+// Copyright and registration on the left, policy links on the right. Wraps to two stacked rows
+// when the two do not fit side by side.
+.legalBar {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: $spacing-size-4 $spacing-size-8;
+    padding-top: $spacing-size-5;
+    border-top: 1px solid var(--color-border-secondary);
+
+    #{$selector-darkmode} & {
+        border-top-color: var(--color-border-primary);
+    }
+}
+
+.legalInfo {
+    display: flex;
+    flex-direction: column;
+    gap: $spacing-size-1;
+}
+
+.legalInfoSeparator {
+    opacity: 0.6;
+}
+
+.legalLinks {
+    $legal-links-gap: $spacing-size-4;
+
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: $spacing-size-2 $legal-links-gap;
+    margin: 0;
+    // Clips the separator of whichever link starts a wrapped row, since it sits left of the list edge.
+    overflow: hidden;
+
+    li {
+        position: relative;
+        display: flex;
+        align-items: center;
+    }
+
+    // Pipe separators between links, centred in the gap before each link and drawn in CSS with an
+    // empty alternative text so they are never announced.
+    li::before {
+        content: '|' #{'/'} '';
+        position: absolute;
+        left: calc(#{$legal-links-gap} / -2);
+        transform: translateX(-50%);
+        color: var(--color-text-secondary);
+        opacity: 0.4;
+    }
 }

--- a/external/ag-website-shared/src/components/footer/Footer.module.scss
+++ b/external/ag-website-shared/src/components/footer/Footer.module.scss
@@ -68,16 +68,21 @@
     padding-bottom: $spacing-size-10;
 }
 
+// Below desktop the brand column spans the full width and is centred, as the old footer was.
 .brandColumn {
     display: flex;
     flex-direction: column;
+    align-items: center;
     gap: $spacing-size-4;
     flex: 1 1 100%;
+    text-align: center;
 
     @media screen and (min-width: $breakpoint-site-footer-five-column) {
         flex: 1.15 1 0;
         min-width: 200px;
         max-width: 320px;
+        align-items: flex-start;
+        text-align: left;
     }
 }
 
@@ -104,7 +109,12 @@
 .socialLinks {
     display: flex;
     flex-wrap: wrap;
+    justify-content: center;
     gap: $spacing-size-2;
+
+    @media screen and (min-width: $breakpoint-site-footer-five-column) {
+        justify-content: flex-start;
+    }
 
     a {
         display: flex;
@@ -130,19 +140,29 @@
     }
 }
 
+// Single column: centred text. Two columns: the left column is right-aligned and the right column
+// left-aligned so the pair reads as one centred block. Desktop: everything left-aligned.
 .menuColumn {
     display: flex;
     flex-direction: column;
     gap: $spacing-size-3;
     flex: 1 1 100%;
+    text-align: center;
 
-    @media screen and (min-width: $breakpoint-site-footer-two-column) {
+    @media screen and (min-width: $breakpoint-site-footer-two-column) and (max-width: ($breakpoint-site-footer-five-column - 1px)) {
         flex: 1 1 calc(50% - #{$spacing-size-8});
+        text-align: left;
+
+        // The brand column is the first child, so the left column of each pair is an even child.
+        &:nth-child(even) {
+            text-align: right;
+        }
     }
 
     @media screen and (min-width: $breakpoint-site-footer-five-column) {
         flex: 1 1 0;
         min-width: 120px;
+        text-align: left;
     }
 
     ul {
@@ -187,13 +207,19 @@
     display: flex;
     flex-wrap: wrap;
     align-items: center;
-    justify-content: space-between;
+    justify-content: center;
     gap: $spacing-size-4 $spacing-size-8;
     padding-top: $spacing-size-5;
     border-top: 1px solid var(--color-border-secondary);
+    text-align: center;
 
     #{$selector-darkmode} & {
         border-top-color: var(--color-border-primary);
+    }
+
+    @media screen and (min-width: $breakpoint-site-footer-five-column) {
+        justify-content: space-between;
+        text-align: left;
     }
 }
 
@@ -213,10 +239,15 @@
     display: flex;
     flex-wrap: wrap;
     align-items: center;
+    justify-content: center;
     gap: $spacing-size-2 $legal-links-gap;
     margin: 0;
     // Clips the separator of whichever link starts a wrapped row, since it sits left of the list edge.
     overflow: hidden;
+
+    @media screen and (min-width: $breakpoint-site-footer-five-column) {
+        justify-content: flex-start;
+    }
 
     li {
         position: relative;
@@ -225,13 +256,16 @@
     }
 
     // Pipe separators between links, centred in the gap before each link and drawn in CSS with an
-    // empty alternative text so they are never announced.
-    li::before {
-        content: '|' #{'/'} '';
-        position: absolute;
-        left: calc(#{$legal-links-gap} / -2);
-        transform: translateX(-50%);
-        color: var(--color-text-secondary);
-        opacity: 0.4;
+    // empty alternative text so they are never announced. Desktop only: the clipping above needs
+    // the list left-aligned, and the centred mobile list separates links by the gap alone.
+    @media screen and (min-width: $breakpoint-site-footer-five-column) {
+        li::before {
+            content: '|' #{'/'} '';
+            position: absolute;
+            left: calc(#{$legal-links-gap} / -2);
+            transform: translateX(-50%);
+            color: var(--color-text-secondary);
+            opacity: 0.4;
+        }
     }
 }

--- a/external/ag-website-shared/src/components/footer/Footer.module.scss
+++ b/external/ag-website-shared/src/components/footer/Footer.module.scss
@@ -58,10 +58,13 @@
 
 // Brand column plus one column per navigation group. Columns wrap: one per row on phones, two per
 // row on small screens, and everything on a single row from the five-column breakpoint up.
+//
+// The desktop minimums must fit at the breakpoint itself, or the last column wraps just above it:
+// 920px viewport - 2 x 20px margins = 880px, against 200px + 4 x 120px + 4 x 32px gaps = 808px.
 .footerColumns {
     display: flex;
     flex-wrap: wrap;
-    gap: $spacing-size-8 $spacing-size-10;
+    gap: $spacing-size-8;
     padding-bottom: $spacing-size-10;
 }
 
@@ -73,7 +76,7 @@
 
     @media screen and (min-width: $breakpoint-site-footer-five-column) {
         flex: 1.15 1 0;
-        min-width: 230px;
+        min-width: 200px;
         max-width: 320px;
     }
 }
@@ -134,12 +137,12 @@
     flex: 1 1 100%;
 
     @media screen and (min-width: $breakpoint-site-footer-two-column) {
-        flex: 1 1 calc(50% - #{$spacing-size-10});
+        flex: 1 1 calc(50% - #{$spacing-size-8});
     }
 
     @media screen and (min-width: $breakpoint-site-footer-five-column) {
         flex: 1 1 0;
-        min-width: 140px;
+        min-width: 120px;
     }
 
     ul {

--- a/external/ag-website-shared/src/components/footer/Footer.module.scss
+++ b/external/ag-website-shared/src/components/footer/Footer.module.scss
@@ -202,10 +202,6 @@
     #{$selector-darkmode} & {
         border-top-color: var(--color-border-primary);
     }
-
-    @media screen and (min-width: $breakpoint-site-footer-five-column) {
-        justify-content: flex-start;
-    }
 }
 
 .legalLinks {
@@ -224,11 +220,8 @@
     }
 
     a {
-        text-decoration: underline;
-        text-decoration-color: color-mix(in srgb, var(--color-text-secondary), var(--color-bg-primary) 80%);
-        text-underline-offset: 4px;
         color: var(--color-text-secondary);
-        transition: color $transition-default-timing;
+        font-weight: var(--text-regular);
 
         &:hover {
             color: var(--color-text-primary);

--- a/external/ag-website-shared/src/components/footer/Footer.module.scss
+++ b/external/ag-website-shared/src/components/footer/Footer.module.scss
@@ -4,27 +4,126 @@
     width: 100%;
     border-top: 1px solid var(--color-border-secondary);
     padding-top: $spacing-size-10;
-    padding-bottom: $spacing-size-10;
+    padding-bottom: calc($spacing-size-10 * 2);
     background-color: var(--color-bg-primary);
-    color: var(--color-text-secondary);
+    color: var(--color-white);
 
     #{$selector-darkmode} & {
         color: var(--color-fg-primary);
+        background-color: var(--color-bg-primary);
         border-top: 1px solid var(--color-border-primary);
     }
 
     p {
-        margin-bottom: 0;
         color: var(--color-text-secondary);
         opacity: 0.666;
     }
 
-    a {
+    h4 {
+        color: var(--color-fg-primary);
+        font-weight: var(--text-semibold);
+        opacity: 1;
+        #{$selector-darkmode} & {
+            color: var(--color-fg-white);
+        }
+    }
+
+    svg {
+        fill: var(--color-white);
+    }
+}
+
+.footerColumns {
+    max-width: calc(var(--layout-max-width-small) + var(--layout-horizontal-margins) * 2);
+    margin-right: auto;
+    margin-left: auto;
+    padding: $spacing-size-2;
+
+    @media screen and (min-width: $breakpoint-site-footer-five-column) {
+        justify-content: space-between;
+    }
+}
+
+.footerColumns .menuColumn:last-child a::after {
+    content: ' ↗';
+    opacity: 0.85;
+}
+
+.footerInfo {
+    margin-top: -4%;
+    display: flex;
+    flex-direction: column;
+    gap: $spacing-size-4;
+}
+
+.menuColumn {
+    margin-bottom: $spacing-size-10;
+    width: var(--layout-width-4-4);
+    display: flex;
+    gap: $spacing-size-3;
+    flex-direction: column;
+
+    p {
+        margin-bottom: 0;
+    }
+
+    .menuColumnTitle {
+        display: block;
+        font-size: var(--text-fs-base);
+        line-height: var(--text-lh-base);
+        font-weight: var(--text-semibold);
+        color: var(--color-text-primary);
+    }
+
+    &:first-child {
+        width: 100%;
+        text-align: center;
+    }
+
+    @media screen and (min-width: $breakpoint-site-footer-two-column) and (max-width: $breakpoint-site-footer-five-column) {
+        width: var(--layout-width-2-4);
+
+        &:nth-child(even) {
+            text-align: right;
+        }
+    }
+
+    @media screen and (min-width: $breakpoint-site-footer-five-column) {
+        width: auto;
+
+        &:first-child {
+            max-width: 18%;
+            min-width: 230px;
+            margin-right: -4%;
+            text-align: left;
+        }
+
+        &:last-child {
+            text-align: right;
+        }
+    }
+
+    ul {
+        display: block;
+    }
+
+    li {
+        overflow: hidden;
+    }
+
+    li a {
         text-decoration: underline;
+        display: inline-block;
+        min-width: $spacing-size-12;
+        margin-top: -12px;
+        margin-bottom: -12px;
+        padding-top: 12px;
+        padding-bottom: 20px;
         text-decoration-color: color-mix(in srgb, var(--color-text-secondary), var(--color-bg-primary) 80%);
         text-underline-offset: 4px;
         color: var(--color-text-secondary);
         transition: color $transition-default-timing;
+        opacity: 1;
         font-weight: var(--text-regular);
 
         &:hover {
@@ -38,6 +137,12 @@
     }
 
     :global(.icon) {
+        display: inline;
+        position: relative;
+        width: 22px;
+        height: 22px;
+        top: -1px;
+        margin-right: $spacing-size-1;
         opacity: 0.6666;
         transition: opacity $transition-default-timing;
         fill: var(--color-text-tertiary);
@@ -48,54 +153,13 @@
     }
 }
 
-.footerInner {
-    max-width: var(--layout-max-width-small);
-    margin-right: auto;
-    margin-left: auto;
-    padding-right: var(--layout-horizontal-margins);
-    padding-left: var(--layout-horizontal-margins);
-}
-
-// Brand column plus one column per navigation group. Columns wrap: one per row on phones, two per
-// row on small screens, and everything on a single row from the five-column breakpoint up.
-//
-// The desktop minimums must fit at the breakpoint itself, or the last column wraps just above it:
-// 920px viewport - 2 x 20px margins = 880px, against 200px + 4 x 120px + 4 x 32px gaps = 808px.
-.footerColumns {
-    display: flex;
-    flex-wrap: wrap;
-    gap: $spacing-size-8;
-    padding-bottom: $spacing-size-10;
-}
-
-// Below desktop the brand column spans the full width and is centred, as the old footer was.
-.brandColumn {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: $spacing-size-4;
-    flex: 1 1 100%;
-    text-align: center;
+.logoContainer a {
+    display: inline-block;
 
     @media screen and (min-width: $breakpoint-site-footer-five-column) {
-        flex: 1.15 1 0;
-        min-width: 200px;
-        max-width: 320px;
-        align-items: flex-start;
-        text-align: left;
+        margin-top: -18px;
+        margin-left: -12px;
     }
-}
-
-.tagline {
-    max-width: 260px;
-    text-wrap: pretty;
-}
-
-.logoContainer a {
-    display: inline-flex;
-    min-height: unset;
-    margin-top: -$spacing-size-2;
-    margin-left: -10px;
 
     :global(.logotype) * {
         fill: var(--color-logo-text);
@@ -106,131 +170,42 @@
     }
 }
 
-.socialLinks {
+.listStyleNone {
     display: flex;
-    flex-wrap: wrap;
-    justify-content: center;
-    gap: $spacing-size-2;
+    flex-direction: row;
+    list-style: none;
+    padding-left: 0;
+    opacity: 0.7;
 
-    @media screen and (min-width: $breakpoint-site-footer-five-column) {
-        justify-content: flex-start;
-    }
-
-    a {
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        width: 36px;
-        height: 36px;
-        border: 1px solid var(--color-border-primary);
-        border-radius: var(--radius-xs);
-        text-decoration: none;
-        transition:
-            color $transition-default-timing,
-            border-color $transition-default-timing;
-
-        &:hover {
-            border-color: var(--color-text-primary);
-        }
-    }
-
-    :global(.icon) {
-        width: 20px;
-        height: 20px;
+    #{$selector-darkmode} & {
+        opacity: 1;
     }
 }
 
-// Single column: centred text. Two columns: the left column is right-aligned and the right column
-// left-aligned so the pair reads as one centred block. Desktop: everything left-aligned.
-.menuColumn {
-    display: flex;
-    flex-direction: column;
-    gap: $spacing-size-3;
-    flex: 1 1 100%;
-    text-align: center;
-
-    @media screen and (min-width: $breakpoint-site-footer-two-column) and (max-width: ($breakpoint-site-footer-five-column - 1px)) {
-        flex: 1 1 calc(50% - #{$spacing-size-8});
-        text-align: left;
-
-        // The brand column is the first child, so the left column of each pair is an even child.
-        &:nth-child(even) {
-            text-align: right;
-        }
-    }
-
-    @media screen and (min-width: $breakpoint-site-footer-five-column) {
-        flex: 1 1 0;
-        min-width: 120px;
-        text-align: left;
-    }
-
-    ul {
-        display: block;
-        margin: 0;
-    }
-
-    li {
-        overflow: hidden;
-    }
-
-    li a {
-        display: inline-block;
-        min-width: $spacing-size-12;
-        margin-top: -12px;
-        margin-bottom: -12px;
-        padding-top: 12px;
-        padding-bottom: 20px;
-    }
-
-    :global(.icon) {
-        display: inline;
-        position: relative;
-        width: 22px;
-        height: 22px;
-        top: -1px;
-        margin-right: $spacing-size-1;
-    }
+.headerTitle {
+    padding-top: $spacing-size-4;
+    color: var(--color-text-secondary);
 }
 
-.menuColumnTitle {
-    display: block;
-    font-size: var(--text-fs-base);
-    line-height: var(--text-lh-base);
-    font-weight: var(--text-semibold);
-    color: var(--color-text-primary);
-}
-
-// Copyright and registration on the left, policy links on the right. Wraps to two stacked rows
-// when the two do not fit side by side.
+// Legal and policy links in their own strip under the menu columns, so they no longer compete with
+// navigation. Left-aligned with pipe separators on desktop; centred and separated by the gap alone
+// below that, since clipping the leading separator of a wrapped row relies on left alignment.
 .legalBar {
     display: flex;
-    flex-wrap: wrap;
-    align-items: center;
     justify-content: center;
-    gap: $spacing-size-4 $spacing-size-8;
-    padding-top: $spacing-size-5;
+    max-width: calc(var(--layout-max-width-small) + var(--layout-horizontal-margins) * 2);
+    margin-right: auto;
+    margin-left: auto;
+    padding: $spacing-size-6 $spacing-size-2 0;
     border-top: 1px solid var(--color-border-secondary);
-    text-align: center;
 
     #{$selector-darkmode} & {
         border-top-color: var(--color-border-primary);
     }
 
     @media screen and (min-width: $breakpoint-site-footer-five-column) {
-        justify-content: space-between;
-        text-align: left;
+        justify-content: flex-start;
     }
-}
-
-.legalInfo {
-    display: flex;
-    flex-direction: column;
-    gap: $spacing-size-1;
-}
-
-.legalInfoSeparator {
-    opacity: 0.6;
 }
 
 .legalLinks {
@@ -238,27 +213,34 @@
 
     display: flex;
     flex-wrap: wrap;
-    align-items: center;
     justify-content: center;
     gap: $spacing-size-2 $legal-links-gap;
     margin: 0;
     // Clips the separator of whichever link starts a wrapped row, since it sits left of the list edge.
     overflow: hidden;
 
-    @media screen and (min-width: $breakpoint-site-footer-five-column) {
-        justify-content: flex-start;
-    }
-
     li {
         position: relative;
-        display: flex;
-        align-items: center;
     }
 
-    // Pipe separators between links, centred in the gap before each link and drawn in CSS with an
-    // empty alternative text so they are never announced. Desktop only: the clipping above needs
-    // the list left-aligned, and the centred mobile list separates links by the gap alone.
+    a {
+        text-decoration: underline;
+        text-decoration-color: color-mix(in srgb, var(--color-text-secondary), var(--color-bg-primary) 80%);
+        text-underline-offset: 4px;
+        color: var(--color-text-secondary);
+        transition: color $transition-default-timing;
+
+        &:hover {
+            color: var(--color-text-primary);
+            opacity: 0.6;
+        }
+    }
+
     @media screen and (min-width: $breakpoint-site-footer-five-column) {
+        justify-content: flex-start;
+
+        // Pipe separators, centred in the gap before each link and drawn in CSS with an empty
+        // alternative text so they are never announced.
         li::before {
             content: '|' #{'/'} '';
             position: absolute;

--- a/external/ag-website-shared/src/components/footer/Footer.module.scss
+++ b/external/ag-website-shared/src/components/footer/Footer.module.scss
@@ -197,11 +197,6 @@
     margin-right: auto;
     margin-left: auto;
     padding: $spacing-size-6 $spacing-size-2 0;
-    border-top: 1px solid var(--color-border-secondary);
-
-    #{$selector-darkmode} & {
-        border-top-color: var(--color-border-primary);
-    }
 }
 
 .legalLinks {

--- a/external/ag-website-shared/src/components/footer/Footer.tsx
+++ b/external/ag-website-shared/src/components/footer/Footer.tsx
@@ -1,30 +1,26 @@
 import type { FooterItem } from '@ag-grid-types';
 import { DevToolsToggle } from '@ag-website-shared/components/dev-tools/DevTools';
-import { Icon, type IconName } from '@ag-website-shared/components/icon/Icon';
+import { Icon } from '@ag-website-shared/components/icon/Icon';
 import { SiteLogo } from '@components/SiteLogo';
 import { urlWithBaseUrl } from '@utils/urlWithBaseUrl';
 import classNames from 'classnames';
 import GithubSlugger from 'github-slugger';
-import type { MouseEvent } from 'react';
 
 import styles from './Footer.module.scss';
 
 /**
- * A footer group renders as a navigation column unless its `placement` moves it into the legal
- * strip or the social icon row. Declared here so a site whose footer type predates `placement`
- * still renders every group as a column.
+ * A footer group renders as a menu column unless its `placement` moves it into the legal strip
+ * under the columns. Declared here so a site whose footer type predates `placement` still renders
+ * every group as a column.
  */
-type FooterGroup = FooterItem & { placement?: 'legal' | 'social' };
-type FooterLink = FooterGroup['links'][number];
+type FooterGroup = FooterItem & { placement?: 'legal' };
 
 interface FooterProps {
     showMicrosoftMessage?: boolean;
     footerItems: FooterGroup[];
-    /** Short product line shown under the logo. Omit to leave the brand column as logo and socials only. */
-    tagline?: string;
 }
 
-const toggleCookiesPrefs = (event: MouseEvent<HTMLAnchorElement>) => {
+const toggleCookiesPrefs = (event) => {
     event.preventDefault();
 
     if (!window.__enzuzoApi) return;
@@ -32,16 +28,10 @@ const toggleCookiesPrefs = (event: MouseEvent<HTMLAnchorElement>) => {
     window.__enzuzoApi.prefCenter.show();
 };
 
-const linkAttributes = ({ url, newTab, showCookiesPrefs }: FooterLink) => ({
-    href: urlWithBaseUrl(url),
-    onClick: showCookiesPrefs ? toggleCookiesPrefs : undefined,
-    ...(newTab ? { target: '_blank', rel: 'noreferrer' } : {}),
-});
-
-const MenuColumns = ({ columns }: { columns: FooterGroup[] }) => {
+const MenuColumns = ({ footerItems }: { footerItems: FooterGroup[] }) => {
     const slugger = new GithubSlugger();
 
-    return columns.map(({ title, links }) => {
+    return footerItems.map(({ title, links }) => {
         // Associate each link list with its (non-heading) title so assistive tech still announces the
         // group label. SE-45 deliberately drops the <h2> to keep these out of the page heading outline.
         const titleId = `footer-${new GithubSlugger().slug(title)}`;
@@ -51,11 +41,17 @@ const MenuColumns = ({ columns }: { columns: FooterGroup[] }) => {
                     {title}
                 </span>
                 <ul className="list-style-none" aria-labelledby={titleId}>
-                    {links.map((link) => (
-                        <li key={`${title}_${link.name}`}>
-                            <a id={`${slugger.slug(link.name)}-nav`} tabIndex={0} {...linkAttributes(link)}>
-                                {link.iconName && <Icon name={link.iconName as IconName} />}
-                                {link.name}
+                    {links.map(({ name, url, newTab, iconName, showCookiesPrefs }: any) => (
+                        <li key={`${title}_${name}`}>
+                            <a
+                                id={`${slugger.slug(name)}-nav`}
+                                tabIndex={0}
+                                href={urlWithBaseUrl(url)}
+                                onClick={showCookiesPrefs ? toggleCookiesPrefs : undefined}
+                                {...(newTab ? { target: '_blank', rel: 'noreferrer' } : {})}
+                            >
+                                {iconName && <Icon name={iconName} />}
+                                {name}
                             </a>
                         </li>
                     ))}
@@ -65,38 +61,22 @@ const MenuColumns = ({ columns }: { columns: FooterGroup[] }) => {
     });
 };
 
-const SocialLinks = ({ group }: { group: FooterGroup }) => {
-    const slugger = new GithubSlugger();
-
-    return (
-        <ul className={classNames('list-style-none', styles.socialLinks)} aria-label={group.title}>
-            {group.links.map((link) => (
-                <li key={link.name}>
-                    <a
-                        id={`${slugger.slug(link.name)}-nav`}
-                        tabIndex={0}
-                        aria-label={link.name}
-                        title={link.name}
-                        {...linkAttributes(link)}
-                    >
-                        {link.iconName ? <Icon name={link.iconName as IconName} /> : link.name}
-                    </a>
-                </li>
-            ))}
-        </ul>
-    );
-};
-
 // Separators between the links are drawn in CSS so they stay out of the accessibility tree.
 const LegalLinks = ({ group }: { group: FooterGroup }) => {
     const slugger = new GithubSlugger();
 
     return (
-        <ul className={classNames('list-style-none', styles.legalLinks)} aria-label={group.title}>
-            {group.links.map((link) => (
-                <li key={link.name}>
-                    <a id={`${slugger.slug(link.name)}-nav`} tabIndex={0} {...linkAttributes(link)}>
-                        {link.name}
+        <ul className={classNames('list-style-none', 'text-sm', styles.legalLinks)} aria-label={group.title}>
+            {group.links.map(({ name, url, newTab, showCookiesPrefs }) => (
+                <li key={name}>
+                    <a
+                        id={`${slugger.slug(name)}-nav`}
+                        tabIndex={0}
+                        href={urlWithBaseUrl(url)}
+                        onClick={showCookiesPrefs ? toggleCookiesPrefs : undefined}
+                        {...(newTab ? { target: '_blank', rel: 'noreferrer' } : {})}
+                    >
+                        {name}
                     </a>
                 </li>
             ))}
@@ -104,46 +84,55 @@ const LegalLinks = ({ group }: { group: FooterGroup }) => {
     );
 };
 
-export const Footer = ({ showMicrosoftMessage, footerItems, tagline }: FooterProps) => {
+export const Footer = ({ showMicrosoftMessage, footerItems }: FooterProps) => {
     const columns = footerItems.filter((item) => !item.placement);
-    const socialGroup = footerItems.find((item) => item.placement === 'social');
     const legalGroup = footerItems.find((item) => item.placement === 'legal');
 
     return (
         <footer className={styles.footer}>
-            <div className={styles.footerInner}>
-                <div className={styles.footerColumns}>
-                    <div className={styles.brandColumn}>
-                        <div className={styles.logoContainer}>
-                            <SiteLogo />
-                        </div>
-                        {tagline && <p className={classNames('text-sm', styles.tagline)}>{tagline}</p>}
-                        {socialGroup && <SocialLinks group={socialGroup} />}
+            <div className={classNames(styles.footerColumns, 'layout-grid')}>
+                <div className={styles.menuColumn}>
+                    <div className={styles.logoContainer}>
+                        <SiteLogo />
                     </div>
-                    <MenuColumns columns={columns} />
-                </div>
+                    <div className={styles.footerInfo}>
+                        <p className="text-sm">&copy; AG Grid Ltd 2015-{new Date().getFullYear()}</p>
 
-                <div className={styles.legalBar}>
-                    <div className={classNames('text-sm', styles.legalInfo)}>
-                        <p>
-                            &copy; AG Grid Ltd 2015&ndash;{new Date().getFullYear()}
-                            <span className={styles.legalInfoSeparator}> &middot; </span>
-                            Company&nbsp;No.&nbsp;07318192
-                            <span className={styles.legalInfoSeparator}> &middot; </span>
+                        <p className="text-sm">
+                            <DevToolsToggle>AG Grid Ltd registered</DevToolsToggle> in England&nbsp;&amp;&nbsp;Wales.
+                            <br />
+                            Company&nbsp;No.&nbsp;07318192.
+                            <br />
                             VAT&nbsp;no.&nbsp;GB998360167
                         </p>
-                        <p>
-                            <DevToolsToggle>AG Grid Ltd registered</DevToolsToggle> in England&nbsp;&amp;&nbsp;Wales
-                            <span className={styles.legalInfoSeparator}> &middot; </span>
-                            70&nbsp;Wilson&nbsp;Street, London&nbsp;EC2A&nbsp;2DB
+
+                        <p className="text-sm">
+                            Registered address
+                            <br />
+                            AG Grid Ltd
+                            <br />
+                            70 Wilson Street
+                            <br />
+                            London
+                            <br />
+                            EC2A 2DB
+                            <br />
                         </p>
+
                         {showMicrosoftMessage && (
-                            <p>The Microsoft logo is a trademark of the Microsoft group of companies.</p>
+                            <p className="text-sm">
+                                The Microsoft logo is a trademark of the Microsoft group of companies.
+                            </p>
                         )}
                     </div>
-                    {legalGroup && <LegalLinks group={legalGroup} />}
                 </div>
+                <MenuColumns footerItems={columns} />
             </div>
+            {legalGroup && (
+                <div className={classNames(styles.legalBar, 'layout-grid')}>
+                    <LegalLinks group={legalGroup} />
+                </div>
+            )}
         </footer>
     );
 };

--- a/external/ag-website-shared/src/components/footer/Footer.tsx
+++ b/external/ag-website-shared/src/components/footer/Footer.tsx
@@ -1,30 +1,47 @@
 import type { FooterItem } from '@ag-grid-types';
 import { DevToolsToggle } from '@ag-website-shared/components/dev-tools/DevTools';
-import { Icon } from '@ag-website-shared/components/icon/Icon';
+import { Icon, type IconName } from '@ag-website-shared/components/icon/Icon';
 import { SiteLogo } from '@components/SiteLogo';
 import { urlWithBaseUrl } from '@utils/urlWithBaseUrl';
 import classNames from 'classnames';
 import GithubSlugger from 'github-slugger';
+import type { MouseEvent } from 'react';
 
 import styles from './Footer.module.scss';
 
+/**
+ * A footer group renders as a navigation column unless its `placement` moves it into the legal
+ * strip or the social icon row. Declared here so a site whose footer type predates `placement`
+ * still renders every group as a column.
+ */
+type FooterGroup = FooterItem & { placement?: 'legal' | 'social' };
+type FooterLink = FooterGroup['links'][number];
+
 interface FooterProps {
     showMicrosoftMessage?: boolean;
-    footerItems: FooterItem[];
+    footerItems: FooterGroup[];
+    /** Short product line shown under the logo. Omit to leave the brand column as logo and socials only. */
+    tagline?: string;
 }
 
-const MenuColumns = ({ footerItems }: { footerItems: FooterItem[] }) => {
+const toggleCookiesPrefs = (event: MouseEvent<HTMLAnchorElement>) => {
+    event.preventDefault();
+
+    if (!window.__enzuzoApi) return;
+
+    window.__enzuzoApi.prefCenter.show();
+};
+
+const linkAttributes = ({ url, newTab, showCookiesPrefs }: FooterLink) => ({
+    href: urlWithBaseUrl(url),
+    onClick: showCookiesPrefs ? toggleCookiesPrefs : undefined,
+    ...(newTab ? { target: '_blank', rel: 'noreferrer' } : {}),
+});
+
+const MenuColumns = ({ columns }: { columns: FooterGroup[] }) => {
     const slugger = new GithubSlugger();
 
-    const toggleCookiesPrefs = (event) => {
-        event.preventDefault();
-
-        if (!window.__enzuzoApi) return;
-
-        window.__enzuzoApi.prefCenter.show();
-    };
-
-    return footerItems.map(({ title, links }) => {
+    return columns.map(({ title, links }) => {
         // Associate each link list with its (non-heading) title so assistive tech still announces the
         // group label. SE-45 deliberately drops the <h2> to keep these out of the page heading outline.
         const titleId = `footer-${new GithubSlugger().slug(title)}`;
@@ -34,17 +51,11 @@ const MenuColumns = ({ footerItems }: { footerItems: FooterItem[] }) => {
                     {title}
                 </span>
                 <ul className="list-style-none" aria-labelledby={titleId}>
-                    {links.map(({ name, url, newTab, iconName, showCookiesPrefs }: any) => (
-                        <li key={`${title}_${name}`}>
-                            <a
-                                id={`${slugger.slug(name)}-nav`}
-                                tabIndex={0}
-                                href={urlWithBaseUrl(url)}
-                                onClick={showCookiesPrefs ? toggleCookiesPrefs : undefined}
-                                {...(newTab ? { target: '_blank', rel: 'noreferrer' } : {})}
-                            >
-                                {iconName && <Icon name={iconName} />}
-                                {name}
+                    {links.map((link) => (
+                        <li key={`${title}_${link.name}`}>
+                            <a id={`${slugger.slug(link.name)}-nav`} tabIndex={0} {...linkAttributes(link)}>
+                                {link.iconName && <Icon name={link.iconName as IconName} />}
+                                {link.name}
                             </a>
                         </li>
                     ))}
@@ -54,46 +65,84 @@ const MenuColumns = ({ footerItems }: { footerItems: FooterItem[] }) => {
     });
 };
 
-export const Footer = ({ showMicrosoftMessage, footerItems }: FooterProps) => {
+const SocialLinks = ({ group }: { group: FooterGroup }) => {
+    const slugger = new GithubSlugger();
+
+    return (
+        <ul className={classNames('list-style-none', styles.socialLinks)} aria-label={group.title}>
+            {group.links.map((link) => (
+                <li key={link.name}>
+                    <a
+                        id={`${slugger.slug(link.name)}-nav`}
+                        tabIndex={0}
+                        aria-label={link.name}
+                        title={link.name}
+                        {...linkAttributes(link)}
+                    >
+                        {link.iconName ? <Icon name={link.iconName as IconName} /> : link.name}
+                    </a>
+                </li>
+            ))}
+        </ul>
+    );
+};
+
+// Separators between the links are drawn in CSS so they stay out of the accessibility tree.
+const LegalLinks = ({ group }: { group: FooterGroup }) => {
+    const slugger = new GithubSlugger();
+
+    return (
+        <ul className={classNames('list-style-none', styles.legalLinks)} aria-label={group.title}>
+            {group.links.map((link) => (
+                <li key={link.name}>
+                    <a id={`${slugger.slug(link.name)}-nav`} tabIndex={0} {...linkAttributes(link)}>
+                        {link.name}
+                    </a>
+                </li>
+            ))}
+        </ul>
+    );
+};
+
+export const Footer = ({ showMicrosoftMessage, footerItems, tagline }: FooterProps) => {
+    const columns = footerItems.filter((item) => !item.placement);
+    const socialGroup = footerItems.find((item) => item.placement === 'social');
+    const legalGroup = footerItems.find((item) => item.placement === 'legal');
+
     return (
         <footer className={styles.footer}>
-            <div className={classNames(styles.footerColumns, 'layout-grid')}>
-                <div className={styles.menuColumn}>
-                    <div className={styles.logoContainer}>
-                        <SiteLogo />
+            <div className={styles.footerInner}>
+                <div className={styles.footerColumns}>
+                    <div className={styles.brandColumn}>
+                        <div className={styles.logoContainer}>
+                            <SiteLogo />
+                        </div>
+                        {tagline && <p className={classNames('text-sm', styles.tagline)}>{tagline}</p>}
+                        {socialGroup && <SocialLinks group={socialGroup} />}
                     </div>
-                    <div className={styles.footerInfo}>
-                        <p className="text-sm">&copy; AG Grid Ltd 2015-{new Date().getFullYear()}</p>
+                    <MenuColumns columns={columns} />
+                </div>
 
-                        <p className="text-sm">
-                            <DevToolsToggle>AG Grid Ltd registered</DevToolsToggle> in England&nbsp;&amp;&nbsp;Wales.
-                            <br />
-                            Company&nbsp;No.&nbsp;07318192.
-                            <br />
+                <div className={styles.legalBar}>
+                    <div className={classNames('text-sm', styles.legalInfo)}>
+                        <p>
+                            &copy; AG Grid Ltd 2015&ndash;{new Date().getFullYear()}
+                            <span className={styles.legalInfoSeparator}> &middot; </span>
+                            Company&nbsp;No.&nbsp;07318192
+                            <span className={styles.legalInfoSeparator}> &middot; </span>
                             VAT&nbsp;no.&nbsp;GB998360167
                         </p>
-
-                        <p className="text-sm">
-                            Registered address
-                            <br />
-                            AG Grid Ltd
-                            <br />
-                            70 Wilson Street
-                            <br />
-                            London
-                            <br />
-                            EC2A 2DB
-                            <br />
+                        <p>
+                            <DevToolsToggle>AG Grid Ltd registered</DevToolsToggle> in England&nbsp;&amp;&nbsp;Wales
+                            <span className={styles.legalInfoSeparator}> &middot; </span>
+                            70&nbsp;Wilson&nbsp;Street, London&nbsp;EC2A&nbsp;2DB
                         </p>
-
                         {showMicrosoftMessage && (
-                            <p className="text-sm">
-                                The Microsoft logo is a trademark of the Microsoft group of companies.
-                            </p>
+                            <p>The Microsoft logo is a trademark of the Microsoft group of companies.</p>
                         )}
                     </div>
+                    {legalGroup && <LegalLinks group={legalGroup} />}
                 </div>
-                <MenuColumns footerItems={footerItems} />
             </div>
         </footer>
     );


### PR DESCRIPTION
## Summary

Moves the legal and policy links (Terms of Use, Privacy Policy, Cookies Policy, Manage Cookies, Modern Slavery, Sitemap) out of **The Company** column into a pipe-separated strip under the footer columns. Everything else about the footer is unchanged.

- Footer groups in `footer.json` gain an optional `placement: "legal"`. Groups without it render as columns as before, so the shared component keeps working for sites whose footer data predates the field.
- Existing links are only regrouped; nothing is removed.
- Desktop: left-aligned strip with pipe separators, drawn in CSS with empty alternative text so they are never announced. Below the five-column breakpoint the strip is centred and separated by the gap alone, as the old mobile footer had no separators.
- The markdown related-links test is updated for the new grouping (legal pages now relate to each other rather than to About).

## Test plan

- [x] `./checks.sh` passes
- [x] `./behave.sh --project ag-grid-docs` passes
- [x] Checked in the browser at desktop, tablet and phone widths