### PR TITLE
Only re-persist consent-owned head elements across view transitions

### DIFF
--- a/documentation/ag-grid-docs/public/scripts/persist-cookie-consent.js
+++ b/documentation/ag-grid-docs/public/scripts/persist-cookie-consent.js
@@ -19,7 +19,11 @@
  */
 (function () {
     var BODY_ROOTS = ':scope > .ez-consent, :scope > [id^="ez-cookie"], :scope > [id^="enzuzo-"]';
-    var HEAD_STYLES = 'style[id^="enzuzo_cb"], style[ez-style], [data-astro-transition-persist]';
+    // Only re-persist the elements this script tagged on an earlier navigation. A bare
+    // [data-astro-transition-persist] would also match the AG stylesheets that
+    // persist-injected-styles.js has already given a placeholder, and a second placeholder for
+    // the same id is left behind as an empty <style> that accumulates on every navigation.
+    var HEAD_STYLES = 'style[id^="enzuzo_cb"], style[ez-style], [data-astro-transition-persist^="enzuzo-"]';
     // Enzuzo's base and modal stylesheets carry no id or attribute, so they are matched on the
     // class names they style instead.
     var UNTAGGED_HEAD_STYLES = 'style:not([data-astro-transition-persist])';


### PR DESCRIPTION
## Summary

Fixes a leak in `persist-cookie-consent.js`, found by the review bot on the charts and studio ports of the Manage Cookies work (ag-grid/ag-charts#8127, ag-grid/ag-studio#2771).

The script re-persists Enzuzo's head elements across client-side navigations. Its selector included a bare `[data-astro-transition-persist]`, which also matches the AG stylesheets that `persist-injected-styles.js` has already tagged and given a placeholder, because that script's listener runs first. Both scripts then append a placeholder for the same id to the incoming head. Astro pairs each live element with one placeholder and appends the rest, so the surplus lands in the live head as an empty `<style>` carrying an AG persist id. On the next navigation that empty element is itself matched and persisted, so every navigation from a page that mounted a grid adds one empty style element per AG stylesheet, without bound.

The fix narrows the match to `[data-astro-transition-persist^="enzuzo-"]`, the ids this script assigns, which keeps the Enzuzo styles alive without touching the AG ones. The same one-line change is applied in the two ports so the three copies stay identical.

## Test plan

- [x] `./checks.sh` passes