### PR TITLE
AG-3390 Embed example source in docs pages at build time for crawlers (b36.1.0)

### DIFF
--- a/documentation/ag-grid-docs/astro.config.mjs
+++ b/documentation/ag-grid-docs/astro.config.mjs
@@ -114,6 +114,13 @@ const {
     DISABLE_EXAMPLE_RUNNER,
 
     /*
+     * Disable embedding each example's source in the docs page HTML for crawlers
+     *
+     * The example runner keeps fetching the source at runtime either way
+     */
+    DISABLE_EXAMPLE_SOURCE_EMBED,
+
+    /*
      * Disable markdown doc generation
      */
     DISABLE_MARKDOWN_DOCS,
@@ -161,6 +168,7 @@ console.log(
             CHECK_REDIRECTS,
             QUICK_BUILD_PAGES,
             DISABLE_EXAMPLE_RUNNER,
+            DISABLE_EXAMPLE_SOURCE_EMBED,
             DISABLE_MARKDOWN_DOCS,
             CHARTS_SITEMAP_INDEX_URL,
             CHARTS_ROBOTS_DISALLOW_JSON_URL,

--- a/documentation/ag-grid-docs/src/components/docs/components/DocsExampleRunner.astro
+++ b/documentation/ag-grid-docs/src/components/docs/components/DocsExampleRunner.astro
@@ -1,9 +1,13 @@
 ---
-import { getPageNameFromPath } from '@components/docs/utils/urlPaths';
+import { getFrameworkFromPath, getPageNameFromPath } from '@components/docs/utils/urlPaths';
 import ExampleRunnerContainer from '@components/example-runner/components/ExampleRunnerContainer.astro';
+import ExampleRunnerSourceCode from '@components/example-runner/components/ExampleRunnerSourceCode.astro';
+import { getExampleViewerFiles, type ExampleViewerFiles } from '@components/example-runner/utils/exampleViewerFiles';
+import { resolveInternalFramework } from '@components/example-runner/utils/resolveInternalFramework';
 import { getIsDev } from '@utils/env';
+import { getInternalFramework } from '@utils/framework';
 import { DocsExampleRunner } from './DocsExampleRunner';
-import { DISABLE_EXAMPLE_RUNNER } from '@constants';
+import { DISABLE_EXAMPLE_RUNNER, DISABLE_EXAMPLE_SOURCE_EMBED } from '@constants';
 import { getGeneratedContents, type GeneratedExampleParams } from '@components/example-generator';
 import { getSupportedFrameworks } from '@components/docs/utils/filesData';
 
@@ -19,27 +23,40 @@ interface Props {
 const { title, name, exampleHeight, typescriptOnly, suppressDarkMode, consoleBufferSize } = Astro.props as Props;
 
 const pageName = getPageNameFromPath(Astro.url.pathname);
+const framework = getFrameworkFromPath(Astro.url.pathname);
 const isDev = getIsDev();
 
 const supportedFrameworks = await getSupportedFrameworks({ pageName, exampleName: name });
+const supportedFrameworksList = Array.from(supportedFrameworks || []);
+
+// The TypeScript variant, as the markdown twin page embeds, so crawlers get the same source from
+// both. A visitor's own language choice is still fetched by the island as before.
+const { internalFramework } = resolveInternalFramework({
+    docsInternalFramework: getInternalFramework({ framework, useTypescript: true }),
+    supportedFrameworks: supportedFrameworksList,
+    typescriptOnly,
+});
 const generatedExampleParams: GeneratedExampleParams = {
     type: 'docs',
-    // If there are supported frameworks, take the first one, otherwise the contents should be the same as vanilla
-    framework: supportedFrameworks?.values().next().value || 'vanilla',
+    framework: internalFramework,
     pageName,
     exampleName: name,
 };
 
 let hasExampleConsoleLog = false;
+let sourceCode: ExampleViewerFiles | undefined;
 try {
-    // NOTE: Even though we have the contents at build time, we are not passing
-    // it into the component, so that we can load the contents at runtime.
-    // This avoids the page being bigger than it needs to be, if the user does
-    // not scroll to the example.
     const contents = await getGeneratedContents(generatedExampleParams);
     // Get whether example has console log component at build time, so that we
     // can show it on page load.
     hasExampleConsoleLog = Boolean(contents?.hasExampleConsoleLog);
+
+    // NOTE: The island still fetches the contents at runtime rather than taking them as props,
+    // so the page only carries the source once: in the crawlable panel below, which the island
+    // removes once it has mounted.
+    if (contents && !DISABLE_EXAMPLE_SOURCE_EMBED) {
+        sourceCode = getExampleViewerFiles(contents, internalFramework);
+    }
 } catch (error) {
     console.error('Error generating contents for:', generatedExampleParams);
 }
@@ -64,8 +81,15 @@ try {
                 isDev={isDev}
                 hasExampleConsoleLog={hasExampleConsoleLog}
                 consoleBufferSize={consoleBufferSize}
-                supportedFrameworks={Array.from(supportedFrameworks || [])}
+                supportedFrameworks={supportedFrameworksList}
             />
+            {sourceCode && (
+                <ExampleRunnerSourceCode
+                    internalFramework={internalFramework}
+                    files={sourceCode.files}
+                    mainFileName={sourceCode.mainFileName}
+                />
+            )}
         </ExampleRunnerContainer>
     )
 }

--- a/documentation/ag-grid-docs/src/components/docs/components/DocsExampleRunner.tsx
+++ b/documentation/ag-grid-docs/src/components/docs/components/DocsExampleRunner.tsx
@@ -3,6 +3,8 @@ import { getLoadingIFrameId } from '@ag-website-shared/components/loading-logo/g
 import type { GeneratedContents } from '@components/example-generator/types';
 import { ExampleRunner } from '@components/example-runner/components/ExampleRunner';
 import { ExternalLinks } from '@components/example-runner/components/ExternalLinks';
+import { pruneExampleFiles } from '@components/example-runner/utils/exampleViewerFiles';
+import { resolveInternalFramework } from '@components/example-runner/utils/resolveInternalFramework';
 import { useStore } from '@nanostores/react';
 import { $internalFramework, $internalFrameworkState } from '@stores/frameworkStore';
 import { $queryClient, defaultQueryOptions } from '@stores/queryClientStore';
@@ -31,34 +33,6 @@ interface Props {
     supportedFrameworks?: InternalFramework[];
 }
 
-const getInternalFramework = (
-    docsInternalFramework: InternalFramework,
-    supportedFrameworks: InternalFramework[] | undefined
-): { internalFramework: InternalFramework; isUsingAlternativeInternalFramework: boolean } => {
-    let internalFramework = docsInternalFramework;
-    let isUsingAlternativeInternalFramework = false;
-    if (supportedFrameworks && supportedFrameworks.length > 0) {
-        if (!supportedFrameworks.includes(docsInternalFramework)) {
-            const bestAlternative: Record<InternalFramework, InternalFramework[]> = {
-                vanilla: ['typescript'],
-                typescript: ['vanilla'],
-                reactFunctional: ['reactFunctionalTs', 'typescript', 'vanilla'],
-                reactFunctionalTs: ['reactFunctional', 'typescript', 'vanilla'],
-                angular: ['typescript', 'vanilla'],
-                vue3: ['typescript', 'vanilla'],
-            };
-            const alternatives = bestAlternative[docsInternalFramework];
-            const alternative = alternatives.find((alternative) => supportedFrameworks.includes(alternative));
-            if (alternative) {
-                internalFramework = alternative;
-                isUsingAlternativeInternalFramework = true;
-            }
-        }
-    }
-
-    return { internalFramework, isUsingAlternativeInternalFramework };
-};
-
 const DocsExampleRunnerInner = ({
     name,
     title,
@@ -81,11 +55,15 @@ const DocsExampleRunnerInner = ({
 
     const storeInternalFramework = useStore($internalFramework);
     const internalFrameworkState = useStore($internalFrameworkState);
-    const { internalFramework: computedInternalFramework, isUsingAlternativeInternalFramework } = useMemo(
-        () => getInternalFramework(storeInternalFramework, supportedFrameworks),
-        [storeInternalFramework, supportedFrameworks]
+    const { internalFramework, isUsingAlternativeInternalFramework } = useMemo(
+        () =>
+            resolveInternalFramework({
+                docsInternalFramework: storeInternalFramework,
+                supportedFrameworks,
+                typescriptOnly,
+            }),
+        [storeInternalFramework, supportedFrameworks, typescriptOnly]
     );
-    const internalFramework = typescriptOnly ? 'typescript' : computedInternalFramework;
     const urlConfig: UrlParams = useMemo(
         () => ({ internalFramework, pageName, exampleName }),
         [internalFramework, pageName, exampleName]
@@ -109,25 +87,7 @@ const DocsExampleRunnerInner = ({
                             return {};
                         }
 
-                        const isTs =
-                            internalFramework === 'reactFunctionalTs' ||
-                            internalFramework === 'typescript' ||
-                            internalFramework === 'angular';
-                        if (!isTs) {
-                            delete json.files['interfaces.ts'];
-                        }
-                        if (internalFramework.startsWith('vue') || internalFramework.startsWith('react')) {
-                            delete json.files['index.html'];
-                        }
-
-                        // Don't include the example spec files in the example runner for now
-                        Object.keys(json.files)
-                            .filter((file) => file?.includes('.spec.') || file?.includes('.test.'))
-                            .forEach((specFile) => {
-                                delete json.files[specFile];
-                            });
-
-                        return json;
+                        return { ...json, files: pruneExampleFiles(json.files, internalFramework) };
                     }),
             ]) as Promise<[GeneratedContents]>;
         },
@@ -140,6 +100,12 @@ const DocsExampleRunnerInner = ({
         plunkrHtmlUrl: getExamplePlunkrUrl(urlConfig),
         codeSandboxHtmlUrl: getExampleCodeSandboxUrl(urlConfig),
     };
+
+    useEffect(() => {
+        // The build embeds a hidden copy of the source for crawlers; this island now owns the code
+        // viewer, so drop it rather than carry the source twice.
+        document.getElementById(id)?.querySelector('[data-example-source-code]')?.remove();
+    }, [id]);
 
     useEffect(() => {
         if (isError) {

--- a/documentation/ag-grid-docs/src/components/example-runner/components/ExampleRunnerSourceCode.astro
+++ b/documentation/ag-grid-docs/src/components/example-runner/components/ExampleRunnerSourceCode.astro
@@ -1,0 +1,36 @@
+---
+/**
+ * Build-time copy of the example source the Code button reveals, so crawlers can index it.
+ *
+ * The example runner itself is a client-only island and fetches this same source at runtime, so
+ * the panel is hidden and the island removes it once it mounts. It must show exactly the files
+ * the code viewer shows: content that only a crawler could ever see would count as cloaking.
+ */
+import type { InternalFramework } from '@ag-grid-types';
+import type { FileContents } from '@components/example-generator/types';
+
+interface Props {
+    internalFramework: InternalFramework;
+    files: FileContents;
+    mainFileName: string;
+}
+
+const { internalFramework, files, mainFileName } = Astro.props;
+
+// Main file first, so the most useful content leads
+const fileNames = [mainFileName, ...Object.keys(files).filter((fileName) => fileName !== mainFileName)].filter(
+    (fileName) => files[fileName] !== undefined
+);
+---
+
+<div class="example-runner-source-code" data-example-source-code data-internal-framework={internalFramework} hidden>
+    {
+        fileNames.map((fileName) => (
+            <figure>
+                <figcaption>{fileName}</figcaption>
+                {/* prettier-ignore */}
+                <pre><code data-file-name={fileName} set:text={files[fileName]} /></pre>
+            </figure>
+        ))
+    }
+</div>

--- a/documentation/ag-grid-docs/src/components/example-runner/utils/exampleViewerFiles.test.ts
+++ b/documentation/ag-grid-docs/src/components/example-runner/utils/exampleViewerFiles.test.ts
@@ -1,0 +1,103 @@
+import type { GeneratedContents } from '@components/example-generator/types';
+import { describe, expect, it } from 'vitest';
+
+import { getExampleViewerFiles, pruneExampleFiles } from './exampleViewerFiles';
+
+const files = {
+    'main.ts': 'const gridOptions = {};\n',
+    'interfaces.ts': 'export interface IRow {}\n',
+    'index.html': '<div id="myGrid"></div>\n',
+    'styles.css': '.red { color: red; }\n',
+    'example.spec.ts': "test('grid', () => {});\n",
+    'main.test.ts': "test('grid', () => {});\n",
+};
+
+describe('pruneExampleFiles', () => {
+    it('drops spec and test files for every framework', () => {
+        for (const internalFramework of ['vanilla', 'typescript', 'reactFunctionalTs', 'angular', 'vue3'] as const) {
+            const pruned = Object.keys(pruneExampleFiles(files, internalFramework));
+            expect(pruned, internalFramework).not.toContain('example.spec.ts');
+            expect(pruned, internalFramework).not.toContain('main.test.ts');
+        }
+    });
+
+    it('hides the TypeScript interfaces from the JavaScript variants only', () => {
+        expect(Object.keys(pruneExampleFiles(files, 'vanilla'))).not.toContain('interfaces.ts');
+        expect(Object.keys(pruneExampleFiles(files, 'reactFunctional'))).not.toContain('interfaces.ts');
+        expect(Object.keys(pruneExampleFiles(files, 'typescript'))).toContain('interfaces.ts');
+        expect(Object.keys(pruneExampleFiles(files, 'reactFunctionalTs'))).toContain('interfaces.ts');
+        expect(Object.keys(pruneExampleFiles(files, 'angular'))).toContain('interfaces.ts');
+    });
+
+    it('hides the HTML shell for React and Vue, whose markup lives in the component', () => {
+        expect(Object.keys(pruneExampleFiles(files, 'reactFunctional'))).not.toContain('index.html');
+        expect(Object.keys(pruneExampleFiles(files, 'reactFunctionalTs'))).not.toContain('index.html');
+        expect(Object.keys(pruneExampleFiles(files, 'vue3'))).not.toContain('index.html');
+        expect(Object.keys(pruneExampleFiles(files, 'vanilla'))).toContain('index.html');
+        expect(Object.keys(pruneExampleFiles(files, 'typescript'))).toContain('index.html');
+        expect(Object.keys(pruneExampleFiles(files, 'angular'))).toContain('index.html');
+    });
+
+    it('keeps the remaining files and their contents, without mutating the input', () => {
+        const input = { ...files };
+        const pruned = pruneExampleFiles(input, 'typescript');
+
+        expect(pruned).toEqual({
+            'main.ts': files['main.ts'],
+            'interfaces.ts': files['interfaces.ts'],
+            'index.html': files['index.html'],
+            'styles.css': files['styles.css'],
+        });
+        expect(input).toEqual(files);
+    });
+});
+
+describe('getExampleViewerFiles', () => {
+    const contents = {
+        files: {
+            ...files,
+            'main.ts': [
+                "const AI_API_TOKEN = 'secret-token';",
+                'const gridOptions = {};',
+                '/** DARK INTEGRATED START **/',
+                'document.documentElement.dataset.agThemeMode = "dark";',
+                '/** DARK INTEGRATED END **/',
+                '',
+            ].join('\n'),
+        },
+        entryFileName: 'main.ts',
+        mainFileName: 'main.ts',
+    } as unknown as GeneratedContents;
+
+    it('prunes for the framework and strips the generator harness from the main file', () => {
+        const { files: viewerFiles, mainFileName } = getExampleViewerFiles(contents, 'vanilla');
+
+        expect(mainFileName).toBe('main.ts');
+        expect(Object.keys(viewerFiles)).toEqual(['main.ts', 'index.html', 'styles.css']);
+        expect(viewerFiles['main.ts']).not.toContain('DARK INTEGRATED');
+        expect(viewerFiles['main.ts']).toContain('const gridOptions = {};');
+    });
+
+    it('redacts AI API tokens so they never reach the page', () => {
+        const { files: viewerFiles } = getExampleViewerFiles(contents, 'typescript');
+
+        expect(viewerFiles['main.ts']).not.toContain('secret-token');
+        expect(viewerFiles['main.ts']).toContain("const AI_API_TOKEN = '<TOKEN_REDACTED>'");
+    });
+
+    it('falls back to the entry file when there is no main file', () => {
+        const { mainFileName } = getExampleViewerFiles(
+            { ...contents, mainFileName: undefined } as unknown as GeneratedContents,
+            'typescript'
+        );
+
+        expect(mainFileName).toBe('main.ts');
+    });
+
+    it('leaves the generated contents untouched', () => {
+        const before = JSON.stringify(contents);
+        getExampleViewerFiles(contents, 'vanilla');
+
+        expect(JSON.stringify(contents)).toBe(before);
+    });
+});

--- a/documentation/ag-grid-docs/src/components/example-runner/utils/exampleViewerFiles.ts
+++ b/documentation/ag-grid-docs/src/components/example-runner/utils/exampleViewerFiles.ts
@@ -1,0 +1,56 @@
+import type { InternalFramework } from '@ag-grid-types';
+import { TYPESCRIPT_INTERNAL_FRAMEWORKS } from '@components/example-generator/types';
+import type { FileContents, GeneratedContents } from '@components/example-generator/types';
+import { stripOutExampleGeneratorCode } from '@components/example-runner/components/stripOutExampleGeneratorCode';
+
+export interface ExampleViewerFiles {
+    /** Files the code viewer shows, cleaned of the example generator harness */
+    files: FileContents;
+    /** File selected when the code viewer opens */
+    mainFileName: string;
+}
+
+const isSpecFile = (fileName: string) => fileName.includes('.spec.') || fileName.includes('.test.');
+
+/**
+ * Drop the generated files the example runner code viewer does not show for the internal framework:
+ * TypeScript interfaces for JavaScript variants, the HTML shell for React and Vue, and test specs.
+ *
+ * Returns a new map; `files` is left untouched.
+ */
+export function pruneExampleFiles(files: FileContents, internalFramework: InternalFramework): FileContents {
+    const isTs = TYPESCRIPT_INTERNAL_FRAMEWORKS.includes(internalFramework);
+    const hidesIndexHtml = internalFramework.startsWith('vue') || internalFramework.startsWith('react');
+
+    return Object.fromEntries(
+        Object.entries(files).filter(([fileName]) => {
+            if (!isTs && fileName === 'interfaces.ts') {
+                return false;
+            }
+            if (hidesIndexHtml && fileName === 'index.html') {
+                return false;
+            }
+            return !isSpecFile(fileName);
+        })
+    );
+}
+
+/**
+ * The files exactly as the example runner code viewer presents them: pruned for the internal
+ * framework and stripped of the harness the example generator injects.
+ *
+ * Shared by the build-time renders (the crawlable source panel and the markdown twin pages) so
+ * they cannot drift from what the Code button reveals.
+ */
+export function getExampleViewerFiles(
+    contents: GeneratedContents,
+    internalFramework: InternalFramework
+): ExampleViewerFiles {
+    const files = pruneExampleFiles(contents.files, internalFramework);
+    stripOutExampleGeneratorCode(files);
+
+    return {
+        files,
+        mainFileName: contents.mainFileName ?? contents.entryFileName,
+    };
+}

--- a/documentation/ag-grid-docs/src/components/example-runner/utils/resolveInternalFramework.test.ts
+++ b/documentation/ag-grid-docs/src/components/example-runner/utils/resolveInternalFramework.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveInternalFramework } from './resolveInternalFramework';
+
+describe('resolveInternalFramework', () => {
+    it('keeps the docs framework when the example places no restriction', () => {
+        expect(resolveInternalFramework({ docsInternalFramework: 'vue3' })).toEqual({
+            internalFramework: 'vue3',
+            isUsingAlternativeInternalFramework: false,
+        });
+        expect(resolveInternalFramework({ docsInternalFramework: 'vue3', supportedFrameworks: [] })).toEqual({
+            internalFramework: 'vue3',
+            isUsingAlternativeInternalFramework: false,
+        });
+    });
+
+    it('keeps the docs framework when the example supports it', () => {
+        expect(
+            resolveInternalFramework({
+                docsInternalFramework: 'reactFunctional',
+                supportedFrameworks: ['reactFunctional', 'typescript'],
+            })
+        ).toEqual({ internalFramework: 'reactFunctional', isUsingAlternativeInternalFramework: false });
+    });
+
+    it('falls back to the closest supported alternative', () => {
+        expect(
+            resolveInternalFramework({
+                docsInternalFramework: 'reactFunctional',
+                supportedFrameworks: ['typescript', 'reactFunctionalTs'],
+            })
+        ).toEqual({ internalFramework: 'reactFunctionalTs', isUsingAlternativeInternalFramework: true });
+
+        expect(
+            resolveInternalFramework({ docsInternalFramework: 'angular', supportedFrameworks: ['vanilla'] })
+        ).toEqual({ internalFramework: 'vanilla', isUsingAlternativeInternalFramework: true });
+    });
+
+    it('keeps the docs framework when no alternative is supported either', () => {
+        expect(resolveInternalFramework({ docsInternalFramework: 'vue3', supportedFrameworks: ['angular'] })).toEqual({
+            internalFramework: 'vue3',
+            isUsingAlternativeInternalFramework: false,
+        });
+    });
+
+    it('pins typescriptOnly examples to TypeScript', () => {
+        expect(
+            resolveInternalFramework({
+                docsInternalFramework: 'reactFunctional',
+                supportedFrameworks: ['reactFunctionalTs'],
+                typescriptOnly: true,
+            })
+        ).toEqual({ internalFramework: 'typescript', isUsingAlternativeInternalFramework: true });
+    });
+});

--- a/documentation/ag-grid-docs/src/components/example-runner/utils/resolveInternalFramework.ts
+++ b/documentation/ag-grid-docs/src/components/example-runner/utils/resolveInternalFramework.ts
@@ -1,0 +1,55 @@
+import type { InternalFramework } from '@ag-grid-types';
+
+/**
+ * Closest internal frameworks to fall back to, in order, when an example does not support the one
+ * the docs are set to.
+ */
+const BEST_ALTERNATIVE: Record<InternalFramework, InternalFramework[]> = {
+    vanilla: ['typescript'],
+    typescript: ['vanilla'],
+    reactFunctional: ['reactFunctionalTs', 'typescript', 'vanilla'],
+    reactFunctionalTs: ['reactFunctional', 'typescript', 'vanilla'],
+    angular: ['typescript', 'vanilla'],
+    vue3: ['typescript', 'vanilla'],
+};
+
+export interface ResolvedInternalFramework {
+    internalFramework: InternalFramework;
+    /** The example does not support the docs framework, so a fallback is shown */
+    isUsingAlternativeInternalFramework: boolean;
+}
+
+/**
+ * Work out which internal framework the example runner shows for an example.
+ *
+ * Starts from the docs internal framework, falls back to the best supported alternative when the
+ * example restricts its `supportedFrameworks`, and is pinned to TypeScript for `typescriptOnly`
+ * examples.
+ */
+export function resolveInternalFramework({
+    docsInternalFramework,
+    supportedFrameworks,
+    typescriptOnly,
+}: {
+    docsInternalFramework: InternalFramework;
+    supportedFrameworks?: InternalFramework[];
+    typescriptOnly?: boolean;
+}): ResolvedInternalFramework {
+    let internalFramework = docsInternalFramework;
+    let isUsingAlternativeInternalFramework = false;
+
+    if (supportedFrameworks && supportedFrameworks.length > 0 && !supportedFrameworks.includes(docsInternalFramework)) {
+        const alternative = BEST_ALTERNATIVE[docsInternalFramework].find((candidate) =>
+            supportedFrameworks.includes(candidate)
+        );
+        if (alternative) {
+            internalFramework = alternative;
+            isUsingAlternativeInternalFramework = true;
+        }
+    }
+
+    return {
+        internalFramework: typescriptOnly ? 'typescript' : internalFramework,
+        isUsingAlternativeInternalFramework,
+    };
+}

--- a/documentation/ag-grid-docs/src/constants.ts
+++ b/documentation/ag-grid-docs/src/constants.ts
@@ -35,6 +35,9 @@ export const FRAMEWORK_DISPLAY_TEXT: Record<Framework, string> = {
 
 export const DISABLE_EXAMPLE_RUNNER = isTruthy(import.meta.env?.DISABLE_EXAMPLE_RUNNER);
 
+// Turn off the hidden, crawlable copy of each example's source that docs pages embed at build time
+export const DISABLE_EXAMPLE_SOURCE_EMBED = isTruthy(import.meta.env?.DISABLE_EXAMPLE_SOURCE_EMBED);
+
 // Turn off per-page markdown (`.md`) generation for LLMs. When set, no `.md`
 // routes are emitted and the docs pages omit the markdown affordances
 export const DISABLE_MARKDOWN_DOCS = isTruthy(import.meta.env?.DISABLE_MARKDOWN_DOCS);

--- a/documentation/ag-grid-docs/src/content/docs/example-source-code.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/example-source-code.spec.ts
@@ -1,0 +1,65 @@
+import { expect, test } from '@playwright/test';
+
+// Docs pages embed a hidden, build-time copy of each example's source so crawlers can index it.
+// The example runner island then removes that copy and shows the same files behind its Code button.
+// Both halves matter: the raw HTML has to carry the code, and the page a user sees must not carry
+// it twice or show anything a crawler could not.
+
+// The HTML embeds the TypeScript variant, matching the markdown twin page. A first visit to a React
+// page shows the JavaScript variant in the code viewer (the docs default), so the two main files differ.
+const PAGES = [
+    {
+        path: 'react-data-grid/aggregation/',
+        exampleName: 'aggregation-overview',
+        embeddedMainFile: 'index.tsx',
+        viewerMainFile: 'index.jsx',
+    },
+    {
+        path: 'javascript-data-grid/aggregation/',
+        exampleName: 'aggregation-overview',
+        embeddedMainFile: 'main.ts',
+        viewerMainFile: 'main.ts',
+    },
+];
+
+test.describe('Example source embedded for crawlers', () => {
+    for (const { path, exampleName, embeddedMainFile, viewerMainFile } of PAGES) {
+        test(`${path} serves the ${exampleName} source in its HTML`, async ({ request, baseURL }) => {
+            const response = await request.get(new URL(path, baseURL).href);
+            expect(response.ok()).toBe(true);
+            const html = await response.text();
+
+            const panel = html.match(
+                new RegExp(
+                    `<div id="example-${exampleName}"[\\s\\S]*?<div class="example-runner-source-code"[^>]*>([\\s\\S]*?)</div>`
+                )
+            );
+            expect(panel, 'hidden source panel inside the example container').not.toBeNull();
+
+            const panelHtml = panel![0];
+            expect(panelHtml).toContain(' hidden');
+            expect(panelHtml).toContain(`<figcaption>${embeddedMainFile}</figcaption>`);
+            expect(panelHtml).toContain(`<code data-file-name="${embeddedMainFile}">`);
+            // Aggregation overview groups and aggregates the Olympic winners data
+            expect(panelHtml).toContain('aggFunc');
+            // Test specs and the generator's harness are not part of what the Code button shows
+            expect(panelHtml).not.toContain('data-file-name="example.spec.');
+            expect(panelHtml).not.toContain('DARK INTEGRATED');
+        });
+
+        test(`${path} shows the same ${exampleName} source behind the Code button`, async ({ page }) => {
+            await page.goto(path);
+
+            const container = page.locator(`#example-${exampleName}`);
+            // `exact`, so the CodeSandbox button in the same footer cannot match
+            const codeButton = container.getByRole('button', { name: 'Code', exact: true });
+            await expect(codeButton).toBeVisible();
+            // The island owns the code viewer once mounted, so the build-time copy is gone
+            await expect(container.locator('[data-example-source-code]')).toHaveCount(0);
+
+            await codeButton.click();
+            await expect(container.getByRole('button', { name: viewerMainFile })).toBeVisible();
+            await expect(container.locator('pre.code')).toContainText('aggFunc');
+        });
+    }
+});

--- a/documentation/ag-grid-docs/src/utils/markdoc/renderMarkdocResolvers.ts
+++ b/documentation/ag-grid-docs/src/utils/markdoc/renderMarkdocResolvers.ts
@@ -4,7 +4,7 @@ import { toAbsoluteUrl } from '@ag-website-shared/markdoc/toAbsoluteUrl';
 import { getPageImages, getPagePath } from '@components/docs/utils/filesData';
 import { getExampleLinkUrl } from '@components/docs/utils/urlPaths';
 import { getGeneratedContents } from '@components/example-generator';
-import { stripOutExampleGeneratorCode } from '@components/example-runner/components/stripOutExampleGeneratorCode';
+import { getExampleViewerFiles } from '@components/example-runner/utils/exampleViewerFiles';
 import * as snippetTransformer from '@components/snippet/snippetTransformer';
 import { agGridVersion } from '@constants';
 import { getInternalFramework } from '@utils/framework';
@@ -65,15 +65,12 @@ export function createGridMarkdownResolvers({ siteRoot }: { siteRoot?: string } 
                 if (!contents) {
                     return null;
                 }
-                const fileName = contents.mainFileName ?? contents.entryFileName;
-                if (!fileName || !contents.files?.[fileName]) {
+                // The same cleaned files the on-page code viewer shows, so the reader/LLM
+                // sees identical source.
+                const { files, mainFileName: fileName } = getExampleViewerFiles(contents, internalFramework);
+                if (!fileName || !files[fileName]) {
                     return null;
                 }
-                // Strip the harness the example generator injects (test-id setup,
-                // console logging, teardown, theme switcher, redacted AI tokens) so the
-                // reader/LLM sees the same clean source as the on-page code viewer.
-                const files = { ...contents.files };
-                stripOutExampleGeneratorCode(files);
                 const cleanCode = files[fileName].trim();
                 const liveUrl = toAbsoluteUrl(
                     getExampleLinkUrl({ internalFramework, pageName, exampleName: name }),


### PR DESCRIPTION
## Summary

Port of #15126 to `b36.1.0`. Clean cherry-pick of the merged commit.

Docs pages now embed a hidden, build-time copy of each example's source so crawlers can index it. The example runner keeps working exactly as before: the code only appears when the **Code** button is clicked. See #15126 for the full description.

One adaptation: the Playwright spec's `blockConsentAndAnalytics` helper does not exist on this branch (added later by AG-18114), so that call is dropped. The spec does not check console output, so nothing else depends on it.

## Testing

- Vitest: the 13 new cases pass on this branch.
- `nx run-many -t build-tsc lint -p ag-grid-docs`: lint passes; no type errors in the docs project.
- The Playwright spec was not executed on this branch (needs a full grid build).