### PR TITLE
Export a FooterLink type and use it in the footer component

### DIFF
--- a/documentation/ag-grid-docs/src/content.config.ts
+++ b/documentation/ag-grid-docs/src/content.config.ts
@@ -1,3 +1,4 @@
+import type { IconName } from '@ag-website-shared/components/icon/Icon';
 import { ALL_INTERNAL_FRAMEWORKS, FRAMEWORKS } from '@constants';
 // NOTE: Use glob, instead of file for single object files unless the file is an
 // array of objects
@@ -198,7 +199,9 @@ const footer = defineCollection({
                     url: z.string(),
                     newTab: z.boolean().optional(),
                     showCookiesPrefs: z.boolean().optional(),
-                    iconName: z.string().optional(),
+                    // Typed as IconName without importing the icon map, which would pull the SVG and React icon
+                    // modules into content config loading. Names are not validated at load time.
+                    iconName: z.custom<IconName>((value) => typeof value === 'string').optional(),
                 })
             ),
         })

--- a/documentation/ag-grid-docs/src/types/ag-grid.d.ts
+++ b/documentation/ag-grid-docs/src/types/ag-grid.d.ts
@@ -28,17 +28,19 @@ export interface MenuItem {
     childPaths?: string[];
 }
 
+export interface FooterLink {
+    name: string;
+    url: string;
+    newTab?: boolean;
+    showCookiesPrefs?: boolean;
+    iconName?: string;
+}
+
 export interface FooterItem {
     title: string;
     /** Where the group renders: the legal strip under the columns, or (default) a menu column. */
     placement?: 'legal';
-    links: {
-        name: string;
-        url: string;
-        newTab?: boolean;
-        showCookiesPrefs?: boolean;
-        iconName?: string;
-    }[];
+    links: FooterLink[];
 }
 
 export type ModuleMappings = CollectionEntry<'moduleMappings'>;

--- a/documentation/ag-grid-docs/src/types/ag-grid.d.ts
+++ b/documentation/ag-grid-docs/src/types/ag-grid.d.ts
@@ -1,4 +1,4 @@
-import type { IconName } from '@ag-website-shared/icon/Icon';
+import type { IconName } from '@ag-website-shared/components/icon/Icon';
 import type { CollectionEntry } from 'astro:content';
 
 export type Framework = 'javascript' | 'react' | 'angular' | 'vue';
@@ -33,7 +33,7 @@ export interface FooterLink {
     url: string;
     newTab?: boolean;
     showCookiesPrefs?: boolean;
-    iconName?: string;
+    iconName?: IconName;
 }
 
 export interface FooterItem {

--- a/external/ag-website-shared/src/components/footer/Footer.tsx
+++ b/external/ag-website-shared/src/components/footer/Footer.tsx
@@ -1,4 +1,4 @@
-import type { FooterItem } from '@ag-grid-types';
+import type { FooterItem, FooterLink } from '@ag-grid-types';
 import { DevToolsToggle } from '@ag-website-shared/components/dev-tools/DevTools';
 import { Icon } from '@ag-website-shared/components/icon/Icon';
 import { SiteLogo } from '@components/SiteLogo';
@@ -8,16 +8,9 @@ import GithubSlugger from 'github-slugger';
 
 import styles from './Footer.module.scss';
 
-/**
- * A footer group renders as a menu column unless its `placement` moves it into the legal strip
- * under the columns. Declared here so a site whose footer type predates `placement` still renders
- * every group as a column.
- */
-type FooterGroup = FooterItem & { placement?: 'legal' };
-
 interface FooterProps {
     showMicrosoftMessage?: boolean;
-    footerItems: FooterGroup[];
+    footerItems: FooterItem[];
 }
 
 const toggleCookiesPrefs = (event) => {
@@ -28,7 +21,7 @@ const toggleCookiesPrefs = (event) => {
     window.__enzuzoApi.prefCenter.show();
 };
 
-const MenuColumns = ({ footerItems }: { footerItems: FooterGroup[] }) => {
+const MenuColumns = ({ footerItems }: { footerItems: FooterItem[] }) => {
     const slugger = new GithubSlugger();
 
     return footerItems.map(({ title, links }) => {
@@ -41,7 +34,7 @@ const MenuColumns = ({ footerItems }: { footerItems: FooterGroup[] }) => {
                     {title}
                 </span>
                 <ul className="list-style-none" aria-labelledby={titleId}>
-                    {links.map(({ name, url, newTab, iconName, showCookiesPrefs }: any) => (
+                    {links.map(({ name, url, newTab, iconName, showCookiesPrefs }: FooterLink) => (
                         <li key={`${title}_${name}`}>
                             <a
                                 id={`${slugger.slug(name)}-nav`}
@@ -62,12 +55,12 @@ const MenuColumns = ({ footerItems }: { footerItems: FooterGroup[] }) => {
 };
 
 // Separators between the links are drawn in CSS so they stay out of the accessibility tree.
-const LegalLinks = ({ group }: { group: FooterGroup }) => {
+const LegalLinks = ({ group }: { group: FooterItem }) => {
     const slugger = new GithubSlugger();
 
     return (
         <ul className={classNames('list-style-none', 'text-sm', styles.legalLinks)} aria-label={group.title}>
-            {group.links.map(({ name, url, newTab, showCookiesPrefs }) => (
+            {group.links.map(({ name, url, newTab, showCookiesPrefs }: FooterLink) => (
                 <li key={name}>
                     <a
                         id={`${slugger.slug(name)}-nav`}


### PR DESCRIPTION
## Summary

Syncs the shared footer component with the version now on the charts (ag-grid/ag-charts#8124) and studio (ag-grid/ag-studio#2761) legal-strip branches, so the three copies of `external/ag-website-shared/.../Footer.tsx` are identical again ahead of the next subrepo sync.

- Extracts the footer link shape from `FooterItem` into an exported `FooterLink` interface in the grid's site types.
- The component imports it and annotates both link callbacks with it, replacing the `any` on the menu column callback.
- Drops the local `FooterGroup` alias. It only existed to tolerate a site whose `FooterItem` lacked `placement`, and every site now declares it.
- Types footer link `iconName` as the icon component's `IconName` in the site types and the footer content schema, so the shared component's `<Icon name>` prop type-checks. Fixes the site types' import path for `IconName` where it was wrong or missing.

No behaviour change.

## Test plan

- [x] `./checks.sh` passes
- [x] `./behave.sh --project ag-grid-docs` passes