### PR TITLE
Fix the invisible grid in the Column Sizing fit-grid-width example

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/column-sizing/_examples/continuous-auto-size-fit-grid-width/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/column-sizing/_examples/continuous-auto-size-fit-grid-width/example.spec.ts
@@ -58,6 +58,12 @@ async function expectColumnsToFillGrid(page: Page): Promise<void> {
     expect(overflow).toBeLessThanOrEqual(1);
 }
 
+async function expectGridVisible(page: Page): Promise<void> {
+    const box = await page.locator('.ag-root-wrapper').first().boundingBox();
+    expect(box?.height ?? 0).toBeGreaterThan(100);
+    await expect(page.locator('.ag-row').first()).toBeInViewport();
+}
+
 test.agExample(import.meta, () => {
     test.eachFramework('distributes the grid width across the columns on load', async ({ page }) => {
         await ensureGridReady(page);
@@ -65,6 +71,7 @@ test.agExample(import.meta, () => {
 
         await expect(headerCells(page)).toHaveCount(5);
         await expectColumnsToFillGrid(page);
+        await expectGridVisible(page);
     });
 
     test.eachFramework(

--- a/documentation/ag-grid-docs/src/content/docs/column-sizing/_examples/continuous-auto-size-fit-grid-width/styles.css
+++ b/documentation/ag-grid-docs/src/content/docs/column-sizing/_examples/continuous-auto-size-fit-grid-width/styles.css
@@ -17,6 +17,7 @@
 
 .grid-sizer {
     width: 100%;
+    height: 100%;
 }
 
 .grid {


### PR DESCRIPTION
Fix [AG-18494](https://ag-grid.atlassian.net/browse/AG-18494) 

`continuous-auto-size-fit-grid-width` rendered a 1px-tall grid in React, Angular and Vue — DOM and rows present, nothing on screen. The framework variants put an inline `height: 100%` on the grid div, overriding `.grid { height: 320px }`, and `.grid-sizer` had no resolved height to fill.

Giving `.grid-sizer` `height: 100%` fixes all three; vanilla/TypeScript is unchanged at 320px. The spec only measured column widths, which a collapsed grid still reports correctly, so it stayed green — it now also asserts the grid has real height and the first row is in the viewport.

Verified: the other eight examples on the Column Sizing page render correctly in all four frameworks; the reverse check (forcing the sizer back to `height: auto`) collapses the wrapper to 1.3px, so the new assertion is discriminating. `./docs-e2e.sh continuous-auto-size-fit-grid-width` — 20 passed.