### PR TITLE
AG-3390: align the chevrons and centre the docs header dropdowns

### DIFF
--- a/external/ag-website-shared/src/components/markdown-actions/MarkdownActions.module.scss
+++ b/external/ag-website-shared/src/components/markdown-actions/MarkdownActions.module.scss
@@ -13,6 +13,10 @@
     justify-content: space-between;
     gap: $spacing-size-4;
     height: 36px;
+    // The base button padding is deliberately uneven (see elements/_button.scss) to sit a
+    // text label optically within a button it also sizes. Here the height is fixed and the
+    // contents are flex-centred, so that unevenness only pushes them ~1px above the middle.
+    padding-block: 0;
     border: 1px solid var(--color-input-border);
     border-radius: var(--radius-sm);
     color: var(--color-fg-primary);

--- a/external/ag-website-shared/src/components/select/Select.module.scss
+++ b/external/ag-website-shared/src/components/select/Select.module.scss
@@ -124,6 +124,11 @@
 }
 
 .chevronDown {
+    // Block, so the icon is centred as a box rather than sitting on the text baseline of
+    // the wrapper Radix renders around it. Inline, it landed ~2px low by a font-dependent
+    // amount that differed again per engine (worst in Firefox), which read as this chevron
+    // being out of line with the one on the button beside it.
+    display: block;
     opacity: 0.5;
     height: 16px;
     width: 16px;

--- a/external/ag-website-shared/src/components/select/Select.module.scss
+++ b/external/ag-website-shared/src/components/select/Select.module.scss
@@ -13,6 +13,10 @@
     border-radius: var(--radius-sm);
     font-weight: normal;
     height: 32px;
+    // The base button padding is deliberately uneven (see elements/_button.scss) to sit a
+    // text label optically within a button it also sizes. Here the height is fixed and the
+    // contents are flex-centred, so that unevenness only pushes them ~1px above the middle.
+    padding-block: 0;
     gap: 16px;
     color: var(--color-fg-primary);
     background-color: var(--color-bg-primary);


### PR DESCRIPTION
Aligns the chevrons on the docs header's AI Options and framework dropdowns, and centres both triggers' contents vertically.

https://ag-grid.atlassian.net/browse/AG-3390

Fix [AG-3390](https://ag-grid.atlassian.net/browse/AG-3390)
