### PR TITLE
Run docs example tests for the pages a deploy changed

### DIFF
--- a/.github/actions/test-framework-examples/action.yml
+++ b/.github/actions/test-framework-examples/action.yml
@@ -1,6 +1,10 @@
 name: 'Run Framework Example Tests'
 description: 'Run Framework Example Tests'
 inputs:
+  ref:
+    description: "Revision to check out (default: the ref the event would pick)"
+    required: false
+    default: ''
   framework:
     description: "Framework to use, or 'all' to run every framework in one pass"
     required: true
@@ -30,9 +34,13 @@ inputs:
 runs:
   using: "composite"
   steps:
+    # A caller testing a deployed site must pin this to the deployed revision: left to its
+    # default this checks out the event's ref, which on workflow_run is the default-branch
+    # head, and would silently replace a revision the caller had already checked out.
     - name: Checkout
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
+        ref: ${{ inputs.ref }}
         fetch-depth: 1
 
     # These tests run Playwright against a remote deployed site (base_url), so they need

--- a/.github/actions/test-framework-examples/action.yml
+++ b/.github/actions/test-framework-examples/action.yml
@@ -2,7 +2,7 @@ name: 'Run Framework Example Tests'
 description: 'Run Framework Example Tests'
 inputs:
   framework:
-    description: 'Framework to use'
+    description: "Framework to use, or 'all' to run every framework in one pass"
     required: true
     default: 'invalid-framework'
   browsers:
@@ -15,9 +15,17 @@ inputs:
     required: false
     default: 'https://grid-staging.ag-grid.com/'
   test_pattern:
-    description: 'Test pattern to run'
+    description: 'Space-separated Playwright file patterns to run (empty = every test)'
     required: false
     default: ''
+  shard_index:
+    description: 'Playwright shard index'
+    required: false
+    default: '1'
+  shard_total:
+    description: 'Playwright shard count'
+    required: false
+    default: '1'
     
 runs:
   using: "composite"
@@ -86,13 +94,16 @@ runs:
       env:
         CI: 'true'
       shell: bash
-      run: ./docs-e2e.sh ${{ inputs.test_pattern }} --framework ${{ inputs.framework }} --url "${{ inputs.base_url || 'https://grid-staging.ag-grid.com/' }}" ${{ inputs.browsers == 'all' && '--all-browsers' || '' }} --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
+      # An empty --framework would make the gate consume the following --url as its value, so
+      # 'all' omits the flag entirely rather than passing a blank one. Playwright then runs every
+      # framework variant in the one pass, which is what an unset FRAMEWORK means.
+      run: ./docs-e2e.sh ${{ inputs.test_pattern }} ${{ inputs.framework != 'all' && format('--framework {0}', inputs.framework) || '' }} --url "${{ inputs.base_url || 'https://grid-staging.ag-grid.com/' }}" ${{ inputs.browsers == 'all' && '--all-browsers' || '' }} --shard=${{ inputs.shard_index }}/${{ inputs.shard_total }}
     
     - name: Upload Test Report
       id: upload-recipes-report
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: ${{ !cancelled() }}
       with:
-        name: playwright-${{ inputs.framework }}-examples-${{ matrix.shardIndex }}-of-${{ matrix.shardTotal }}
+        name: playwright-${{ inputs.framework }}-examples-${{ inputs.shard_index }}-of-${{ inputs.shard_total }}
         path: reports/
         retention-days: ${{env.DEFAULT_RETENTION_DAYS}}

--- a/.github/workflows/doc-tests-changed.yml
+++ b/.github/workflows/doc-tests-changed.yml
@@ -1,17 +1,24 @@
 name: Documentation Tests (Changed Pages)
 description: Run the docs example tests for the pages a deploy actually changed
 
-# The fast counterpart to doc-tests.yml. That suite runs the whole ~1000-spec estate nightly;
-# this one runs only the pages touched by the commit that was just deployed, so a broken example
-# surfaces minutes after merge instead of the next morning.
+# An early-warning signal, not a gate. doc-tests.yml runs the whole ~1000-spec estate nightly
+# and is the source of truth for example health; this runs only the pages touched by the commit
+# that was just deployed, so a broken example surfaces minutes after merge instead of the next
+# morning. Because the nightly covers everything anyway, this workflow is deliberately
+# best-effort: if it cannot work out what changed it logs why and exits green, it keeps no state
+# between runs, and a missed range costs at most a day of latency. Do not harden it into
+# something authoritative - that is what the nightly is for.
 #
-# It cannot live in CI: these tests drive a deployed site, and CI has no dev server. Staging is
-# only deployed from `latest` (see the `Deploy to Staging` step in ci.yml), so this hangs off
-# CI's completion the same way post-deploy-verification.yml does and tests what is now live.
+# These tests drive the deployed staging site, which is only deployed from `latest` (see the
+# `Deploy to Staging` step in ci.yml), so this hangs off CI's completion the same way
+# post-deploy-verification.yml does and tests what is now live.
 #
 # Scope: changed doc pages only. A grid *source* change can break any page, and the specs sitting
 # at the root of src/content/docs (example-demos, example-source-code, ...) sweep across all of
-# them — none of that is covered here. This complements the nightly; it does not replace it.
+# them - none of that is covered here.
+#
+# No concurrency group: each deploy tests its own range (previous deploy...this deploy), so
+# cancelling an in-flight run would leave that range untested. Runs are short; let them overlap.
 
 on:
   workflow_run:
@@ -21,7 +28,7 @@ on:
   workflow_dispatch:
     inputs:
       base_sha:
-        description: 'Commit to diff against (blank = the last commit this workflow tested)'
+        description: 'Commit to diff against (blank = the previous successful CI deploy of latest)'
         required: false
         default: ''
       base_url:
@@ -47,13 +54,6 @@ env:
   # is a commit on our own latest; the untrusted-checkout pattern OSSF/Scorecard flags is a
   # fork's head, which that guard excludes. A dispatch has no triggering run, so github.sha.
   DEPLOYED_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
-  BASELINE_ARTIFACT: tested-sha
-
-# A second deploy landing while this runs makes the in-flight result stale, so drop it and test
-# the newer commit instead. A manual dispatch is somebody's deliberate run and is left alone.
-concurrency:
-  group: doc-tests-changed-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
 
 permissions:
   contents: read
@@ -74,67 +74,22 @@ jobs:
        github.event.workflow_run.head_repository.full_name == github.repository)
     outputs:
       patterns: ${{ steps.resolve.outputs.patterns }}
-      pages: ${{ steps.resolve.outputs.pages }}
       count: ${{ steps.resolve.outputs.count }}
-      has_tests: ${{ steps.resolve.outputs.has_tests }}
-      resolved: ${{ steps.resolve.outputs.resolved }}
-      deployed: ${{ steps.deploy_check.outputs.deployed }}
       base_sha: ${{ steps.baseline.outputs.sha }}
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ env.DEPLOYED_SHA }}
-          # The diff needs both ends of the range and their merge base in the checkout, and
-          # the baseline is the previously tested commit. 50 covers a normal merge cadence;
-          # beyond that the resolver reports no range rather than guessing.
+          # The diff needs both ends of the range and their merge base in the checkout. 50
+          # covers a normal merge cadence; beyond that the resolver skips rather than guessing.
           fetch-depth: 50
-
-
-      # CI success does not by itself mean the docs reached staging: the deploy lives in CI's
-      # `docs` job, and a skipped job leaves the run green. Today that cannot happen on a push
-      # (detect-changes forces run_docs_ci for non-PR events) and a failed deploy fails CI, so
-      # this asserts a chain that currently holds rather than one that is enforced. If it ever
-      # stops holding, testing would silently run against a stale site - and record-baseline
-      # would mark those pages tested - so check it explicitly and do nothing if it is false.
-      - name: Check the docs were deployed
-        id: deploy_check
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Run metadata, not run content: safe to read from the event payload.
-          CI_RUN_ID: ${{ github.event.workflow_run.id }}
-        run: |
-          # A dispatch has no triggering run and may deliberately target any URL.
-          if [ -z "${CI_RUN_ID}" ]; then
-            echo "deployed=true" >> "$GITHUB_OUTPUT"
-            echo "Manual dispatch; taking the target site as given."
-            exit 0
-          fi
-          CONCLUSION=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${CI_RUN_ID}/jobs" \
-            --paginate \
-            --jq '.jobs[] | select(.name == "Docs Build & Link Checker") | .conclusion' \
-            | head -1)
-          if [ "${CONCLUSION}" = "success" ]; then
-            echo "deployed=true" >> "$GITHUB_OUTPUT"
-            echo "CI run ${CI_RUN_ID} deployed the docs."
-            exit 0
-          fi
-          echo "deployed=false" >> "$GITHUB_OUTPUT"
-          {
-            echo "### Skipped: the docs were not deployed"
-            echo
-            echo "CI run \`${CI_RUN_ID}\`'s docs job reported \`${CONCLUSION:-no such job}\`, so"
-            echo "staging does not carry this commit and testing it would describe the previous"
-            echo "deploy. No baseline is recorded, so the next run re-selects this range."
-          } | tee -a "$GITHUB_STEP_SUMMARY"
 
       - name: Resolve baseline commit
         id: baseline
-        if: steps.deploy_check.outputs.deployed == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OVERRIDE: ${{ inputs.base_sha }}
-          BASELINE_ARTIFACT: ${{ env.BASELINE_ARTIFACT }}
         run: |
           if [ -n "${OVERRIDE}" ]; then
             echo "sha=${OVERRIDE}" >> "$GITHUB_OUTPUT"
@@ -142,43 +97,30 @@ jobs:
             exit 0
           fi
 
-          # The baseline is the SHA a previous run recorded as tested, carried in an artifact
-          # rather than derived from run metadata: a run's own headSha is the default-branch head
-          # at the time, not the commit it deployed, so no arithmetic on it yields the right
-          # answer. This walks back over recent successful runs rather than trusting the newest,
-          # because a run can succeed without recording one - a dispatch, or a run that found the
-          # range unreadable. Mirrors the csp-report job in post-deploy-verification.yml.
-          RUNS=$(gh run list \
-            --workflow doc-tests-changed.yml \
-            --branch latest \
-            --status success \
-            --limit 10 \
-            --json databaseId \
-            --jq '.[].databaseId')
-
+          # CI on latest is push-triggered, so each successful CI run's headSha is exactly the
+          # commit it deployed. The previous deploy is therefore the newest successful CI run
+          # other than our own that is an ancestor of the deployed commit. The ancestor check
+          # covers a newer commit whose CI finished before ours triggered this workflow.
           SHA=""
-          for ID in ${RUNS}; do
-            if ! ARTIFACTS=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${ID}/artifacts" \
-              --jq '.artifacts[] | select(.expired == false) | .name'); then
-              echo "::warning title=Baseline::Could not list artifacts for run ${ID}; skipping it."
-              continue
-            fi
-            if grep -qx "${BASELINE_ARTIFACT}" <<<"${ARTIFACTS}"; then
-              if gh run download "${ID}" --repo "${GITHUB_REPOSITORY}" --name "${BASELINE_ARTIFACT}" --dir ./baseline; then
-                SHA=$(tr -d '[:space:]' < ./baseline/tested-sha.txt)
-                echo "Baseline recorded by run ${ID}."
-                break
-              fi
-              echo "::warning title=Baseline::Could not download the baseline from run ${ID}; skipping it."
+          for CANDIDATE in $(gh run list \
+              --workflow CI \
+              --branch latest \
+              --event push \
+              --status success \
+              --limit 10 \
+              --json headSha \
+              --jq '.[].headSha'); do
+            if [ "${CANDIDATE}" != "${DEPLOYED_SHA}" ] && git merge-base --is-ancestor "${CANDIDATE}" "${DEPLOYED_SHA}" 2>/dev/null; then
+              SHA="${CANDIDATE}"
+              break
             fi
           done
 
           echo "sha=${SHA}" >> "$GITHUB_OUTPUT"
-          echo "Baseline: ${SHA:-none (no recent run recorded one)}"
+          echo "Baseline: ${SHA:-none (no earlier successful CI run reachable in this checkout)}"
 
       - name: Resolve changed doc pages
         id: resolve
-        if: steps.deploy_check.outputs.deployed == 'true'
         # Both SHAs go through the environment rather than being interpolated into the command
         # line: base_sha is a dispatch input, so an expression here would be a shell-injection
         # point.
@@ -187,31 +129,9 @@ jobs:
           HEAD_SHA: ${{ env.DEPLOYED_SHA }}
         run: node scripts/ci/resolve-changed-doc-pages.mjs "${BASE_SHA}" "${HEAD_SHA}"
 
-      - name: Summarise scope
-        if: steps.deploy_check.outputs.deployed == 'true'
-        env:
-          PAGES: ${{ steps.resolve.outputs.pages }}
-          COUNT: ${{ steps.resolve.outputs.count }}
-          BASE: ${{ steps.baseline.outputs.sha }}
-          HEAD: ${{ env.DEPLOYED_SHA }}
-        run: |
-          {
-            if [ "${COUNT}" = "0" ]; then
-              echo "### No changed doc pages with tests"
-              echo
-              echo "Nothing to run for \`${BASE:-none}...${HEAD}\`."
-            else
-              echo "### Testing ${COUNT} changed doc page(s)"
-              echo
-              tr ',' '\n' <<<"${PAGES}" | sed 's/^/- /'
-              echo
-              echo "Range: \`${BASE:-none}...${HEAD}\`"
-            fi
-          } | tee -a "$GITHUB_STEP_SUMMARY"
-
   test:
     needs: resolve
-    if: ${{ needs.resolve.outputs.has_tests == 'true' }}
+    if: ${{ needs.resolve.outputs.count != '0' }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
     name: Test Changed Pages
@@ -301,34 +221,3 @@ jobs:
           CURRENT_COMMIT_SHA: ${{ env.DEPLOYED_SHA }}
           PREV_COMMIT_SHA: ${{ needs.resolve.outputs.base_sha }}
           IS_SUCCESS: 'false'
-
-  # Advances the baseline only for a run whose verdict covers the normal staging range: the
-  # docs reached staging, the range was readable, and the tests either passed or had nothing to
-  # run. A failure, a cancellation or an unreadable range records nothing, so the next run
-  # re-selects the same range instead of stepping over it.
-  #
-  # Manual dispatches never record. They can point at another site or pin their own base_sha, so
-  # their verdict does not describe the staging range this baseline stands for - recording it
-  # would mark untested pages as tested.
-  record-baseline:
-    needs: [resolve, test]
-    if: >
-      always() && github.event_name == 'workflow_run' &&
-      needs.resolve.result == 'success' &&
-      needs.resolve.outputs.deployed == 'true' &&
-      needs.resolve.outputs.resolved == 'true' &&
-      (needs.test.result == 'success' || needs.test.result == 'skipped')
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    name: Record Tested Commit
-    steps:
-      - name: Write tested commit
-        run: echo "${DEPLOYED_SHA}" > ./tested-sha.txt
-      # An artifact rather than the cache: the next run has to find this by walking back over
-      # recent runs, and a 30-day artifact outlives the cache's idle eviction.
-      - name: Upload tested commit
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: ${{ env.BASELINE_ARTIFACT }}
-          path: ./tested-sha.txt
-          retention-days: ${{ env.DEFAULT_RETENTION_DAYS }}

--- a/.github/workflows/doc-tests-changed.yml
+++ b/.github/workflows/doc-tests-changed.yml
@@ -39,6 +39,15 @@ env:
   CI: true
   DEFAULT_RETENTION_DAYS: 30
   AG_LIBRARY: grid
+  # The commit whose CI run deployed the site under test. For workflow_run that is the
+  # triggering run's head, NOT github.sha: CI does not cancel an in-flight latest run, so a
+  # second merge can already be default-branch HEAD while the first is still deploying, and
+  # github.sha would then test the newer commit's specs against the older commit's deploy.
+  # Reading head_sha is safe here because the job guard admits only same-repo pushes, so it
+  # is a commit on our own latest; the untrusted-checkout pattern OSSF/Scorecard flags is a
+  # fork's head, which that guard excludes. A dispatch has no triggering run, so github.sha.
+  DEPLOYED_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
+  BASELINE_CACHE_PREFIX: doc-tests-changed-tested-
 
 # A second deploy landing while this runs makes the in-flight result stale, so drop it and test
 # the newer commit instead. A manual dispatch is somebody's deliberate run and is left alone.
@@ -73,13 +82,21 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          # The default-branch HEAD, which under the job `if:` above is the deployed commit.
-          # Deliberately not workflow_run.head_sha — that is the untrusted-input pattern.
-          ref: ${{ github.sha }}
-          # The diff needs both ends of the range in the checkout, and the baseline is the
-          # previously deployed commit. 50 covers a normal merge cadence; beyond that the
-          # resolver reports no range rather than guessing.
+          ref: ${{ env.DEPLOYED_SHA }}
+          # The diff needs both ends of the range and their merge base in the checkout, and
+          # the baseline is the previously tested commit. 50 covers a normal merge cadence;
+          # beyond that the resolver reports no range rather than guessing.
           fetch-depth: 50
+
+      # The previous baseline cannot come from `gh run list`: a run's headSha is its own head,
+      # which for workflow_run is the default-branch HEAD rather than the commit it deployed.
+      # So each run records the SHA it actually tested and the next one reads it back.
+      - name: Restore last tested commit
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ./tested-sha.txt
+          key: ${{ env.BASELINE_CACHE_PREFIX }}${{ env.DEPLOYED_SHA }}
+          restore-keys: ${{ env.BASELINE_CACHE_PREFIX }}
 
       - name: Resolve baseline commit
         id: baseline
@@ -92,18 +109,35 @@ jobs:
             echo "Using the dispatched baseline ${OVERRIDE}."
             exit 0
           fi
-          # This run is still in_progress, so --status completed cannot select it. The last
-          # completed run's head SHA is the commit this workflow last had a verdict on —
-          # including a failed one, so a red run's range is re-tested rather than skipped over.
+          # Written by record-baseline on the last run that reached a verdict.
+          if [ -f ./tested-sha.txt ]; then
+            SHA=$(tr -d '[:space:]' < ./tested-sha.txt)
+            if [ -n "${SHA}" ]; then
+              echo "sha=${SHA}" >> "$GITHUB_OUTPUT"
+              echo "Baseline: ${SHA} (last tested commit)."
+              exit 0
+            fi
+          fi
+
+          # Cache entries are evicted eventually, so fall back to the last run that concluded
+          # `success`. Its headSha can be newer than the commit that run deployed, which would
+          # make this baseline too recent and under-select, so take its parent to err the other
+          # way: over-selecting costs a few minutes of extra tests, under-selecting silently
+          # drops a page. `--status` matches conclusions too, so cancelled and skipped runs -
+          # which tested nothing, and are the majority of `completed` - cannot be picked.
           SHA=$(gh run list \
             --workflow doc-tests-changed.yml \
             --branch latest \
-            --status completed \
+            --status success \
             --limit 1 \
             --json headSha \
             --jq '.[0].headSha // ""')
+          if [ -n "${SHA}" ]; then
+            PARENT=$(git rev-parse --verify --quiet "${SHA}^" || true)
+            SHA=${PARENT:-$SHA}
+          fi
           echo "sha=${SHA}" >> "$GITHUB_OUTPUT"
-          echo "Baseline: ${SHA:-none (first run)}"
+          echo "Baseline: ${SHA:-none (no cached commit and no successful run)}"
 
       - name: Resolve changed doc pages
         id: resolve
@@ -112,7 +146,7 @@ jobs:
         # point.
         env:
           BASE_SHA: ${{ steps.baseline.outputs.sha }}
-          HEAD_SHA: ${{ github.sha }}
+          HEAD_SHA: ${{ env.DEPLOYED_SHA }}
         run: node scripts/ci/resolve-changed-doc-pages.mjs "${BASE_SHA}" "${HEAD_SHA}"
 
       - name: Summarise scope
@@ -120,18 +154,19 @@ jobs:
           PAGES: ${{ steps.resolve.outputs.pages }}
           COUNT: ${{ steps.resolve.outputs.count }}
           BASE: ${{ steps.baseline.outputs.sha }}
+          HEAD: ${{ env.DEPLOYED_SHA }}
         run: |
           {
             if [ "${COUNT}" = "0" ]; then
               echo "### No changed doc pages with tests"
               echo
-              echo "Nothing to run for \`${BASE:-none}...${GITHUB_SHA}\`."
+              echo "Nothing to run for \`${BASE:-none}...${HEAD}\`."
             else
               echo "### Testing ${COUNT} changed doc page(s)"
               echo
               tr ',' '\n' <<<"${PAGES}" | sed 's/^/- /'
               echo
-              echo "Range: \`${BASE:-none}...${GITHUB_SHA}\`"
+              echo "Range: \`${BASE:-none}...${HEAD}\`"
             fi
           } | tee -a "$GITHUB_STEP_SUMMARY"
 
@@ -148,7 +183,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ github.sha }}
+          ref: ${{ env.DEPLOYED_SHA }}
           fetch-depth: 1
       # Same composite action the nightly uses, so the two suites cannot drift in how they set up
       # or invoke Playwright. One job covering every framework on every browser, unsharded: a
@@ -172,7 +207,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ github.sha }}
+          ref: ${{ env.DEPLOYED_SHA }}
           fetch-depth: 1
 
       - name: Download test reports
@@ -223,6 +258,26 @@ jobs:
           SLACK_BOT_OAUTH_TOKEN: ${{ secrets.SLACK_BOT_OAUTH_TOKEN }}
           SLACK_CHANNEL: '#ci-grid-gate'
           CTRF_REPORT_FILE: ./ctrf-report.json
-          CURRENT_COMMIT_SHA: ${{ github.sha }}
+          CURRENT_COMMIT_SHA: ${{ env.DEPLOYED_SHA }}
           PREV_COMMIT_SHA: ${{ needs.resolve.outputs.base_sha }}
           IS_SUCCESS: 'false'
+
+  # Advances the baseline only when this run actually reached a verdict on its range - tests
+  # passed, or there was nothing to test. A failure or a cancellation deliberately records
+  # nothing, so the next run re-selects the same range instead of stepping over it.
+  record-baseline:
+    needs: [resolve, test]
+    if: >
+      always() && needs.resolve.result == 'success' &&
+      (needs.test.result == 'success' || needs.test.result == 'skipped')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    name: Record Tested Commit
+    steps:
+      - name: Write tested commit
+        run: echo "${DEPLOYED_SHA}" > ./tested-sha.txt
+      - name: Save tested commit
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ./tested-sha.txt
+          key: ${{ env.BASELINE_CACHE_PREFIX }}${{ env.DEPLOYED_SHA }}

--- a/.github/workflows/doc-tests-changed.yml
+++ b/.github/workflows/doc-tests-changed.yml
@@ -1,0 +1,228 @@
+name: Documentation Tests (Changed Pages)
+description: Run the docs example tests for the pages a deploy actually changed
+
+# The fast counterpart to doc-tests.yml. That suite runs the whole ~1000-spec estate nightly;
+# this one runs only the pages touched by the commit that was just deployed, so a broken example
+# surfaces minutes after merge instead of the next morning.
+#
+# It cannot live in CI: these tests drive a deployed site, and CI has no dev server. Staging is
+# only deployed from `latest` (see the `Deploy to Staging` step in ci.yml), so this hangs off
+# CI's completion the same way post-deploy-verification.yml does and tests what is now live.
+#
+# Scope: changed doc pages only. A grid *source* change can break any page, and the specs sitting
+# at the root of src/content/docs (example-demos, example-source-code, ...) sweep across all of
+# them — none of that is covered here. This complements the nightly; it does not replace it.
+
+on:
+  workflow_run:
+    workflows: ['CI']
+    types: [completed]
+    branches: ['latest']
+  workflow_dispatch:
+    inputs:
+      base_sha:
+        description: 'Commit to diff against (blank = the last commit this workflow tested)'
+        required: false
+        default: ''
+      base_url:
+        description: 'URL to test against'
+        required: false
+        default: 'https://grid-staging.ag-grid.com/'
+      notify:
+        description: 'Notify Slack on failure'
+        type: boolean
+        required: false
+        default: false
+
+env:
+  NX_NO_CLOUD: true
+  CI: true
+  DEFAULT_RETENTION_DAYS: 30
+  AG_LIBRARY: grid
+
+# A second deploy landing while this runs makes the in-flight result stale, so drop it and test
+# the newer commit instead. A manual dispatch is somebody's deliberate run and is left alone.
+concurrency:
+  group: doc-tests-changed-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
+
+permissions:
+  contents: read
+  # read is sufficient: the only actions-scope consumer is `gh run list` for the baseline SHA.
+  actions: read
+
+jobs:
+  resolve:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    name: Resolve Changed Pages
+    # Mirrors post-deploy-verification.yml: for workflow_run, only same-repo pushes whose CI run
+    # succeeded, which keeps this off the untrusted-checkout path OSSF/Scorecard flags.
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.event == 'push' &&
+       github.event.workflow_run.head_repository.full_name == github.repository)
+    outputs:
+      patterns: ${{ steps.resolve.outputs.patterns }}
+      pages: ${{ steps.resolve.outputs.pages }}
+      count: ${{ steps.resolve.outputs.count }}
+      has_tests: ${{ steps.resolve.outputs.has_tests }}
+      base_sha: ${{ steps.baseline.outputs.sha }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # The default-branch HEAD, which under the job `if:` above is the deployed commit.
+          # Deliberately not workflow_run.head_sha — that is the untrusted-input pattern.
+          ref: ${{ github.sha }}
+          # The diff needs both ends of the range in the checkout, and the baseline is the
+          # previously deployed commit. 50 covers a normal merge cadence; beyond that the
+          # resolver reports no range rather than guessing.
+          fetch-depth: 50
+
+      - name: Resolve baseline commit
+        id: baseline
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OVERRIDE: ${{ inputs.base_sha }}
+        run: |
+          if [ -n "${OVERRIDE}" ]; then
+            echo "sha=${OVERRIDE}" >> "$GITHUB_OUTPUT"
+            echo "Using the dispatched baseline ${OVERRIDE}."
+            exit 0
+          fi
+          # This run is still in_progress, so --status completed cannot select it. The last
+          # completed run's head SHA is the commit this workflow last had a verdict on —
+          # including a failed one, so a red run's range is re-tested rather than skipped over.
+          SHA=$(gh run list \
+            --workflow doc-tests-changed.yml \
+            --branch latest \
+            --status completed \
+            --limit 1 \
+            --json headSha \
+            --jq '.[0].headSha // ""')
+          echo "sha=${SHA}" >> "$GITHUB_OUTPUT"
+          echo "Baseline: ${SHA:-none (first run)}"
+
+      - name: Resolve changed doc pages
+        id: resolve
+        # Both SHAs go through the environment rather than being interpolated into the command
+        # line: base_sha is a dispatch input, so an expression here would be a shell-injection
+        # point.
+        env:
+          BASE_SHA: ${{ steps.baseline.outputs.sha }}
+          HEAD_SHA: ${{ github.sha }}
+        run: node scripts/ci/resolve-changed-doc-pages.mjs "${BASE_SHA}" "${HEAD_SHA}"
+
+      - name: Summarise scope
+        env:
+          PAGES: ${{ steps.resolve.outputs.pages }}
+          COUNT: ${{ steps.resolve.outputs.count }}
+          BASE: ${{ steps.baseline.outputs.sha }}
+        run: |
+          {
+            if [ "${COUNT}" = "0" ]; then
+              echo "### No changed doc pages with tests"
+              echo
+              echo "Nothing to run for \`${BASE:-none}...${GITHUB_SHA}\`."
+            else
+              echo "### Testing ${COUNT} changed doc page(s)"
+              echo
+              tr ',' '\n' <<<"${PAGES}" | sed 's/^/- /'
+              echo
+              echo "Range: \`${BASE:-none}...${GITHUB_SHA}\`"
+            fi
+          } | tee -a "$GITHUB_STEP_SUMMARY"
+
+  test:
+    needs: resolve
+    if: ${{ needs.resolve.outputs.has_tests == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    name: Test Changed Pages
+    # Scoped to this job rather than the workflow: the credential is only needed by the requests
+    # to the deployed site, and report-publishing steps have no business reading it.
+    env:
+      AWS_CI_BYPASS_SECRET: ${{ secrets.AWS_CI_BYPASS_SECRET }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+      # Same composite action the nightly uses, so the two suites cannot drift in how they set up
+      # or invoke Playwright. One job covering every framework on every browser, unsharded: a
+      # filtered run is a few hundred tests at most, and splitting it would re-pay the cache
+      # restore, community build and browser install per split for no test-time saving. The
+      # nightly runs only vanilla and reactFunctionalTs across all three browsers because at
+      # full estate size the rest is not worth the hours; that trade does not apply here.
+      - uses: ./.github/actions/test-framework-examples
+        with:
+          base_url: ${{ inputs.base_url || 'https://grid-staging.ag-grid.com/' }}
+          framework: all
+          browsers: all
+          test_pattern: ${{ needs.resolve.outputs.patterns }}
+
+  report:
+    needs: [resolve, test]
+    if: always() && needs.test.result != 'skipped'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    name: Report
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+
+      - name: Download test reports
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: combined-reports
+
+      - name: Normalise example test reports
+        run: node documentation/ag-grid-docs/scripts/normalise-ctrf-reports.mjs combined-reports
+
+      - name: Publish combined test report
+        uses: ctrf-io/github-test-reporter@e500b992f936420eb633c91644cf10d4d71df700 # v1.1.0
+        with:
+          report-path: 'combined-reports/**/*.json'
+          summary-report: true
+          flaky-report: true
+          skipped-report: false
+          group-by: filePath
+          write-ctrf-to-file: ./ctrf-report.json
+
+      # Fixed-size, unlike the reporter's folded report, whose uncapped per-failure traces can
+      # push the step summary past GitHub's 1MB limit and get the whole summary dropped.
+      - name: Summarise failed tests
+        if: always()
+        run: node documentation/ag-grid-docs/scripts/summarise-ctrf-failures.mjs ./ctrf-report.json
+
+      - name: Upload combined CTRF report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ctrf-report
+          path: ./ctrf-report.json
+          retention-days: ${{ env.DEFAULT_RETENTION_DAYS }}
+
+      # Failures only, and only for latest. A pass needs no announcement — this runs on every
+      # deploy, so a "back to green" message per merge would drown the channel. No JIRA ticket
+      # either: a failure here belongs to the commit that just landed, and the nightly owns
+      # ticketing for the estate as a whole.
+      - name: Notify Slack
+        if: >
+          always() && needs.test.result == 'failure' &&
+          github.ref_name == 'latest' &&
+          (github.event_name == 'workflow_run' || inputs.notify)
+        continue-on-error: true
+        uses: ./external/ag-shared/github/actions/slack-integration
+        with:
+          AG_LIBRARY: ${{ env.AG_LIBRARY }}
+          SLACK_BOT_OAUTH_TOKEN: ${{ secrets.SLACK_BOT_OAUTH_TOKEN }}
+          SLACK_CHANNEL: '#ci-grid-gate'
+          CTRF_REPORT_FILE: ./ctrf-report.json
+          CURRENT_COMMIT_SHA: ${{ github.sha }}
+          PREV_COMMIT_SHA: ${{ needs.resolve.outputs.base_sha }}
+          IS_SUCCESS: 'false'

--- a/.github/workflows/doc-tests-changed.yml
+++ b/.github/workflows/doc-tests-changed.yml
@@ -77,6 +77,7 @@ jobs:
       pages: ${{ steps.resolve.outputs.pages }}
       count: ${{ steps.resolve.outputs.count }}
       has_tests: ${{ steps.resolve.outputs.has_tests }}
+      deployed: ${{ steps.deploy_check.outputs.deployed }}
       base_sha: ${{ steps.baseline.outputs.sha }}
     steps:
       - name: Checkout
@@ -98,8 +99,46 @@ jobs:
           key: ${{ env.BASELINE_CACHE_PREFIX }}${{ env.DEPLOYED_SHA }}
           restore-keys: ${{ env.BASELINE_CACHE_PREFIX }}
 
+      # CI success does not by itself mean the docs reached staging: the deploy lives in CI's
+      # `docs` job, and a skipped job leaves the run green. Today that cannot happen on a push
+      # (detect-changes forces run_docs_ci for non-PR events) and a failed deploy fails CI, so
+      # this asserts a chain that currently holds rather than one that is enforced. If it ever
+      # stops holding, testing would silently run against a stale site - and record-baseline
+      # would mark those pages tested - so check it explicitly and do nothing if it is false.
+      - name: Check the docs were deployed
+        id: deploy_check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Run metadata, not run content: safe to read from the event payload.
+          CI_RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          # A dispatch has no triggering run and may deliberately target any URL.
+          if [ -z "${CI_RUN_ID}" ]; then
+            echo "deployed=true" >> "$GITHUB_OUTPUT"
+            echo "Manual dispatch; taking the target site as given."
+            exit 0
+          fi
+          CONCLUSION=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${CI_RUN_ID}/jobs" \
+            --paginate \
+            --jq '.jobs[] | select(.name == "Docs Build & Link Checker") | .conclusion' \
+            | head -1)
+          if [ "${CONCLUSION}" = "success" ]; then
+            echo "deployed=true" >> "$GITHUB_OUTPUT"
+            echo "CI run ${CI_RUN_ID} deployed the docs."
+            exit 0
+          fi
+          echo "deployed=false" >> "$GITHUB_OUTPUT"
+          {
+            echo "### Skipped: the docs were not deployed"
+            echo
+            echo "CI run \`${CI_RUN_ID}\`'s docs job reported \`${CONCLUSION:-no such job}\`, so"
+            echo "staging does not carry this commit and testing it would describe the previous"
+            echo "deploy. No baseline is recorded, so the next run re-selects this range."
+          } | tee -a "$GITHUB_STEP_SUMMARY"
+
       - name: Resolve baseline commit
         id: baseline
+        if: steps.deploy_check.outputs.deployed == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OVERRIDE: ${{ inputs.base_sha }}
@@ -141,6 +180,7 @@ jobs:
 
       - name: Resolve changed doc pages
         id: resolve
+        if: steps.deploy_check.outputs.deployed == 'true'
         # Both SHAs go through the environment rather than being interpolated into the command
         # line: base_sha is a dispatch input, so an expression here would be a shell-injection
         # point.
@@ -150,6 +190,7 @@ jobs:
         run: node scripts/ci/resolve-changed-doc-pages.mjs "${BASE_SHA}" "${HEAD_SHA}"
 
       - name: Summarise scope
+        if: steps.deploy_check.outputs.deployed == 'true'
         env:
           PAGES: ${{ steps.resolve.outputs.pages }}
           COUNT: ${{ steps.resolve.outputs.count }}
@@ -269,6 +310,7 @@ jobs:
     needs: [resolve, test]
     if: >
       always() && needs.resolve.result == 'success' &&
+      needs.resolve.outputs.deployed == 'true' &&
       (needs.test.result == 'success' || needs.test.result == 'skipped')
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.github/workflows/doc-tests-changed.yml
+++ b/.github/workflows/doc-tests-changed.yml
@@ -47,7 +47,7 @@ env:
   # is a commit on our own latest; the untrusted-checkout pattern OSSF/Scorecard flags is a
   # fork's head, which that guard excludes. A dispatch has no triggering run, so github.sha.
   DEPLOYED_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
-  BASELINE_CACHE_PREFIX: doc-tests-changed-tested-
+  BASELINE_ARTIFACT: tested-sha
 
 # A second deploy landing while this runs makes the in-flight result stale, so drop it and test
 # the newer commit instead. A manual dispatch is somebody's deliberate run and is left alone.
@@ -77,6 +77,7 @@ jobs:
       pages: ${{ steps.resolve.outputs.pages }}
       count: ${{ steps.resolve.outputs.count }}
       has_tests: ${{ steps.resolve.outputs.has_tests }}
+      resolved: ${{ steps.resolve.outputs.resolved }}
       deployed: ${{ steps.deploy_check.outputs.deployed }}
       base_sha: ${{ steps.baseline.outputs.sha }}
     steps:
@@ -89,15 +90,6 @@ jobs:
           # beyond that the resolver reports no range rather than guessing.
           fetch-depth: 50
 
-      # The previous baseline cannot come from `gh run list`: a run's headSha is its own head,
-      # which for workflow_run is the default-branch HEAD rather than the commit it deployed.
-      # So each run records the SHA it actually tested and the next one reads it back.
-      - name: Restore last tested commit
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ./tested-sha.txt
-          key: ${{ env.BASELINE_CACHE_PREFIX }}${{ env.DEPLOYED_SHA }}
-          restore-keys: ${{ env.BASELINE_CACHE_PREFIX }}
 
       # CI success does not by itself mean the docs reached staging: the deploy lives in CI's
       # `docs` job, and a skipped job leaves the run green. Today that cannot happen on a push
@@ -142,41 +134,47 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OVERRIDE: ${{ inputs.base_sha }}
+          BASELINE_ARTIFACT: ${{ env.BASELINE_ARTIFACT }}
         run: |
           if [ -n "${OVERRIDE}" ]; then
             echo "sha=${OVERRIDE}" >> "$GITHUB_OUTPUT"
             echo "Using the dispatched baseline ${OVERRIDE}."
             exit 0
           fi
-          # Written by record-baseline on the last run that reached a verdict.
-          if [ -f ./tested-sha.txt ]; then
-            SHA=$(tr -d '[:space:]' < ./tested-sha.txt)
-            if [ -n "${SHA}" ]; then
-              echo "sha=${SHA}" >> "$GITHUB_OUTPUT"
-              echo "Baseline: ${SHA} (last tested commit)."
-              exit 0
-            fi
-          fi
 
-          # Cache entries are evicted eventually, so fall back to the last run that concluded
-          # `success`. Its headSha can be newer than the commit that run deployed, which would
-          # make this baseline too recent and under-select, so take its parent to err the other
-          # way: over-selecting costs a few minutes of extra tests, under-selecting silently
-          # drops a page. `--status` matches conclusions too, so cancelled and skipped runs -
-          # which tested nothing, and are the majority of `completed` - cannot be picked.
-          SHA=$(gh run list \
+          # The baseline is the SHA a previous run recorded as tested, carried in an artifact
+          # rather than derived from run metadata: a run's own headSha is the default-branch head
+          # at the time, not the commit it deployed, so no arithmetic on it yields the right
+          # answer. This walks back over recent successful runs rather than trusting the newest,
+          # because a run can succeed without recording one - a dispatch, or a run that found the
+          # range unreadable. Mirrors the csp-report job in post-deploy-verification.yml.
+          RUNS=$(gh run list \
             --workflow doc-tests-changed.yml \
             --branch latest \
             --status success \
-            --limit 1 \
-            --json headSha \
-            --jq '.[0].headSha // ""')
-          if [ -n "${SHA}" ]; then
-            PARENT=$(git rev-parse --verify --quiet "${SHA}^" || true)
-            SHA=${PARENT:-$SHA}
-          fi
+            --limit 10 \
+            --json databaseId \
+            --jq '.[].databaseId')
+
+          SHA=""
+          for ID in ${RUNS}; do
+            if ! ARTIFACTS=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${ID}/artifacts" \
+              --jq '.artifacts[] | select(.expired == false) | .name'); then
+              echo "::warning title=Baseline::Could not list artifacts for run ${ID}; skipping it."
+              continue
+            fi
+            if grep -qx "${BASELINE_ARTIFACT}" <<<"${ARTIFACTS}"; then
+              if gh run download "${ID}" --repo "${GITHUB_REPOSITORY}" --name "${BASELINE_ARTIFACT}" --dir ./baseline; then
+                SHA=$(tr -d '[:space:]' < ./baseline/tested-sha.txt)
+                echo "Baseline recorded by run ${ID}."
+                break
+              fi
+              echo "::warning title=Baseline::Could not download the baseline from run ${ID}; skipping it."
+            fi
+          done
+
           echo "sha=${SHA}" >> "$GITHUB_OUTPUT"
-          echo "Baseline: ${SHA:-none (no cached commit and no successful run)}"
+          echo "Baseline: ${SHA:-none (no recent run recorded one)}"
 
       - name: Resolve changed doc pages
         id: resolve
@@ -234,6 +232,7 @@ jobs:
       # full estate size the rest is not worth the hours; that trade does not apply here.
       - uses: ./.github/actions/test-framework-examples
         with:
+          ref: ${{ env.DEPLOYED_SHA }}
           base_url: ${{ inputs.base_url || 'https://grid-staging.ag-grid.com/' }}
           framework: all
           browsers: all
@@ -303,14 +302,21 @@ jobs:
           PREV_COMMIT_SHA: ${{ needs.resolve.outputs.base_sha }}
           IS_SUCCESS: 'false'
 
-  # Advances the baseline only when this run actually reached a verdict on its range - tests
-  # passed, or there was nothing to test. A failure or a cancellation deliberately records
-  # nothing, so the next run re-selects the same range instead of stepping over it.
+  # Advances the baseline only for a run whose verdict covers the normal staging range: the
+  # docs reached staging, the range was readable, and the tests either passed or had nothing to
+  # run. A failure, a cancellation or an unreadable range records nothing, so the next run
+  # re-selects the same range instead of stepping over it.
+  #
+  # Manual dispatches never record. They can point at another site or pin their own base_sha, so
+  # their verdict does not describe the staging range this baseline stands for - recording it
+  # would mark untested pages as tested.
   record-baseline:
     needs: [resolve, test]
     if: >
-      always() && needs.resolve.result == 'success' &&
+      always() && github.event_name == 'workflow_run' &&
+      needs.resolve.result == 'success' &&
       needs.resolve.outputs.deployed == 'true' &&
+      needs.resolve.outputs.resolved == 'true' &&
       (needs.test.result == 'success' || needs.test.result == 'skipped')
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -318,8 +324,11 @@ jobs:
     steps:
       - name: Write tested commit
         run: echo "${DEPLOYED_SHA}" > ./tested-sha.txt
-      - name: Save tested commit
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      # An artifact rather than the cache: the next run has to find this by walking back over
+      # recent runs, and a 30-day artifact outlives the cache's idle eviction.
+      - name: Upload tested commit
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
+          name: ${{ env.BASELINE_ARTIFACT }}
           path: ./tested-sha.txt
-          key: ${{ env.BASELINE_CACHE_PREFIX }}${{ env.DEPLOYED_SHA }}
+          retention-days: ${{ env.DEFAULT_RETENTION_DAYS }}

--- a/.github/workflows/doc-tests.yml
+++ b/.github/workflows/doc-tests.yml
@@ -149,6 +149,8 @@ jobs:
           framework: vanilla
           browsers: all
           test_pattern: ${{github.event.inputs.test_pattern}}
+          shard_index: ${{ matrix.shardIndex }}
+          shard_total: ${{ matrix.shardTotal }}
 
   test-typescript:
     needs: initialise
@@ -171,6 +173,8 @@ jobs:
           framework: typescript
           browsers: chromium
           test_pattern: ${{github.event.inputs.test_pattern}}
+          shard_index: ${{ matrix.shardIndex }}
+          shard_total: ${{ matrix.shardTotal }}
 
   test-reactFunctionalTs:
     needs: initialise
@@ -193,6 +197,8 @@ jobs:
           framework: reactFunctionalTs
           browsers: all
           test_pattern: ${{github.event.inputs.test_pattern}}
+          shard_index: ${{ matrix.shardIndex }}
+          shard_total: ${{ matrix.shardTotal }}
 
   test-vue3:
     needs: initialise
@@ -215,6 +221,8 @@ jobs:
           framework: vue3
           browsers: chromium
           test_pattern: ${{github.event.inputs.test_pattern}}
+          shard_index: ${{ matrix.shardIndex }}
+          shard_total: ${{ matrix.shardTotal }}
 
   test-angular:
     needs: initialise
@@ -237,6 +245,8 @@ jobs:
           framework: angular
           browsers: chromium
           test_pattern: ${{github.event.inputs.test_pattern}}
+          shard_index: ${{ matrix.shardIndex }}
+          shard_total: ${{ matrix.shardTotal }}
 
 
   test-recipes:

--- a/scripts/ci/resolve-changed-doc-pages.mjs
+++ b/scripts/ci/resolve-changed-doc-pages.mjs
@@ -1,0 +1,138 @@
+// Maps a commit range onto the docs-page Playwright filters that cover it.
+//
+// Specs are co-located with the pages they test
+// (src/content/docs/<page>/_examples/<example>/example.spec.ts) and Playwright's testDir is
+// src/content/docs/, so a changed file's path *is* the filter — no page-to-spec table to keep
+// in sync. Emits one `content/docs/<page>/` regex per changed page, which Playwright ORs.
+//
+// Usage: node scripts/ci/resolve-changed-doc-pages.mjs <baseSha> <headSha>
+//
+// Outputs (GITHUB_OUTPUT, when set): patterns, pages, count, has_tests.
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const DOCS_ROOT = 'documentation/ag-grid-docs/src/content/docs';
+
+function fail(message) {
+    console.error(`::error title=Changed doc pages::${message}`);
+    process.exit(1);
+}
+
+const [baseSha, headSha] = process.argv.slice(2);
+if (!headSha) {
+    fail('Usage: resolve-changed-doc-pages.mjs <baseSha> <headSha>');
+}
+
+function git(...args) {
+    return execFileSync('git', args, { encoding: 'utf8' });
+}
+
+function hasCommit(sha) {
+    try {
+        // stdio ignored: git writes "fatal: Not a valid object name" to stderr, which would
+        // otherwise surface in the log as if the run had broken.
+        execFileSync('git', ['cat-file', '-e', `${sha}^{commit}`], { stdio: 'ignore' });
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+// A shallow or force-pushed baseline is not an error worth failing the run over — it just means
+// there is no range to diff, so there is nothing to test rather than everything to test.
+// Deliberately NOT falling back to "run the whole suite": that is the nightly's job, and a
+// silent full run here would be a 90-minute surprise.
+if (!baseSha || baseSha === headSha || !hasCommit(baseSha) || !hasCommit(headSha) || !hasMergeBase(baseSha, headSha)) {
+    const why = !baseSha
+        ? 'no previous run to diff against'
+        : baseSha === headSha
+          ? 'the deployed commit is unchanged since the last run'
+          : 'the range has no common ancestor in this (shallow) checkout';
+    console.log(`No commit range to inspect: ${why}.`);
+    writeOutputs({ patterns: '', pages: '', count: 0, has_tests: 'false' });
+    process.exit(0);
+}
+
+// Three-dot, i.e. diff against the merge base rather than the two endpoints. On latest the
+// range is linear and the two agree, but on a branch whose base has moved on, a two-dot diff
+// reports every upstream change in between as though this range had made it - inverted - and
+// would select pages this commit never touched.
+function hasMergeBase(a, b) {
+    try {
+        // A shallow checkout can hold both ends of the range without holding their common
+        // ancestor, and a three-dot diff needs it.
+        execFileSync('git', ['merge-base', a, b], { stdio: 'ignore' });
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+const changed = git('diff', '--name-only', `${baseSha}...${headSha}`).split('\n').filter(Boolean);
+
+// A page directory is the single segment under DOCS_ROOT. The specs sitting directly inside
+// DOCS_ROOT (example-demos, example-source-code, ...) sweep across every page rather than
+// belonging to one, so no changed directory selects them and a filtered run does not pretend to
+// cover them. page-verification.spec.ts is excluded from the browser projects outright —
+// post-deploy-verification.yml owns it.
+const pages = new Set();
+for (const file of changed) {
+    if (!file.startsWith(`${DOCS_ROOT}/`)) {
+        continue;
+    }
+    const [page, ...rest] = file.slice(DOCS_ROOT.length + 1).split('/');
+    if (rest.length === 0) {
+        continue;
+    }
+    pages.add(page);
+}
+
+// A page whose examples carry no spec contributes no tests; including it would make Playwright
+// exit "no tests found" and fail the run on a docs change that simply has nothing to verify.
+const withSpecs = [...pages].sort().filter((page) => hasSpec(path.join(DOCS_ROOT, page)));
+
+function hasSpec(dir) {
+    let entries;
+    try {
+        entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+        return false; // deleted in this range
+    }
+    for (const entry of entries) {
+        if (entry.isDirectory()) {
+            if (hasSpec(path.join(dir, entry.name))) {
+                return true;
+            }
+        } else if (entry.name.endsWith('.spec.ts')) {
+            return true;
+        }
+    }
+    return false;
+}
+
+const patterns = withSpecs.map((page) => `content/docs/${page}/`);
+
+const skipped = [...pages].sort().filter((page) => !withSpecs.includes(page));
+console.log(`Changed doc pages: ${pages.size || 'none'}`);
+if (withSpecs.length) {
+    console.log(`  with specs: ${withSpecs.join(', ')}`);
+}
+if (skipped.length) {
+    console.log(`  without specs (skipped): ${skipped.join(', ')}`);
+}
+
+writeOutputs({
+    patterns: patterns.join(' '),
+    pages: withSpecs.join(','),
+    count: withSpecs.length,
+    has_tests: String(withSpecs.length > 0),
+});
+
+function writeOutputs(outputs) {
+    if (!process.env.GITHUB_OUTPUT) {
+        return;
+    }
+    const lines = Object.entries(outputs).map(([key, value]) => `${key}=${value}`);
+    fs.appendFileSync(process.env.GITHUB_OUTPUT, `${lines.join('\n')}\n`);
+}

--- a/scripts/ci/resolve-changed-doc-pages.mjs
+++ b/scripts/ci/resolve-changed-doc-pages.mjs
@@ -7,70 +7,29 @@
 //
 // Usage: node scripts/ci/resolve-changed-doc-pages.mjs <baseSha> <headSha>
 //
-// Outputs (GITHUB_OUTPUT, when set): patterns, pages, count, has_tests, resolved.
-//
-// `resolved` is the difference between "this range holds nothing to test" and "this range
-// could not be read". Both run no tests, but only the first may advance the caller's
-// baseline: advancing past a range that was never read drops it for good.
+// Outputs (GITHUB_OUTPUT, when set): patterns, count. Both are empty/0 when there is nothing
+// to test, including when the range cannot be read; the step summary says which.
 import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 
 const DOCS_ROOT = 'documentation/ag-grid-docs/src/content/docs';
 
-function fail(message) {
-    console.error(`::error title=Changed doc pages::${message}`);
-    process.exit(1);
-}
-
 const [baseSha, headSha] = process.argv.slice(2);
 if (!headSha) {
-    fail('Usage: resolve-changed-doc-pages.mjs <baseSha> <headSha>');
+    console.error('::error title=Changed doc pages::Usage: resolve-changed-doc-pages.mjs <baseSha> <headSha>');
+    process.exit(1);
 }
 
 function git(...args) {
     return execFileSync('git', args, { encoding: 'utf8' });
 }
 
-function hasCommit(sha) {
-    try {
-        // stdio ignored: git writes "fatal: Not a valid object name" to stderr, which would
-        // otherwise surface in the log as if the run had broken.
-        execFileSync('git', ['cat-file', '-e', `${sha}^{commit}`], { stdio: 'ignore' });
-        return true;
-    } catch {
-        return false;
-    }
-}
-
-// No baseline at all is the bootstrap case, and an unchanged head means nothing has happened
-// since: both are genuinely empty ranges, so the caller may record this commit and move on.
-if (!baseSha || baseSha === headSha) {
-    const why = !baseSha ? 'no previous run to diff against' : 'the deployed commit is unchanged since the last run';
-    console.log(`No commit range to inspect: ${why}.`);
-    writeOutputs({ patterns: '', pages: '', count: 0, has_tests: 'false', resolved: 'true' });
-    process.exit(0);
-}
-
-// A baseline that exists but cannot be reached in this checkout is different in kind: the range
-// is unread, not empty, so `resolved` is false and the caller must leave the baseline alone for
-// the next run to pick up. Deliberately NOT falling back to running the whole suite either -
-// that is the nightly's job, and a silent full run here would be a 90-minute surprise.
-if (!hasCommit(baseSha) || !hasCommit(headSha) || !hasMergeBase(baseSha, headSha)) {
-    console.log(`Cannot read the range ${baseSha}...${headSha}: no common ancestor in this (shallow) checkout.`);
-    console.log('::warning title=Changed doc pages::Range unavailable; leaving the baseline for the next run.');
-    writeOutputs({ patterns: '', pages: '', count: 0, has_tests: 'false', resolved: 'false' });
-    process.exit(0);
-}
-
-// Three-dot, i.e. diff against the merge base rather than the two endpoints. On latest the
-// range is linear and the two agree, but on a branch whose base has moved on, a two-dot diff
-// reports every upstream change in between as though this range had made it - inverted - and
-// would select pages this commit never touched.
 function hasMergeBase(a, b) {
     try {
         // A shallow checkout can hold both ends of the range without holding their common
-        // ancestor, and a three-dot diff needs it.
+        // ancestor, and a three-dot diff needs it. stdio ignored so git's "fatal:" does not
+        // surface in the log as if the run had broken.
         execFileSync('git', ['merge-base', a, b], { stdio: 'ignore' });
         return true;
     } catch {
@@ -78,6 +37,48 @@ function hasMergeBase(a, b) {
     }
 }
 
+function hasSpec(dir) {
+    let entries;
+    try {
+        entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+        return false; // deleted in this range
+    }
+    return entries.some((entry) =>
+        entry.isDirectory() ? hasSpec(path.join(dir, entry.name)) : entry.name.endsWith('.spec.ts')
+    );
+}
+
+function finish(patterns, summary) {
+    console.log(summary);
+    if (process.env.GITHUB_STEP_SUMMARY) {
+        fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${summary}\n`);
+    }
+    if (process.env.GITHUB_OUTPUT) {
+        fs.appendFileSync(process.env.GITHUB_OUTPUT, `patterns=${patterns.join(' ')}\ncount=${patterns.length}\n`);
+    }
+}
+
+if (!baseSha) {
+    finish([], `### Nothing to test\n\nNo previous deploy to diff \`${headSha}\` against.`);
+    process.exit(0);
+}
+
+// Deliberately NOT falling back to running the whole suite: that is the nightly's job, and a
+// silent full run here would be a 90-minute surprise.
+if (!hasMergeBase(baseSha, headSha)) {
+    console.log('::warning title=Changed doc pages::Range unavailable in this shallow checkout.');
+    finish(
+        [],
+        `### Nothing to test\n\nCould not read \`${baseSha}...${headSha}\`: no common ancestor in this checkout.`
+    );
+    process.exit(0);
+}
+
+// Three-dot, i.e. diff against the merge base rather than the two endpoints. On latest the
+// range is linear and the two agree, but on a branch whose base has moved on, a two-dot diff
+// reports every upstream change in between as though this range had made it - inverted - and
+// would select pages this commit never touched.
 const changed = git('diff', '--name-only', `${baseSha}...${headSha}`).split('\n').filter(Boolean);
 
 // A page directory is the single segment under DOCS_ROOT. The specs sitting directly inside
@@ -87,62 +88,27 @@ const changed = git('diff', '--name-only', `${baseSha}...${headSha}`).split('\n'
 // post-deploy-verification.yml owns it.
 const pages = new Set();
 for (const file of changed) {
-    if (!file.startsWith(`${DOCS_ROOT}/`)) {
-        continue;
+    const rel = file.startsWith(`${DOCS_ROOT}/`) ? file.slice(DOCS_ROOT.length + 1) : '';
+    if (rel.includes('/')) {
+        pages.add(rel.split('/')[0]);
     }
-    const [page, ...rest] = file.slice(DOCS_ROOT.length + 1).split('/');
-    if (rest.length === 0) {
-        continue;
-    }
-    pages.add(page);
 }
 
 // A page whose examples carry no spec contributes no tests; including it would make Playwright
 // exit "no tests found" and fail the run on a docs change that simply has nothing to verify.
-const withSpecs = [...pages].sort().filter((page) => hasSpec(path.join(DOCS_ROOT, page)));
+const sorted = [...pages].sort();
+const withSpecs = sorted.filter((page) => hasSpec(path.join(DOCS_ROOT, page)));
+const skipped = sorted.filter((page) => !withSpecs.includes(page));
 
-function hasSpec(dir) {
-    let entries;
-    try {
-        entries = fs.readdirSync(dir, { withFileTypes: true });
-    } catch {
-        return false; // deleted in this range
-    }
-    for (const entry of entries) {
-        if (entry.isDirectory()) {
-            if (hasSpec(path.join(dir, entry.name))) {
-                return true;
-            }
-        } else if (entry.name.endsWith('.spec.ts')) {
-            return true;
-        }
-    }
-    return false;
-}
-
-const patterns = withSpecs.map((page) => `content/docs/${page}/`);
-
-const skipped = [...pages].sort().filter((page) => !withSpecs.includes(page));
-console.log(`Changed doc pages: ${pages.size || 'none'}`);
-if (withSpecs.length) {
-    console.log(`  with specs: ${withSpecs.join(', ')}`);
-}
+const lines = withSpecs.length
+    ? [`### Testing ${withSpecs.length} changed doc page(s)`, '', ...withSpecs.map((p) => `- ${p}`)]
+    : ['### No changed doc pages with tests'];
 if (skipped.length) {
-    console.log(`  without specs (skipped): ${skipped.join(', ')}`);
+    lines.push('', `Changed but without specs: ${skipped.join(', ')}`);
 }
+lines.push('', `Range: \`${baseSha}...${headSha}\``);
 
-writeOutputs({
-    patterns: patterns.join(' '),
-    pages: withSpecs.join(','),
-    count: withSpecs.length,
-    has_tests: String(withSpecs.length > 0),
-    resolved: 'true',
-});
-
-function writeOutputs(outputs) {
-    if (!process.env.GITHUB_OUTPUT) {
-        return;
-    }
-    const lines = Object.entries(outputs).map(([key, value]) => `${key}=${value}`);
-    fs.appendFileSync(process.env.GITHUB_OUTPUT, `${lines.join('\n')}\n`);
-}
+finish(
+    withSpecs.map((page) => `content/docs/${page}/`),
+    lines.join('\n')
+);

--- a/scripts/ci/resolve-changed-doc-pages.mjs
+++ b/scripts/ci/resolve-changed-doc-pages.mjs
@@ -7,7 +7,11 @@
 //
 // Usage: node scripts/ci/resolve-changed-doc-pages.mjs <baseSha> <headSha>
 //
-// Outputs (GITHUB_OUTPUT, when set): patterns, pages, count, has_tests.
+// Outputs (GITHUB_OUTPUT, when set): patterns, pages, count, has_tests, resolved.
+//
+// `resolved` is the difference between "this range holds nothing to test" and "this range
+// could not be read". Both run no tests, but only the first may advance the caller's
+// baseline: advancing past a range that was never read drops it for good.
 import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
@@ -39,18 +43,23 @@ function hasCommit(sha) {
     }
 }
 
-// A shallow or force-pushed baseline is not an error worth failing the run over — it just means
-// there is no range to diff, so there is nothing to test rather than everything to test.
-// Deliberately NOT falling back to "run the whole suite": that is the nightly's job, and a
-// silent full run here would be a 90-minute surprise.
-if (!baseSha || baseSha === headSha || !hasCommit(baseSha) || !hasCommit(headSha) || !hasMergeBase(baseSha, headSha)) {
-    const why = !baseSha
-        ? 'no previous run to diff against'
-        : baseSha === headSha
-          ? 'the deployed commit is unchanged since the last run'
-          : 'the range has no common ancestor in this (shallow) checkout';
+// No baseline at all is the bootstrap case, and an unchanged head means nothing has happened
+// since: both are genuinely empty ranges, so the caller may record this commit and move on.
+if (!baseSha || baseSha === headSha) {
+    const why = !baseSha ? 'no previous run to diff against' : 'the deployed commit is unchanged since the last run';
     console.log(`No commit range to inspect: ${why}.`);
-    writeOutputs({ patterns: '', pages: '', count: 0, has_tests: 'false' });
+    writeOutputs({ patterns: '', pages: '', count: 0, has_tests: 'false', resolved: 'true' });
+    process.exit(0);
+}
+
+// A baseline that exists but cannot be reached in this checkout is different in kind: the range
+// is unread, not empty, so `resolved` is false and the caller must leave the baseline alone for
+// the next run to pick up. Deliberately NOT falling back to running the whole suite either -
+// that is the nightly's job, and a silent full run here would be a 90-minute surprise.
+if (!hasCommit(baseSha) || !hasCommit(headSha) || !hasMergeBase(baseSha, headSha)) {
+    console.log(`Cannot read the range ${baseSha}...${headSha}: no common ancestor in this (shallow) checkout.`);
+    console.log('::warning title=Changed doc pages::Range unavailable; leaving the baseline for the next run.');
+    writeOutputs({ patterns: '', pages: '', count: 0, has_tests: 'false', resolved: 'false' });
     process.exit(0);
 }
 
@@ -127,6 +136,7 @@ writeOutputs({
     pages: withSpecs.join(','),
     count: withSpecs.length,
     has_tests: String(withSpecs.length > 0),
+    resolved: 'true',
 });
 
 function writeOutputs(outputs) {


### PR DESCRIPTION
Runs the docs example tests for only the doc pages a deploy touched, so a broken
example surfaces minutes after merge to `latest` rather than in the next
nightly. Complements `doc-tests.yml`; does not replace it — a grid source change
can break any page, and the cross-page specs at the root of `src/content/docs`
are not covered here.

Specs are co-located with the pages they test, so the mapping needs no lookup
table: `resolve-changed-doc-pages.mjs` turns a commit range into one
`content/docs/<page>/` Playwright filter per changed page. It cannot run in CI,
which has no dev server — staging is only deployed from `latest`, so this hangs
off CI's completion like `post-deploy-verification.yml` does.

No JIRA ticket.

Validated on this PR with a temporary `pull_request` trigger (since removed):
a docs-page edit, an example edit on that same page, and an example-only edit on
a second page each selected the right page(s); 144 tests across five frameworks
and three browsers for two pages, 3.1m.